### PR TITLE
[refactor] 활동사진 지연로딩 제거

### DIFF
--- a/frontend/src/components/common/LazyImage/LazyImage.test.tsx
+++ b/frontend/src/components/common/LazyImage/LazyImage.test.tsx
@@ -85,24 +85,6 @@ describe('LazyImage 컴포넌트', () => {
     expect(mockDisconnect).toHaveBeenCalled();
   });
 
-  it('index prop에 따라 지연 시간이 적용되어야 함', () => {
-    render(<LazyImage {...defaultProps} index={2} delayMs={100} />);
-
-    const [[callback]] = mockIntersectionObserver.mock.calls;
-    const entry = { isIntersecting: true };
-    act(() => {
-      callback([entry], {} as IntersectionObserver);
-    });
-
-    expect(screen.queryByRole('img')).not.toBeInTheDocument();
-
-    act(() => {
-      jest.advanceTimersByTime(200);
-    });
-
-    expect(screen.getByRole('img')).toBeInTheDocument();
-  });
-
   it('onError prop이 호출되어야 함', async () => {
     const onError = jest.fn();
     render(<LazyImage {...defaultProps} onError={onError} />);

--- a/frontend/src/components/common/LazyImage/LazyImage.tsx
+++ b/frontend/src/components/common/LazyImage/LazyImage.tsx
@@ -4,43 +4,32 @@ interface LazyImageProps {
   src: string;
   alt: string;
   onError?: () => void;
-  index?: number;
-  delayMs?: number;
 }
 
-const LazyImage = ({
-  src,
-  alt,
-  onError,
-  index = 0,
-  delayMs = 200,
-}: LazyImageProps) => {
+const LazyImage = ({ src, alt, onError }: LazyImageProps) => {
   const [shouldLoad, setShouldLoad] = useState(false);
   const [isVisible, setIsVisible] = useState(false);
   const imgRef = useRef<HTMLImageElement | null>(null);
 
   useEffect(() => {
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          const delay = index * delayMs;
-          const timeout = setTimeout(() => {
-            setShouldLoad(true);
-          }, delay);
-          observer.disconnect();
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) {
+        const delay = 200;
+        const timeout = setTimeout(() => {
+          setShouldLoad(true);
+        }, delay);
+        observer.disconnect();
 
-          return () => clearTimeout(timeout);
-        }
-      },
-      { threshold: 0.1 },
-    );
+        return () => clearTimeout(timeout);
+      }
+    });
 
     if (imgRef.current) {
       observer.observe(imgRef.current);
     }
 
     return () => observer.disconnect();
-  }, [index, delayMs]);
+  }, []);
 
   useEffect(() => {
     if (shouldLoad) {

--- a/frontend/src/components/common/LazyImage/LazyImage.tsx
+++ b/frontend/src/components/common/LazyImage/LazyImage.tsx
@@ -12,15 +12,15 @@ const LazyImage = ({ src, alt, onError }: LazyImageProps) => {
   const imgRef = useRef<HTMLImageElement | null>(null);
 
   useEffect(() => {
+    let timeout: ReturnType<typeof setTimeout>;
+
     const observer = new IntersectionObserver(([entry]) => {
       if (entry.isIntersecting) {
         const delay = 200;
-        const timeout = setTimeout(() => {
+        timeout = setTimeout(() => {
           setShouldLoad(true);
         }, delay);
         observer.disconnect();
-
-        return () => clearTimeout(timeout);
       }
     });
 
@@ -28,7 +28,10 @@ const LazyImage = ({ src, alt, onError }: LazyImageProps) => {
       observer.observe(imgRef.current);
     }
 
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+      clearTimeout(timeout);
+    };
   }, []);
 
   useEffect(() => {

--- a/frontend/src/components/common/LazyImage/LazyImage.tsx
+++ b/frontend/src/components/common/LazyImage/LazyImage.tsx
@@ -15,7 +15,7 @@ const LazyImage = ({ src, alt, onError }: LazyImageProps) => {
 
     const observer = new IntersectionObserver(([entry]) => {
       if (entry.isIntersecting) {
-        const delay = 200;
+        const delay = 100;
         timeout = setTimeout(() => {
           setIsVisible(true);
         }, delay);

--- a/frontend/src/components/common/LazyImage/LazyImage.tsx
+++ b/frontend/src/components/common/LazyImage/LazyImage.tsx
@@ -7,7 +7,6 @@ interface LazyImageProps {
 }
 
 const LazyImage = ({ src, alt, onError }: LazyImageProps) => {
-  const [shouldLoad, setShouldLoad] = useState(false);
   const [isVisible, setIsVisible] = useState(false);
   const imgRef = useRef<HTMLImageElement | null>(null);
 
@@ -18,7 +17,7 @@ const LazyImage = ({ src, alt, onError }: LazyImageProps) => {
       if (entry.isIntersecting) {
         const delay = 200;
         timeout = setTimeout(() => {
-          setShouldLoad(true);
+          setIsVisible(true);
         }, delay);
         observer.disconnect();
       }
@@ -33,12 +32,6 @@ const LazyImage = ({ src, alt, onError }: LazyImageProps) => {
       clearTimeout(timeout);
     };
   }, []);
-
-  useEffect(() => {
-    if (shouldLoad) {
-      setIsVisible(true);
-    }
-  }, [shouldLoad]);
 
   return isVisible ? (
     <img ref={imgRef} src={src} alt={alt} onError={onError} />

--- a/frontend/src/pages/ClubDetailPage/components/PhotoList/PhotoList.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/PhotoList/PhotoList.tsx
@@ -104,8 +104,6 @@ const PhotoList = ({ feeds: photos, sectionRefs }: PhotoListProps) => {
                   <LazyImage
                     src={url}
                     alt={`활동 사진 ${index + 1}`}
-                    index={index}
-                    delayMs={200}
                     onError={() => handleImageError(index)}
                   />
                 ) : (


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #353 

## 📝작업 내용

### 기존 동작
- 이미지 순서대로 순차 로딩 방식

### 문제점
- 데스크탑인 경우 다수의 이미지가 순차로딩되는 효과가 버벅거리는 것처럼 보입니다.

https://github.com/user-attachments/assets/15f40dde-3fcf-4fac-ab39-0760fd72ef36



### 개선하기
- ```delay * delayMs```에서```delayMs```제거하여 일정 시간으로 유지. [a13e618](https://github.com/Moadong/moadong/pull/354/commits/a13e618e872cf3b238c6d769553061a3e647bef9)
- 순차로딩 테스트코드 제거 [ecadd77](https://github.com/Moadong/moadong/pull/354/commits/ecadd77cfe3934e90ea4296f11e0f802ff94b658)

https://github.com/user-attachments/assets/68e78bab-2bb3-43be-841d-1feaa4d5876e


## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - 이미지 지연 로딩 기능에서 개별 지연 시간(index, delayMs) 설정 옵션을 제거하고, 고정된 100ms 지연으로 단순화하였습니다.

- **Tests**
  - index와 delayMs prop 관련 테스트를 삭제하였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->