### PR TITLE
[fix] ClubTag 컴포넌트의 중복 key 문제 해결

### DIFF
--- a/frontend/src/pages/ClubDetailPage/components/ClubProfile/ClubProfile.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubProfile/ClubProfile.tsx
@@ -25,13 +25,19 @@ const ClubProfile = ({
       <Styled.ClubInfo>
         <Styled.ClubName>{name}</Styled.ClubName>
         <Styled.TagContainer>
-          <ClubTag type={division}>{division}</ClubTag>
-          <ClubTag type={category}>{category}</ClubTag>
-          {tags.map((tag) => (
-            <ClubTag key={tag} type='자유'>
-              {tag}
-            </ClubTag>
-          ))}
+          <ClubTag key={`division-${name}`} type={division}>
+            {division}
+          </ClubTag>
+          <ClubTag key={`category-${name}`} type={category}>
+            {category}
+          </ClubTag>
+          {tags
+            .filter((tag) => tag.trim())
+            .map((tag) => (
+              <ClubTag key={`tag-${name}-${tag}`} type='자유'>
+                {tag}
+              </ClubTag>
+            ))}
         </Styled.TagContainer>
       </Styled.ClubInfo>
     </Styled.ClubContainer>

--- a/frontend/src/pages/MainPage/components/ClubCard/ClubCard.tsx
+++ b/frontend/src/pages/MainPage/components/ClubCard/ClubCard.tsx
@@ -40,13 +40,15 @@ const ClubCard = ({ club }: { club: Club }) => {
       </Styled.CardHeader>
       <Styled.Introduction>{club.introduction}</Styled.Introduction>
       <Styled.TagsContainer>
-        <ClubTag type={club.division} />
-        <ClubTag type={club.category} />
-        {club.tags.map((tag) => (
-          <ClubTag key={tag} type={'자유'}>
-            {tag}
-          </ClubTag>
-        ))}
+        <ClubTag key={`division-${club.id}`} type={club.division} />
+        <ClubTag key={`category-${club.id}`} type={club.category} />
+        {club.tags
+          .filter((tag) => tag.trim())
+          .map((tag) => (
+            <ClubTag key={`tag-${club.id}-${tag}`} type={'자유'}>
+              {tag}
+            </ClubTag>
+          ))}
       </Styled.TagsContainer>
     </Styled.CardContainer>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #378

## 📝작업 내용

### 문제 상황
- ClubTag 컴포넌트에서 중복된 key 값으로 인한 React 경고 발생
- 빈 문자열이 태그로 들어올 때 동일한 key가 생성되는 문제

### 해결 방법
1. ClubCard와 ClubProfile 컴포넌트에서 빈 태그 필터링
2. tag.trim()을 사용하여 공백만 있는 태그도 제거
3. 각 태그 타입별로 고유한 key 값 부여

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
빈 태그밖에 없는 카드는 나오지 않습니다. 어떻게 처리하면 좋을까요?

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 동아리 태그에서 공백이나 비어 있는 태그가 표시되지 않도록 개선되었습니다.
  - 태그 표시 시 고유한 키가 적용되어 태그 렌더링의 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->