### PR TITLE
[style] 관리자페이지 회원정보관리 UI 수정

### DIFF
--- a/frontend/src/pages/AdminPage/components/SideBar/SideBar.tsx
+++ b/frontend/src/pages/AdminPage/components/SideBar/SideBar.tsx
@@ -23,6 +23,14 @@ const SideBar = ({ clubName }: SideBarProps) => {
     [location.pathname],
   );
 
+  const handleTabClick = (tab: (typeof tabs)[number], index: number) => {
+    if (tab.label === '회원 정보 관리') {
+      alert('회원 정보 관리 탭은 준비 중입니다☺️');
+      return;
+    }
+    navigate(tab.path);
+  };
+
   return (
     <Styled.SidebarWrapper>
       <Styled.SidebarHeader>설정</Styled.SidebarHeader>
@@ -35,7 +43,7 @@ const SideBar = ({ clubName }: SideBarProps) => {
           <Styled.SidebarButton
             key={tab.label}
             className={activeTab === index ? 'active' : ''}
-            onClick={() => navigate(tab.path)}>
+            onClick={() => handleTabClick(tab, index)}>
             {tab.label}
           </Styled.SidebarButton>
         ))}

--- a/frontend/src/pages/AdminPage/tabs/AccountEditTab/AccountEditTab.styles.ts
+++ b/frontend/src/pages/AdminPage/tabs/AccountEditTab/AccountEditTab.styles.ts
@@ -1,0 +1,14 @@
+import styled from 'styled-components';
+
+export const IdInputContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  gap: 10px;
+`;
+
+export const ForgotPasswordText = styled.h3`
+  color: #cdcdcd;
+  font-weight: 300;
+  margin-bottom: 5px;
+`;

--- a/frontend/src/pages/AdminPage/tabs/AccountEditTab/AccountEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/AccountEditTab/AccountEditTab.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
+import * as Styled from './AccountEditTab.styles';
 import InputField from '@/components/common/InputField/InputField';
+import Button from '@/components/common/Button/Button';
 
 const AccountEditTab = () => {
   const [username, setUsername] = useState('');
@@ -8,46 +10,49 @@ const AccountEditTab = () => {
   return (
     <div>
       <h1>계정 정보 수정</h1>
+      <br />
+      <br />
+      <Styled.IdInputContainer>
+        <InputField
+          label='아이디'
+          placeholder='아이디를 입력해주세요'
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          onClear={() => setUsername('')}
+          maxLength={20}
+          disabled={true}
+        />
+        <Button width={'150px'} animated onClick={() => alert('수정 완료')}>
+          변경
+        </Button>
+      </Styled.IdInputContainer>
+      <br />
 
       <InputField
-        label='아이디'
-        placeholder='아이디를 입력해주세요'
-        value={username}
-        onChange={(e) => setUsername(e.target.value)}
-        onClear={() => setUsername('')}
-        maxLength={20}
-        disabled={true}
-      />
-
-      <InputField
-        label='비밀번호'
-        placeholder='비밀번호를 입력해주세요'
-        type='password'
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-        onClear={() => setPassword('')}
-        maxLength={20}
-        disabled={true}
-      />
-
-      <InputField
-        label='아이디'
-        placeholder='아이디를 입력해주세요'
+        placeholder='새 비밀번호'
         value={username}
         onChange={(e) => setUsername(e.target.value)}
         onClear={() => setUsername('')}
         maxLength={20}
       />
+      <br />
 
       <InputField
-        label='비밀번호'
-        placeholder='비밀번호를 입력해주세요'
+        placeholder='새 비밀번호 재입력'
         type='password'
         value={password}
         onChange={(e) => setPassword(e.target.value)}
         onClear={() => setPassword('')}
         maxLength={20}
       />
+      <br />
+
+      <Styled.ForgotPasswordText>
+        비밀번호를 잊으셨나요?
+      </Styled.ForgotPasswordText>
+      <Button width={'100%'} animated onClick={() => alert('수정 완료')}>
+        비밀번호 변경하기
+      </Button>
     </div>
   );
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #265 

## 📝작업 내용
### UI수정
![스크린샷 2025-04-02 22 49 07](https://github.com/user-attachments/assets/11714b77-5d3a-43fe-873d-a375f60a525c)

### 회원정보관리탭 임시 접근제한 fae1e9af2a540821f659ff4ee64a5e8939fd9791


## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항