### PR TITLE
[feature] 로그아웃 API 연결 및 로그인 시 HttpOnly 쿠키 처리

### DIFF
--- a/frontend/src/apis/auth/login.ts
+++ b/frontend/src/apis/auth/login.ts
@@ -17,6 +17,7 @@ export const login = async (
 ): Promise<LoginResponseData> => {
   const response = await fetch(`${API_BASE_URL}/auth/user/login`, {
     method: 'POST',
+    credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
     },

--- a/frontend/src/apis/auth/logout.ts
+++ b/frontend/src/apis/auth/logout.ts
@@ -8,6 +8,6 @@ export const logout = async (): Promise<void> => {
   });
 
   if (!response.ok) {
-    throw new Error(`로그아웃에 실패하였습니다: ${response.statusText}`);
+    throw new Error(`로그아웃에 실패하였습니다 ${response.statusText}`);
   }
 };

--- a/frontend/src/apis/auth/logout.ts
+++ b/frontend/src/apis/auth/logout.ts
@@ -1,0 +1,13 @@
+import API_BASE_URL from '@/constants/api';
+import { secureFetch } from '@/apis/auth/secureFetch';
+
+export const logout = async (): Promise<void> => {
+  const response = await secureFetch(`${API_BASE_URL}/auth/user/logout`, {
+    method: 'GET',
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    throw new Error(`로그아웃에 실패하였습니다: ${response.statusText}`);
+  }
+};

--- a/frontend/src/pages/AdminPage/components/SideBar/SideBar.tsx
+++ b/frontend/src/pages/AdminPage/components/SideBar/SideBar.tsx
@@ -69,7 +69,7 @@ const SideBar = ({ clubLogo, clubName }: SideBarProps) => {
     try {
       await logout();
       localStorage.removeItem('accessToken');
-      navigate('/admin/login', { replace: true }); // 로그인 페이지로 이동
+      navigate('/admin/login', { replace: true });
     } catch (error) {
       console.error(error);
       alert('로그아웃에 실패했습니다.');

--- a/frontend/src/pages/AdminPage/components/SideBar/SideBar.tsx
+++ b/frontend/src/pages/AdminPage/components/SideBar/SideBar.tsx
@@ -9,6 +9,7 @@ import {
   useUploadClubLogo,
   useDeleteClubLogo,
 } from '@/hooks/queries/club/useClubLogo';
+import { logout } from '@/apis/auth/logout';
 
 interface SideBarProps {
   clubName: string;
@@ -64,9 +65,15 @@ const SideBar = ({ clubLogo, clubName }: SideBarProps) => {
     navigate(tab.path);
   };
 
-  const handleLogout = () => {
-    localStorage.removeItem('accessToken');
-    navigate('/admin/login', { replace: true });
+  const handleLogout = async () => {
+    try {
+      await logout();
+      localStorage.removeItem('accessToken');
+      navigate('/admin/login', { replace: true }); // 로그인 페이지로 이동
+    } catch (error) {
+      console.error(error);
+      alert('로그아웃에 실패했습니다.');
+    }
   };
 
   return (


### PR DESCRIPTION
## #️⃣연관된 이슈

> #284 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지/동영상 첨부 가능)
### 1. 로그아웃 API 구현 및 연결
로그아웃 요청 시, 서버에서 refresh_token을 삭제하고, HttpOnly 쿠키를 만료 처리하도록 구현

<br />

### 2. 로그인 시 HttpOnly 쿠키 처리
로그인 시, 서버에서 refresh_token을 HttpOnly 쿠키로 설정하고, credentials: 'include' 설정을 통해 자동으로 쿠키를 관리

## 🫡 참고사항