### PR TITLE
[feature] 통계관련 엔티티 및 기능 구현

### DIFF
--- a/backend/src/main/java/moadong/club/controller/ClubController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubController.java
@@ -57,6 +57,7 @@ public class ClubController {
         ClubDetailedResponse clubDetailedPageResponse = clubDetailedPageService.getClubDetailedPage(clubId);
         return Response.ok(clubDetailedPageResponse);
     }
+
     @GetMapping("/search/")
     @Operation(summary = "키워드에 맞는 클럽을 검색합니다.(모집,분과,종류에 따른 구분)",
             description = "모집,분과,종류에 필터링 이후 이름,태그,소개에 따라 검색합니다.<br>"

--- a/backend/src/main/java/moadong/club/controller/ClubController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubController.java
@@ -2,6 +2,7 @@ package moadong.club.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.AllArgsConstructor;
 import moadong.club.payload.request.ClubCreateRequest;
 import moadong.club.payload.request.ClubUpdateRequest;
@@ -9,6 +10,7 @@ import moadong.club.payload.response.ClubDetailedResponse;
 import moadong.club.payload.response.ClubSearchResponse;
 import moadong.club.service.ClubCommandService;
 import moadong.club.service.ClubDetailedPageService;
+import moadong.club.service.ClubMetricService;
 import moadong.club.service.ClubSearchService;
 import moadong.global.payload.Response;
 import org.springframework.http.ResponseEntity;
@@ -30,6 +32,7 @@ public class ClubController {
     private final ClubCommandService clubCommandService;
     private final ClubDetailedPageService clubDetailedPageService;
     private final ClubSearchService clubSearchService;
+    private final ClubMetricService clubMetricService;
 
     @PostMapping("")
     @Operation(summary = "클럽 생성", description = "클럽을 생성합니다.")
@@ -47,7 +50,10 @@ public class ClubController {
 
     @GetMapping("/{clubId}")
     @Operation(summary = "클럽 상세 정보 조회", description = "클럽 상세 정보를 조회합니다.")
-    public ResponseEntity<?> getClubDetailedPage(@PathVariable String clubId) {
+    public ResponseEntity<?> getClubDetailedPage(
+        HttpServletRequest request,
+        @PathVariable String clubId) {
+        clubMetricService.patch(clubId, request.getRemoteAddr());
         ClubDetailedResponse clubDetailedPageResponse = clubDetailedPageService.getClubDetailedPage(clubId);
         return Response.ok(clubDetailedPageResponse);
     }

--- a/backend/src/main/java/moadong/club/controller/ClubMetricController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubMetricController.java
@@ -2,10 +2,7 @@ package moadong.club.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
-import java.util.List;
 import lombok.AllArgsConstructor;
-import moadong.club.payload.response.ClubDetailedResponse;
 import moadong.club.service.ClubMetricService;
 import moadong.global.payload.Response;
 import org.springframework.http.ResponseEntity;
@@ -26,7 +23,7 @@ public class ClubMetricController {
     @Operation(summary = "클럽 일일 통계 조회", description = "클럽 일일 통계를 조회합니다.<br>"
         + "30일 이내의 통계를 조회합니다.")
     public ResponseEntity<?> getDailyActiveUserWitClub(@PathVariable String clubId) {
-        List<Integer> metric = clubMetricService.getDailyActiveUserWitClub(clubId);
+        int[] metric = clubMetricService.getDailyActiveUserWitClub(clubId);
         return Response.ok(metric);
     }
 

--- a/backend/src/main/java/moadong/club/controller/ClubMetricController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubMetricController.java
@@ -21,7 +21,7 @@ public class ClubMetricController {
 
     @GetMapping("/{clubId}/daily")
     @Operation(summary = "클럽 일간 통계 조회", description = "클럽 일간 통계를 조회합니다.<br>"
-        + "오늘 부터 30일 이내의 통계를 순서대로 조회합니다.")
+        + "오늘부터 30일이내의 통계를 순서대로 조회합니다.")
     public ResponseEntity<?> getDailyActiveUserWitClub(@PathVariable String clubId) {
         int[] metric = clubMetricService.getDailyActiveUserWitClub(clubId);
         return Response.ok(metric);
@@ -29,9 +29,17 @@ public class ClubMetricController {
 
     @GetMapping("/{clubId}/weekly")
     @Operation(summary = "클럽 주간 통계 조회", description = "클럽 주간 통계를 조회합니다.<br>"
-        + "현재 주부터 12전 주까지의 통계를 순서대로 조회합니다.<br>")
+        + "현재주부터 12주전까지의 통계를 순서대로 조회합니다.<br>")
     public ResponseEntity<?> getWeeklyActiveUserWitClub(@PathVariable String clubId) {
         int[] metric = clubMetricService.getWeeklyActiveUserWitClub(clubId);
+        return Response.ok(metric);
+    }
+
+    @GetMapping("/{clubId}/monthly")
+    @Operation(summary = "클럽 월간 통계 조회", description = "클럽 월간 통계를 조회합니다.<br>"
+        + "현재월부터 12개월전까지의 통계를 순서대로 조회합니다.<br>")
+    public ResponseEntity<?> getMonthlyActiveUserWitClub(@PathVariable String clubId) {
+        int[] metric = clubMetricService.getMonthlyActiveUserWitClub(clubId);
         return Response.ok(metric);
     }
 

--- a/backend/src/main/java/moadong/club/controller/ClubMetricController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubMetricController.java
@@ -1,0 +1,33 @@
+package moadong.club.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import moadong.club.payload.response.ClubDetailedResponse;
+import moadong.club.service.ClubMetricService;
+import moadong.global.payload.Response;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/club/metric")
+@AllArgsConstructor
+@Tag(name = "Club_Metric", description = "클럽 통계 API")
+public class ClubMetricController {
+
+    private final ClubMetricService clubMetricService;
+
+    @GetMapping("/{clubId}/daily")
+    @Operation(summary = "클럽 일일 통계 조회", description = "클럽 일일 통계를 조회합니다.<br>"
+        + "30일 이내의 통계를 조회합니다.")
+    public ResponseEntity<?> getDailyActiveUserWitClub(@PathVariable String clubId) {
+        List<Integer> metric = clubMetricService.getDailyActiveUserWitClub(clubId);
+        return Response.ok(metric);
+    }
+
+}

--- a/backend/src/main/java/moadong/club/controller/ClubMetricController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubMetricController.java
@@ -20,10 +20,18 @@ public class ClubMetricController {
     private final ClubMetricService clubMetricService;
 
     @GetMapping("/{clubId}/daily")
-    @Operation(summary = "클럽 일일 통계 조회", description = "클럽 일일 통계를 조회합니다.<br>"
-        + "30일 이내의 통계를 조회합니다.")
+    @Operation(summary = "클럽 일간 통계 조회", description = "클럽 일간 통계를 조회합니다.<br>"
+        + "오늘 부터 30일 이내의 통계를 순서대로 조회합니다.")
     public ResponseEntity<?> getDailyActiveUserWitClub(@PathVariable String clubId) {
         int[] metric = clubMetricService.getDailyActiveUserWitClub(clubId);
+        return Response.ok(metric);
+    }
+
+    @GetMapping("/{clubId}/weekly")
+    @Operation(summary = "클럽 주간 통계 조회", description = "클럽 주간 통계를 조회합니다.<br>"
+        + "현재 주부터 12전 주까지의 통계를 순서대로 조회합니다.<br>")
+    public ResponseEntity<?> getWeeklyActiveUserWitClub(@PathVariable String clubId) {
+        int[] metric = clubMetricService.getWeeklyActiveUserWitClub(clubId);
         return Response.ok(metric);
     }
 

--- a/backend/src/main/java/moadong/club/entity/ClubMetric.java
+++ b/backend/src/main/java/moadong/club/entity/ClubMetric.java
@@ -1,0 +1,42 @@
+package moadong.club.entity;
+
+import jakarta.persistence.Id;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document("club_metrics")
+@AllArgsConstructor
+@Getter
+public class ClubMetric {
+
+    @Id
+    private String id;
+
+    private String clubId;
+
+    private String ip;
+
+    private LocalDateTime inAt;
+
+    private LocalDateTime outAt;
+
+    private LocalDate date;
+
+    @Builder
+    public ClubMetric(String clubId, String ip) {
+        LocalDateTime now = LocalDateTime.now();
+        this.clubId = clubId;
+        this.ip = ip;
+        this.inAt = now;
+        this.outAt = now;
+        this.date = now.toLocalDate();
+    }
+
+    public void update() {
+        this.outAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/moadong/club/entity/ClubMetric.java
+++ b/backend/src/main/java/moadong/club/entity/ClubMetric.java
@@ -3,6 +3,8 @@ package moadong.club.entity;
 import jakarta.persistence.Id;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,7 +30,7 @@ public class ClubMetric {
 
     @Builder
     public ClubMetric(String clubId, String ip) {
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime();
         this.clubId = clubId;
         this.ip = ip;
         this.inAt = now;
@@ -37,6 +39,6 @@ public class ClubMetric {
     }
 
     public void update() {
-        this.outAt = LocalDateTime.now();
+        this.outAt = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime();
     }
 }

--- a/backend/src/main/java/moadong/club/entity/ClubMetric.java
+++ b/backend/src/main/java/moadong/club/entity/ClubMetric.java
@@ -3,15 +3,15 @@ package moadong.club.entity;
 import jakarta.persistence.Id;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 @Document("club_metrics")
 @AllArgsConstructor
+@NoArgsConstructor
 @Getter
 public class ClubMetric {
 
@@ -30,7 +30,7 @@ public class ClubMetric {
 
     @Builder
     public ClubMetric(String clubId, String ip) {
-        LocalDateTime now = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime();
+        LocalDateTime now = LocalDateTime.now();
         this.clubId = clubId;
         this.ip = ip;
         this.inAt = now;
@@ -39,6 +39,6 @@ public class ClubMetric {
     }
 
     public void update() {
-        this.outAt = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime();
+        this.outAt = LocalDateTime.now();
     }
 }

--- a/backend/src/main/java/moadong/club/repository/ClubMetricRepository.java
+++ b/backend/src/main/java/moadong/club/repository/ClubMetricRepository.java
@@ -1,6 +1,7 @@
 package moadong.club.repository;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import moadong.club.entity.ClubMetric;
 import org.springframework.data.mongodb.repository.MongoRepository;
@@ -10,5 +11,7 @@ import org.springframework.stereotype.Repository;
 public interface ClubMetricRepository extends MongoRepository<ClubMetric, String> {
 
     Optional<ClubMetric> findByClubIdAndIpAndDate(String clubId, String ip, LocalDate date);
+
+    List<ClubMetric> findByClubIdAndDateAfter(String clubId, LocalDate date);
 
 }

--- a/backend/src/main/java/moadong/club/repository/ClubMetricRepository.java
+++ b/backend/src/main/java/moadong/club/repository/ClubMetricRepository.java
@@ -1,0 +1,14 @@
+package moadong.club.repository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import moadong.club.entity.ClubMetric;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ClubMetricRepository extends MongoRepository<ClubMetric, String> {
+
+    Optional<ClubMetric> findByClubIdAndIpAndDate(String clubId, String ip, LocalDate date);
+
+}

--- a/backend/src/main/java/moadong/club/service/ClubMetricService.java
+++ b/backend/src/main/java/moadong/club/service/ClubMetricService.java
@@ -1,0 +1,31 @@
+package moadong.club.service;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+import moadong.club.entity.ClubMetric;
+import moadong.club.repository.ClubMetricRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class ClubMetricService {
+
+    private final ClubMetricRepository clubMetricRepository;
+
+    public void patch(String clubId, String remoteAddr) {
+        Optional<ClubMetric> optional = clubMetricRepository.findByClubIdAndIpAndDate(
+            clubId, remoteAddr, LocalDate.now());
+
+        if (optional.isPresent()) {
+            optional.get().update();
+        } else {
+            clubMetricRepository.save(ClubMetric.builder()
+                .clubId(clubId)
+                .ip(remoteAddr)
+                .build());
+        }
+
+    }
+
+}

--- a/backend/src/main/java/moadong/club/service/ClubMetricService.java
+++ b/backend/src/main/java/moadong/club/service/ClubMetricService.java
@@ -2,8 +2,6 @@ package moadong.club.service;
 
 import java.time.LocalDate;
 import java.time.Period;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
@@ -18,23 +16,26 @@ public class ClubMetricService {
     private final ClubMetricRepository clubMetricRepository;
 
     public void patch(String clubId, String remoteAddr) {
-        LocalDate nowDate = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDate();
+        LocalDate nowDate = LocalDate.now();
         Optional<ClubMetric> optional = clubMetricRepository.findByClubIdAndIpAndDate(
             clubId, remoteAddr, nowDate);
 
+        ClubMetric metric;
         if (optional.isPresent()) {
-            optional.get().update();
+            metric = optional.get();
+            metric.update();
         } else {
-            clubMetricRepository.save(ClubMetric.builder()
+            metric = ClubMetric.builder()
                 .clubId(clubId)
                 .ip(remoteAddr)
-                .build());
+                .build();
         }
+        clubMetricRepository.save(metric);
 
     }
 
-    public List<Integer> getDailyActiveUserWitClub(String clubId) {
-        LocalDate now = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDate();
+    public int[] getDailyActiveUserWitClub(String clubId) {
+        LocalDate now = LocalDate.now();
         //해당 클럽에 대해 30일 전까지의 통계를 모두 불러온다
         LocalDate from = now.minusDays(30);
         List<ClubMetric> metrics = clubMetricRepository.findByClubIdAndDateAfter(clubId, from);
@@ -47,6 +48,6 @@ public class ClubMetricService {
             dailyMetric[period.getDays()]++;
         }
 
-        return null;
+        return dailyMetric;
     }
 }

--- a/backend/src/main/java/moadong/club/service/ClubMetricService.java
+++ b/backend/src/main/java/moadong/club/service/ClubMetricService.java
@@ -1,6 +1,8 @@
 package moadong.club.service;
 
 import java.time.LocalDate;
+import java.time.Period;
+import java.util.List;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import moadong.club.entity.ClubMetric;
@@ -28,4 +30,19 @@ public class ClubMetricService {
 
     }
 
+    public List<Integer> getDailyActiveUserWitClub(String clubId) {
+        //해당 클럽에 대해 30일 전까지의 통계를 모두 불러온다
+        LocalDate date = LocalDate.now().minusDays(30);
+        List<ClubMetric> metrics = clubMetricRepository.findByClubIdAndDateAfter(clubId, date);
+
+        //30일간의 통계를 일별로 나누어 저장할 배열
+        int[] dailyMetric = new int[30];
+        for (ClubMetric metric : metrics) {
+            Period period = Period.between(metric.getDate(), LocalDate.now());
+
+            dailyMetric[period.getDays()]++;
+        }
+
+        return null;
+    }
 }

--- a/backend/src/main/java/moadong/club/service/ClubMetricService.java
+++ b/backend/src/main/java/moadong/club/service/ClubMetricService.java
@@ -2,6 +2,7 @@ package moadong.club.service;
 
 import java.time.LocalDate;
 import java.time.Period;
+import java.time.YearMonth;
 import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -71,5 +72,27 @@ public class ClubMetricService {
         }
 
         return weeklyMetric;
+    }
+
+    public int[] getMonthlyActiveUserWitClub(String clubId) {
+        LocalDate now = LocalDate.now();
+        YearMonth currentMonth = YearMonth.from(now); // 현재 년-월
+        YearMonth fromMonth = currentMonth.minusMonths(12); // 12개월 전
+
+        List<ClubMetric> metrics = clubMetricRepository.findByClubIdAndDateAfter(clubId, fromMonth.atDay(1));
+
+        // 12개월간의 통계를 월별로 저장할 배열
+        int[] monthlyMetric = new int[12];
+
+        for (ClubMetric metric : metrics) {
+            YearMonth metricMonth = YearMonth.from(metric.getDate()); // metric이 속한 년-월
+            int monthsAgo = (int) ChronoUnit.MONTHS.between(metricMonth, currentMonth);
+
+            if (monthsAgo >= 0 && monthsAgo < 12) {
+                monthlyMetric[monthsAgo]++;
+            }
+        }
+
+        return monthlyMetric;
     }
 }

--- a/backend/src/main/java/moadong/club/service/ClubMetricService.java
+++ b/backend/src/main/java/moadong/club/service/ClubMetricService.java
@@ -2,6 +2,8 @@ package moadong.club.service;
 
 import java.time.LocalDate;
 import java.time.Period;
+import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
@@ -36,7 +38,6 @@ public class ClubMetricService {
 
     public int[] getDailyActiveUserWitClub(String clubId) {
         LocalDate now = LocalDate.now();
-        //해당 클럽에 대해 30일 전까지의 통계를 모두 불러온다
         LocalDate from = now.minusDays(30);
         List<ClubMetric> metrics = clubMetricRepository.findByClubIdAndDateAfter(clubId, from);
 
@@ -49,5 +50,26 @@ public class ClubMetricService {
         }
 
         return dailyMetric;
+    }
+
+    public int[] getWeeklyActiveUserWitClub(String clubId) {
+        LocalDate now = LocalDate.now();
+        LocalDate from = now.minusDays(84);
+        List<ClubMetric> metrics = clubMetricRepository.findByClubIdAndDateAfter(clubId, from);
+
+        //12주간의 통계를 주별로 나누어 저장할 배열
+        int[] weeklyMetric = new int[12];
+        LocalDate nowMonday = now.with(ChronoField.DAY_OF_WEEK, 1);
+        for (ClubMetric metric : metrics) {
+            LocalDate metricMonday = metric.getDate()
+                .with(ChronoField.DAY_OF_WEEK, 1); // metric의 해당 주 월요일
+            int weeksAgo = (int) ChronoUnit.WEEKS.between(metricMonday, nowMonday);
+
+            if (weeksAgo >= 0 && weeksAgo < 12) {
+                weeklyMetric[weeksAgo]++;
+            }
+        }
+
+        return weeklyMetric;
     }
 }

--- a/backend/src/main/java/moadong/club/service/ClubMetricService.java
+++ b/backend/src/main/java/moadong/club/service/ClubMetricService.java
@@ -2,6 +2,8 @@ package moadong.club.service;
 
 import java.time.LocalDate;
 import java.time.Period;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
@@ -16,8 +18,9 @@ public class ClubMetricService {
     private final ClubMetricRepository clubMetricRepository;
 
     public void patch(String clubId, String remoteAddr) {
+        LocalDate nowDate = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDate();
         Optional<ClubMetric> optional = clubMetricRepository.findByClubIdAndIpAndDate(
-            clubId, remoteAddr, LocalDate.now());
+            clubId, remoteAddr, nowDate);
 
         if (optional.isPresent()) {
             optional.get().update();
@@ -31,14 +34,15 @@ public class ClubMetricService {
     }
 
     public List<Integer> getDailyActiveUserWitClub(String clubId) {
+        LocalDate now = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDate();
         //해당 클럽에 대해 30일 전까지의 통계를 모두 불러온다
-        LocalDate date = LocalDate.now().minusDays(30);
-        List<ClubMetric> metrics = clubMetricRepository.findByClubIdAndDateAfter(clubId, date);
+        LocalDate from = now.minusDays(30);
+        List<ClubMetric> metrics = clubMetricRepository.findByClubIdAndDateAfter(clubId, from);
 
         //30일간의 통계를 일별로 나누어 저장할 배열
         int[] dailyMetric = new int[30];
         for (ClubMetric metric : metrics) {
-            Period period = Period.between(metric.getDate(), LocalDate.now());
+            Period period = Period.between(metric.getDate(), now);
 
             dailyMetric[period.getDays()]++;
         }


### PR DESCRIPTION
## #️⃣연관된 이슈
- #83 

## 📝작업 내용
### 통계 기능 구현
특정 동아리를 지목하여 일간, 주간, 월간 통계를 조회하는 기능을 구현하였습니다.
![image](https://github.com/user-attachments/assets/0f7b2eac-4750-4954-accc-cca85d1f34fe)


### Collection이름 복수형으로 변경
단수형이였던 collection이름들을 모두 복수형으로 변경하고, 데이터를 옮겨두었습니다.
<img src="https://github.com/user-attachments/assets/007e163a-7ba7-4eaa-9ec8-ebfcd9fc3c9c" align="center" width="49%">

### erd cloud 업데이트
새로운 GCP 인스턴스구축을 위한 계정(Pororo)에 erd cloud를 전부 복제 및 업데이트 해두었습니다.
<img src="https://github.com/user-attachments/assets/d6308c14-85f4-402b-a953-5058e6384d86" align="center" width="49%">
<br>
<img src="https://github.com/user-attachments/assets/c14f6e4a-0575-42d9-b00c-acc7f9dbb3b1" align="center" width="49%">

## 🫡 참고사항
- MongoDB는 오로지 UTC만을 적용합니다. 따라서, 저장시에 한국시간으로 변경해도 의미가 없으며, 조회시 한국시간으로 변화하는 과정이 꼭 필요합니다.