### PR TITLE
[fix] 모바일 환경에서 배너 슬라이더 초기 렌더링 문제 해결

### DIFF
--- a/frontend/src/pages/MainPage/components/Banner/Banner.tsx
+++ b/frontend/src/pages/MainPage/components/Banner/Banner.tsx
@@ -17,23 +17,33 @@ const Banner = ({ desktopBanners, mobileBanners }: BannerComponentProps) => {
   const [isMobile, setIsMobile] = useState(window.innerWidth <= 500);
   const [currentSlideIndex, setCurrentSlideIndex] = useState(1);
   const [slideWidth, setSlideWidth] = useState(0);
-  const [isAnimating, setIsAnimating] = useState(true);
+  const [isAnimating, setIsAnimating] = useState(false);
   const [isTransitioning, setIsTransitioning] = useState(false);
+  const [isReady, setIsReady] = useState(false);
 
   const banners = isMobile ? mobileBanners : desktopBanners;
   const extendedBanners = [banners[banners.length - 1], ...banners, banners[0]];
 
   const updateSlideWidth = useCallback(() => {
     if (slideRef.current) {
-      setSlideWidth(slideRef.current.offsetWidth);
-      slideRef.current.style.transform = `translateX(-${currentSlideIndex * slideRef.current.offsetWidth}px)`;
+      const width = slideRef.current.offsetWidth;
+      setSlideWidth(width);
+      if (width > 0) {
+        slideRef.current.style.transform = `translateX(-${currentSlideIndex * width}px)`;
+        if (!isReady) {
+          setIsReady(true);
+          setIsAnimating(true);
+        }
+      }
     }
-  }, [currentSlideIndex]);
+  }, [currentSlideIndex, isReady]);
 
   useEffect(() => {
     updateSlideWidth();
     const handleResize = debounce(() => {
       setIsMobile(window.innerWidth <= 500);
+      setIsReady(false);
+      setIsAnimating(false);
       updateSlideWidth();
     }, 200);
 
@@ -44,7 +54,7 @@ const Banner = ({ desktopBanners, mobileBanners }: BannerComponentProps) => {
   }, [updateSlideWidth]);
 
   useEffect(() => {
-    if (!slideRef.current) return;
+    if (!slideRef.current || slideWidth === 0) return;
 
     if (isAnimating) {
       slideRef.current.style.transform = `translateX(-${currentSlideIndex * slideWidth}px)`;
@@ -77,27 +87,28 @@ const Banner = ({ desktopBanners, mobileBanners }: BannerComponentProps) => {
   }, [currentSlideIndex, slideWidth, banners.length, isAnimating]);
 
   const moveToNextSlide = useCallback(() => {
-    if (isTransitioning) return;
+    if (isTransitioning || !isReady) return;
     setIsTransitioning(true);
     setIsAnimating(true);
     setCurrentSlideIndex((prev) => prev + 1);
-  }, [isTransitioning]);
+  }, [isTransitioning, isReady]);
 
   const moveToPrevSlide = useCallback(() => {
-    if (isTransitioning) return;
+    if (isTransitioning || !isReady) return;
     setIsTransitioning(true);
     setIsAnimating(true);
     setCurrentSlideIndex((prev) => prev - 1);
-  }, [isTransitioning]);
+  }, [isTransitioning, isReady]);
 
   useEffect(() => {
-    if (slideWidth === 0) return;
+    if (slideWidth === 0 || !isReady) return;
+
     const interval = setInterval(() => {
       moveToNextSlide();
     }, 3000);
 
     return () => clearInterval(interval);
-  }, [moveToNextSlide, slideWidth]);
+  }, [moveToNextSlide, slideWidth, isReady]);
 
   return (
     <Styled.BannerContainer>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #380

## 📝작업 내용

### 문제 상황
- 모바일 버전에서 최초 렌더링 시 배너의 10분의 1정도가 왼쪽으로 넘어가 있는 현상이 있었습니다.

### 원인
- 이는 모바일에서 ```slideWidth``` 계산이 늦게 되어 발생하는 문제였습니다. 
- 그래서 리사이즈 시 상태 초기화 로직을 개선해봤습니다.

### 문제 해결
1. isReady 상태 추가로 초기화 완료 여부 추적
2. `slideWidth`가 계산되기 전에는 transform 적용 방지
3. 초기화 완료 후에만 슬라이드 애니메이션 시작
4. 리사이즈 시 상태 초기화 로직 개선

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 배너 컴포넌트가 완전히 준비되기 전에는 슬라이드 애니메이션과 전환이 발생하지 않도록 개선하여 초기 렌더링 및 창 크기 변경 시 발생할 수 있는 깜빡임이나 오류를 방지했습니다.  
- **스타일**
  - 슬라이드 전환 효과가 더욱 자연스럽게 동작하도록 애니메이션 타이밍이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->