### PR TITLE
[feature]검색 결과가 동아리 이름 오름차순으로 정렬되도록 변경

### DIFF
--- a/backend/src/main/java/moadong/club/service/ClubSearchService.java
+++ b/backend/src/main/java/moadong/club/service/ClubSearchService.java
@@ -33,8 +33,11 @@ public class ClubSearchService {
         result = result.stream()
                 .sorted(
                         //
-                        Comparator.comparingInt((ClubSearchResult club) -> RecruitmentStatus.getPriorityFromString(club.recruitmentStatus()))
-                                .thenComparingInt((ClubSearchResult club) -> ClubCategory.getPriorityFromString(club.category())))
+                        Comparator
+                                .comparingInt((ClubSearchResult club) -> RecruitmentStatus.getPriorityFromString(club.recruitmentStatus()))
+                                .thenComparingInt((ClubSearchResult club) -> ClubCategory.getPriorityFromString(club.category()))
+                                .thenComparing(ClubSearchResult::name)
+                )
                 .collect(Collectors.toList());
 
         return ClubSearchResponse.builder()


### PR DESCRIPTION
#️⃣연관된 이슈

> #327 

## 📝작업 내용

같은 카테고리안에 속한 동아리들 검색 결과에서 동아리 이름 오름차순에 따라 정렬되도록 변경한다.
단, 영어 이후 한글로 정렬합니다.