### PR TITLE
[feature]JWT 토큰 전달 시 관리자가 생성한 동아리 아이디 반환 API 추가

### DIFF
--- a/backend/src/main/java/moadong/club/entity/Club.java
+++ b/backend/src/main/java/moadong/club/entity/Club.java
@@ -39,6 +39,8 @@ public class Club {
     @NotNull
     private ClubState state;
 
+    private String userId;
+
 
     @Field("recruitmentInformation")
     private ClubRecruitmentInformation clubRecruitmentInformation;

--- a/backend/src/main/java/moadong/club/repository/ClubRepository.java
+++ b/backend/src/main/java/moadong/club/repository/ClubRepository.java
@@ -14,6 +14,8 @@ import org.springframework.stereotype.Repository;
 public interface ClubRepository extends MongoRepository<Club, String> {
     Optional<Club> findClubById(ObjectId id);
     Optional<List<Club>> findClubByState(ClubState clubState);
+
+    Optional<Club> findClubByUserId(String userId);
     @Query("{'division': {$regex: '^?0$', $options: 'i'}}")
     Optional<List<Club>> findClubByDivisionIgnoreCaseExact(String division);
 

--- a/backend/src/main/java/moadong/user/controller/UserController.java
+++ b/backend/src/main/java/moadong/user/controller/UserController.java
@@ -12,6 +12,7 @@ import moadong.user.payload.request.UserLoginRequest;
 import moadong.user.payload.request.UserRegisterRequest;
 import moadong.user.payload.request.UserUpdateRequest;
 import moadong.user.payload.response.AccessTokenResponse;
+import moadong.user.payload.response.LoginResponse;
 import moadong.user.service.UserCommandService;
 import moadong.user.view.UserSwaggerView;
 import org.springframework.http.ResponseEntity;
@@ -45,8 +46,8 @@ public class UserController {
     @PostMapping("/login")
     public ResponseEntity<?> loginUser(@RequestBody @Validated UserLoginRequest request,
         HttpServletResponse response) {
-        AccessTokenResponse accessTokenResponse = userCommandService.loginUser(request, response);
-        return Response.ok(accessTokenResponse);
+        LoginResponse loginResponse = userCommandService.loginUser(request, response);
+        return Response.ok(loginResponse);
     }
 
     @PostMapping("/refresh")

--- a/backend/src/main/java/moadong/user/controller/UserController.java
+++ b/backend/src/main/java/moadong/user/controller/UserController.java
@@ -6,24 +6,22 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
 import moadong.global.payload.Response;
+import moadong.global.util.JwtProvider;
 import moadong.user.annotation.CurrentUser;
 import moadong.user.payload.CustomUserDetails;
 import moadong.user.payload.request.UserLoginRequest;
 import moadong.user.payload.request.UserRegisterRequest;
 import moadong.user.payload.request.UserUpdateRequest;
 import moadong.user.payload.response.AccessTokenResponse;
+import moadong.user.payload.response.FindUserClubResponse;
 import moadong.user.payload.response.LoginResponse;
 import moadong.user.service.UserCommandService;
 import moadong.user.view.UserSwaggerView;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/auth/user")
@@ -32,6 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final UserCommandService userCommandService;
+    private final JwtProvider jwtProvider;
 
     @PostMapping("/register")
     @Operation(
@@ -65,6 +64,13 @@ public class UserController {
         @RequestBody @Validated UserUpdateRequest userUpdateRequest) {
         userCommandService.update(user.getUserId(), userUpdateRequest);
         return Response.ok("success update");
+    }
+
+    @PostMapping("/find/club")
+    @PreAuthorize("isAuthenticated()")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> findUserClub(@AuthenticationPrincipal CustomUserDetails userDetails){
+        return Response.ok(new FindUserClubResponse(userDetails.getId()));
     }
 
 }

--- a/backend/src/main/java/moadong/user/payload/response/FindUserClubResponse.java
+++ b/backend/src/main/java/moadong/user/payload/response/FindUserClubResponse.java
@@ -1,0 +1,6 @@
+package moadong.user.payload.response;
+
+public record FindUserClubResponse(
+        String clubId
+) {
+}

--- a/backend/src/main/java/moadong/user/payload/response/LoginResponse.java
+++ b/backend/src/main/java/moadong/user/payload/response/LoginResponse.java
@@ -1,0 +1,7 @@
+package moadong.user.payload.response;
+
+public record LoginResponse(
+        String accessToken,
+        String clubId
+) {
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #227 

## 📝작업 내용

### JWT 토큰 전달 시 관리자가 생성한 동아리 아이디 반환 API 추가
![image](https://github.com/user-attachments/assets/c1c5664a-143d-4b5c-9730-138bf5944c8e)

### Login 시에도 진행되도록 추가
![image](https://github.com/user-attachments/assets/8225afbb-bfb4-49ba-9fc4-f4e920b98fa0)

### 수정 사항 
Club Entity에 userId 필드 추가
![image](https://github.com/user-attachments/assets/b89f709b-4b43-44f8-be47-509e0b18417d)


## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항