### PR TITLE
[fix] Jest 테스트 시 SVG import 오류 해결

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   testEnvironment: 'jsdom',
   transform: {
     '^.+\\.tsx?$': ['ts-jest', {}],
+    '\\.(svg|png|jpg|jpeg|gif)$': 'jest-transform-stub',
   },
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -64,6 +64,7 @@
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "jest-fetch-mock": "^3.0.3",
+        "jest-transform-stub": "^2.0.0",
         "mini-css-extract-plugin": "^2.9.2",
         "path": "^0.12.7",
         "prettier": "^3.4.2",
@@ -12487,6 +12488,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/jest-transform-stub": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jest-transform-stub/-/jest-transform-stub-2.0.0.tgz",
+      "integrity": "sha512-lspHaCRx/mBbnm3h4uMMS3R5aZzMwyNpNIJLXj4cEsV0mIUtS4IjYJLSoyjRCtnxb6RIGJ4NL2quZzfIeNhbkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jest-util": {
       "version": "29.7.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -75,6 +75,7 @@
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "jest-fetch-mock": "^3.0.3",
+    "jest-transform-stub": "^2.0.0",
     "mini-css-extract-plugin": "^2.9.2",
     "path": "^0.12.7",
     "prettier": "^3.4.2",


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #421 (테스트 환경에서 이미지 파일 import 시 SyntaxError 발생)


## 📝 작업 내용

- `jest-transform-stub` 라이브러리 설치
- `jest.config.js`에 `.svg`, `.png` 등 이미지 파일에 대한 transform 설정 추가
- 테스트 시 이미지 import 관련 SyntaxError(`Unexpected token '<'`) 문제 해결


## ✅ 문제 상황

- `SNS_CONFIG` 객체에 플랫폼별 아이콘(SVG/PNG)을 import하여 사용하는 로직이 추가되면서 테스트 실행 시 다음과 같은 에러 발생

  ```ts
  SyntaxError: Unexpected token '<'
  ```
- 이는 Jest가 `.svg` 파일을 JS처럼 파싱하려다 실패한 문제로, 정적 파일에 대한 처리 설정이 누락된 상태였음

 ### 결론: Jest는 기본적으로 JS/TS만 이해하고, .svg, .png, .css 등 정적 자원은 이해 못 함
그래서 해결 방법은 이런 정적 파일들을 모두 가짜(mock) 파일로 치환하거나 특정 도구 (jest-transform-stub)로 처리 규칙을 명시해줘야함




## 🛠️ 해결 결과

- `jest-transform-stub`을 도입하여 `.svg`, `.png` 등 정적 에셋을 mock 처리 - 쉽게 말하면 이미지를 문자열로 대체!!
- Jest 설정 파일(`jest.config.js`)에 이미지 파일을 위한 `transform` 항목 추가


## 🫡 참고사항

- [`jest-transform-stub` npm 페이지](https://www.npmjs.com/package/jest-transform-stub)
- [Jest 공식 문서 - Code Transformation](https://jestjs.io/docs/code-transformation)
