### PR TITLE
[fix] 소개페이지 a태그 클릭 시 파란색 전환효과 및 밑줄 표시 제거

### DIFF
--- a/frontend/src/components/common/Header/Header.styles.ts
+++ b/frontend/src/components/common/Header/Header.styles.ts
@@ -71,6 +71,7 @@ export const IntroduceButtonStyles = styled.a`
   font-size: 14px;
   line-height: 42px;
   cursor: pointer;
+  color: inherit;
 
   @media (max-width: 698px) {
     width: 63px;

--- a/frontend/src/components/common/Header/Header.styles.ts
+++ b/frontend/src/components/common/Header/Header.styles.ts
@@ -72,6 +72,7 @@ export const IntroduceButtonStyles = styled.a`
   line-height: 42px;
   cursor: pointer;
   color: inherit;
+  text-decoration: none;
 
   @media (max-width: 698px) {
     width: 63px;

--- a/frontend/src/components/common/Header/Header.styles.ts
+++ b/frontend/src/components/common/Header/Header.styles.ts
@@ -74,6 +74,11 @@ export const IntroduceButtonStyles = styled.a`
   color: inherit;
   text-decoration: none;
 
+  &:visited {
+    color: inherit;
+    text-decoration: none;
+  }
+
   @media (max-width: 698px) {
     width: 63px;
     height: 43px;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #350

## 📝작업 내용

- 부모의 글자색 상속하여 글자색 변경 방지
- 밑줄 제거

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Introduce 버튼의 링크 색상과 밑줄 스타일이 일관되게 유지되도록 개선되었습니다. 방문한 링크도 동일한 색상과 스타일이 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->