### PR TITLE
[feature] 배너 자동 슬라이드

### DIFF
--- a/frontend/src/pages/MainPage/components/Banner/Banner.styles.ts
+++ b/frontend/src/pages/MainPage/components/Banner/Banner.styles.ts
@@ -1,8 +1,5 @@
 import styled from 'styled-components';
-
-export interface BannerProps {
-  backgroundImage?: string;
-}
+import { BannerProps } from './Banner';
 
 export const BannerContainer = styled.div`
   padding: 0 40px;

--- a/frontend/src/pages/MainPage/components/Banner/Banner.tsx
+++ b/frontend/src/pages/MainPage/components/Banner/Banner.tsx
@@ -1,7 +1,10 @@
 import React, { useRef, useState, useEffect, useCallback } from 'react';
 import * as Styled from './Banner.styles';
-import { BannerProps } from './Banner.styles';
 import { SlideButton } from '@/utils/banners';
+
+export interface BannerProps {
+  backgroundImage?: string;
+}
 
 interface BannerComponentProps {
   banners: BannerProps[];

--- a/frontend/src/pages/MainPage/components/Banner/Banner.tsx
+++ b/frontend/src/pages/MainPage/components/Banner/Banner.tsx
@@ -12,14 +12,16 @@ interface BannerComponentProps {
 
 const Banner = ({ banners }: BannerComponentProps) => {
   const slideRef = useRef<HTMLDivElement>(null);
-  const [currentSlideIndex, setCurrentSlideIndex] = useState(0);
+  const [currentSlideIndex, setCurrentSlideIndex] = useState(1);
   const [slideWidth, setSlideWidth] = useState(0);
   const [isAnimating, setIsAnimating] = useState(true);
+  const [isTransitioning, setIsTransitioning] = useState(false);
+
+  const extendedBanners = [banners[banners.length - 1], ...banners, banners[0]];
 
   const updateSlideWidth = useCallback(() => {
     if (slideRef.current) {
       setSlideWidth(slideRef.current.offsetWidth);
-      setIsAnimating(false);
       slideRef.current.style.transform = `translateX(-${currentSlideIndex * slideRef.current.offsetWidth}px)`;
     }
   }, [currentSlideIndex]);
@@ -34,21 +36,52 @@ const Banner = ({ banners }: BannerComponentProps) => {
   }, [updateSlideWidth]);
 
   useEffect(() => {
-    if (slideRef.current) {
-      setIsAnimating(true);
+    if (!slideRef.current) return;
+
+    if (isAnimating) {
       slideRef.current.style.transform = `translateX(-${currentSlideIndex * slideWidth}px)`;
+    } else {
+      // 애니메이션 없이 즉시 이동
+      if (currentSlideIndex === 1) {
+        slideRef.current.style.transform = `translateX(-${slideWidth}px)`;
+      } else if (currentSlideIndex === banners.length) {
+        slideRef.current.style.transform = `translateX(-${banners.length * slideWidth}px)`;
+      }
     }
-  }, [currentSlideIndex, slideWidth]);
+
+    const transitionEndHandler = () => {
+      if (currentSlideIndex === banners.length + 1) {
+        setIsAnimating(false);
+        setCurrentSlideIndex(1);
+      } else if (currentSlideIndex === 0) {
+        setIsAnimating(false);
+        setCurrentSlideIndex(banners.length);
+      }
+      setIsTransitioning(false);
+    };
+
+    slideRef.current.addEventListener('transitionend', transitionEndHandler);
+    return () => {
+      slideRef.current?.removeEventListener(
+        'transitionend',
+        transitionEndHandler,
+      );
+    };
+  }, [currentSlideIndex, slideWidth, banners.length, isAnimating]);
 
   const moveToNextSlide = useCallback(() => {
-    setCurrentSlideIndex((prev) => (prev + 1) % banners.length);
-  }, [banners.length]);
+    if (isTransitioning) return;
+    setIsTransitioning(true);
+    setIsAnimating(true);
+    setCurrentSlideIndex((prev) => prev + 1);
+  }, [isTransitioning]);
 
-  const moveToPrevSlide = () => {
-    setCurrentSlideIndex(
-      (prev) => (prev - 1 + banners.length) % banners.length,
-    );
-  };
+  const moveToPrevSlide = useCallback(() => {
+    if (isTransitioning) return;
+    setIsTransitioning(true);
+    setIsAnimating(true);
+    setCurrentSlideIndex((prev) => prev - 1);
+  }, [isTransitioning]);
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -70,7 +103,7 @@ const Banner = ({ banners }: BannerComponentProps) => {
           </Styled.SlideButton>
         </Styled.ButtonContainer>
         <Styled.SlideWrapper ref={slideRef} isAnimating={isAnimating}>
-          {banners.map((banner, index) => (
+          {extendedBanners.map((banner, index) => (
             <Styled.BannerItem key={index}>
               <img
                 src={banner.backgroundImage}

--- a/frontend/src/pages/MainPage/components/Banner/Banner.tsx
+++ b/frontend/src/pages/MainPage/components/Banner/Banner.tsx
@@ -37,15 +37,23 @@ const Banner = ({ banners }: BannerComponentProps) => {
     }
   }, [currentSlideIndex, slideWidth]);
 
-  const moveToNextSlide = () => {
+  const moveToNextSlide = useCallback(() => {
     setCurrentSlideIndex((prev) => (prev + 1) % banners.length);
-  };
+  }, [banners.length]);
 
   const moveToPrevSlide = () => {
     setCurrentSlideIndex(
       (prev) => (prev - 1 + banners.length) % banners.length,
     );
   };
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      moveToNextSlide();
+    }, 3000);
+
+    return () => clearInterval(interval);
+  }, [moveToNextSlide]);
 
   return (
     <Styled.BannerContainer>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #103 

## 📝작업 내용

> 3초마다 배너가 자동으로 넘어가도록 합니다

## 3초마다 슬라이드
### <code>moveToNextSlide</code> 함수
- useEffect 내부에서 3초마다 실행
- 배너의 수(banner.length)가 바뀔 때마다 재생성

### useCallback 사용
- useEffect로 인해 생기는 불필요한 리렌더링을 방지
- **배너의 수**가 바뀌지 않는 한 같은 함수 인스턴스를 유지하여 불필요하게 useEffect가 실행되는 것을 방지하기 위함

## 무한 슬라이드

- <code>extendedBanners</code>: 기존 banner에 첫번째 슬라이드를 추가
- 마지막 슬라이드에서 첫번째 슬라이드로 이동된 후, 애니메이션을 없앤 상태에서 **다시 첫번째 슬라이드로 전환**시킴으로써 사용자는 무한으로 배너가 돌아가는 것처럼 인식
- <code>transitionEndHandler</code>함수가 마지막 슬라이드 혹은 첫번째 슬라이드인지 인식하여 애니메이션 효과를 일시적으로 없앰

## 수정된 것
1. <code> moveToPrevSlide</code>에도 useCallback 적용

2. 배너 타입  BannnerProps를 <code>Banner.tsx</code>로 이동

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항