### PR TITLE
[chore] 자동 포트 탐색 기능

### DIFF
--- a/frontend/config/webpack.dev.ts
+++ b/frontend/config/webpack.dev.ts
@@ -62,7 +62,7 @@ export default getAvailablePort(DEFAULT_PORT).then((port) => {
       },
     ],
     devServer: {
-      port, // 동적으로 설정된 포트 사용
+      port,
       open: true,
       historyApiFallback: true,
     },

--- a/frontend/config/webpack.dev.ts
+++ b/frontend/config/webpack.dev.ts
@@ -12,9 +12,8 @@ async function getAvailablePort(defaultPort: number): Promise<number> {
   return await detectPort(defaultPort);
 }
 
-async function createWebpackConfig(): Promise<webpack.Configuration> {
-  const port = await getAvailablePort(DEFAULT_PORT);
-  console.log(port);
+export default getAvailablePort(DEFAULT_PORT).then((port) => {
+  console.log(`🚀 Using available port: ${port}`);
 
   const configuration: webpack.Configuration = {
     mode: 'development',
@@ -63,7 +62,7 @@ async function createWebpackConfig(): Promise<webpack.Configuration> {
       },
     ],
     devServer: {
-      port,
+      port, // 동적으로 설정된 포트 사용
       open: true,
       historyApiFallback: true,
     },
@@ -76,7 +75,4 @@ async function createWebpackConfig(): Promise<webpack.Configuration> {
   };
 
   return merge(common, configuration);
-}
-
-// Webpack이 비동기 설정을 지원하지 않기 때문에, `export default`로 직접 반환할 수 없음
-export default createWebpackConfig();
+});

--- a/frontend/config/webpack.dev.ts
+++ b/frontend/config/webpack.dev.ts
@@ -4,38 +4,49 @@ import { merge } from 'webpack-merge';
 const RefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
 import 'webpack-dev-server';
 import common from './webpack.common';
+import detectPort from 'detect-port';
 
-const configuration: webpack.Configuration = {
-  mode: 'development',
-  devtool: 'inline-source-map',
-  output: {
-    path: path.resolve(__dirname, '../dist'),
-    filename: '[name].bundle.js',
-    publicPath: '/',
-  },
-  module: {
-    rules: [
+const DEFAULT_PORT = 3000;
+
+async function getAvailablePort(defaultPort: number): Promise<number> {
+  return await detectPort(defaultPort);
+}
+
+async function createWebpackConfig(): Promise<webpack.Configuration> {
+  const port = await getAvailablePort(DEFAULT_PORT);
+  console.log(port);
+
+  const configuration: webpack.Configuration = {
+    mode: 'development',
+    devtool: 'inline-source-map',
+    output: {
+      path: path.resolve(__dirname, '../dist'),
+      filename: '[name].bundle.js',
+      publicPath: '/',
+    },
+    module: {
+      rules: [
+        {
+          test: /\.css$/,
+          use: ['style-loader', 'css-loader'],
+          exclude: /node_modules/,
+        },
+      ],
+    },
+    plugins: [
+      new RefreshWebpackPlugin(),
       {
-        test: /\.css$/,
-        use: ['style-loader', 'css-loader'],
-        exclude: /node_modules/,
-      },
-    ],
-  },
-  plugins: [
-    new RefreshWebpackPlugin(),
-    {
-      apply: (compiler) => {
-        compiler.hooks.done.tap('done', (stats) => {
-          if (stats.hasErrors()) {
-            console.error(
-              '❌ Webpack Build Failed! Please check errors above.',
-            );
-            console.error(stats.toJson().errors);
-          } else if (stats.hasWarnings()) {
-            console.warn('⚠️ Webpack Build Completed with Warnings.');
-          } else {
-            console.log(`
+        apply: (compiler) => {
+          compiler.hooks.done.tap('done', (stats) => {
+            if (stats.hasErrors()) {
+              console.error(
+                '❌ Webpack Build Failed! Please check errors above.',
+              );
+              console.error(stats.toJson().errors);
+            } else if (stats.hasWarnings()) {
+              console.warn('⚠️ Webpack Build Completed with Warnings.');
+            } else {
+              console.log(`
 --------------------------------------------------------
 🎉  WEBPACK BUILD SUCCESSFULLY COMPLETED!
 ✅  Files Generated: ${stats
@@ -43,25 +54,29 @@ const configuration: webpack.Configuration = {
                 .assets.map((asset) => asset.name)
                 .join(', ')}
 ⏱️  Build Time: ${stats.endTime - stats.startTime} ms
-🌐  Server Running at: http://localhost:3000
+🌐  Server Running at: http://localhost:${port}
 --------------------------------------------------------
-                        `);
-          }
-        });
+              `);
+            }
+          });
+        },
       },
+    ],
+    devServer: {
+      port,
+      open: true,
+      historyApiFallback: true,
     },
-  ],
-  devServer: {
-    port: 3000,
-    open: true,
-    historyApiFallback: true,
-  },
-  watchOptions: {
-    ignored: /node_modules/,
-  },
-  stats: {
-    all: false,
-  },
-};
+    watchOptions: {
+      ignored: /node_modules/,
+    },
+    stats: {
+      all: false,
+    },
+  };
 
-export default merge(common, configuration);
+  return merge(common, configuration);
+}
+
+// Webpack이 비동기 설정을 지원하지 않기 때문에, `export default`로 직접 반환할 수 없음
+export default createWebpackConfig();

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -42,6 +42,7 @@
         "chromatic": "^11.25.0",
         "css-loader": "^7.1.2",
         "css-minimizer-webpack-plugin": "^7.0.0",
+        "detect-port": "^2.1.0",
         "eslint": "^9.17.0",
         "eslint-plugin-react": "^7.37.3",
         "eslint-plugin-storybook": "^0.11.2",
@@ -3845,6 +3846,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/address": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/address/-/address-2.0.3.tgz",
+      "integrity": "sha512-XNAb/a6TCqou+TufU8/u11HCu9x1gYvOoxLwtlXgIqmkrYQADVv6ljyW2zwiPhHz9R1gItAWpuDrdJMmrOBFEA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -5636,6 +5647,23 @@
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/detect-port": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-2.1.0.tgz",
+      "integrity": "sha512-epZuWb/6Q62L+nDHJc/hQAqf8pylsqgk3BpZXVBx1CDnr3nkrVNn73Uu1rXcFzkNcc+hkP3whuOg7JZYaQB65Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "address": "^2.0.1"
+      },
+      "bin": {
+        "detect": "dist/commonjs/bin/detect-port.js",
+        "detect-port": "dist/commonjs/bin/detect-port.js"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
     },
     "node_modules/devlop": {
       "version": "1.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,6 +51,7 @@
     "chromatic": "^11.25.0",
     "css-loader": "^7.1.2",
     "css-minimizer-webpack-plugin": "^7.0.0",
+    "detect-port": "^2.1.0",
     "eslint": "^9.17.0",
     "eslint-plugin-react": "^7.37.3",
     "eslint-plugin-storybook": "^0.11.2",


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #100 

## 📝작업 내용

자동으로 localhost의 port 탐색이 가능하도록 개선하였습니다.

```typescript
import detectPort from 'detect-port';

const DEFAULT_PORT = 3000;

async function getAvailablePort(defaultPort: number): Promise<number> {
  return await detectPort(defaultPort);
}
```
- [detect-port](https://www.npmjs.com/package/detect-port) 를 사용
- <code>detectPort(defaultPort)</code> : 비동기적으로 사용 가능한 포트를 반환하는 함수

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항