### PR TITLE
[feature] 상시모집 동아리 alert창에 전화번호 띄우기

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -57,6 +57,7 @@
         "fork-ts-checker-webpack-plugin": "^9.0.2",
         "html-webpack-plugin": "^5.6.3",
         "jest": "^29.7.0",
+        "jest-environment-jsdom": "^29.7.0",
         "jest-fetch-mock": "^3.0.3",
         "mini-css-extract-plugin": "^2.9.2",
         "path": "^0.12.7",
@@ -3520,6 +3521,16 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
@@ -3892,6 +3903,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsdom": {
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
+      "integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -4099,6 +4122,13 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.12.tgz",
       "integrity": "sha512-bTHG8fcxEqv1M9+TD14P8ok8hjxoOCkfKc8XXLaaD05kI7ohpeI956jtDOD3XHKBQrlyPughUtzm1jtVhHpA5Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4718,6 +4748,14 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/abab": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+      "deprecated": "Use your platform's native atob() and btoa() methods instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -4754,6 +4792,17 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-globals": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
+      "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.1.0",
+        "acorn-walk": "^8.0.2"
+      }
+    },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -4764,6 +4813,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/address": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/address/-/address-2.0.3.tgz",
@@ -4772,6 +4834,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/ajv": {
@@ -5120,6 +5195,13 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -5993,6 +6075,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -6701,11 +6796,90 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssom": "~0.3.6"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cssstyle/node_modules/cssom": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
+      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -6787,6 +6961,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
+      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.0.2",
@@ -6912,6 +7093,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -7071,6 +7262,30 @@
         }
       ],
       "license": "BSD-2-Clause"
+    },
+    "node_modules/domexception": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/domexception/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/domhandler": {
       "version": "4.3.1",
@@ -8037,6 +8252,38 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/eslint": {
       "version": "9.17.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.17.0.tgz",
@@ -8930,6 +9177,22 @@
         "node": ">=10"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -9570,6 +9833,19 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/html-entities": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.5.2.tgz",
@@ -9745,6 +10021,21 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/http-proxy-middleware": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
@@ -9768,6 +10059,20 @@
         "@types/express": {
           "optional": true
         }
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/human-signals": {
@@ -10359,6 +10664,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -11108,6 +11420,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jest-environment-jsdom": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
+      "integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/jsdom": "^20.0.0",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jsdom": "^20.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jest-environment-node": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
@@ -11769,6 +12109,89 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
+      "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "acorn": "^8.8.1",
+        "acorn-globals": "^7.0.0",
+        "cssom": "^0.5.0",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^3.0.2",
+        "decimal.js": "^10.4.2",
+        "domexception": "^4.0.0",
+        "escodegen": "^2.0.0",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.2",
+        "parse5": "^7.1.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.2",
+        "w3c-xmlserializer": "^4.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^2.0.0",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0",
+        "ws": "^8.11.0",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/jsesc": {
@@ -13410,6 +13833,13 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.20",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.20.tgz",
+      "integrity": "sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -14744,6 +15174,19 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -14785,6 +15228,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -15571,6 +16021,19 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.25.0",
@@ -16662,6 +17125,13 @@
         "webpack": ">=2"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tabbable": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
@@ -16917,6 +17387,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie/node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/tr46": {
@@ -17493,6 +17989,17 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/url/node_modules/punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -17613,6 +18120,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/walker": {
@@ -18033,6 +18553,42 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -18232,6 +18788,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -67,6 +67,7 @@
     "fork-ts-checker-webpack-plugin": "^9.0.2",
     "html-webpack-plugin": "^5.6.3",
     "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
     "jest-fetch-mock": "^3.0.3",
     "mini-css-extract-plugin": "^2.9.2",
     "path": "^0.12.7",

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTab.tsx
@@ -27,7 +27,6 @@ const ClubInfoEditTab = () => {
 
   useEffect(() => {
     if (clubDetail) {
-      // [x] FIXME: 동아리회장 이름, 번호 필드명 수정해야 함
       setClubName(clubDetail.name);
       setClubPresidentName(clubDetail.presidentName);
       setTelephoneNumber(clubDetail.presidentPhoneNumber);

--- a/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
@@ -40,7 +40,6 @@ const ClubDetailPage = () => {
     return <div>에러가 발생했습니다.</div>;
   }
 
-  console.log(clubDetail.recruitmentPeriod);
   return (
     <>
       {showHeader && <Header />}

--- a/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
@@ -51,6 +51,9 @@ const ClubDetailPage = () => {
           division={clubDetail.division}
           tags={clubDetail.tags}
           logo={clubDetail.logo}
+          recruitmentPeriod={clubDetail.recruitmentPeriod}
+          recruitmentForm={clubDetail.recruitmentForm}
+          presidentPhoneNumber={clubDetail.presidentPhoneNumber}
         />
         <InfoTabs onTabClick={scrollToSection} />
         <InfoBox sectionRefs={sectionRefs} clubDetail={clubDetail} />
@@ -61,7 +64,11 @@ const ClubDetailPage = () => {
         <PhotoList sectionRefs={sectionRefs} feeds={clubDetail.feeds} />
       </Styled.PageContainer>
       <Footer />
-      <ClubDetailFooter recruitmentPeriod={clubDetail.recruitmentPeriod} />
+      <ClubDetailFooter
+        recruitmentPeriod={clubDetail.recruitmentPeriod}
+        recruitmentForm={clubDetail.recruitmentForm}
+        presidentPhoneNumber={clubDetail.presidentPhoneNumber}
+      />
     </>
   );
 };

--- a/frontend/src/pages/ClubDetailPage/components/ClubApplyButton/ClubApplyButton.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubApplyButton/ClubApplyButton.tsx
@@ -3,7 +3,8 @@ import useMixpanelTrack from '@/hooks/useMixpanelTrack';
 import styled from 'styled-components';
 
 interface ButtonProps {
-  onClick?: () => void;
+  recruitmentForm?: string;
+  presidentPhoneNumber?: string;
 }
 
 const Button = styled.button`
@@ -35,17 +36,21 @@ const Button = styled.button`
   }
 `;
 
-const ClubApplyButton = ({ onClick }: ButtonProps) => {
+const ClubApplyButton = ({
+  recruitmentForm,
+  presidentPhoneNumber,
+}: ButtonProps) => {
   const trackEvent = useMixpanelTrack();
 
   const handleClick = () => {
     trackEvent('Club Apply Button Clicked');
 
-    if (onClick) {
-      onClick();
+    // [x] FIXME: recruitmentForm 있을 때는 리다이렉트
+    if (presidentPhoneNumber) {
+      alert(`${presidentPhoneNumber} 으로 연락하여 지원해 주세요.`);
+    } else {
+      alert('모집이 마감되었습니다. 다음에 지원해 주세요.');
     }
-    // []FIXME: 모집 마감 시 alert창 띄우기
-    alert('모집이 마감되었습니다. 다음에 지원해 주세요.');
   };
 
   return <Button onClick={handleClick}>지원하기</Button>;

--- a/frontend/src/pages/ClubDetailPage/components/ClubDetailFooter/ClubDetailFooter.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubDetailFooter/ClubDetailFooter.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import * as Styled from './ClubDetailFooter.styles';
 import DeadlineBadge from '@/pages/ClubDetailPage/components/DeadlineBadge/DeadlineBadge';
 import ClubApplyButton from '@/pages/ClubDetailPage/components/ClubApplyButton/ClubApplyButton';
@@ -19,11 +19,11 @@ const ClubDetailFooter = ({
   const { recruitmentStart, recruitmentEnd } =
     parseRecruitmentPeriod(recruitmentPeriod);
 
-  const today = useMemo(() => new Date(), []);
-
-  const deadlineText = useMemo(() => {
-    return getDeadlineText(recruitmentStart, recruitmentEnd, today);
-  }, [recruitmentStart, recruitmentEnd, today]);
+  const deadlineText = getDeadlineText(
+    recruitmentStart,
+    recruitmentEnd,
+    new Date(),
+  );
 
   return (
     <Styled.ClubDetailFooterContainer>

--- a/frontend/src/pages/ClubDetailPage/components/ClubDetailFooter/ClubDetailFooter.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubDetailFooter/ClubDetailFooter.tsx
@@ -1,17 +1,39 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import * as Styled from './ClubDetailFooter.styles';
 import DeadlineBadge from '@/pages/ClubDetailPage/components/DeadlineBadge/DeadlineBadge';
 import ClubApplyButton from '@/pages/ClubDetailPage/components/ClubApplyButton/ClubApplyButton';
+import { parseRecruitmentPeriod } from '@/utils/stringToDate';
+import getDeadlineText from '@/utils/getDeadLineText';
 
 interface ClubDetailFooterProps {
   recruitmentPeriod: string;
+  recruitmentForm: string;
+  presidentPhoneNumber: string;
 }
 
-const ClubDetailFooter = ({ recruitmentPeriod }: ClubDetailFooterProps) => {
+const ClubDetailFooter = ({
+  recruitmentPeriod,
+  recruitmentForm,
+  presidentPhoneNumber,
+}: ClubDetailFooterProps) => {
+  const { recruitmentStart, recruitmentEnd } =
+    parseRecruitmentPeriod(recruitmentPeriod);
+
+  const today = useMemo(() => new Date(), []);
+
+  const deadlineText = useMemo(() => {
+    return getDeadlineText(recruitmentStart, recruitmentEnd, today);
+  }, [recruitmentStart, recruitmentEnd, today]);
+
   return (
     <Styled.ClubDetailFooterContainer>
-      <DeadlineBadge recruitmentPeriod={recruitmentPeriod} />
-      <ClubApplyButton />
+      <DeadlineBadge deadlineText={deadlineText} />
+      <ClubApplyButton
+        {...(deadlineText !== '모집 마감' && {
+          recruitmentForm,
+          presidentPhoneNumber,
+        })}
+      />
     </Styled.ClubDetailFooterContainer>
   );
 };

--- a/frontend/src/pages/ClubDetailPage/components/ClubDetailHeader/ClubDetailHeader.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubDetailHeader/ClubDetailHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import * as Styled from './ClubDetailHeader.styles';
 import ClubProfile from '@/pages/ClubDetailPage/components/ClubProfile/ClubProfile';
 import ClubApplyButton from '@/pages/ClubDetailPage/components/ClubApplyButton/ClubApplyButton';
@@ -28,11 +28,11 @@ const ClubDetailHeader = ({
   const { recruitmentStart, recruitmentEnd } =
     parseRecruitmentPeriod(recruitmentPeriod);
 
-  const today = useMemo(() => new Date(), []);
-
-  const deadlineText = useMemo(() => {
-    return getDeadlineText(recruitmentStart, recruitmentEnd, today);
-  }, [recruitmentStart, recruitmentEnd, today]);
+  const deadlineText = getDeadlineText(
+    recruitmentStart,
+    recruitmentEnd,
+    new Date(),
+  );
 
   return (
     <Styled.ClubDetailHeaderContainer>

--- a/frontend/src/pages/ClubDetailPage/components/ClubDetailHeader/ClubDetailHeader.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubDetailHeader/ClubDetailHeader.tsx
@@ -1,14 +1,18 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import * as Styled from './ClubDetailHeader.styles';
 import ClubProfile from '@/pages/ClubDetailPage/components/ClubProfile/ClubProfile';
 import ClubApplyButton from '@/pages/ClubDetailPage/components/ClubApplyButton/ClubApplyButton';
-
+import { parseRecruitmentPeriod } from '@/utils/stringToDate';
+import getDeadlineText from '@/utils/getDeadLineText';
 interface ClubDetailHeaderProps {
   name: string;
   category: string;
   division: string;
   tags: string[];
   logo: string;
+  recruitmentPeriod: string;
+  recruitmentForm?: string;
+  presidentPhoneNumber?: string;
 }
 
 const ClubDetailHeader = ({
@@ -17,7 +21,19 @@ const ClubDetailHeader = ({
   division,
   tags,
   logo,
+  recruitmentPeriod,
+  recruitmentForm,
+  presidentPhoneNumber,
 }: ClubDetailHeaderProps) => {
+  const { recruitmentStart, recruitmentEnd } =
+    parseRecruitmentPeriod(recruitmentPeriod);
+
+  const today = useMemo(() => new Date(), []);
+
+  const deadlineText = useMemo(() => {
+    return getDeadlineText(recruitmentStart, recruitmentEnd, today);
+  }, [recruitmentStart, recruitmentEnd, today]);
+
   return (
     <Styled.ClubDetailHeaderContainer>
       <ClubProfile
@@ -27,7 +43,12 @@ const ClubDetailHeader = ({
         tags={tags}
         logo={logo}
       />
-      <ClubApplyButton />
+      <ClubApplyButton
+        {...(deadlineText !== '모집 마감' && {
+          recruitmentForm,
+          presidentPhoneNumber,
+        })}
+      />
     </Styled.ClubDetailHeaderContainer>
   );
 };

--- a/frontend/src/pages/ClubDetailPage/components/DeadlineBadge/DeadlineBadge.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/DeadlineBadge/DeadlineBadge.tsx
@@ -1,32 +1,11 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import * as Styled from './DeadlineBadge.styles';
-import { parseRecruitmentPeriod } from '@/utils/stringToDate';
 
 interface DeadlineBadgeProps {
-  recruitmentPeriod: string;
+  deadlineText: string;
 }
 
-const DeadlineBadge = ({ recruitmentPeriod }: DeadlineBadgeProps) => {
-  const { recruitmentStart, recruitmentEnd } = useMemo(() => {
-    return parseRecruitmentPeriod(recruitmentPeriod);
-  }, [recruitmentPeriod]);
-
-  const today = useMemo(() => new Date(), []);
-
-  const deadlineText = useMemo(() => {
-    if (
-      recruitmentStart &&
-      recruitmentEnd &&
-      today >= recruitmentStart &&
-      today <= recruitmentEnd
-    ) {
-      const diffTime = recruitmentEnd.getTime() - today.getTime();
-      const days = Math.floor(diffTime / (1000 * 60 * 60 * 24));
-      return days > 0 ? `D-${days}` : 'D-Day';
-    }
-    return '모집 마감';
-  }, [today, recruitmentStart, recruitmentEnd]);
-
+const DeadlineBadge = ({ deadlineText }: DeadlineBadgeProps) => {
   return (
     <Styled.DeadlineBadgeWrapper>
       <Styled.DeadlineBadgeText>{deadlineText}</Styled.DeadlineBadgeText>

--- a/frontend/src/utils/getDeadLineText.test.ts
+++ b/frontend/src/utils/getDeadLineText.test.ts
@@ -1,32 +1,34 @@
 import getDeadlineText from './getDeadLineText';
 
 describe('getDeadlineText 함수 테스트', () => {
-  test.each([
-    [
-      new Date('2025-04-01'),
-      new Date('2025-04-10'),
-      new Date('2025-04-10'),
+  it('오늘이 모집 종료일인 경우 D-Day를 반환해야 한다', () => {
+    const recruitmentStart = new Date('2025-04-01');
+    const recruitmentEnd = new Date('2025-04-10');
+    const today = new Date('2025-04-10');
+    expect(getDeadlineText(recruitmentStart, recruitmentEnd, today)).toBe(
       'D-Day',
-    ],
-    [
-      new Date('2025-04-01'),
-      new Date('2025-04-10'),
-      new Date('2025-04-05'),
+    );
+  });
+
+  it('모집 종료일까지 5일 남은 경우 D-5를 반환해야 한다', () => {
+    const recruitmentStart = new Date('2025-04-01');
+    const recruitmentEnd = new Date('2025-04-10');
+    const today = new Date('2025-04-05');
+    expect(getDeadlineText(recruitmentStart, recruitmentEnd, today)).toBe(
       'D-5',
-    ],
-    [
-      new Date('2025-04-01'),
-      new Date('2025-04-10'),
-      new Date('2025-04-11'),
+    );
+  });
+
+  it('오늘이 모집 종료일 이후인 경우 모집 마감을 반환해야 한다', () => {
+    const recruitmentStart = new Date('2025-04-01');
+    const recruitmentEnd = new Date('2025-04-10');
+    const today = new Date('2025-04-11');
+    expect(getDeadlineText(recruitmentStart, recruitmentEnd, today)).toBe(
       '모집 마감',
-    ],
-    [null, null, new Date('2025-04-10'), '모집 마감'],
-  ])(
-    'recruitmentStart: %s, recruitmentEnd: %s, today: %s => %s',
-    (recruitmentStart, recruitmentEnd, today, expectedResult) => {
-      expect(getDeadlineText(recruitmentStart, recruitmentEnd, today)).toBe(
-        expectedResult,
-      );
-    },
-  );
+    );
+  });
+
+  it('모집 기간이 null인 경우 모집 마감을 반환해야 한다', () => {
+    expect(getDeadlineText(null, null)).toBe('모집 마감');
+  });
 });

--- a/frontend/src/utils/getDeadLineText.test.ts
+++ b/frontend/src/utils/getDeadLineText.test.ts
@@ -31,4 +31,13 @@ describe('getDeadlineText 함수 테스트', () => {
   it('모집 기간이 null인 경우 모집 마감을 반환해야 한다', () => {
     expect(getDeadlineText(null, null)).toBe('모집 마감');
   });
+
+  it('모집 시작일이 아직 남은 경우 모집 전을 반환해야 한다.', () => {
+    const recruitmentStart = new Date('2025-04-01');
+    const recruitmentEnd = new Date('2025-04-10');
+    const today = new Date('2025-03-30');
+    expect(getDeadlineText(recruitmentStart, recruitmentEnd, today)).toBe(
+      '모집 전',
+    );
+  });
 });

--- a/frontend/src/utils/getDeadLineText.test.ts
+++ b/frontend/src/utils/getDeadLineText.test.ts
@@ -1,34 +1,32 @@
 import getDeadlineText from './getDeadLineText';
 
 describe('getDeadlineText 함수 테스트', () => {
-  it('오늘이 모집 종료일인 경우 D-Day를 반환해야 한다', () => {
-    const recruitmentStart = new Date('2025-04-01');
-    const recruitmentEnd = new Date('2025-04-10');
-    const today = new Date('2025-04-10');
-    expect(getDeadlineText(recruitmentStart, recruitmentEnd, today)).toBe(
+  test.each([
+    [
+      new Date('2025-04-01'),
+      new Date('2025-04-10'),
+      new Date('2025-04-10'),
       'D-Day',
-    );
-  });
-
-  it('모집 종료일까지 5일 남은 경우 D-5를 반환해야 한다', () => {
-    const recruitmentStart = new Date('2025-04-01');
-    const recruitmentEnd = new Date('2025-04-10');
-    const today = new Date('2025-04-05');
-    expect(getDeadlineText(recruitmentStart, recruitmentEnd, today)).toBe(
+    ],
+    [
+      new Date('2025-04-01'),
+      new Date('2025-04-10'),
+      new Date('2025-04-05'),
       'D-5',
-    );
-  });
-
-  it('오늘이 모집 종료일 이후인 경우 모집 마감을 반환해야 한다', () => {
-    const recruitmentStart = new Date('2025-04-01');
-    const recruitmentEnd = new Date('2025-04-10');
-    const today = new Date('2025-04-11');
-    expect(getDeadlineText(recruitmentStart, recruitmentEnd, today)).toBe(
+    ],
+    [
+      new Date('2025-04-01'),
+      new Date('2025-04-10'),
+      new Date('2025-04-11'),
       '모집 마감',
-    );
-  });
-
-  it('모집 기간이 null인 경우 모집 마감을 반환해야 한다', () => {
-    expect(getDeadlineText(null, null)).toBe('모집 마감');
-  });
+    ],
+    [null, null, new Date('2025-04-10'), '모집 마감'],
+  ])(
+    'recruitmentStart: %s, recruitmentEnd: %s, today: %s => %s',
+    (recruitmentStart, recruitmentEnd, today, expectedResult) => {
+      expect(getDeadlineText(recruitmentStart, recruitmentEnd, today)).toBe(
+        expectedResult,
+      );
+    },
+  );
 });

--- a/frontend/src/utils/getDeadLineText.test.ts
+++ b/frontend/src/utils/getDeadLineText.test.ts
@@ -1,0 +1,34 @@
+import getDeadlineText from './getDeadLineText';
+
+describe('getDeadlineText 함수 테스트', () => {
+  it('오늘이 모집 종료일인 경우 D-Day를 반환해야 한다', () => {
+    const recruitmentStart = new Date('2025-04-01');
+    const recruitmentEnd = new Date('2025-04-10');
+    const today = new Date('2025-04-10');
+    expect(getDeadlineText(recruitmentStart, recruitmentEnd, today)).toBe(
+      'D-Day',
+    );
+  });
+
+  it('모집 종료일까지 5일 남은 경우 D-5를 반환해야 한다', () => {
+    const recruitmentStart = new Date('2025-04-01');
+    const recruitmentEnd = new Date('2025-04-10');
+    const today = new Date('2025-04-05');
+    expect(getDeadlineText(recruitmentStart, recruitmentEnd, today)).toBe(
+      'D-5',
+    );
+  });
+
+  it('오늘이 모집 종료일 이후인 경우 모집 마감을 반환해야 한다', () => {
+    const recruitmentStart = new Date('2025-04-01');
+    const recruitmentEnd = new Date('2025-04-10');
+    const today = new Date('2025-04-11');
+    expect(getDeadlineText(recruitmentStart, recruitmentEnd, today)).toBe(
+      '모집 마감',
+    );
+  });
+
+  it('모집 기간이 null인 경우 모집 마감을 반환해야 한다', () => {
+    expect(getDeadlineText(null, null)).toBe('모집 마감');
+  });
+});

--- a/frontend/src/utils/getDeadLineText.ts
+++ b/frontend/src/utils/getDeadLineText.ts
@@ -1,0 +1,19 @@
+const getDeadlineText = (
+  recruitmentStart: Date | null,
+  recruitmentEnd: Date | null,
+  today: Date = new Date(),
+): string => {
+  if (
+    recruitmentStart &&
+    recruitmentEnd &&
+    today >= recruitmentStart &&
+    today <= recruitmentEnd
+  ) {
+    const diffTime = recruitmentEnd.getTime() - today.getTime();
+    const days = Math.floor(diffTime / (1000 * 60 * 60 * 24));
+    return days > 0 ? `D-${days}` : 'D-Day';
+  }
+  return '모집 마감';
+};
+
+export default getDeadlineText;

--- a/frontend/src/utils/getDeadLineText.ts
+++ b/frontend/src/utils/getDeadLineText.ts
@@ -1,19 +1,17 @@
+import { isAfter, isBefore, differenceInCalendarDays } from 'date-fns';
+
 const getDeadlineText = (
   recruitmentStart: Date | null,
   recruitmentEnd: Date | null,
   today: Date = new Date(),
 ): string => {
-  if (
-    recruitmentStart &&
-    recruitmentEnd &&
-    today >= recruitmentStart &&
-    today <= recruitmentEnd
-  ) {
-    const diffTime = recruitmentEnd.getTime() - today.getTime();
-    const days = Math.floor(diffTime / (1000 * 60 * 60 * 24));
-    return days > 0 ? `D-${days}` : 'D-Day';
-  }
-  return '모집 마감';
+  console.log(recruitmentEnd, recruitmentStart);
+  if (!recruitmentStart || !recruitmentEnd) return '모집 마감';
+  if (isBefore(today, recruitmentStart)) return '모집 전';
+  if (isAfter(today, recruitmentEnd)) return '모집 마감';
+
+  const days = differenceInCalendarDays(recruitmentEnd, today);
+  return days > 0 ? `D-${days}` : 'D-Day';
 };
 
 export default getDeadlineText;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #311 

## 📝작업 내용

### 지원마감 처리
1. 모집인 경우 -> 모집링크로 변경
- 구글폼 있을 시 리다이렉트
- 없다면 alert ```{번호}로 연락주세요!```

2. 모집이 아닌 경우 -> 모집 마감으로 처리
- alert ```모집이 마감되었습니다. 다음에 지원해 주세요!```

### prop전달
1. clubDetailPage -> clubDetailHeader -> clubApplyButton
2. clubDetailPage -> clubDetailFooter -> deadlineText, clubApplyButton

-> prop을 2단계로 전달하는 것까지 큰 문제는 없다고 생각했습니다. 

### 마감일 계산 유틸함수 테스트추가 
- [9ad9a18](https://github.com/Moadong/moadong/pull/312/commits/9ad9a1891c3b5b5cf9b0e8c4d48c9aadcc68ec82)
- jsdom 패키지 설치

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
현재 모집 중인 동아리는 모두 상시모집인데 구글폼을 사용하지 않아서 구글폼 리다이렉트 로직은 추가하지 않았습니다. 

## 🫡 참고사항