### PR TITLE
[feature] 일일 인기동아리 조회

### DIFF
--- a/backend/src/main/java/moadong/club/controller/ClubController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubController.java
@@ -45,7 +45,8 @@ public class ClubController {
         + "category는 분류(취미교양 등), division은 분과(중동 등)입니다.")
     @PreAuthorize("isAuthenticated()")
     @SecurityRequirement(name = "BearerAuth")
-    public ResponseEntity<?> createClub(@CurrentUser CustomUserDetails user, @RequestBody ClubCreateRequest request) {
+    public ResponseEntity<?> createClub(@CurrentUser CustomUserDetails user,
+        @RequestBody ClubCreateRequest request) {
         String clubId = clubCommandService.createClub(request);
         return Response.ok("success create club", "clubId : " + clubId);
     }
@@ -76,7 +77,11 @@ public class ClubController {
     public ResponseEntity<?> getClubDetailedPage(
         HttpServletRequest request,
         @PathVariable String clubId) {
-        clubMetricService.patch(clubId, request.getRemoteAddr());
+        String ip = request.getHeader("X-Forwarded-For");
+        if (ip == null || ip.isEmpty()) {
+            ip = request.getRemoteAddr();
+        }
+        clubMetricService.patch(clubId, ip);
         ClubDetailedResponse clubDetailedPageResponse = clubDetailedPageService.getClubDetailedPage(
             clubId);
         return Response.ok(clubDetailedPageResponse);

--- a/backend/src/main/java/moadong/club/controller/ClubMetricController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubMetricController.java
@@ -3,6 +3,7 @@ package moadong.club.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import moadong.club.service.ClubMetricService;
 import moadong.global.payload.Response;
@@ -11,14 +12,13 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/club/metric")
 @AllArgsConstructor
 @Tag(name = "Club_Metric", description = "클럽 통계 API")
-@PreAuthorize("isAuthenticated()")
-@SecurityRequirement(name = "BearerAuth")
 public class ClubMetricController {
 
     private final ClubMetricService clubMetricService;
@@ -26,6 +26,8 @@ public class ClubMetricController {
     @GetMapping("/{clubId}/daily")
     @Operation(summary = "클럽 일간 통계 조회", description = "클럽 일간 통계를 조회합니다.<br>"
         + "오늘부터 30일이내의 통계를 순서대로 조회합니다.")
+    @PreAuthorize("isAuthenticated()")
+    @SecurityRequirement(name = "BearerAuth")
     public ResponseEntity<?> getDailyActiveUserWitClub(@PathVariable String clubId) {
         int[] metric = clubMetricService.getDailyActiveUserWitClub(clubId);
         return Response.ok(metric);
@@ -34,6 +36,8 @@ public class ClubMetricController {
     @GetMapping("/{clubId}/weekly")
     @Operation(summary = "클럽 주간 통계 조회", description = "클럽 주간 통계를 조회합니다.<br>"
         + "현재주부터 12주전까지의 통계를 순서대로 조회합니다.<br>")
+    @PreAuthorize("isAuthenticated()")
+    @SecurityRequirement(name = "BearerAuth")
     public ResponseEntity<?> getWeeklyActiveUserWitClub(@PathVariable String clubId) {
         int[] metric = clubMetricService.getWeeklyActiveUserWitClub(clubId);
         return Response.ok(metric);
@@ -42,9 +46,18 @@ public class ClubMetricController {
     @GetMapping("/{clubId}/monthly")
     @Operation(summary = "클럽 월간 통계 조회", description = "클럽 월간 통계를 조회합니다.<br>"
         + "현재월부터 12개월전까지의 통계를 순서대로 조회합니다.<br>")
+    @PreAuthorize("isAuthenticated()")
+    @SecurityRequirement(name = "BearerAuth")
     public ResponseEntity<?> getMonthlyActiveUserWitClub(@PathVariable String clubId) {
         int[] metric = clubMetricService.getMonthlyActiveUserWitClub(clubId);
         return Response.ok(metric);
+    }
+
+    @GetMapping("/ranking")
+    @Operation(summary = "동아리 조회순 조회", description = "동아리 상세페이지를 조회한 순서대로 n개 출력합니다.<br>")
+    public ResponseEntity<?> getClubDailyRanking(@RequestParam int n) {
+        List<String> clubs = clubMetricService.getDailyRanking(n);
+        return Response.ok(clubs);
     }
 
 }

--- a/backend/src/main/java/moadong/club/repository/ClubMetricRepository.java
+++ b/backend/src/main/java/moadong/club/repository/ClubMetricRepository.java
@@ -14,4 +14,5 @@ public interface ClubMetricRepository extends MongoRepository<ClubMetric, String
 
     List<ClubMetric> findByClubIdAndDateAfter(String clubId, LocalDate date);
 
+    List<ClubMetric> findAllByDate(LocalDate now);
 }

--- a/backend/src/main/java/moadong/club/repository/ClubRepository.java
+++ b/backend/src/main/java/moadong/club/repository/ClubRepository.java
@@ -2,7 +2,6 @@ package moadong.club.repository;
 
 import java.util.List;
 import java.util.Optional;
-
 import moadong.club.entity.Club;
 import moadong.club.enums.ClubState;
 import org.bson.types.ObjectId;
@@ -12,10 +11,13 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ClubRepository extends MongoRepository<Club, String> {
+
     Optional<Club> findClubById(ObjectId id);
+
     Optional<List<Club>> findClubByState(ClubState clubState);
 
     Optional<Club> findClubByUserId(String userId);
+
     @Query("{'division': {$regex: '^?0$', $options: 'i'}}")
     Optional<List<Club>> findClubByDivisionIgnoreCaseExact(String division);
 
@@ -23,14 +25,20 @@ public interface ClubRepository extends MongoRepository<Club, String> {
     Optional<List<Club>> findClubByCategoryIgnoreCaseExact(String category);
 
     @Query("{'state': ?0, 'category': {$regex: '^?1$', $options: 'i'}}")
-    Optional<List<Club>> findClubByStateAndCategoryIgnoreCaseExact(ClubState clubState, String category);
+    Optional<List<Club>> findClubByStateAndCategoryIgnoreCaseExact(ClubState clubState,
+        String category);
 
     @Query("{'state': ?0, 'division': {$regex: '^?1$', $options: 'i'}}")
-    Optional<List<Club>> findClubByStateAndDivisionIgnoreCaseExact(ClubState clubState, String division);
+    Optional<List<Club>> findClubByStateAndDivisionIgnoreCaseExact(ClubState clubState,
+        String division);
 
     @Query("{'category': {$regex: '^?0$', $options: 'i'}, 'division': {$regex: '^?1$', $options: 'i'}}")
-    Optional<List<Club>> findClubByCategoryAndDivisionIgnoreCaseExact(String category, String division);
+    Optional<List<Club>> findClubByCategoryAndDivisionIgnoreCaseExact(String category,
+        String division);
 
     @Query("{'state': ?0, 'category': {$regex: '^?1$', $options: 'i'}, 'division': {$regex: '^?2$', $options: 'i'}}")
-    Optional<List<Club>> findClubByStateAndCategoryAndDivisionIgnoreCaseExact(ClubState clubState, String category, String division);
+    Optional<List<Club>> findClubByStateAndCategoryAndDivisionIgnoreCaseExact(ClubState clubState,
+        String category, String division);
+
+    List<Club> findAllByName(List<String> clubs);
 }

--- a/backend/src/main/java/moadong/club/service/ClubMetricService.java
+++ b/backend/src/main/java/moadong/club/service/ClubMetricService.java
@@ -5,17 +5,24 @@ import java.time.Period;
 import java.time.YearMonth;
 import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
+import moadong.club.entity.Club;
 import moadong.club.entity.ClubMetric;
 import moadong.club.repository.ClubMetricRepository;
+import moadong.club.repository.ClubRepository;
 import org.springframework.stereotype.Service;
 
 @Service
 @AllArgsConstructor
 public class ClubMetricService {
 
+    private final ClubRepository clubRepository;
     private final ClubMetricRepository clubMetricRepository;
 
     public void patch(String clubId, String remoteAddr) {
@@ -79,7 +86,8 @@ public class ClubMetricService {
         YearMonth currentMonth = YearMonth.from(now); // 현재 년-월
         YearMonth fromMonth = currentMonth.minusMonths(12); // 12개월 전
 
-        List<ClubMetric> metrics = clubMetricRepository.findByClubIdAndDateAfter(clubId, fromMonth.atDay(1));
+        List<ClubMetric> metrics = clubMetricRepository.findByClubIdAndDateAfter(clubId,
+            fromMonth.atDay(1));
 
         // 12개월간의 통계를 월별로 저장할 배열
         int[] monthlyMetric = new int[12];
@@ -94,5 +102,24 @@ public class ClubMetricService {
         }
 
         return monthlyMetric;
+    }
+
+    public List<String> getDailyRanking(int n) {
+        List<ClubMetric> todayMetrics = clubMetricRepository.findAllByDate(LocalDate.now());
+        Map<String, Long> clubViewCount = todayMetrics.stream()
+            .collect(Collectors.groupingBy(ClubMetric::getClubId, Collectors.counting()));
+        List<Map.Entry<String, Long>> sortedList = new ArrayList<>(clubViewCount.entrySet());
+        sortedList.sort((a, b) -> Math.toIntExact(b.getValue()) - Math.toIntExact(a.getValue()));
+
+        List<String> clubIds = sortedList.stream()
+            .limit(n)
+            .map(Entry::getKey)
+            .collect(Collectors.toList());
+
+        List<Club> clubs = clubRepository.findAllById(clubIds);
+
+        return clubs.stream()
+            .map(Club::getName)
+            .toList();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- #248 

## 📝작업 내용
- 기존에 request가 nginx를 거쳐 들어오면 172.18.0.1로 통일되는 문제를 해결하고, 실제 요청을 보낸 ip주소를 메트릭으로 저장합니다.
- 동아리를 인기순으로 조회합니다. 파라미터에 따라 개수를 지정할 수 있습니다.

## 중점적으로 리뷰받고 싶은 부분(선택)

## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항