### PR TITLE
[feature] 동아리명은 믹스패널에 arguments로 전달

### DIFF
--- a/frontend/src/hooks/useTrackPageView.ts
+++ b/frontend/src/hooks/useTrackPageView.ts
@@ -1,33 +1,33 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 import mixpanel from 'mixpanel-browser';
 
-const useTrackPageView = (pageName: string) => {
+const useTrackPageView = (pageName: string, clubName?: string) => {
   const location = useLocation();
+  const isTracked = useRef(false);
+  const startTime = useRef(Date.now());
 
   useEffect(() => {
-    const startTime = Date.now();
-
-    // 페이지 방문 이벤트
     mixpanel.track(`${pageName} Visited`, {
       url: window.location.href,
       timestamp: startTime,
       referrer: document.referrer || 'direct',
+      clubName,
     });
 
     const trackPageDuration = () => {
-      const duration = Date.now() - startTime;
+      if (isTracked.current) return;
+      const duration = Date.now() - startTime.current;
       mixpanel.track(`${pageName} Duration`, {
         url: window.location.href,
-        duration: duration, // milliseconds
-        duration_seconds: Math.round(duration / 1000), // Convert to seconds
+        duration: duration,
+        duration_seconds: Math.round(duration / 1000),
+        clubName,
       });
+      isTracked.current = true;
     };
 
-    // 사용자가 페이지를 떠날 때 (페이지 종료 또는 새 페이지 이동)
     window.addEventListener('beforeunload', trackPageDuration);
-
-    // 사용자가 탭을 변경하거나 백그라운드로 이동할 때
     document.addEventListener('visibilitychange', () => {
       if (document.hidden) {
         trackPageDuration();
@@ -35,10 +35,11 @@ const useTrackPageView = (pageName: string) => {
     });
 
     return () => {
+      trackPageDuration();
       window.removeEventListener('beforeunload', trackPageDuration);
       document.removeEventListener('visibilitychange', trackPageDuration);
     };
-  }, [location.pathname]);
+  }, [location.pathname, clubName]);
 };
 
 export default useTrackPageView;

--- a/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
@@ -30,7 +30,7 @@ const ClubDetailPage = () => {
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
-  useTrackPageView(`ClubDetailPage ${clubDetail?.name || ''}`);
+  useTrackPageView(`ClubDetailPage visited`, clubDetail?.name);
 
   if (!clubDetail) {
     return null;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #397

## 📝작업 내용

### 동아리명이 전달되지 않는 문제 
- `useTrackPageView`에 clubName 전달
- `arguments`로 전달
```typescript
// clubDetailPage
  useTrackPageView(`ClubDetailPage visited`, clubDetail?.name);

// useTrackPageView
 mixpanel.track(`${pageName} Duration`, {
        url: window.location.href,
        duration: duration,
        duration_seconds: Math.round(duration / 1000),
        clubName,
      });
```
### 이벤트 속성 결과
<img width="349" alt="스크린샷 2025-05-13 17 32 30" src="https://github.com/user-attachments/assets/f8fda39b-2c92-4e2b-bcc6-1add5fec6780" />


### 언마운트 시에도 체류시간 계산

```typescript
return () => {
      trackPageDuration();
      window.removeEventListener('beforeunload', trackPageDuration);
      document.removeEventListener('visibilitychange', trackPageDuration);
    };
```
-  사용자가 다른 페이지로 이동하는 경우를 고려하여, 클린업 시에 유지시간을 계산하도록 했습니다. 

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 페이지 방문 추적 시 클럽 이름 정보를 추가로 기록합니다.
  - 페이지 방문 시간 측정이 더욱 정확해졌습니다.

- **버그 수정**
  - 페이지 종료 시 방문 시간 기록이 누락되는 문제를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->