### PR TITLE
[fix] 상세페이지 검색창 클릭 시 메인페이지로 이동

### DIFF
--- a/frontend/src/components/common/SearchBox/SearchBox.tsx
+++ b/frontend/src/components/common/SearchBox/SearchBox.tsx
@@ -37,7 +37,7 @@ const SearchBox = () => {
         value={keyword}
         onChange={(e) => setKeyword(e.target.value)}
       />
-      <Styled.SearchButton onClick={handleSearchClick}>
+      <Styled.SearchButton type='button' onClick={handleSearchClick}>
         <img src={SearchIcon} alt='Search Button' />
       </Styled.SearchButton>
     </Styled.SearchBoxStyles>

--- a/frontend/src/components/common/SearchBox/SearchBox.tsx
+++ b/frontend/src/components/common/SearchBox/SearchBox.tsx
@@ -3,12 +3,16 @@ import { useSearch } from '@/context/SearchContext';
 import useMixpanelTrack from '@/hooks/useMixpanelTrack';
 import * as Styled from './SearchBox.styles';
 import SearchIcon from '@/assets/images/icons/search_button_icon.svg';
+import { useNavigate } from 'react-router-dom';
 
 const SearchBox = () => {
   const { keyword, setKeyword } = useSearch();
   const trackEvent = useMixpanelTrack();
+  const navigate = useNavigate();
 
   const handleSearchClick = () => {
+    redirectToMainIfSearchTriggeredOutside();
+
     if (!keyword.trim()) {
       console.log('검색어가 비어 있어 트래킹하지 않습니다.');
       return;
@@ -18,6 +22,12 @@ const SearchBox = () => {
     console.log(`검색 실행: ${keyword}`);
 
     setKeyword(keyword);
+  };
+
+  const redirectToMainIfSearchTriggeredOutside = () => {
+    if (window.location.pathname !== '/') {
+      navigate('/');
+    }
   };
 
   return (


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #249 

## 📝작업 내용

### 리다이렉트 함수 추가
- 메인페이지가 아닌 다른 모든 페이지에서 검색창 클릭시 메인페이지로 리다이렉트 370fbfda229aa0c766f8acd281c3d62e17d6572c

### 검색버튼 클릭 시 새로고침 문제 해결
- [노션-트러블슈팅](https://www.notion.so/1c7aad23209680c8be6ae69d4821875f?pvs=4) 

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항