### PR TITLE
[refactor]상세 조회 시 DB 필드가 없는 겂들이 null로 반환되던 걸 blank로 변경

### DIFF
--- a/backend/src/main/java/moadong/club/payload/dto/ClubDetailedResult.java
+++ b/backend/src/main/java/moadong/club/payload/dto/ClubDetailedResult.java
@@ -35,23 +35,24 @@ public record ClubDetailedResult(
                 + clubRecruitmentInformation.getRecruitmentEnd().format(formatter);
         }
         return ClubDetailedResult.builder()
-            .id(club.getId())
-            .name(club.getName())
-            .logo(club.getClubRecruitmentInformation().getLogo())
-            .tags(clubRecruitmentInformation.getTags())
-            .state(club.getState().getDesc())
-            .feeds(clubRecruitmentInformation.getFeedImages())
-            .category(club.getCategory())
-            .division(club.getDivision())
-            .introduction(clubRecruitmentInformation.getIntroduction())
-            .description(clubRecruitmentInformation.getDescription())
-            .presidentName(clubRecruitmentInformation.getPresidentName())
-            .presidentPhoneNumber(clubRecruitmentInformation.getPresidentTelephoneNumber())
-            .recruitmentPeriod(period)
-            .recruitmentTarget(clubRecruitmentInformation.getRecruitmentTarget())
-            .recruitmentStatus(clubRecruitmentInformation.getRecruitmentStatus().getDescription())
-            .recruitmentForm(clubRecruitmentInformation.getRecruitmentForm())
-            .build();
+                .id(club.getId() == null ? "" : club.getId())
+                .name(club.getName() == null ? "" : club.getName())
+                .logo(clubRecruitmentInformation.getLogo() == null ? "" : clubRecruitmentInformation.getLogo())
+                .tags(clubRecruitmentInformation.getTags() == null ? List.of() : clubRecruitmentInformation.getTags())
+                .state(club.getState() == null ? "" : club.getState().getDesc())
+                .feeds(clubRecruitmentInformation.getFeedImages() == null ? List.of() : clubRecruitmentInformation.getFeedImages())
+                .category(club.getCategory() == null ? "" : club.getCategory())
+                .division(club.getDivision() == null ? "" : club.getDivision())
+                .introduction(clubRecruitmentInformation.getIntroduction() == null ? "" : clubRecruitmentInformation.getIntroduction())
+                .description(clubRecruitmentInformation.getDescription() == null ? "" : clubRecruitmentInformation.getDescription())
+                .presidentName(clubRecruitmentInformation.getPresidentName() == null ? "" : clubRecruitmentInformation.getPresidentName())
+                .presidentPhoneNumber(clubRecruitmentInformation.getPresidentTelephoneNumber() == null ? "" : clubRecruitmentInformation.getPresidentTelephoneNumber())
+                .recruitmentPeriod(period)
+                .recruitmentTarget(clubRecruitmentInformation.getRecruitmentTarget() == null ? "" : clubRecruitmentInformation.getRecruitmentTarget())
+                .recruitmentStatus(clubRecruitmentInformation.getRecruitmentStatus() == null
+                        ? "" : clubRecruitmentInformation.getRecruitmentStatus().getDescription())
+                .recruitmentForm(clubRecruitmentInformation.getRecruitmentForm() == null ? "" : clubRecruitmentInformation.getRecruitmentForm())
+                .build();
     }
 
 }

--- a/backend/src/main/java/moadong/club/payload/dto/ClubSearchResult.java
+++ b/backend/src/main/java/moadong/club/payload/dto/ClubSearchResult.java
@@ -17,18 +17,4 @@ public record ClubSearchResult(
     String recruitmentStatus
 ) {
 
-    public static ClubSearchResult of(ClubSearchResult search, ClubRecruitmentInformation information,
-        List<String> tags) {
-        return ClubSearchResult.builder()
-            .id(search.id())
-            .name(search.name())
-            .logo(search.logo())
-            .tags(tags)
-            .state(search.state())
-            .category(search.category())
-            .division(search.division())
-            .introduction(information.getIntroduction())
-            .recruitmentStatus(information.getRecruitmentStatus().toString())
-            .build();
-    }
 }

--- a/backend/src/main/java/moadong/club/repository/ClubSearchRepository.java
+++ b/backend/src/main/java/moadong/club/repository/ClubSearchRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
 import org.springframework.data.mongodb.core.aggregation.AggregationResults;
+import org.springframework.data.mongodb.core.aggregation.ConditionalOperators;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.stereotype.Repository;
 
@@ -49,8 +50,10 @@ public class ClubSearchRepository {
             Aggregation.project("name", "state", "category", "division")
                 .and("recruitmentInformation.introduction").as("introduction")
                 .and("recruitmentInformation.recruitmentStatus").as("recruitmentStatus")
-                .and("recruitmentInformation.logo").as("logo")
-                .and("recruitmentInformation.tags").as("tags"));
+                    .and(ConditionalOperators.ifNull("$recruitmentInformation.logo").then(""))
+                    .as("logo")
+                    .and(ConditionalOperators.ifNull("$recruitmentInformation.tags").then(""))
+                    .as("tags"));
 
         operations.add(
             Aggregation.sort(Sort.by(Sort.Order.asc("division"), Sort.Order.asc("category"))));


### PR DESCRIPTION
#️⃣연관된 이슈

> ex) #239 

## 📝작업 내용

상세 정보 조회시에 null 값이 들어오면 빈칸처리
![image](https://github.com/user-attachments/assets/9b647763-adfc-4f71-8fd6-f72982837ec1)

검색 시에 로고와 태그가 null이면 빈칸처리
![image](https://github.com/user-attachments/assets/95168acd-ee78-4d03-809e-a396a2977e5b)

