### PR TITLE
[style] 모바일 검색창 크기 키우기

### DIFF
--- a/frontend/src/components/common/Header/Header.styles.ts
+++ b/frontend/src/components/common/Header/Header.styles.ts
@@ -112,7 +112,6 @@ export const MobileHeaderWrapper = styled.div`
 export const MobileMainIcon = styled.button`
   width: 32.562px;
   height: 26px;
-  aspect-ratio: 32.56/26;
   background-color: transparent;
   border: none;
   cursor: pointer;

--- a/frontend/src/components/common/Header/Header.styles.ts
+++ b/frontend/src/components/common/Header/Header.styles.ts
@@ -94,7 +94,7 @@ export const MobileHeaderContainer = styled.header`
     top: 0;
     left: 0;
     right: 0;
-    height: 46px;
+    height: 56px;
     padding: 0px 20px;
     margin: 0 auto;
     z-index: 2;
@@ -110,28 +110,29 @@ export const MobileHeaderWrapper = styled.div`
 `;
 
 export const MobileMainIcon = styled.button`
-  width: 26px;
-  height: 22px;
+  width: 32.562px;
+  height: 26px;
+  aspect-ratio: 32.56/26;
   background-color: transparent;
   border: none;
   cursor: pointer;
 
   img {
-    width: 26px;
+    width: 32.562px;
     height: auto;
     object-fit: cover;
   }
 `;
 
 export const MobileMenu = styled.button`
-  width: 18px;
-  height: 14px;
+  width: 20px;
+  height: 16px;
   background-color: transparent;
   border: none;
   cursor: pointer;
 
   img {
-    width: 18px;
+    width: 20px;
     height: auto;
     object-fit: cover;
   }

--- a/frontend/src/components/common/SearchBox/SearchBox.styles.ts
+++ b/frontend/src/components/common/SearchBox/SearchBox.styles.ts
@@ -49,6 +49,7 @@ export const SearchInputStyles = styled.input`
 `;
 
 export const SearchButton = styled.button<{ isFocused: boolean }>`
+  flex-shrink: 0;
   border: none;
   background-color: transparent;
   font-size: 16px;

--- a/frontend/src/components/common/SearchBox/SearchBox.styles.ts
+++ b/frontend/src/components/common/SearchBox/SearchBox.styles.ts
@@ -12,7 +12,7 @@ export const SearchBoxContainer = styled.form<{ isFocused: boolean }>`
   background-color: #eeeeee;
 
   @media (max-width: 500px) {
-    width: 255x;
+    width: 255px;
     height: 36px;
     padding: 6px 16px;
 

--- a/frontend/src/components/common/SearchBox/SearchBox.styles.ts
+++ b/frontend/src/components/common/SearchBox/SearchBox.styles.ts
@@ -23,7 +23,7 @@ export const SearchBoxContainer = styled.form<{ isFocused: boolean }>`
 `;
 
 export const SearchInputStyles = styled.input`
-  width: 100%;
+  width: calc(100% - 32px);
   background-color: transparent;
   height: 36px;
   border: none;

--- a/frontend/src/components/common/SearchBox/SearchBox.styles.ts
+++ b/frontend/src/components/common/SearchBox/SearchBox.styles.ts
@@ -72,8 +72,10 @@ export const SearchButton = styled.button<{ isFocused: boolean }>`
   }
 
   @media (max-width: 500px) {
-    width: 14px;
-    height: 14px;
+    img {
+      width: 14px;
+      height: 14px;
+    }
 
     filter: ${({ isFocused }) =>
       isFocused

--- a/frontend/src/components/common/SearchBox/SearchBox.styles.ts
+++ b/frontend/src/components/common/SearchBox/SearchBox.styles.ts
@@ -55,30 +55,17 @@ export const SearchButton = styled.button<{ isFocused: boolean }>`
   font-size: 16px;
   cursor: pointer;
 
+  width: 16px;
+  height: 16px;
+
   img {
-    width: 16px;
-    height: 16px;
-  }
-
-  @media (max-width: 698px) {
-    img {
-      width: 14px;
-      height: 14px;
-    }
-  }
-
-  @media (max-width: 550px) {
-    img {
-      width: 12px;
-      height: 12px;
-    }
+    width: 100%;
+    height: 100%;
   }
 
   @media (max-width: 500px) {
-    img {
-      width: 14px;
-      height: 14px;
-    }
+    width: 14px;
+    height: 14px;
 
     filter: ${({ isFocused }) =>
       isFocused

--- a/frontend/src/components/common/SearchBox/SearchBox.styles.ts
+++ b/frontend/src/components/common/SearchBox/SearchBox.styles.ts
@@ -23,6 +23,7 @@ export const SearchBoxContainer = styled.form<{ isFocused: boolean }>`
 `;
 
 export const SearchInputStyles = styled.input`
+  flex: 1;
   width: calc(100% - 32px);
   background-color: transparent;
   height: 36px;
@@ -33,6 +34,7 @@ export const SearchInputStyles = styled.input`
   &::placeholder {
     transition: opacity 0.3s;
   }
+
   &:focus::placeholder {
     opacity: 0;
   }

--- a/frontend/src/components/common/SearchBox/SearchBox.styles.ts
+++ b/frontend/src/components/common/SearchBox/SearchBox.styles.ts
@@ -3,17 +3,18 @@ import styled from 'styled-components';
 export const SearchBoxContainer = styled.form<{ isFocused: boolean }>`
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  width: 300px;
+  justify-content: center;
+  width: 345px;
   height: 36px;
-  padding: 10px 20px;
+  padding: 3px 20px;
   border: transparent;
   border-radius: 41px;
   background-color: #eeeeee;
 
   @media (max-width: 500px) {
-    width: 270px;
-    height: 28px;
+    width: 255x;
+    height: 36px;
+    padding: 6px 16px;
 
     border: 1px solid
       ${({ isFocused }) =>
@@ -39,6 +40,10 @@ export const SearchInputStyles = styled.input`
   @media (max-width: 550px) {
     font-size: 10px;
   }
+
+  @media (max-width: 500px) {
+    font-size: 14px;
+  }
 `;
 
 export const SearchButton = styled.button<{ isFocused: boolean }>`
@@ -46,7 +51,6 @@ export const SearchButton = styled.button<{ isFocused: boolean }>`
   background-color: transparent;
   font-size: 16px;
   cursor: pointer;
-  margin-top: 2px;
 
   img {
     width: 16px;
@@ -68,6 +72,9 @@ export const SearchButton = styled.button<{ isFocused: boolean }>`
   }
 
   @media (max-width: 500px) {
+    width: 14px;
+    height: 14px;
+
     filter: ${({ isFocused }) =>
       isFocused
         ? 'invert(36%) sepia(83%) saturate(746%) hue-rotate(359deg) brightness(95%) contrast(92%)'

--- a/frontend/src/pages/MainPage/components/Banner/Banner.styles.ts
+++ b/frontend/src/pages/MainPage/components/Banner/Banner.styles.ts
@@ -14,7 +14,7 @@ export const BannerContainer = styled.div`
   position: relative;
 
   @media (max-width: 500px) {
-    margin-top: 42px;
+    margin-top: 56px;
     padding: 0;
   }
 `;

--- a/frontend/src/pages/MainPage/components/CategoryButtonList/CategoryButtonList.styles.ts
+++ b/frontend/src/pages/MainPage/components/CategoryButtonList/CategoryButtonList.styles.ts
@@ -11,7 +11,7 @@ export const CategoryButtonContainer = styled.div`
     margin-top: 16px;
     background-color: white;
     position: sticky;
-    top: 46px;
+    top: 56px;
     z-index: 1;
   }
 `;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #359 

## 📝작업 내용

1. ```SearchBoxContainer```의 justify-content 속성 ```space-between```에서 ```center```로 변경
2. margin 확보 위해 input 태그 ```flex: 1``` 및 ```width: calc(100%-32px)```로 설정

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Style**
  - 모바일 헤더와 아이콘 크기가 전체적으로 커졌으며, 모바일 환경에서 헤더와 카테고리 버튼의 위치가 상향 조정되었습니다.
  - 검색창의 가로 폭과 정렬, 패딩, 버튼 크기 등이 모바일 환경에 맞게 개선되었습니다.
  - 배너의 상단 여백이 모바일 화면에서 더 넓어졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->