### PR TITLE
[fix] 메인페이지 카드리스트 UI 오류 수정

### DIFF
--- a/frontend/src/pages/MainPage/MainPage.styles.ts
+++ b/frontend/src/pages/MainPage/MainPage.styles.ts
@@ -34,7 +34,7 @@ export const CardList = styled.div`
     grid-template-columns: repeat(2, 1fr);
   }
 
-  @media (max-width: 700px) {
+  @media (max-width: 750px) {
     grid-template-columns: repeat(1, 1fr);
   }
   @media (max-width: 500px) {

--- a/frontend/src/pages/MainPage/components/ClubCard/ClubCard.styles.ts
+++ b/frontend/src/pages/MainPage/components/ClubCard/ClubCard.styles.ts
@@ -26,6 +26,10 @@ const CardContainer = styled.div<{ state: string; isClicked: boolean }>`
   &:active {
     transform: scale(0.98);
   }
+
+  @media (max-width: 300px) {
+    height: auto;
+  }
 `;
 
 const CardHeader = styled.div`


### PR DESCRIPTION
## #️⃣연관된 이슈

> #137

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지/동영상 첨부 가능)

문제 발생 이유: 디자이너 요청으로 카드 간의 gap 값을 늘리게 되었습니다.
문제 분석: 카드 간의 gap을 늘리게 되면서 기존의 미디어쿼리 동작이 영향을 받아 카드들이 깨지거나 잘못 표시되는 현상이 발생했습니다.
해결 방법: 미디어쿼리 조건을 수정하여 다양한 화면 크기에서 카드들이 정상적으로 배치되도록 수정하였습니다.