### PR TITLE
[feature] 활동사진, 로고파일 최대용량 10MB로 설정

### DIFF
--- a/frontend/src/apis/createFeedImage.ts
+++ b/frontend/src/apis/createFeedImage.ts
@@ -1,10 +1,16 @@
 import API_BASE_URL from '@/constants/api';
 import { secureFetch } from '@/apis/auth/secureFetch';
+import { MAX_FILE_SIZE } from '@/constants/uploadLimit';
 
 export const createFeedImage = async (file: File, clubId: string) => {
   try {
+    if (file.size > MAX_FILE_SIZE) {
+      throw new Error('파일 크기가 10MB를 초과합니다.');
+    }
+
     const formData = new FormData();
     formData.append('feed', file);
+
     const response = await secureFetch(
       `${API_BASE_URL}/api/club/${clubId}/feed`,
       {

--- a/frontend/src/apis/updateClubLogo.ts
+++ b/frontend/src/apis/updateClubLogo.ts
@@ -1,7 +1,12 @@
 import API_BASE_URL from '@/constants/api';
 import { secureFetch } from '@/apis/auth/secureFetch';
+import { MAX_FILE_SIZE } from '@/constants/uploadLimit';
 
 export const uploadClubLogo = async (clubId: string, file: File) => {
+  if (file.size > MAX_FILE_SIZE) {
+    throw new Error('파일 크기가 10MB를 초과합니다.');
+  }
+
   const formData = new FormData();
   formData.append('logo', file);
 

--- a/frontend/src/constants/uploadLimit.ts
+++ b/frontend/src/constants/uploadLimit.ts
@@ -1,0 +1,1 @@
+export const MAX_FILE_SIZE = 10 * 1024 * 1024;

--- a/frontend/src/pages/AdminPage/components/ImageUpload/ImageUpload.tsx
+++ b/frontend/src/pages/AdminPage/components/ImageUpload/ImageUpload.tsx
@@ -3,6 +3,7 @@ import * as Styled from './ImageUpload.styles';
 import UploadAddIcon from '@/assets/images/upload-add.png';
 import useCreateFeedImage from '@/hooks/queries/club/useCreateFeedImage';
 import { ImageUploadProps } from '@/types/club';
+import { MAX_FILE_SIZE } from '@/constants/uploadLimit';
 
 export const ImageUpload = ({
   clubId,
@@ -19,8 +20,16 @@ export const ImageUpload = ({
 
   const changeImage = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = event.target.files;
+
     if (files) {
-      createFeedImage({ file: files[0], clubId });
+      const file = files[0];
+
+      if (file.size > MAX_FILE_SIZE) {
+        alert('파일 크기가 10MB를 초과합니다.');
+        return;
+      }
+
+      createFeedImage({ file, clubId });
     }
   };
 

--- a/frontend/src/pages/AdminPage/components/SideBar/SideBar.tsx
+++ b/frontend/src/pages/AdminPage/components/SideBar/SideBar.tsx
@@ -9,6 +9,7 @@ import {
   useUploadClubLogo,
   useDeleteClubLogo,
 } from '@/hooks/queries/club/useClubLogo';
+import { MAX_FILE_SIZE } from '@/constants/uploadLimit';
 
 interface SideBarProps {
   clubName: string;
@@ -33,6 +34,11 @@ const SideBar = ({ clubLogo, clubName }: SideBarProps) => {
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
+
+    if (file.size > MAX_FILE_SIZE) {
+      alert('파일 크기가 10MB를 초과합니다.');
+      return;
+    }
 
     uploadMutation.mutate(file, {
       onError: () => {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #298 

## 📝작업 내용

### api 조건 추가
```typescript
    if (file.size > MAX_FILE_SIZE) {
      throw new Error('파일 크기가 10MB를 초과합니다.');
    }
```
- 로고 및 활동사진 업로드 api에 파일 크기 조건을 추가했습니다.

### 실제 컴포넌트에서 alert 설정

```typescript
  const files = event.target.files;

    if (files) {
      const file = files[0];

      if (file.size > MAX_FILE_SIZE) {
        alert('파일 크기가 10MB를 초과합니다.');
        return;
      }
```
- 파일크기 조건을 한 번 더 검사하여 무결성을 높였습니다.
- 동시에 alert창을 추가했습니다.

### 파일크기 상수로 분리 46af530c6c28f8e4677139884a03c20d7bd64ad3

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항