### PR TITLE
[refactor] 상세페이지 url 클럽이름으로 변경

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,7 +33,7 @@ const App = () => {
               }
             />
             <Route
-              path='/club/:clubId'
+              path='/club/:clubName'
               element={
                 <Suspense fallback={null}>
                   <ClubDetailPage />

--- a/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
@@ -16,6 +16,7 @@ import useAutoScroll from '@/hooks/useAutoScroll';
 import { useGetClubDetail } from '@/hooks/queries/club/useGetClubDetail';
 
 const ClubDetailPage = () => {
+  const { clubName } = useParams<{ clubName: string }>();
   const { sectionRefs, scrollToSection } = useAutoScroll();
   const [showHeader, setShowHeader] = useState(window.innerWidth > 500);
 

--- a/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { useParams } from 'react-router-dom';
 import * as Styled from '@/styles/PageContainer.styles';
 import Header from '@/components/common/Header/Header';
@@ -15,10 +16,11 @@ import useAutoScroll from '@/hooks/useAutoScroll';
 import { useGetClubDetail } from '@/hooks/queries/club/useGetClubDetail';
 
 const ClubDetailPage = () => {
-  const { clubId } = useParams<{ clubId: string }>();
   const { sectionRefs, scrollToSection } = useAutoScroll();
   const [showHeader, setShowHeader] = useState(window.innerWidth > 500);
 
+  const location = useLocation();
+  const clubId = (location.state as { clubId?: string })?.clubId;
   const { data: clubDetail, error } = useGetClubDetail(clubId || '');
 
   useEffect(() => {

--- a/frontend/src/pages/MainPage/components/ClubCard/ClubCard.tsx
+++ b/frontend/src/pages/MainPage/components/ClubCard/ClubCard.tsx
@@ -26,7 +26,11 @@ const ClubCard = ({ club }: { club: Club }) => {
 
     setTimeout(() => {
       setIsClicked(false);
-      navigate(`/club/${club.id}`);
+      navigate(`/club/${encodeURIComponent(club.name)}`, {
+        state: {
+          clubId: club.id,
+        },
+      });
     }, 150);
   };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #267 

## 📝작업 내용

### useLocation으로 clubId가져오기 71ec97c5a75d30d0a135b0b9f8970a56cfd0b23a

### clubCard navigate url 수정 6f3b83f5124870e7566bf4da9571ec2b6d938cbf

### 결과
- 한글
![스크린샷 2025-04-03 02 32 20](https://github.com/user-attachments/assets/47f1a8d2-9410-405f-84b6-09e854ef6789)

- 영어
![스크린샷 2025-04-03 02 32 48](https://github.com/user-attachments/assets/fc06e12d-a586-4945-ab5b-d05c1dc52867)

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항