### PR TITLE
[fix] PhotoList 리팩토링 및 잠재적 버그 대응 작업

### DIFF
--- a/frontend/src/hooks/PhotoList/useResponsiveLayout.ts
+++ b/frontend/src/hooks/PhotoList/useResponsiveLayout.ts
@@ -19,13 +19,10 @@ export const useResponsiveLayout = (
       }
     };
 
-    const handleResize = debounce(
-      () => () => {
-        updateIsMobile();
-        updateContainerWidth();
-      },
-      200,
-    );
+    const handleResize = debounce(() => {
+      updateIsMobile();
+      updateContainerWidth();
+    }, 200);
 
     handleResize();
     window.addEventListener('resize', handleResize);

--- a/frontend/src/pages/ClubDetailPage/components/PhotoList/PhotoList.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/PhotoList/PhotoList.tsx
@@ -52,10 +52,11 @@ const PhotoList = ({ feeds, sectionRefs, clubName }: PhotoListProps) => {
     <Styled.PhotoListContainer
       ref={(el) => {
         sectionRefs.current[INFOTABS_SCROLL_INDEX.PHOTO_LIST_TAB] = el;
-      }}>
+      }}
+    >
       <Styled.PhotoListTitle>활동 사진</Styled.PhotoListTitle>
 
-      <Styled.PhotoListWrapper>
+      <Styled.PhotoListWrapper ref={containerRef}>
         <Styled.PhotoList translateX={translateX} photoCount={photoUrls.length}>
           <PhotoCardList
             photoUrls={photoUrls}

--- a/frontend/src/pages/ClubDetailPage/components/PhotoList/PhotoModal/PhotoModal.styles.ts
+++ b/frontend/src/pages/ClubDetailPage/components/PhotoList/PhotoModal/PhotoModal.styles.ts
@@ -12,7 +12,10 @@ export const ModalOverlay = styled.div`
   z-index: 100;
   animation: fadeIn 0.2s ease-in-out;
   background-color: rgba(0, 0, 0, 0.7);
-  backdrop-filter: blur(4px);
++  @supports (backdrop-filter: blur(4px)) {
++    backdrop-filter: blur(4px);
++    background-color: rgba(0, 0, 0, 0.6);
++  }
 
   @keyframes fadeIn {
     from {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #389 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지/동영상 첨부 가능)
### 1. debounce 함수 사용 오류 수정
- `() => () => {}` 형태의 잘못된 함수 전달을 단일 콜백 함수로 수정
- resize 이벤트 발생 시 레이아웃 계산(`updateIsMobile`, `updateContainerWidth`)이 정상 작동하도록 복구

### 2. PhotoList 컴포넌트의 containerRef 누락 문제 해결
- `PhotoListWrapper`에 `ref={containerRef}`를 연결
- `useResponsiveLayout` 훅이 DOM 크기를 제대로 측정할 수 있도록 개선

### 3. ModalOverlay의 성능 최적화 및 점진적 향상 적용
- `backdrop-filter`를 `@supports`로 감싸 브라우저 지원 여부에 따라 처리
- 미지원 브라우저에서는 fallback 배경색만 적용되어 성능 저하 방지


## 🗂 변경된 파일

- `frontend/src/hooks/PhotoList/useResponsiveLayout.ts`
- `frontend/src/pages/ClubDetailPage/components/PhotoList/PhotoList.tsx`
- `frontend/src/pages/ClubDetailPage/components/PhotoList/PhotoModal/PhotoModal.styles.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - PhotoList 컴포넌트에서 ref 콜백 문법 오류를 수정하고, 컨테이너에 ref 속성을 추가하여 참조가 가능하도록 개선했습니다.
- **스타일**
  - PhotoModal의 오버레이 스타일이 브라우저의 `backdrop-filter` 지원 여부에 따라 동적으로 적용되도록 변경되었습니다. 지원 시 블러 효과와 투명도가 조정되고, 미지원 시 기존 배경색과 투명도가 유지됩니다.
- **리팩터**
  - 반응형 레이아웃 관련 resize 이벤트 핸들러의 디바운스 처리가 간결하게 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->