### PR TITLE
[refactor] 인터페이스 및 타입 통합 리팩토링

### DIFF
--- a/frontend/src/pages/AdminPage/components/ImagePreview/ImagePreview.tsx
+++ b/frontend/src/pages/AdminPage/components/ImagePreview/ImagePreview.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import * as Styled from './ImagePreview.styles';
-import { ImagePreviewProps } from '@/types/club';
 import delete_button_icon from '@/assets/images/icons/delete_button_icon.svg';
+interface ImagePreviewProps {
+  image: string;
+  onDelete: () => void;
+}
 
 export const ImagePreview = ({ image, onDelete }: ImagePreviewProps) => {
   return (

--- a/frontend/src/pages/AdminPage/components/ImageUpload/ImageUpload.tsx
+++ b/frontend/src/pages/AdminPage/components/ImageUpload/ImageUpload.tsx
@@ -2,10 +2,13 @@ import React, { useRef } from 'react';
 import * as Styled from './ImageUpload.styles';
 // import UploadAddIcon from '@/assets/images/upload-add.png';
 import useCreateFeedImage from '@/hooks/queries/club/useCreateFeedImage';
-import { ImageUploadProps } from '@/types/club';
 import Button from '@/components/common/Button/Button';
 import { MAX_FILE_SIZE } from '@/constants/uploadLimit';
-
+interface ImageUploadProps {
+  clubId: string;
+  onChangeImageList: (image: string) => void;
+  imageCount: number;
+}
 
 export const ImageUpload = ({
   clubId,
@@ -22,13 +25,12 @@ export const ImageUpload = ({
   });
 
   const changeImage = async (event: React.ChangeEvent<HTMLInputElement>) => {
-
     const file = event.target.files?.[0];
     if (!file) return;
     if (file.size > MAX_FILE_SIZE) {
-            alert('선택한 사진 용량이 10MB를 초과합니다.');
-            return;
-          }
+      alert('선택한 사진 용량이 10MB를 초과합니다.');
+      return;
+    }
     createFeedImage({ file, clubId });
   };
 

--- a/frontend/src/pages/ClubDetailPage/components/InfoBox/InfoBox.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/InfoBox/InfoBox.tsx
@@ -18,12 +18,12 @@ interface InfoBoxProps {
   clubDetail: ClubDetail;
 }
 
-type InfoListWithRef = InfoList & {
+interface ClubInfoSectionWithRef extends ClubInfoSection {
   refIndex: INFOTABS_SCROLL_INDEX;
-};
+}
 
 const InfoBox = ({ sectionRefs, clubDetail }: InfoBoxProps) => {
-  const infoData: InfoListWithRef[] = [
+  const infoData: ClubInfoSectionWithRef[] = [
     {
       title: '모집정보',
       descriptions: [

--- a/frontend/src/pages/ClubDetailPage/components/InfoBox/InfoBox.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/InfoBox/InfoBox.tsx
@@ -1,8 +1,17 @@
 import React from 'react';
 import * as Styled from './InfoBox.styles';
-import { InfoList } from '@/types/Info';
 import { ClubDetail } from '@/types/club';
 import { INFOTABS_SCROLL_INDEX } from '@/constants/scrollSections';
+
+interface ClubInfoItem {
+  label: string;
+  value: string;
+}
+
+interface ClubInfoSection {
+  title: string;
+  descriptions: ClubInfoItem[];
+}
 
 interface InfoBoxProps {
   sectionRefs: React.RefObject<(HTMLDivElement | null)[]>;

--- a/frontend/src/types/Info.ts
+++ b/frontend/src/types/Info.ts
@@ -1,9 +1,0 @@
-export type Description = {
-  label: string;
-  value: string;
-};
-
-export type InfoList = {
-  title: string;
-  descriptions: Description[];
-};

--- a/frontend/src/types/club.ts
+++ b/frontend/src/types/club.ts
@@ -24,14 +24,3 @@ export interface ClubDescription {
   id: string;
   description: string | null;
 }
-
-export interface ImageUploadProps {
-  clubId: string;
-  onChangeImageList: (image: string) => void;
-  imageCount: number;
-}
-
-export interface ImagePreviewProps {
-  image: string;
-  onDelete: () => void;
-}

--- a/frontend/src/types/club.ts
+++ b/frontend/src/types/club.ts
@@ -10,14 +10,14 @@ export interface Club {
 }
 
 export interface ClubDetail extends Club {
+  description: string;
   state: string;
   feeds: string[];
-  description: string;
   presidentName: string;
   presidentPhoneNumber: string;
+  recruitmentForm: string;
   recruitmentPeriod: string;
   recruitmentTarget: string;
-  recruitmentForm: string;
 }
 
 export interface ClubDescription {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #356 

## 📝작업 내용

### 분리된 타입 파일 다시 통합 
- ```ImageProps``` 들은 각각 하나의 파일에서만 사용되므로 분리할 필요까지 없어보여 파일내로 이동시켰습니다. a629e24c8b6797adf3198c2935848fa903ae2875
- ```info.ts```파일 또한 ```InfoBox.tsx```에서만 사용되기 때문에 분리되어있던 타입을 옮겼습니다. 
- type에서 interface로 변경했습니다. 6388d29ae8304cc570eebe9c04696f15c4978f56

### 필드 순서 변경
- 백엔드에서 필드 정의 된 순서로 바꾸었습니다. 

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?



## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Refactor**
	- 일부 컴포넌트에서 사용하던 타입 정의를 외부 파일에서 내부로 이동하여 관리 방식을 변경했습니다.
	- 불필요해진 타입 정의 파일이 삭제되었습니다.

- **Style**
	- 코드 들여쓰기가 일부 수정되어 가독성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->