### PR TITLE
[refactor] 카테고리 버튼 UX 개선 및 카드 리스트 깜빡임 이슈 수정

### DIFF
--- a/frontend/src/hooks/queries/club/useGetCardList.ts
+++ b/frontend/src/hooks/queries/club/useGetCardList.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
 import { getClubList } from '@/apis/getClubList';
 
 export const useGetCardList = (
@@ -10,5 +10,6 @@ export const useGetCardList = (
   return useQuery({
     queryKey: ['clubs', keyword, recruitmentStatus, division, category],
     queryFn: () => getClubList(keyword, recruitmentStatus, division, category),
+    placeholderData: keepPreviousData,
   });
 };

--- a/frontend/src/pages/MainPage/components/CategoryButtonList/CategoryButtonList.styles.ts
+++ b/frontend/src/pages/MainPage/components/CategoryButtonList/CategoryButtonList.styles.ts
@@ -23,7 +23,6 @@ export const CategoryButton = styled.button`
   border: none;
   background: none;
   cursor: pointer;
-  border-radius: 12px;
   padding: 8px;
   transition: transform 0.1s ease;
 

--- a/frontend/src/pages/MainPage/components/CategoryButtonList/CategoryButtonList.styles.ts
+++ b/frontend/src/pages/MainPage/components/CategoryButtonList/CategoryButtonList.styles.ts
@@ -23,10 +23,19 @@ export const CategoryButton = styled.button`
   border: none;
   background: none;
   cursor: pointer;
+  border-radius: 12px;
+  padding: 8px;
+  transition: transform 0.1s ease;
+
+  &:active {
+    transform: scale(0.95);
+  }
 
   img {
     width: 36px;
     height: 36px;
+    transition: transform 0.2s ease;
+
     @media (max-width: 500px) {
       margin-top: 5px;
       width: 30px;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #343 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지/동영상 첨부 가능)

### 1️⃣ useGetCardList 개선
- React Query의 keepPreviousData 옵션 추가
- 카테고리 변경 시 카드 리스트 깜빡임 현상 해결


### 2️⃣ CategoryButtonList 버튼 스타일 개선
- 클릭시  눌리는 애니메이션 적용
- 버튼 크기가 다소 작다는 피드백을 반영해 패딩을 추가하여 터치 영역을 넓힘

> 전체적으로 더 부드럽고 편한 UX를 제공


## 중점적으로 리뷰받고 싶은 부분(선택)


## 논의하고 싶은 부분(선택)
선택된 카테고리에 대한 별도 스타일링도 시도했으나, 디자인이 오히려 어색해져서 그냥 이정도만 했습니다!
선택된 카테고리 알 수 있게 하려면 디자인이 있어야할 것 같습니다

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **스타일**
  - 카테고리 버튼에 패딩과 누름 효과(스케일 다운) 및 부드러운 변환 애니메이션이 추가되어 더욱 직관적인 인터랙션을 제공합니다.
- **버그 수정**
  - 카드 리스트를 새로 불러올 때 이전 데이터가 플레이스홀더로 표시되어, 로딩 중에도 기존 정보가 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->