### PR TITLE
로고와 피드 이미지 업로드 및 삭제 기능 구현 및 리팩터링

### DIFF
--- a/backend/src/main/java/moadong/gcs/controller/ClubImageController.java
+++ b/backend/src/main/java/moadong/gcs/controller/ClubImageController.java
@@ -5,7 +5,7 @@ import java.util.List;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import moadong.gcs.dto.ImageDeleteRequest;
+import moadong.gcs.dto.FeedDeleteRequest;
 import moadong.gcs.service.ClubImageService;
 import moadong.global.payload.Response;
 import org.springframework.http.MediaType;
@@ -13,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -30,25 +31,40 @@ public class ClubImageController {
 
     @PostMapping(value = "/{clubId}/logo", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "로고 이미지 업로드", description = "로고 이미지를 저장소에 업로드합니다.")
-    public ResponseEntity<?> uploadFeed(@PathVariable String clubId,
+    public ResponseEntity<?> uploadLogo(@PathVariable String clubId,
                                         @RequestPart("logo") MultipartFile file) {
         String fileUrl = clubImageService.uploadLogo(clubId, file);
         return Response.ok(fileUrl);
     }
 
-    @DeleteMapping("/images")
-    @Operation(summary = "동아리 이미지 삭제", description = "저장소에 있는 동아리 이미지를 삭제합니다.")
-    public ResponseEntity<?> deleteFile(@RequestBody ImageDeleteRequest imageDeleteRequest) {
-        clubImageService.deleteFile(imageDeleteRequest.filePath());
-        return Response.ok("success delete image");
+    @DeleteMapping(value = "/{clubId}/logo")
+    @Operation(summary = "로고 이미지 삭제", description = "로고 이미지를 저장소에서 삭제합니다.")
+    public ResponseEntity<?> deleteLogo(@PathVariable String clubId) {
+        clubImageService.deleteLogo(clubId);
+        return Response.ok("success delete logo");
+    }
+
+    @PutMapping(value = "/{clubId}/feeds", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "피드 이미지 업로드", description = "피드 이미지를 저장소에 새로 업로드합니다.")
+    public ResponseEntity<?> putFeeds(@PathVariable String clubId,
+                                      @RequestPart("feeds") List<MultipartFile> files) {
+        clubImageService.putFeeds(clubId, files);
+        return Response.ok("success put feeds");
     }
 
     @PostMapping(value = "/{clubId}/feeds", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @Operation(summary = "피드 이미지 업로드", description = "피드 이미지를 저장소에 업로드합니다.")
-    public ResponseEntity<?> uploadFeed(@PathVariable String clubId,
-                                        @RequestPart("feeds") List<MultipartFile> files) {
+    @Operation(summary = "피드 이미지 업로드", description = "피드 이미지를 저장소에 추가합니다.")
+    public ResponseEntity<?> uploadFeeds(@PathVariable String clubId,
+                                      @RequestPart("feeds") List<MultipartFile> files) {
         clubImageService.uploadFeeds(clubId, files);
-        return Response.ok("success upload feeds");
+        return Response.ok("success put feeds");
     }
 
+    @DeleteMapping(value = "/{clubId}/feeds")
+    @Operation(summary = "동아리 이미지 삭제", description = "저장소에 있는 동아리 이미지를 삭제합니다.")
+    public ResponseEntity<?> deleteFeeds(@PathVariable String clubId,
+                                         @RequestBody FeedDeleteRequest request) {
+        clubImageService.deleteFeeds(clubId, request.feeds());
+        return Response.ok("success delete feeds");
+    }
 }

--- a/backend/src/main/java/moadong/gcs/controller/ClubImageController.java
+++ b/backend/src/main/java/moadong/gcs/controller/ClubImageController.java
@@ -1,11 +1,11 @@
 package moadong.gcs.controller;
 
-import java.util.List;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-import moadong.gcs.dto.FeedDeleteRequest;
+import moadong.gcs.domain.FileType;
+import moadong.gcs.dto.FeedUpdateRequest;
 import moadong.gcs.service.ClubImageService;
 import moadong.global.payload.Response;
 import org.springframework.http.MediaType;
@@ -13,7 +13,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -44,27 +43,20 @@ public class ClubImageController {
         return Response.ok("success delete logo");
     }
 
-    @PutMapping(value = "/{clubId}/feeds", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @Operation(summary = "피드 이미지 업로드", description = "피드 이미지를 저장소에 새로 업로드합니다.")
-    public ResponseEntity<?> putFeeds(@PathVariable String clubId,
-                                      @RequestPart("feeds") List<MultipartFile> files) {
-        clubImageService.putFeeds(clubId, files);
-        return Response.ok("success put feeds");
-    }
-
-    @PostMapping(value = "/{clubId}/feeds", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    // TODO : Signed URL 을 통한 업로드로 추후 변경
+    @PostMapping(value = "/{clubId}/feed", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "피드 이미지 업로드", description = "피드 이미지를 저장소에 추가합니다.")
-    public ResponseEntity<?> uploadFeeds(@PathVariable String clubId,
-                                      @RequestPart("feeds") List<MultipartFile> files) {
-        clubImageService.uploadFeeds(clubId, files);
+    public ResponseEntity<?> uploadFeed(@PathVariable String clubId,
+                                        @RequestPart("feed") MultipartFile file) {
+        return Response.ok(clubImageService.uploadFile(clubId, file, FileType.FEED));
+    }
+
+    @PostMapping(value = "/{clubId}/feeds")
+    @Operation(summary = "피드 정보 갱신", description = "피드 이미지를 저장소(gcs)에 새로 업로드합니다.")
+    public ResponseEntity<?> putFeeds(@PathVariable String clubId,
+                                      @RequestBody FeedUpdateRequest feeds) {
+        clubImageService.updateFeeds(clubId, feeds.feeds());
         return Response.ok("success put feeds");
     }
 
-    @DeleteMapping(value = "/{clubId}/feeds")
-    @Operation(summary = "동아리 이미지 삭제", description = "저장소에 있는 동아리 이미지를 삭제합니다.")
-    public ResponseEntity<?> deleteFeeds(@PathVariable String clubId,
-                                         @RequestBody FeedDeleteRequest request) {
-        clubImageService.deleteFeeds(clubId, request.feeds());
-        return Response.ok("success delete feeds");
-    }
 }

--- a/backend/src/main/java/moadong/gcs/domain/FileType.java
+++ b/backend/src/main/java/moadong/gcs/domain/FileType.java
@@ -1,0 +1,17 @@
+package moadong.gcs.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum FileType {
+    LOGO("logo"),
+    FEED("feed");
+
+    // 저장된 값 리턴
+    private final String path;
+
+    FileType(String path) {
+        this.path = path;  // 생성자로 전달된 값 저장
+    }
+
+}

--- a/backend/src/main/java/moadong/gcs/dto/FeedDeleteRequest.java
+++ b/backend/src/main/java/moadong/gcs/dto/FeedDeleteRequest.java
@@ -1,0 +1,6 @@
+package moadong.gcs.dto;
+
+import java.util.List;
+
+public record FeedDeleteRequest(List<String> feeds) {
+}

--- a/backend/src/main/java/moadong/gcs/dto/FeedDeleteRequest.java
+++ b/backend/src/main/java/moadong/gcs/dto/FeedDeleteRequest.java
@@ -1,6 +1,0 @@
-package moadong.gcs.dto;
-
-import java.util.List;
-
-public record FeedDeleteRequest(List<String> feeds) {
-}

--- a/backend/src/main/java/moadong/gcs/dto/FeedUpdateRequest.java
+++ b/backend/src/main/java/moadong/gcs/dto/FeedUpdateRequest.java
@@ -1,0 +1,6 @@
+package moadong.gcs.dto;
+
+import java.util.List;
+
+public record FeedUpdateRequest(List<String> feeds) {
+}

--- a/backend/src/main/java/moadong/gcs/dto/ImageDeleteRequest.java
+++ b/backend/src/main/java/moadong/gcs/dto/ImageDeleteRequest.java
@@ -1,4 +1,0 @@
-package moadong.gcs.dto;
-
-public record ImageDeleteRequest(String filePath) {
-}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #199 

## 📝작업 내용

> 로고와 피드 이미지 업로드 및 삭제 기능 구현 및 리팩터링
<img width="1656" alt="image" src="https://github.com/user-attachments/assets/3d8672d2-e9dc-4556-9e23-1b2d0d147cae" />

---
- 로고의 경우 1개의 로고 이미지만 유지되어 새로운 로고가 추가될 경우 이전의 로고는 삭제되도록 구현하였고 별개로 로고의 Delete 요청도 가능하게 구현하였습니다.
---
- 이미지 업로드 관련하여 logo와 feed를 분류할 수 있는 FileType Enum을 추가하였습니다.
---
- 피드 업로드 기능을 분리하여 구현하였는데, 이는 추후 Signed  URL을 통해 프론트 측에서 파일을 직접 클라우드에 올리는 방식으로 수정될 것을 대비하여 미리 분리해 두었습니다.
- 현재는 MultipartFile을 받아 백엔드 서버에서 업로드해 주는 방식으로 구현하여 정상적으로 동작되도록 하였습니다.
- 또한 현재는 Post 메서드로 구현되어 있지만 Signed URL이 구현될 경우 Get 메서드로 수정될 예정입니다.
- 추후 Signed url 작업이 필요한 곳은 TODO로 표시해 두었습니다.
<img width="1632" alt="image" src="https://github.com/user-attachments/assets/8c0ab3da-542e-414e-bc53-4eba6a2d1488" />

---
- 피드 이미지는 Post 메서드로 통일하여 저장하도록 하였습니다.
- post 요청시 저장되어 있는 정보와 새로 들어온 정보를 비교하여 없어진 데이터를 자동으로 삭제 요청하도록 수정하였습니다.
- 이를 통해 사진을 삭제하고 싶다면 별다른 Delete 요청이 아닌 Post 요청으로 삭제하고 싶은 url만 제외하고 보내면 자동으로 삭제되도록 구현되었습니다.
<img width="777" alt="image" src="https://github.com/user-attachments/assets/a08c5dad-8496-407a-81d9-52bd900790b2" />




