### PR TITLE
[fix] SnsLinkIcons 컴포넌트에서 apiSocialLinks가 없을 경우 null 반환 추가

### DIFF
--- a/frontend/src/pages/ClubDetailPage/components/SnsLinkIcons/SnsLinkIcons.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/SnsLinkIcons/SnsLinkIcons.tsx
@@ -8,6 +8,7 @@ interface SnsLinkIconsProps {
 }
 
 const SnsLinkIcons = ({ apiSocialLinks }: SnsLinkIconsProps) => {
+  if (!apiSocialLinks) return null;
   return (
     <Styled.SnsIconGroup>
       {Object.entries(apiSocialLinks).map(([platform, url]) => {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #413 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지/동영상 첨부 가능)

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 소셜 링크 정보가 없을 때 아이콘이 잘못 표시되거나 오류가 발생하는 문제를 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->