### PR TITLE
[feat] socialLinks 구현

### DIFF
--- a/backend/src/main/java/moadong/club/entity/Club.java
+++ b/backend/src/main/java/moadong/club/entity/Club.java
@@ -6,12 +6,13 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import moadong.club.enums.ClubState;
-import moadong.club.payload.request.ClubRecruitmentInfoUpdateRequest;
 import moadong.club.payload.request.ClubInfoRequest;
+import moadong.club.payload.request.ClubRecruitmentInfoUpdateRequest;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
@@ -41,9 +42,11 @@ public class Club {
 
     private String userId;
 
+    private Map<String, String> socialLinks;
 
     @Field("recruitmentInformation")
     private ClubRecruitmentInformation clubRecruitmentInformation;
+
     public Club() {
         this.name = "";
         this.category = "";
@@ -51,6 +54,7 @@ public class Club {
         this.state = ClubState.UNAVAILABLE;
         this.clubRecruitmentInformation = ClubRecruitmentInformation.builder().build();
     }
+
     public Club(String userId) {
         this.name = "";
         this.category = "";
@@ -74,6 +78,7 @@ public class Club {
         this.category = request.category();
         this.division = request.division();
         this.state = ClubState.AVAILABLE;
+        this.socialLinks = request.socialLinks();
         this.clubRecruitmentInformation.update(request);
     }
 

--- a/backend/src/main/java/moadong/club/entity/ClubRecruitmentInformation.java
+++ b/backend/src/main/java/moadong/club/entity/ClubRecruitmentInformation.java
@@ -10,13 +10,12 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import moadong.club.enums.ClubRecruitmentStatus;
-import moadong.club.payload.request.ClubRecruitmentInfoUpdateRequest;
 import moadong.club.payload.request.ClubInfoRequest;
+import moadong.club.payload.request.ClubRecruitmentInfoUpdateRequest;
 import moadong.global.RegexConstants;
 import org.checkerframework.common.aliasing.qual.Unique;
 
@@ -52,13 +51,12 @@ public class ClubRecruitmentInformation {
     private String recruitmentTarget;
 
     private List<String> feedImages;
+
     private List<String> tags;
 
     @Enumerated(EnumType.STRING)
     @NotNull
     private ClubRecruitmentStatus clubRecruitmentStatus;
-
-    private String recruitmentForm;
 
     public ClubRecruitmentInformation updateLogo(String logo) {
         this.logo = logo;
@@ -90,11 +88,11 @@ public class ClubRecruitmentInformation {
         return recruitmentEnd.atZone(seoulZone);
     }
 
-    public int getFeedAmounts(){
+    public int getFeedAmounts() {
         return this.feedImages.size();
     }
 
-    public void updateFeedImages(List<String> feedImages){
+    public void updateFeedImages(List<String> feedImages) {
         this.feedImages = feedImages;
     }
 
@@ -103,6 +101,5 @@ public class ClubRecruitmentInformation {
         this.presidentName = request.presidentName();
         this.presidentTelephoneNumber = request.presidentPhoneNumber();
         this.tags = request.tags();
-        this.recruitmentForm = request.recruitmentForm();
     }
 }

--- a/backend/src/main/java/moadong/club/payload/dto/ClubDetailedResult.java
+++ b/backend/src/main/java/moadong/club/payload/dto/ClubDetailedResult.java
@@ -61,7 +61,7 @@ public record ClubDetailedResult(
                 : clubRecruitmentInformation.getRecruitmentTarget())
             .recruitmentStatus(clubRecruitmentInformation.getClubRecruitmentStatus() == null
                 ? "" : clubRecruitmentInformation.getClubRecruitmentStatus().getDescription())
-            .socialLinks(club.getSocialLinks() == null ? null
+            .socialLinks(club.getSocialLinks() == null ? Map.of()
                 : club.getSocialLinks())
             .build();
     }

--- a/backend/src/main/java/moadong/club/payload/dto/ClubDetailedResult.java
+++ b/backend/src/main/java/moadong/club/payload/dto/ClubDetailedResult.java
@@ -2,6 +2,7 @@ package moadong.club.payload.dto;
 
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Map;
 import lombok.Builder;
 import moadong.club.entity.Club;
 import moadong.club.entity.ClubRecruitmentInformation;
@@ -21,7 +22,7 @@ public record ClubDetailedResult(
     String recruitmentPeriod,
     String recruitmentTarget,
     String recruitmentStatus,
-    String recruitmentForm,
+    Map<String, String> socialLinks,
     String category,
     String division
 ) {
@@ -35,24 +36,34 @@ public record ClubDetailedResult(
                 + clubRecruitmentInformation.getRecruitmentEnd().format(formatter);
         }
         return ClubDetailedResult.builder()
-                .id(club.getId() == null ? "" : club.getId())
-                .name(club.getName() == null ? "" : club.getName())
-                .logo(clubRecruitmentInformation.getLogo() == null ? "" : clubRecruitmentInformation.getLogo())
-                .tags(clubRecruitmentInformation.getTags() == null ? List.of() : clubRecruitmentInformation.getTags())
-                .state(club.getState() == null ? "" : club.getState().getDesc())
-                .feeds(clubRecruitmentInformation.getFeedImages() == null ? List.of() : clubRecruitmentInformation.getFeedImages())
-                .category(club.getCategory() == null ? "" : club.getCategory())
-                .division(club.getDivision() == null ? "" : club.getDivision())
-                .introduction(clubRecruitmentInformation.getIntroduction() == null ? "" : clubRecruitmentInformation.getIntroduction())
-                .description(clubRecruitmentInformation.getDescription() == null ? "" : clubRecruitmentInformation.getDescription())
-                .presidentName(clubRecruitmentInformation.getPresidentName() == null ? "" : clubRecruitmentInformation.getPresidentName())
-                .presidentPhoneNumber(clubRecruitmentInformation.getPresidentTelephoneNumber() == null ? "" : clubRecruitmentInformation.getPresidentTelephoneNumber())
-                .recruitmentPeriod(period)
-                .recruitmentTarget(clubRecruitmentInformation.getRecruitmentTarget() == null ? "" : clubRecruitmentInformation.getRecruitmentTarget())
-                .recruitmentStatus(clubRecruitmentInformation.getClubRecruitmentStatus() == null
-                        ? "" : clubRecruitmentInformation.getClubRecruitmentStatus().getDescription())
-                .recruitmentForm(clubRecruitmentInformation.getRecruitmentForm() == null ? "" : clubRecruitmentInformation.getRecruitmentForm())
-                .build();
+            .id(club.getId() == null ? "" : club.getId())
+            .name(club.getName() == null ? "" : club.getName())
+            .logo(clubRecruitmentInformation.getLogo() == null ? ""
+                : clubRecruitmentInformation.getLogo())
+            .tags(clubRecruitmentInformation.getTags() == null ? List.of()
+                : clubRecruitmentInformation.getTags())
+            .state(club.getState() == null ? "" : club.getState().getDesc())
+            .feeds(clubRecruitmentInformation.getFeedImages() == null ? List.of()
+                : clubRecruitmentInformation.getFeedImages())
+            .category(club.getCategory() == null ? "" : club.getCategory())
+            .division(club.getDivision() == null ? "" : club.getDivision())
+            .introduction(clubRecruitmentInformation.getIntroduction() == null ? ""
+                : clubRecruitmentInformation.getIntroduction())
+            .description(clubRecruitmentInformation.getDescription() == null ? ""
+                : clubRecruitmentInformation.getDescription())
+            .presidentName(clubRecruitmentInformation.getPresidentName() == null ? ""
+                : clubRecruitmentInformation.getPresidentName())
+            .presidentPhoneNumber(
+                clubRecruitmentInformation.getPresidentTelephoneNumber() == null ? ""
+                    : clubRecruitmentInformation.getPresidentTelephoneNumber())
+            .recruitmentPeriod(period)
+            .recruitmentTarget(clubRecruitmentInformation.getRecruitmentTarget() == null ? ""
+                : clubRecruitmentInformation.getRecruitmentTarget())
+            .recruitmentStatus(clubRecruitmentInformation.getClubRecruitmentStatus() == null
+                ? "" : clubRecruitmentInformation.getClubRecruitmentStatus().getDescription())
+            .socialLinks(club.getSocialLinks() == null ? null
+                : club.getSocialLinks())
+            .build();
     }
 
 }

--- a/backend/src/main/java/moadong/club/payload/request/ClubInfoRequest.java
+++ b/backend/src/main/java/moadong/club/payload/request/ClubInfoRequest.java
@@ -2,6 +2,7 @@ package moadong.club.payload.request;
 
 import jakarta.validation.constraints.NotBlank;
 import java.util.List;
+import java.util.Map;
 
 public record ClubInfoRequest(
     @NotBlank
@@ -16,7 +17,7 @@ public record ClubInfoRequest(
     String introduction,
     String presidentName,
     String presidentPhoneNumber,
-    String recruitmentForm
+    Map<String, String> socialLinks
 ) {
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#362 

## 📝 작업 내용
동아리 관리자는 동아리 관련 SNS 관련 링크를 제공할 수 있습니다.
- Club 엔티티에 socialLinks: Map<String, String> 필드 추가
- 동아리의 인스타그램, 페이스북 등 다양한 SNS 링크를 저장할 수 있도록 지원
- ClubInfoRequest에 socialLinks 필드 추가
- 클라이언트로부터 소셜 링크 데이터를 전달받을 수 있도록 요청 객체 수정
- Club.update() 메서드에 socialLinks 업데이트 로직 반영
- ClubDetailedResult DTO에 socialLinks 필드 추가 및 of() 메서드에 매핑 로직 적용
- 사용되지 않는 recruitmentForm 필드 제거 및 관련 코드 정리

## ⚠️ 주의사항
- ClubRecruitmentInformation의 recruitmentForm 필드를 삭제했으므로, 해당 필드를 사용하는 기존 클라이언트 코드가 있다면 에러가 발생할 수 있습니다. 배포 전 반드시 프론트엔드와 연동 여부를 확인해주세요.
- socialLinks는 Map<String, String> 타입이므로, 입력 데이터의 key-value 구조가 클라이언트와 사전 합의되어야 합니다. 예: {"instagram": "url", "youtube": "url"}.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 동아리 정보에 여러 소셜 링크를 저장할 수 있는 기능이 추가되었습니다.

- **변경 사항**
    - 기존에 단일 모집 양식(recruitmentForm) 필드가 여러 소셜 링크(socialLinks) 필드로 대체되었습니다.
    - 동아리 상세 정보 및 등록/수정 시 소셜 링크 정보를 입력 및 확인할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->