### PR TITLE
[feature] 로그아웃 및 리프레쉬 토큰 관련 기능

### DIFF
--- a/backend/src/main/java/moadong/club/entity/Club.java
+++ b/backend/src/main/java/moadong/club/entity/Club.java
@@ -44,13 +44,20 @@ public class Club {
 
     @Field("recruitmentInformation")
     private ClubRecruitmentInformation clubRecruitmentInformation;
-
     public Club() {
         this.name = "";
         this.category = "";
         this.division = "";
         this.state = ClubState.UNAVAILABLE;
         this.clubRecruitmentInformation = ClubRecruitmentInformation.builder().build();
+    }
+    public Club(String userId) {
+        this.name = "";
+        this.category = "";
+        this.division = "";
+        this.state = ClubState.UNAVAILABLE;
+        this.clubRecruitmentInformation = ClubRecruitmentInformation.builder().build();
+        this.userId = userId;
     }
 
     @Builder

--- a/backend/src/main/java/moadong/global/exception/ErrorCode.java
+++ b/backend/src/main/java/moadong/global/exception/ErrorCode.java
@@ -17,7 +17,8 @@ public enum ErrorCode {
     USER_NOT_EXIST(HttpStatus.BAD_REQUEST, "700-2","존재하지 않는 계정입니다."),
     USER_INVALID_FORMAT(HttpStatus.BAD_REQUEST, "700-3","올바르지 않은 유저 형식입니다."),
     USER_INVALID_LOGIN(HttpStatus.BAD_REQUEST, "700-4","올바르지 않은 로그인"),
-    TOKEN_INVALID(HttpStatus.BAD_REQUEST, "701-1", "올바르지 않은 토큰 양식입니다."),
+    TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "701-1", "올바르지 않은 토큰 양식입니다."),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "701-2", "토큰이 만료되었습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/backend/src/main/java/moadong/user/controller/UserController.java
+++ b/backend/src/main/java/moadong/user/controller/UserController.java
@@ -56,6 +56,7 @@ public class UserController {
     //TODO : 토큰 회전 방식 + DB 리프레쉬 토큰 저장
 
     @GetMapping("/logout")
+    @Operation(summary = "로그아웃", description = "클라이언트의 refresh token을 제거합니다.")
     public ResponseEntity<?> logout(
             @CookieValue(value = "refresh_token", required = false) String refreshToken,
             HttpServletResponse response) {

--- a/backend/src/main/java/moadong/user/controller/UserController.java
+++ b/backend/src/main/java/moadong/user/controller/UserController.java
@@ -21,12 +21,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/auth/user")
@@ -39,20 +34,21 @@ public class UserController {
 
     @PostMapping("/register")
     @Operation(
-        summary = UserSwaggerView.ADMIN_REGISTER_SUMMARY,
-        description = UserSwaggerView.ADMIN_PWD_ROLE_DESCRIPTION
+            summary = UserSwaggerView.ADMIN_REGISTER_SUMMARY,
+            description = UserSwaggerView.ADMIN_PWD_ROLE_DESCRIPTION
     )
     public ResponseEntity<?> registerUser(@RequestBody @Validated UserRegisterRequest request) {
         userCommandService.registerUser(request);
         return Response.ok("success register");
     }
 
-    @PostMapping("/login")@Operation(
-        summary = UserSwaggerView.ADMIN_LOGIN_SUMMARY,
-        description = UserSwaggerView.ADMIN_LOGIN_DESCRIPTION
+    @PostMapping("/login")
+    @Operation(
+            summary = UserSwaggerView.ADMIN_LOGIN_SUMMARY,
+            description = UserSwaggerView.ADMIN_LOGIN_DESCRIPTION
     )
     public ResponseEntity<?> loginUser(@RequestBody @Validated UserLoginRequest request,
-        HttpServletResponse response) {
+                                       HttpServletResponse response) {
         LoginResponse loginResponse = userCommandService.loginUser(request, response);
         return Response.ok(loginResponse);
     }
@@ -60,9 +56,9 @@ public class UserController {
     @PostMapping("/refresh")
     @Operation(summary = "토큰 재발급", description = "refresh token을 이용하여 access token을 재발급합니다.")
     public ResponseEntity<?> refresh(
-        @CookieValue(value = "refresh_token", required = false) String refreshToken) {
+            @CookieValue(value = "refresh_token", required = false) String refreshToken) {
         AccessTokenResponse accessTokenResponse = userCommandService.refreshAccessToken(
-            refreshToken);
+                refreshToken);
         return Response.ok(accessTokenResponse);
     }
 
@@ -71,8 +67,9 @@ public class UserController {
     @PreAuthorize("isAuthenticated()")
     @SecurityRequirement(name = "BearerAuth")
     public ResponseEntity<?> update(@CurrentUser CustomUserDetails user,
-        @RequestBody @Validated UserUpdateRequest userUpdateRequest) {
-        userCommandService.update(user.getUserId(), userUpdateRequest);
+                                    @RequestBody @Validated UserUpdateRequest userUpdateRequest,
+                                    HttpServletResponse response) {
+        userCommandService.update(user.getUserId(), userUpdateRequest, response);
         return Response.ok("success update");
     }
 

--- a/backend/src/main/java/moadong/user/entity/RefreshToken.java
+++ b/backend/src/main/java/moadong/user/entity/RefreshToken.java
@@ -1,0 +1,15 @@
+package moadong.user.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Date;
+
+@AllArgsConstructor
+@Getter
+@Builder(toBuilder = true)
+public class RefreshToken {
+    private String token;
+    private Date expiresAt;
+}

--- a/backend/src/main/java/moadong/user/entity/User.java
+++ b/backend/src/main/java/moadong/user/entity/User.java
@@ -1,6 +1,5 @@
 package moadong.user.entity;
 
-import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -15,10 +14,10 @@ import moadong.user.entity.enums.UserStatus;
 import moadong.user.payload.request.UserUpdateRequest;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
-@Entity
 @Builder
 @Getter
 @AllArgsConstructor
@@ -49,6 +48,9 @@ public class User implements UserDetails {
 
     private Date lastLoginAt;
 
+    @Field("refreshToken")
+    private RefreshToken refreshToken;
+
     @Builder.Default
     @NotNull
     private UserStatus status = UserStatus.ACTIVE;
@@ -68,8 +70,12 @@ public class User implements UserDetails {
         return userId;
     }
 
-    public void update(UserUpdateRequest userUpdateRequest) {
+    public void updateUserProfile(UserUpdateRequest userUpdateRequest) {
         this.userId = userUpdateRequest.userId();
         this.password = userUpdateRequest.password();
     }
+    public void updateRefreshToken(RefreshToken refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
 }

--- a/backend/src/main/java/moadong/user/payload/response/RefreshResponse.java
+++ b/backend/src/main/java/moadong/user/payload/response/RefreshResponse.java
@@ -1,6 +1,6 @@
 package moadong.user.payload.response;
 
-public record AccessTokenResponse(
+public record RefreshResponse(
         String accessToken
 ) {
 }

--- a/backend/src/main/java/moadong/user/repository/UserRepository.java
+++ b/backend/src/main/java/moadong/user/repository/UserRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends MongoRepository<User, String> {
     Optional<User> findUserByUserId(String userId);
+
+    Optional<User> findUserByRefreshToken_Token(String token);
 }

--- a/backend/src/main/java/moadong/user/service/UserCommandService.java
+++ b/backend/src/main/java/moadong/user/service/UserCommandService.java
@@ -8,13 +8,14 @@ import moadong.club.repository.ClubRepository;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
 import moadong.global.util.JwtProvider;
+import moadong.user.entity.RefreshToken;
 import moadong.user.entity.User;
 import moadong.user.payload.CustomUserDetails;
 import moadong.user.payload.request.UserLoginRequest;
 import moadong.user.payload.request.UserRegisterRequest;
 import moadong.user.payload.request.UserUpdateRequest;
-import moadong.user.payload.response.AccessTokenResponse;
 import moadong.user.payload.response.LoginResponse;
+import moadong.user.payload.response.RefreshResponse;
 import moadong.user.repository.UserInformationRepository;
 import moadong.user.repository.UserRepository;
 import moadong.user.util.CookieMaker;
@@ -24,6 +25,8 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.Date;
 
 @Service
 @AllArgsConstructor
@@ -43,11 +46,10 @@ public class UserCommandService {
             User user = userRepository.save(userRegisterRequest.toUserEntity(encodedPw));
             userInformationRepository.save(
                     userRegisterRequest.toUserInformationEntity(user.getId()));
+            createClub(user.getId());
         } catch (MongoWriteException e) {
             throw new RestApiException(ErrorCode.USER_ALREADY_EXIST);
         }
-
-        createClub();
     }
 
     public LoginResponse loginUser(UserLoginRequest userLoginRequest,
@@ -56,33 +58,57 @@ public class UserCommandService {
             Authentication authenticate = authenticationManager.authenticate(
                     new UsernamePasswordAuthenticationToken(userLoginRequest.userId(),
                             userLoginRequest.password()));
-
             CustomUserDetails userDetails = (CustomUserDetails) authenticate.getPrincipal();
-            String accessToken = jwtProvider.generateAccessToken(userDetails.getUsername());
-            String refreshToken = jwtProvider.generateRefreshToken(userDetails.getUsername());
-
-            ResponseCookie cookie = cookieMaker.makeRefreshTokenCookie(refreshToken);
-            response.addHeader("Set-Cookie", cookie.toString());
-
             Club club = clubRepository.findClubByUserId(userDetails.getId())
                     .orElseThrow(() -> new RestApiException(ErrorCode.CLUB_NOT_FOUND));
+            User user = userRepository.findUserByUserId(userDetails.getUserId())
+                    .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_EXIST));
 
+            String accessToken = jwtProvider.generateAccessToken(userDetails.getUsername());
+            RefreshToken refreshToken = jwtProvider.generateRefreshToken(userDetails.getUsername());
+
+            ResponseCookie cookie = cookieMaker.makeRefreshTokenCookie(refreshToken.getToken());
+            response.addHeader("Set-Cookie", cookie.toString());
+
+            user.updateRefreshToken(refreshToken);
+            userRepository.save(user);
             return new LoginResponse(accessToken, club.getId());
         } catch (MongoWriteException e) {
             throw new RestApiException(ErrorCode.USER_ALREADY_EXIST);
         }
     }
 
-    public AccessTokenResponse refreshAccessToken(String refreshToken) {
+    public void logoutUser(String refreshToken) {
+        User user = userRepository.findUserByRefreshToken_Token(refreshToken)
+                .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_EXIST));
+
+        user.updateRefreshToken(null);
+        userRepository.save(user);
+    }
+
+    public RefreshResponse refreshAccessToken(String refreshToken,
+                                              HttpServletResponse response) {
         if (refreshToken.isBlank() ||
                 !jwtProvider.validateToken(refreshToken, jwtProvider.extractUsername(refreshToken))) {
             throw new RestApiException(ErrorCode.TOKEN_INVALID);
         }
         String userId = jwtProvider.extractUsername(refreshToken);
+        User user = userRepository.findUserByUserId(userId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_EXIST));
+
+        if (!user.getRefreshToken().getToken().equals(refreshToken)
+                || jwtProvider.isTokenExpired(refreshToken)) {
+            throw new RestApiException(ErrorCode.TOKEN_INVALID);
+        }
         String accessToken = jwtProvider.generateAccessToken(userId);
-        return new AccessTokenResponse(accessToken);
+        String newRefreshToken = jwtProvider.generateRefreshToken(userId).getToken();
 
+        user.updateRefreshToken(new RefreshToken(newRefreshToken, new Date()));
+        userRepository.save(user);
 
+        ResponseCookie cookie = cookieMaker.makeRefreshTokenCookie(newRefreshToken);
+        response.addHeader("Set-Cookie", cookie.toString());
+        return new RefreshResponse(accessToken);
     }
 
     public void update(String userId,
@@ -90,11 +116,11 @@ public class UserCommandService {
                        HttpServletResponse response) {
         User user = userRepository.findUserByUserId(userId)
                 .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_EXIST));
-        user.update(userUpdateRequest.encryptPassword(passwordEncoder));
+        user.updateUserProfile(userUpdateRequest.encryptPassword(passwordEncoder));
 
         userRepository.save(user);
 
-        String newRefreshToken = jwtProvider.generateRefreshToken(user.getUsername());
+        String newRefreshToken = jwtProvider.generateRefreshToken(user.getUsername()).getToken();
         ResponseCookie cookie = cookieMaker.makeRefreshTokenCookie(newRefreshToken);
         response.addHeader("Set-Cookie", cookie.toString());
     }
@@ -105,8 +131,8 @@ public class UserCommandService {
         return club.getId();
     }
 
-    private void createClub() {
-        Club club = new Club();
+    private void createClub(String userId) {
+        Club club = new Club(userId);
         clubRepository.save(club);
     }
 }

--- a/backend/src/main/java/moadong/user/util/CookieMaker.java
+++ b/backend/src/main/java/moadong/user/util/CookieMaker.java
@@ -1,0 +1,19 @@
+package moadong.user.util;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CookieMaker {
+    @Value("${jwt.refresh.token.expiration.hour}")
+    private int refreshTokenExpirationHour;
+    public ResponseCookie makeRefreshTokenCookie(String refreshToken){
+        return ResponseCookie.from("refresh_token", refreshToken)
+                .httpOnly(true)
+                .path("/")
+                .maxAge((long) refreshTokenExpirationHour * 60 * 60)
+                .secure(true)
+                .build();
+    }
+}

--- a/backend/src/main/java/moadong/user/util/CookieMaker.java
+++ b/backend/src/main/java/moadong/user/util/CookieMaker.java
@@ -8,12 +8,14 @@ import org.springframework.stereotype.Component;
 public class CookieMaker {
     @Value("${jwt.refresh.token.expiration.hour}")
     private int refreshTokenExpirationHour;
-    public ResponseCookie makeRefreshTokenCookie(String refreshToken){
+
+    public ResponseCookie makeRefreshTokenCookie(String refreshToken) {
         return ResponseCookie.from("refresh_token", refreshToken)
                 .httpOnly(true)
                 .path("/")
                 .maxAge((long) refreshTokenExpirationHour * 60 * 60)
                 .secure(true)
+                .sameSite("Strict")
                 .build();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #259 

## 📝작업 내용

- 로그아웃 엔드포인트 추가(클라이언트측의 리프레시 토큰 강제 삭제)
- 리프레시 토큰의 사용처 인증 추가(DB와 비교하여 리프레시 토큰 발급자가 리프레시 토큰을 전송했는지 검증)
- 아이디 비밀번호 수정은 연기