### PR TITLE
[feature] 상세페이지 api 연동

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import GlobalStyles from '@/styles/Global.styles';
@@ -18,7 +18,7 @@ const App = () => {
         <GlobalStyles />
         <Routes>
           <Route path='/' element={<MainPage />} />
-          <Route path='/ClubDetail' element={<ClubDetailPage />} />
+          <Route path='/club/:clubId' element={<ClubDetailPage />} />
           <Route path='/admin' element={<AdminPage />}>
             <Route index element={<Navigate to='club-info' replace />} />
             <Route path='club-info' element={<ClubInfoEditTab />} />

--- a/frontend/src/apis/getClubDetail.ts
+++ b/frontend/src/apis/getClubDetail.ts
@@ -1,0 +1,17 @@
+import API_BASE_URL from '@/constants/api';
+import { ClubDetail } from '@/types/club';
+
+export const getClubDetail = async (clubId: string): Promise<ClubDetail> => {
+  try {
+    const response = await fetch(`${API_BASE_URL}/api/club/${clubId}`);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch: ${response.statusText}`);
+    }
+
+    const result = await response.json();
+    return result.data.club;
+  } catch (error) {
+    console.error('Error fetching club details', error);
+    throw error;
+  }
+};

--- a/frontend/src/hooks/queries/club/useGetClubDetail.ts
+++ b/frontend/src/hooks/queries/club/useGetClubDetail.ts
@@ -1,0 +1,10 @@
+import { getClubDetail } from '@/apis/getClubDetail';
+import { useQuery } from '@tanstack/react-query';
+
+export const useGetClubDetail = (clubId: string) => {
+  return useQuery({
+    queryKey: ['clubDetail', clubId],
+    queryFn: () => getClubDetail(clubId as string),
+    enabled: !!clubId,
+  });
+};

--- a/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
@@ -28,6 +28,8 @@ const ClubDetailPage = () => {
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
+  // [x]TODO: 로딩화면 구현해야 함
+
   if (!clubDetail) {
     return <div>Loading...</div>;
   }

--- a/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
 import Header from '@/components/common/Header/Header';
 import BackNavigationBar from '@/pages/ClubDetailPage/components/BackNavigationBar/BackNavigationBar';
 import ClubDetailHeader from '@/pages/ClubDetailPage/components/ClubDetailHeader/ClubDetailHeader';
@@ -9,13 +10,14 @@ import Footer from '@/components/common/Footer/Footer';
 import ClubDetailFooter from '@/pages/ClubDetailPage/components/ClubDetailFooter/ClubDetailFooter';
 import * as Styled from '@/styles/PageContainer.styles';
 import useAutoScroll from '@/hooks/useAutoScroll';
-import { getClubDetail } from '@/apis/getClubDetail';
-import { ClubDetail } from '@/types/club';
+import { useGetClubDetail } from '@/hooks/queries/club/useGetClubDetail';
 
 const ClubDetailPage = () => {
+  const { clubId } = useParams<{ clubId: string }>();
   const { sectionRefs, scrollToSection } = useAutoScroll();
   const [showHeader, setShowHeader] = useState(window.innerWidth > 500);
-  const [clubDetail, setClubDetail] = useState<ClubDetail | null>(null);
+
+  const { data: clubDetail, isLoading, error } = useGetClubDetail(clubId || '');
 
   useEffect(() => {
     const handleResize = () => {
@@ -26,21 +28,11 @@ const ClubDetailPage = () => {
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const data = await getClubDetail('67c4145f64203e4259638b27');
-        setClubDetail(data);
-      } catch (error) {
-        console.error('Error fetching club details:', error);
-      }
-    };
-    fetchData();
-  }, []);
-
   if (!clubDetail) {
-    return <div>Loading...</div>; // ✅ clubDetail이 null이면 로딩 표시
+    return <div>Loading...</div>;
   }
+
+  if (error) return <p>Error: {error.message}</p>;
 
   return (
     <>

--- a/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import Header from '@/components/common/Header/Header';
 import BackNavigationBar from '@/pages/ClubDetailPage/components/BackNavigationBar/BackNavigationBar';
 import ClubDetailHeader from '@/pages/ClubDetailPage/components/ClubDetailHeader/ClubDetailHeader';
@@ -9,10 +9,13 @@ import Footer from '@/components/common/Footer/Footer';
 import ClubDetailFooter from '@/pages/ClubDetailPage/components/ClubDetailFooter/ClubDetailFooter';
 import * as Styled from '@/styles/PageContainer.styles';
 import useAutoScroll from '@/hooks/useAutoScroll';
+import { getClubDetail } from '@/apis/getClubDetail';
+import { ClubDetail } from '@/types/club';
 
 const ClubDetailPage = () => {
   const { sectionRefs, scrollToSection } = useAutoScroll();
-  const [showHeader, setShowHeader] = React.useState(window.innerWidth > 500);
+  const [showHeader, setShowHeader] = useState(window.innerWidth > 500);
+  const [clubDetail, setClubDetail] = useState<ClubDetail | null>(null);
 
   useEffect(() => {
     const handleResize = () => {
@@ -23,14 +26,35 @@ const ClubDetailPage = () => {
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const data = await getClubDetail('67c4145f64203e4259638b27');
+        setClubDetail(data);
+      } catch (error) {
+        console.error('Error fetching club details:', error);
+      }
+    };
+    fetchData();
+  }, []);
+
+  if (!clubDetail) {
+    return <div>Loading...</div>; // ✅ clubDetail이 null이면 로딩 표시
+  }
+
   return (
     <>
       {showHeader && <Header />}
       <BackNavigationBar />
       <Styled.PageContainer>
-        <ClubDetailHeader />
+        <ClubDetailHeader
+          name={clubDetail.name}
+          classification={clubDetail.classification}
+          division={clubDetail.division}
+          tags={clubDetail.tags}
+        />
         <InfoTabs onTabClick={scrollToSection} />
-        <InfoBox sectionRefs={sectionRefs} />
+        <InfoBox sectionRefs={sectionRefs} clubDetail={clubDetail} />
         <IntroduceBox sectionRefs={sectionRefs} />
       </Styled.PageContainer>
       <Footer />
@@ -38,4 +62,5 @@ const ClubDetailPage = () => {
     </>
   );
 };
+
 export default ClubDetailPage;

--- a/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
@@ -47,7 +47,10 @@ const ClubDetailPage = () => {
         />
         <InfoTabs onTabClick={scrollToSection} />
         <InfoBox sectionRefs={sectionRefs} clubDetail={clubDetail} />
-        <IntroduceBox sectionRefs={sectionRefs} />
+        <IntroduceBox
+          sectionRefs={sectionRefs}
+          description={clubDetail.description}
+        />
       </Styled.PageContainer>
       <Footer />
       <ClubDetailFooter />

--- a/frontend/src/pages/ClubDetailPage/components/ClubDetailHeader/ClubDetailHeader.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubDetailHeader/ClubDetailHeader.tsx
@@ -3,14 +3,26 @@ import * as Styled from './ClubDetailHeader.styles';
 import ClubProfile from '@/pages/ClubDetailPage/components/ClubProfile/ClubProfile';
 import ClubApplyButton from '@/pages/ClubDetailPage/components/ClubApplyButton/ClubApplyButton';
 
-const ClubDetailHeader = () => {
+interface ClubDetailHeaderProps {
+  name: string;
+  classification: string;
+  division: string;
+  tags: string[];
+}
+
+const ClubDetailHeader = ({
+  name,
+  classification,
+  division,
+  tags,
+}: ClubDetailHeaderProps) => {
   return (
     <Styled.ClubDetailHeaderContainer>
       <ClubProfile
-        name={'WAP'}
-        classification={'중동'}
-        division={'학술'}
-        tags={['프로젝트', '소프트웨어']}
+        name={name}
+        classification={classification}
+        division={division}
+        tags={tags}
       />
       <ClubApplyButton />
     </Styled.ClubDetailHeaderContainer>

--- a/frontend/src/pages/ClubDetailPage/components/InfoBox/InfoBox.styles.ts
+++ b/frontend/src/pages/ClubDetailPage/components/InfoBox/InfoBox.styles.ts
@@ -60,4 +60,8 @@ export const LeftText = styled.p`
 
 export const RightText = styled.p`
   flex-grow: 1;
+
+  @media (max-width: 500px) {
+    white-space: nowrap;
+  }
 `;

--- a/frontend/src/pages/ClubDetailPage/components/InfoBox/InfoBox.styles.ts
+++ b/frontend/src/pages/ClubDetailPage/components/InfoBox/InfoBox.styles.ts
@@ -55,6 +55,7 @@ export const DescriptionWrapper = styled.div`
 
 export const LeftText = styled.p`
   color: #9d9d9d;
+  white-space: nowrap;
 `;
 
 export const RightText = styled.p`

--- a/frontend/src/pages/ClubDetailPage/components/InfoBox/InfoBox.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/InfoBox/InfoBox.tsx
@@ -1,29 +1,31 @@
 import React from 'react';
 import * as Styled from './InfoBox.styles';
 import { InfoList } from '@/types/Info';
+import { ClubDetail } from '@/types/club';
 
-const infoData: InfoList[] = [
-  {
-    title: '모집정보',
-    descriptions: [
-      { label: '모집기간', value: '2025.02.24' },
-      { label: '모집대상', value: '부경대학교 재학생' },
-    ],
-  },
-  {
-    title: '동아리정보',
-    descriptions: [
-      { label: '회장이름', value: '이제희' },
-      { label: '전화번호', value: '010-1234-5678' },
-    ],
-  },
-];
-
-const InfoBox = ({
-  sectionRefs,
-}: {
+interface InfoBoxProps {
   sectionRefs: React.RefObject<(HTMLDivElement | null)[]>;
-}) => {
+  clubDetail: ClubDetail;
+}
+
+const InfoBox = ({ sectionRefs, clubDetail }: InfoBoxProps) => {
+  const infoData: InfoList[] = [
+    {
+      title: '모집정보',
+      descriptions: [
+        { label: '모집기간', value: clubDetail.recruitmentPeriod },
+        { label: '모집대상', value: clubDetail.recruitmentTarget },
+      ],
+    },
+    {
+      title: '동아리정보',
+      descriptions: [
+        { label: '회장이름', value: clubDetail.presidentName },
+        { label: '전화번호', value: clubDetail.presidentPhoneNumber },
+      ],
+    },
+  ];
+
   return (
     <Styled.InfoBoxWrapper>
       {infoData.map((info, index) => (

--- a/frontend/src/pages/ClubDetailPage/components/IntroduceBox/IntroduceBox.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/IntroduceBox/IntroduceBox.tsx
@@ -5,58 +5,12 @@ import remarkGfm from 'remark-gfm'; // 링크 및 마크다운 확장 지원
 import rehypeRaw from 'rehype-raw'; // HTML 태그를 지원하려면 필요
 import rehypeSanitize from 'rehype-sanitize';
 
-const markdownContent = `
-### 💻 프로그래밍 중앙 동아리 WAP 30기 신입 개발자 회원 모집 💻
-
-부경대학교 중앙 동아리 WAP은 게임, 웹, 앱 등 다양한 분야의 프로젝트를 중심으로 활동하는 동아리입니다.  
-분야, 주제, 개발 환경 등을 자율적으로 선택하여 한 학기 동안 팀원들과 결과물을 만든 후 발표하는 활동을 합니다.  
-이외에도 이번 학기에 테크톡, 깃 세미나, 배포 세미나, MT 등 다양한 행사가 준비되어 있습니다. 🤗
-
-👥 모집 대상: 개발에 관심 있는 누구나  
-💵 회비: 한 학기당 25,000원
-
-🗓️ 2025-1 WAP 신입 모집 일정
-1. 모집 마감 : 2월 1일(토) ~ 2월 21일(금) 23시 59분  
-2. 서류 합격자 발표 : 2월 22일(토) 18시  
-3. 면접 일정 : 2월 27일(목) ~ 3월 1일(토)  
-4. 최종 합격자 발표 : 3월 2일(일) 18시  
-5. 신입생 OT & 프로젝트 세미나: 3월 4일(화)  
-6. 개총 & 팀 빌딩: 3월 8일(토)  
-
-🏆 WAP의 성과  
-WAP은 2024학년도 2학기 학술 분과 우수 동아리로 선정되었습니다.  
-또한, 동아리 활동을 통해 쌓은 경험을 바탕으로 매년 대외활동 합격자와 수상자를 다수 배출하고 있습니다.  
-지난해에는 소프트웨어 마에스트로, 우아한 테크코스, SSAFY, 네이버 부스트 캠프 등 주요 프로그램에 합격자를 배출했으며, 교내 프로그래밍 경진대회 대상을 포함한 다양한 수상 기록을 달성하였습니다.  
-
-⭐ WAP 부원이 가지는 혜택 5가지  
-1. 협업하며 프로젝트를 진행하고, 직접 결과물을 만들어 개발 경험을 쌓을 수 있습니다.  
-2. 프로젝트 결과물을 동아리 부원 및 외부인에게 발표하고 시연할 수 있습니다.  
-3. 테크톡 활동을 통해 다양한 개발 지식을 배우고 실력을 키울 수 있습니다.  
-4. BITs(Busan IT student)의 구성원으로서 타 학교 IT동아리와 교류할 수 있습니다.  
-5. 동아리에서 개최하는 다양한 행사에 참여할 수 있습니다.  
-
-📢 공지 사항  
-1. 탈락한 지원자에게는 별도의 탈락 통보 메시지가 발송되지 않습니다.  
-2. 면접은 오프라인으로 진행되며, 면접 장소는 서류 합격자 발표 후 안내됩니다  
-(대면이 불가한 경우 오픈채팅방으로 문의 부탁드립니다.)  
-3. 신입 회원은 신입 필수 활동에 반드시 참여해야 하며, 합당한 사유 없이 불참하실 경우 불이익이 주어집니다.  
-
-📝 **[신청 폼 바로가기](https://docs.google.com/forms/d/e/1FAIpQLSc41UNglvB3Y-8SbwjGk5aBh7WTtwlyf5FPJJLwWooRyafLZw/viewform?usp=header)**  
-
-🔗 **관련 링크**  
-- [공식 Github](https://github.com/pknu-wap)  
-- [공식 인스타](https://www.instagram.com/pknu_wap/?hl=ko)  
-
-✉️ **문의 사항**  
-- [카톡 오픈채팅](https://open.kakao.com/o/seDEdF9g)  
-- 부경대학교 WAP 인스타그램 DM [@pknu_wap](https://www.instagram.com/pknu_wap)  
-- 회장: 이제희 010-8512-3292  
-`;
-
 const IntroduceBox = ({
   sectionRefs,
+  description,
 }: {
   sectionRefs: React.RefObject<(HTMLDivElement | null)[]>;
+  description: string;
 }) => {
   return (
     <Styled.IntroduceBoxWrapper
@@ -73,7 +27,7 @@ const IntroduceBox = ({
               <a {...props} target='_blank' rel='noopener noreferrer' />
             ),
           }}>
-          {markdownContent}
+          {description}
         </ReactMarkdown>
       </Styled.IntroduceContentBox>
     </Styled.IntroduceBoxWrapper>

--- a/frontend/src/pages/MainPage/components/ClubCard/ClubCard.styles.ts
+++ b/frontend/src/pages/MainPage/components/ClubCard/ClubCard.styles.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-const CardContainer = styled.div<{ state: string }>`
+const CardContainer = styled.div<{ state: string; isClicked: boolean }>`
   display: flex;
   flex-direction: column;
   border-radius: 14px;
@@ -12,6 +12,20 @@ const CardContainer = styled.div<{ state: string }>`
     state === 'open'
       ? '0 0 14px rgba(0, 166, 255, 0.15)'
       : '0 0 14px rgba(0, 0, 0, 0.08)'};
+  transition:
+    transform 0.2s ease-in-out,
+    box-shadow 0.2s ease-in-out;
+  transform: ${({ isClicked }) => (isClicked ? 'scale(1.05)' : 'scale(1)')};
+  cursor: pointer;
+
+  &:hover {
+    transform: ${({ isClicked }) =>
+      isClicked ? 'scale(1.05)' : 'scale(1.03)'};
+  }
+
+  &:active {
+    transform: scale(0.98);
+  }
 `;
 
 const CardHeader = styled.div`

--- a/frontend/src/pages/MainPage/components/ClubCard/ClubCard.tsx
+++ b/frontend/src/pages/MainPage/components/ClubCard/ClubCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import ClubTag from '@/components/ClubTag/ClubTag';
 import ClubLogo from '@/components/ClubLogo/ClubLogo';
 import ClubStateBox from '@/components/ClubStateBox/ClubStateBox';
@@ -8,14 +8,20 @@ import { useNavigate } from 'react-router-dom';
 
 const ClubCard = ({ club }: { club: Club }) => {
   const navigate = useNavigate();
+  const [isClicked, setIsClicked] = useState(false);
 
   const handleNavigate = () => {
-    navigate(`/club/${club.id}`);
+    setIsClicked(true);
+    setTimeout(() => {
+      setIsClicked(false);
+      navigate(`/club/${club.id}`);
+    }, 150);
   };
 
   return (
     <Styled.CardContainer
       state={club.recruitmentStatus}
+      isClicked={isClicked}
       onClick={handleNavigate}>
       <Styled.CardHeader>
         <Styled.ClubProfile>

--- a/frontend/src/pages/MainPage/components/ClubCard/ClubCard.tsx
+++ b/frontend/src/pages/MainPage/components/ClubCard/ClubCard.tsx
@@ -4,10 +4,19 @@ import ClubLogo from '@/components/ClubLogo/ClubLogo';
 import ClubStateBox from '@/components/ClubStateBox/ClubStateBox';
 import * as Styled from './ClubCard.styles';
 import { Club } from '@/types/club';
+import { useNavigate } from 'react-router-dom';
 
 const ClubCard = ({ club }: { club: Club }) => {
+  const navigate = useNavigate();
+
+  const handleNavigate = () => {
+    navigate(`/club/${club.id}`);
+  };
+
   return (
-    <Styled.CardContainer state={club.recruitmentStatus}>
+    <Styled.CardContainer
+      state={club.recruitmentStatus}
+      onClick={handleNavigate}>
       <Styled.CardHeader>
         <Styled.ClubProfile>
           <ClubLogo imageSrc={club.logo} />

--- a/frontend/src/types/club.ts
+++ b/frontend/src/types/club.ts
@@ -8,3 +8,13 @@ export interface Club {
   classification: string;
   introduction: string;
 }
+
+export interface ClubDetail extends Club {
+  state: string;
+  feeds: string[];
+  description: string;
+  presidentName: string;
+  presidentPhoneNumber: string;
+  recruitmentPeriod: string;
+  recruitmentTarget: string;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #119 

## 📝작업 내용

### 상세페이지 interface 579fd75bcb3faadb829bdb2373e04848ec2f6122

### api 연결 8878a30980b4aa26c11abd46ea067a15449f682d

- InfoBox 8878a30980b4aa26c11abd46ea067a15449f682d
- ClubProfile a46cabf41203c313a5c5be492149d6c32b4e5992

## 3.5 변경사항

### Api 관련

- tanstack-query 적용 2308178d950ef1976ac417621c65e6df877ad656
- IntroduceBox api 연결 e135f0b184e2940ad5af3080975e21e9d0cadb6e
- 상세페이지 useEffect 제거 및 tanstack-query적용 2308178d950ef1976ac417621c65e6df877ad656

### 라우트 변경 02ccfa575c746e81642004c7b37e611b663919ff

## 그 외
- 메인페이지 카드 애니메이션 추가 81c9607e97a0e7a3b50107338aeaa15e7e890f47

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항