### PR TITLE
fix : 시간은 KST를 기준으로 활용

### DIFF
--- a/backend/src/main/java/moadong/club/entity/ClubMetric.java
+++ b/backend/src/main/java/moadong/club/entity/ClubMetric.java
@@ -3,6 +3,8 @@ package moadong.club.entity;
 import jakarta.persistence.Id;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -30,7 +32,7 @@ public class ClubMetric {
 
     @Builder
     public ClubMetric(String clubId, String ip) {
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime();
         this.clubId = clubId;
         this.ip = ip;
         this.inAt = now;
@@ -39,6 +41,6 @@ public class ClubMetric {
     }
 
     public void update() {
-        this.outAt = LocalDateTime.now();
+        this.outAt = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime();
     }
 }

--- a/backend/src/main/java/moadong/club/service/ClubMetricService.java
+++ b/backend/src/main/java/moadong/club/service/ClubMetricService.java
@@ -49,7 +49,7 @@ public class ClubMetricService {
     }
 
     public int[] getDailyActiveUserWitClub(String clubId) {
-        LocalDate now = ZonedDateTime.now(ZoneId.of("Aisa/Seoul")).toLocalDate();
+        LocalDate now = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDate();
         LocalDate from = now.minusDays(30);
         List<ClubMetric> metrics = clubMetricRepository.findByClubIdAndDateAfter(clubId, from);
 
@@ -65,7 +65,7 @@ public class ClubMetricService {
     }
 
     public int[] getWeeklyActiveUserWitClub(String clubId) {
-        LocalDate now = ZonedDateTime.now(ZoneId.of("Aisa/Seoul")).toLocalDate();
+        LocalDate now = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDate();
         LocalDate from = now.minusDays(84);
         List<ClubMetric> metrics = clubMetricRepository.findByClubIdAndDateAfter(clubId, from);
 
@@ -86,7 +86,7 @@ public class ClubMetricService {
     }
 
     public int[] getMonthlyActiveUserWitClub(String clubId) {
-        LocalDate now = ZonedDateTime.now(ZoneId.of("Aisa/Seoul")).toLocalDate();
+        LocalDate now = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDate();
         YearMonth currentMonth = YearMonth.from(now); // 현재 년-월
         YearMonth fromMonth = currentMonth.minusMonths(12); // 12개월 전
 
@@ -113,7 +113,7 @@ public class ClubMetricService {
             return Collections.emptyList();
         }
 
-        LocalDate now = ZonedDateTime.now(ZoneId.of("Aisa/Seoul")).toLocalDate();
+        LocalDate now = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDate();
         List<ClubMetric> todayMetrics = clubMetricRepository.findAllByDate(now);
         Map<String, Long> clubViewCount = todayMetrics.stream()
             .collect(Collectors.groupingBy(ClubMetric::getClubId, Collectors.counting()));
@@ -141,7 +141,7 @@ public class ClubMetricService {
             return new int[0];
         }
 
-        LocalDate today = ZonedDateTime.now(ZoneId.of("Aisa/Seoul")).toLocalDate();
+        LocalDate today = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDate();
         LocalDate fromDate = today.minusDays(n);
         List<ClubMetric> metrics = clubMetricRepository.findAllByDateAfter(fromDate);
 

--- a/backend/src/main/java/moadong/club/service/ClubMetricService.java
+++ b/backend/src/main/java/moadong/club/service/ClubMetricService.java
@@ -3,6 +3,8 @@ package moadong.club.service;
 import java.time.LocalDate;
 import java.time.Period;
 import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -28,7 +30,7 @@ public class ClubMetricService {
     private final ClubMetricRepository clubMetricRepository;
 
     public void patch(String clubId, String remoteAddr) {
-        LocalDate nowDate = LocalDate.now();
+        LocalDate nowDate = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDate();
         Optional<ClubMetric> optional = clubMetricRepository.findByClubIdAndIpAndDate(
             clubId, remoteAddr, nowDate);
 
@@ -47,7 +49,7 @@ public class ClubMetricService {
     }
 
     public int[] getDailyActiveUserWitClub(String clubId) {
-        LocalDate now = LocalDate.now();
+        LocalDate now = ZonedDateTime.now(ZoneId.of("Aisa/Seoul")).toLocalDate();
         LocalDate from = now.minusDays(30);
         List<ClubMetric> metrics = clubMetricRepository.findByClubIdAndDateAfter(clubId, from);
 
@@ -63,7 +65,7 @@ public class ClubMetricService {
     }
 
     public int[] getWeeklyActiveUserWitClub(String clubId) {
-        LocalDate now = LocalDate.now();
+        LocalDate now = ZonedDateTime.now(ZoneId.of("Aisa/Seoul")).toLocalDate();
         LocalDate from = now.minusDays(84);
         List<ClubMetric> metrics = clubMetricRepository.findByClubIdAndDateAfter(clubId, from);
 
@@ -84,7 +86,7 @@ public class ClubMetricService {
     }
 
     public int[] getMonthlyActiveUserWitClub(String clubId) {
-        LocalDate now = LocalDate.now();
+        LocalDate now = ZonedDateTime.now(ZoneId.of("Aisa/Seoul")).toLocalDate();
         YearMonth currentMonth = YearMonth.from(now); // 현재 년-월
         YearMonth fromMonth = currentMonth.minusMonths(12); // 12개월 전
 
@@ -111,7 +113,8 @@ public class ClubMetricService {
             return Collections.emptyList();
         }
 
-        List<ClubMetric> todayMetrics = clubMetricRepository.findAllByDate(LocalDate.now());
+        LocalDate now = ZonedDateTime.now(ZoneId.of("Aisa/Seoul")).toLocalDate();
+        List<ClubMetric> todayMetrics = clubMetricRepository.findAllByDate(now);
         Map<String, Long> clubViewCount = todayMetrics.stream()
             .collect(Collectors.groupingBy(ClubMetric::getClubId, Collectors.counting()));
         List<Map.Entry<String, Long>> sortedList = new ArrayList<>(clubViewCount.entrySet());
@@ -138,7 +141,7 @@ public class ClubMetricService {
             return new int[0];
         }
 
-        LocalDate today = LocalDate.now();
+        LocalDate today = ZonedDateTime.now(ZoneId.of("Aisa/Seoul")).toLocalDate();
         LocalDate fromDate = today.minusDays(n);
         List<ClubMetric> metrics = clubMetricRepository.findAllByDateAfter(fromDate);
 

--- a/backend/src/test/java/moadong/club/service/ClubMetricServiceTest.java
+++ b/backend/src/test/java/moadong/club/service/ClubMetricServiceTest.java
@@ -9,6 +9,8 @@ import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
 import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.temporal.ChronoField;
 import java.util.List;
 import java.util.Optional;
@@ -43,7 +45,7 @@ public class ClubMetricServiceTest {
         // given
         String clubId = "club-1";
         String ip = "192.168.0.1";
-        LocalDate today = LocalDate.now();
+        LocalDate today = ZonedDateTime.now(ZoneId.of("Aisa/Seoul")).toLocalDate();
 
         ClubMetric existingMetric = Mockito.mock(ClubMetric.class);
 
@@ -62,7 +64,7 @@ public class ClubMetricServiceTest {
     void 일일_활성_사용자수_검증() {
         // given
         String clubId = "club-1";
-        LocalDate now = LocalDate.now();
+        LocalDate now = ZonedDateTime.now(ZoneId.of("Aisa/Seoul")).toLocalDate();
 
         List<ClubMetric> metrics = List.of(
             MetricFixture.createClubMetric(now.minusDays(1)),
@@ -94,7 +96,7 @@ public class ClubMetricServiceTest {
     void 주간_활성_사용자수_검증() {
         // given
         String clubId = "club-1";
-        LocalDate now = LocalDate.now();
+        LocalDate now = ZonedDateTime.now(ZoneId.of("Aisa/Seoul")).toLocalDate();
         LocalDate thisWeekMonday = now.with(ChronoField.DAY_OF_WEEK, 1);
 
         List<ClubMetric> metrics = List.of(
@@ -126,7 +128,7 @@ public class ClubMetricServiceTest {
     void 월간_활성_사용자수_검증() {
         // given
         String clubId = "club-1";
-        LocalDate now = LocalDate.now();
+        LocalDate now = ZonedDateTime.now(ZoneId.of("Aisa/Seoul")).toLocalDate();
         YearMonth currentMonth = YearMonth.from(now);
 
         List<ClubMetric> metrics = List.of(
@@ -161,7 +163,7 @@ public class ClubMetricServiceTest {
         @Test
         void 일부_Club_정보가_누락되어도_null_포함하여_정상_동작() {
             // given
-            LocalDate today = LocalDate.now();
+            LocalDate today = ZonedDateTime.now(ZoneId.of("Aisa/Seoul")).toLocalDate();
 
             List<ClubMetric> metrics = List.of(
                 MetricFixture.createClubMetric("club1", today),
@@ -210,7 +212,7 @@ public class ClubMetricServiceTest {
         void ip_중복을_제거하여_카운트_한다() {
             // given
             int n = 3;
-            LocalDate today = LocalDate.now();
+            LocalDate today = ZonedDateTime.now(ZoneId.of("Aisa/Seoul")).toLocalDate();
 
             List<ClubMetric> metrics = List.of(
                 MetricFixture.createClubMetric(today.minusDays(0), "192.0.2.1"),

--- a/backend/src/test/java/moadong/club/service/ClubMetricServiceTest.java
+++ b/backend/src/test/java/moadong/club/service/ClubMetricServiceTest.java
@@ -45,7 +45,7 @@ public class ClubMetricServiceTest {
         // given
         String clubId = "club-1";
         String ip = "192.168.0.1";
-        LocalDate today = ZonedDateTime.now(ZoneId.of("Aisa/Seoul")).toLocalDate();
+        LocalDate today = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDate();
 
         ClubMetric existingMetric = Mockito.mock(ClubMetric.class);
 
@@ -64,7 +64,7 @@ public class ClubMetricServiceTest {
     void 일일_활성_사용자수_검증() {
         // given
         String clubId = "club-1";
-        LocalDate now = ZonedDateTime.now(ZoneId.of("Aisa/Seoul")).toLocalDate();
+        LocalDate now = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDate();
 
         List<ClubMetric> metrics = List.of(
             MetricFixture.createClubMetric(now.minusDays(1)),
@@ -96,7 +96,7 @@ public class ClubMetricServiceTest {
     void 주간_활성_사용자수_검증() {
         // given
         String clubId = "club-1";
-        LocalDate now = ZonedDateTime.now(ZoneId.of("Aisa/Seoul")).toLocalDate();
+        LocalDate now = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDate();
         LocalDate thisWeekMonday = now.with(ChronoField.DAY_OF_WEEK, 1);
 
         List<ClubMetric> metrics = List.of(
@@ -128,7 +128,7 @@ public class ClubMetricServiceTest {
     void 월간_활성_사용자수_검증() {
         // given
         String clubId = "club-1";
-        LocalDate now = ZonedDateTime.now(ZoneId.of("Aisa/Seoul")).toLocalDate();
+        LocalDate now = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDate();
         YearMonth currentMonth = YearMonth.from(now);
 
         List<ClubMetric> metrics = List.of(
@@ -163,7 +163,7 @@ public class ClubMetricServiceTest {
         @Test
         void 일부_Club_정보가_누락되어도_null_포함하여_정상_동작() {
             // given
-            LocalDate today = ZonedDateTime.now(ZoneId.of("Aisa/Seoul")).toLocalDate();
+            LocalDate today = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDate();
 
             List<ClubMetric> metrics = List.of(
                 MetricFixture.createClubMetric("club1", today),
@@ -212,7 +212,7 @@ public class ClubMetricServiceTest {
         void ip_중복을_제거하여_카운트_한다() {
             // given
             int n = 3;
-            LocalDate today = ZonedDateTime.now(ZoneId.of("Aisa/Seoul")).toLocalDate();
+            LocalDate today = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDate();
 
             List<ClubMetric> metrics = List.of(
                 MetricFixture.createClubMetric(today.minusDays(0), "192.0.2.1"),

--- a/backend/src/test/java/moadong/club/service/RecruitmentSchedulerTest.java
+++ b/backend/src/test/java/moadong/club/service/RecruitmentSchedulerTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.List;
@@ -67,13 +68,13 @@ public class RecruitmentSchedulerTest {
         void 모집_스케줄링_성공() {
             // given
             String clubId = "club-1";
-            ZoneId koreaZoneId = ZoneId.of("Asia/Seoul");
 
-            LocalDateTime startDate = LocalDateTime.now().plusDays(1);
+            ZoneId koreaZoneId = ZoneId.of("Asia/Seoul");
+            LocalDateTime now = ZonedDateTime.now(koreaZoneId).toLocalDateTime();
+            LocalDateTime startDate = now.plusDays(1);
             Instant expectedStartInstant = startDate.atZone(koreaZoneId).toInstant()
                 .truncatedTo(ChronoUnit.MILLIS);
-
-            LocalDateTime endDate = LocalDateTime.now().plusDays(2);
+            LocalDateTime endDate = now.plusDays(2);
             Instant expectedEndInstant = endDate.atZone(koreaZoneId).toInstant()
                 .truncatedTo(ChronoUnit.MILLIS);
 


### PR DESCRIPTION
## #️⃣연관된 이슈
- #393 

## 📝작업 내용
한국 시간대만을 사용하는 서비스임을 고려하여 한국 시간대만을 활용하도록 하면 되었기에 최소한의 리팩토링을 수행하였습니다.

```
LocalDate.now() -> ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDate();
```

위와 같이 변경하면 서버에서는 한국 시간대만을 사용하게 될 것이기 때문에 서버의 위치가 어디든 관계없이 정상동작합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
	- 서울(Asia/Seoul) 타임존을 명시적으로 사용하여 날짜 및 시간이 일관되게 처리됩니다.
- **테스트**
	- 테스트 코드에서 현재 날짜 및 시간 계산이 서울 타임존 기준으로 변경되어, 테스트 결과의 일관성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->