### PR TITLE
feat : 사이트 일일 활성사용자수 조회

### DIFF
--- a/backend/src/main/java/moadong/club/controller/ClubMetricController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubMetricController.java
@@ -60,4 +60,13 @@ public class ClubMetricController {
         return Response.ok(clubs);
     }
 
+    @GetMapping("/dau")
+    @Operation(summary = "일일 활성 사용자수 조회", description = "당일부터 n일 이내의 일일 활성 사용자수를 순서대로 조회합니다.<br>"
+        + "ip가 중복된 경우 1로 카운트합니다.<br>"
+        + "동아리 상세페이지를 조회한 기록을 활용합니다.")
+    public ResponseEntity<?> getDailyActiveUser(@RequestParam int n) {
+        int[] daus = clubMetricService.getDailyActiveUser(n);
+        return Response.ok(daus);
+    }
+
 }

--- a/backend/src/main/java/moadong/club/repository/ClubMetricRepository.java
+++ b/backend/src/main/java/moadong/club/repository/ClubMetricRepository.java
@@ -15,4 +15,6 @@ public interface ClubMetricRepository extends MongoRepository<ClubMetric, String
     List<ClubMetric> findByClubIdAndDateAfter(String clubId, LocalDate date);
 
     List<ClubMetric> findAllByDate(LocalDate now);
+
+    List<ClubMetric> findAllByDateAfter(LocalDate fromDate);
 }

--- a/backend/src/main/java/moadong/club/service/ClubMetricService.java
+++ b/backend/src/main/java/moadong/club/service/ClubMetricService.java
@@ -130,7 +130,8 @@ public class ClubMetricService {
     }
 
     public int[] getDailyActiveUser(int n) {
-        LocalDate fromDate = LocalDate.now().minusDays(n);
+        LocalDate today = LocalDate.now();
+        LocalDate fromDate = today.minusDays(n);
         List<ClubMetric> metrics = clubMetricRepository.findAllByDateAfter(fromDate);
 
         Map<LocalDate, Set<String>> daus = metrics.stream()
@@ -139,7 +140,7 @@ public class ClubMetricService {
 
         int[] dausCount = new int[n];
         for (int i = 0; i < n; i++) {
-            LocalDate targetDate = LocalDate.now().minusDays(i);
+            LocalDate targetDate = today.minusDays(i);
             dausCount[i] = daus.getOrDefault(targetDate, Collections.emptySet()).size();
         }
 

--- a/backend/src/main/java/moadong/club/service/ClubMetricService.java
+++ b/backend/src/main/java/moadong/club/service/ClubMetricService.java
@@ -6,10 +6,12 @@ import java.time.YearMonth;
 import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import moadong.club.entity.Club;
@@ -125,5 +127,22 @@ public class ClubMetricService {
                 .map(Club::getName)
                 .orElse(null))
             .toList();
+    }
+
+    public int[] getDailyActiveUser(int n) {
+        LocalDate fromDate = LocalDate.now().minusDays(n);
+        List<ClubMetric> metrics = clubMetricRepository.findAllByDateAfter(fromDate);
+
+        Map<LocalDate, Set<String>> daus = metrics.stream()
+            .collect(Collectors.groupingBy(ClubMetric::getDate,
+                Collectors.mapping(ClubMetric::getIp, Collectors.toSet())));
+
+        int[] dausCount = new int[n];
+        for (int i = 0; i < n; i++) {
+            LocalDate targetDate = LocalDate.now().minusDays(i);
+            dausCount[i] = daus.getOrDefault(targetDate, Collections.emptySet()).size();
+        }
+
+        return dausCount;
     }
 }


### PR DESCRIPTION
- 상세페이지를 조회한 일일 활성 사용자수를 조회합니다. 이때, 같은 ip는 1로 카운트 됩니다.

## #️⃣연관된 이슈
- #313 

## 📝작업 내용
- api 구현
- 로컬테스트
- [api 명세서 작성](https://www.notion.so/1d0aad23209680409d2fd610e811253a)
- 기능 명세서 작성 
  ![image](https://github.com/user-attachments/assets/7d4ae5a6-bd71-4892-8468-a37aa954111b)
