### PR TITLE
[fix] GlobalStyles에서 @import 제거 및 index.html로 폰트 이동

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -5,19 +5,15 @@
     <!-- 네이버 서치어드바이저 태그-->
     <meta
       name="naver-site-verification"
-      content="1923d7ecdc8a948e0678d367073acd93a9a48c6e"
-    />
+      content="1923d7ecdc8a948e0678d367073acd93a9a48c6e" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
-    />
-
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
     <title>Moadong</title>
     <meta
       name="description"
-      content="모아 동아리! 부경대학교 모든 동아리를 한눈에"
-    />
+      content="모아 동아리! 부경대학교 모든 동아리를 한눈에" />
     <link rel="canonical" href="https://www.moadong.com" />
     <!-- 파비콘 -->
     <link rel="icon" href="/favicon.ico" />
@@ -27,8 +23,7 @@
     <meta property="og:title" content="모아동" />
     <meta
       property="og:description"
-      content="모아 동아리! 부경대학교 모든 동아리를 한눈에!"
-    />
+      content="모아 동아리! 부경대학교 모든 동아리를 한눈에!" />
     <meta property="og:url" content="https://www.moadong.com" />
     <meta property="og:site_name" content="Moadong" />
     <meta property="og:image" content="https://www.moadong.com/og_image.png" />
@@ -39,21 +34,17 @@
     <meta name="twitter:card" content="summary" />
     <meta
       name="twitter:title"
-      content="모아 동아리! 부경대학교 모든 동아리를 한눈에!"
-    />
+      content="모아 동아리! 부경대학교 모든 동아리를 한눈에!" />
     <meta
       name="twitter:description"
-      content="부경대 동아리 정보를 한 곳에서 찾아보고, 새로운 동아리에 가입해 보세요!"
-    />
+      content="부경대 동아리 정보를 한 곳에서 찾아보고, 새로운 동아리에 가입해 보세요!" />
     <meta name="twitter:image" content="https://www.moadong.com/og_image.png" />
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css"
-    />
+      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" />
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Krona+One&display=swap"
-    />
+      href="https://fonts.googleapis.com/css2?family=Krona+One&display=swap" />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -5,16 +5,19 @@
     <!-- 네이버 서치어드바이저 태그-->
     <meta
       name="naver-site-verification"
-      content="1923d7ecdc8a948e0678d367073acd93a9a48c6e" />
+      content="1923d7ecdc8a948e0678d367073acd93a9a48c6e"
+    />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
+    />
 
     <title>Moadong</title>
     <meta
       name="description"
-      content="모아 동아리! 부경대학교 모든 동아리를 한눈에" />
+      content="모아 동아리! 부경대학교 모든 동아리를 한눈에"
+    />
     <link rel="canonical" href="https://www.moadong.com" />
     <!-- 파비콘 -->
     <link rel="icon" href="/favicon.ico" />
@@ -24,7 +27,8 @@
     <meta property="og:title" content="모아동" />
     <meta
       property="og:description"
-      content="모아 동아리! 부경대학교 모든 동아리를 한눈에!" />
+      content="모아 동아리! 부경대학교 모든 동아리를 한눈에!"
+    />
     <meta property="og:url" content="https://www.moadong.com" />
     <meta property="og:site_name" content="Moadong" />
     <meta property="og:image" content="https://www.moadong.com/og_image.png" />
@@ -35,11 +39,21 @@
     <meta name="twitter:card" content="summary" />
     <meta
       name="twitter:title"
-      content="모아 동아리! 부경대학교 모든 동아리를 한눈에!" />
+      content="모아 동아리! 부경대학교 모든 동아리를 한눈에!"
+    />
     <meta
       name="twitter:description"
-      content="부경대 동아리 정보를 한 곳에서 찾아보고, 새로운 동아리에 가입해 보세요!" />
+      content="부경대 동아리 정보를 한 곳에서 찾아보고, 새로운 동아리에 가입해 보세요!"
+    />
     <meta name="twitter:image" content="https://www.moadong.com/og_image.png" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Krona+One&display=swap"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/styles/Global.styles.ts
+++ b/frontend/src/styles/Global.styles.ts
@@ -1,8 +1,6 @@
 import { createGlobalStyle } from 'styled-components';
 
 const GlobalStyles = createGlobalStyle`
-  @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css');
-  @import url('https://fonts.googleapis.com/css2?family=Krona+One&display=swap');
   * {
     margin: 0;
     padding: 0;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #374 

## 📝작업 내용
<img width="1202" alt="스크린샷 2025-05-07 01 10 58" src="https://github.com/user-attachments/assets/fcc07caa-0fc8-4f69-bfae-8f90b77de29f" />

styled-components의 createGlobalStyle 내부에서 @import를 사용하는 경우
경고가 발생하므로, 외부 폰트 링크를 index.html로 이동하였습니다.


- Pretendard, Krona One 폰트를 link 태그로 대체
- 글로벌 스타일에서 @import 제거
## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - 외부 폰트(프리텐다드, Krona One) 스타일시트가 HTML에 추가되어 폰트 적용 방식이 변경되었습니다.
  - 글로벌 스타일에서 외부 폰트 import가 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->