### PR TITLE
[feature] 헤더 500-698px 구현

### DIFF
--- a/frontend/src/components/common/Header/Header.styles.ts
+++ b/frontend/src/components/common/Header/Header.styles.ts
@@ -23,12 +23,20 @@ export const HeaderContainer = styled.div`
   justify-content: space-between;
   width: 100%;
   gap: 80px;
+
+  @media (max-width: 698px) {
+    gap: 50px;
+  }
 `;
 
 export const TextCoverStyles = styled.div`
   display: flex;
   width: 365px;
   white-space: nowrap;
+
+  @media (max-width: 698px) {
+    width: 220px;
+  }
 `;
 
 export const LogoButtonStyles = styled.button`
@@ -44,6 +52,15 @@ export const LogoButtonStyles = styled.button`
     height: auto;
     object-fit: cover;
   }
+
+  @media (max-width: 698px) {
+    width: 117px;
+    height: 41px;
+
+    img {
+      width: 117px;
+    }
+  }
 `;
 
 export const IntroduceButtonStyles = styled.a`
@@ -53,6 +70,10 @@ export const IntroduceButtonStyles = styled.a`
   font-weight: 500;
   font-size: 14px;
   line-height: 42px;
-  letter-spacing: -0.02em;
   cursor: pointer;
+
+  @media (max-width: 698px) {
+    width: 63px;
+    height: 43px;
+  }
 `;

--- a/frontend/src/components/common/SearchBox/SearchBox.styles.ts
+++ b/frontend/src/components/common/SearchBox/SearchBox.styles.ts
@@ -14,7 +14,8 @@ export const SearchBoxStyles = styled.form`
 `;
 
 export const SearchInputStyles = styled.input`
-  background-color: #eeeeee;
+  width: 100%;
+  background-color: transparent;
   height: 36px;
   border: none;
   outline: none;
@@ -26,6 +27,10 @@ export const SearchInputStyles = styled.input`
   &:focus::placeholder {
     opacity: 0;
   }
+
+  @media (max-width: 550px) {
+    font-size: 10px;
+  }
 `;
 
 export const SearchButton = styled.button`
@@ -33,8 +38,24 @@ export const SearchButton = styled.button`
   background-color: transparent;
   font-size: 16px;
   cursor: pointer;
+  margin-top: 2px;
+
   img {
     width: 16px;
-    height: auto;
+    height: 16px;
+  }
+
+  @media (max-width: 698px) {
+    img {
+      width: 14px;
+      height: 14px;
+    }
+  }
+
+  @media (max-width: 550px) {
+    img {
+      width: 12px;
+      height: 12px;
+    }
   }
 `;

--- a/frontend/src/pages/MainPage/components/Banner/Banner.styles.ts
+++ b/frontend/src/pages/MainPage/components/Banner/Banner.styles.ts
@@ -90,7 +90,7 @@ export const SlideButton = styled.button`
     object-fit: cover;
   }
 
-  @media (max-width: 500px) {
+  @media (max-width: 698px) {
     width: 35px;
     padding: 6px 12px;
   }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #106 

## 📝작업 내용

> 헤더 500px-698px 구현

<img width="642" alt="스크린샷 2025-02-26 10 00 20" src="https://github.com/user-attachments/assets/c3270c94-11c4-49cd-b71b-70b359c1e357" />


## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항