### PR TITLE
[feature] cloudflare 이미지 저장 기능 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -57,6 +57,11 @@ dependencies {
 	implementation platform('software.amazon.awssdk:bom:2.25.8') // 최신 BOM 관리
 	implementation 'software.amazon.awssdk:s3'
 	implementation 'software.amazon.awssdk:auth'
+
+	// resize tool
+	implementation 'net.coobird:thumbnailator:0.4.14'
+	implementation 'org.springframework:spring-test'
+
 }
 
 //전체 테스트

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -52,6 +52,11 @@ dependencies {
 	implementation 'com.google.api-client:google-api-client:2.0.0'
 	implementation 'com.google.oauth-client:google-oauth-client-jetty:1.34.1'
 	implementation 'com.google.apis:google-api-services-drive:v3-rev20220815-2.0.0'
+
+	// S3
+	implementation platform('software.amazon.awssdk:bom:2.25.8') // 최신 BOM 관리
+	implementation 'software.amazon.awssdk:s3'
+	implementation 'software.amazon.awssdk:auth'
 }
 
 //전체 테스트

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -54,7 +54,7 @@ dependencies {
 	implementation 'com.google.apis:google-api-services-drive:v3-rev20220815-2.0.0'
 
 	// S3
-	implementation platform('software.amazon.awssdk:bom:2.25.8') // 최신 BOM 관리
+	implementation platform('software.amazon.awssdk:bom:2.25.8')
 	implementation 'software.amazon.awssdk:s3'
 	implementation 'software.amazon.awssdk:auth'
 

--- a/backend/src/main/java/moadong/global/exception/ErrorCode.java
+++ b/backend/src/main/java/moadong/global/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     IMAGE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "601-4", "이미지 삭제에 실패하였습니다"),
     KOREAN_FILE_NAME(HttpStatus.INTERNAL_SERVER_ERROR, "601-5", "파일명의 한국어를 인코딩할 수 없습니다."),
     FILE_TRANSFER_ERROR(HttpStatus.BAD_REQUEST, "601-6", "파일을 올바른 형식으로 변경할 수 없습니다."),
+    UNSUPPORTED_FILE_TYPE(HttpStatus.BAD_REQUEST, "601-7", "파일의 확장자가 올바르지 않습니다."),
     USER_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "700-1","이미 존재하는 계정입니다."),
     USER_NOT_EXIST(HttpStatus.BAD_REQUEST, "700-2","존재하지 않는 계정입니다."),
     USER_INVALID_FORMAT(HttpStatus.BAD_REQUEST, "700-3","올바르지 않은 유저 형식입니다."),

--- a/backend/src/main/java/moadong/media/controller/CloudflareImageController.java
+++ b/backend/src/main/java/moadong/media/controller/CloudflareImageController.java
@@ -20,41 +20,42 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
-@RequestMapping("/api/club")
+@RequestMapping("/api/club/cloudflare")
 @Tag(name = "ClubImage", description = "클럽 이미지 관련 API")
 @PreAuthorize("isAuthenticated()")
 @SecurityRequirement(name = "BearerAuth")
-public class ClubImageController {
+public class CloudflareImageController {
 
-    public ClubImageController(@Qualifier("googleDrive") ClubImageService clubImageService) {
+    public CloudflareImageController(@Qualifier("cloudflare") ClubImageService clubImageService) {
         this.clubImageService = clubImageService;
     }
 
+    @Qualifier("cloudflare")
     private final ClubImageService clubImageService;
 
     @PostMapping(value = "/{clubId}/logo", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @Operation(summary = "로고 이미지 업데이트", description = "로고 이미지를 업데이트합니다.")
+    @Operation(summary = "로고 이미지 업데이트", description = "cloudflare 상에 로고 이미지를 업데이트합니다.")
     public ResponseEntity<?> uploadLogo(@PathVariable String clubId,
-        @RequestPart("logo") MultipartFile file) {
+                                        @RequestPart("logo") MultipartFile file) {
         String fileUrl = clubImageService.uploadLogo(clubId, file);
         return Response.ok(fileUrl);
     }
 
     @DeleteMapping(value = "/{clubId}/logo")
-    @Operation(summary = "로고 이미지 삭제", description = "로고 이미지를 저장소에서 삭제합니다.")
+    @Operation(summary = "로고 이미지 삭제", description = "cloudflare 상에 로고 이미지를 저장소에서 삭제합니다.")
     public ResponseEntity<?> deleteLogo(@PathVariable String clubId) {
         clubImageService.deleteLogo(clubId);
         return Response.ok("success delete logo");
     }
 
     @PostMapping(value = "/{clubId}/feed", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @Operation(summary = "피드 이미지 업로드", description = "피드에 사용할 이미지를 업로드하고 주소를 반환받습니다.")
+    @Operation(summary = "피드 이미지 업로드", description = "cloudflare 상에 피드에 사용할 이미지를 업로드하고 주소를 반환받습니다.")
     public ResponseEntity<?> uploadFeed(@PathVariable String clubId, @RequestPart("feed") MultipartFile file) {
         return Response.ok(clubImageService.uploadFeed(clubId, file));
     }
 
     @PostMapping(value = "/{clubId}/feeds")
-    @Operation(summary = "저장된 피드 이미지 업데이트(순서, 삭제 등..)", description = "피드 이미지의 설정을 업데이트 합니다.")
+    @Operation(summary = "저장된 피드 이미지 업데이트(순서, 삭제 등..)", description = "cloudflare 상에 피드 이미지의 설정을 업데이트 합니다.")
     public ResponseEntity<?> putFeeds(@PathVariable String clubId, @RequestBody FeedUpdateRequest feeds) {
         clubImageService.updateFeeds(clubId, feeds.feeds());
         return Response.ok("success put feeds");

--- a/backend/src/main/java/moadong/media/service/CloudflareImageService.java
+++ b/backend/src/main/java/moadong/media/service/CloudflareImageService.java
@@ -1,0 +1,156 @@
+package moadong.media.service;
+
+import static moadong.media.util.ClubImageUtil.containsKoreanOrBlank;
+
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import moadong.club.entity.Club;
+import moadong.club.repository.ClubRepository;
+import moadong.global.exception.ErrorCode;
+import moadong.global.exception.RestApiException;
+import moadong.global.util.ObjectIdConverter;
+import moadong.global.util.RandomStringUtil;
+import moadong.media.domain.FileType;
+import org.bson.types.ObjectId;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Service("cloudflare")
+@RequiredArgsConstructor
+public class CloudflareImageService implements ClubImageService{
+
+    private final ClubRepository clubRepository;
+
+    private final S3Client s3Client;
+
+    @Value("${server.feed.max-count}")
+    private int MAX_FEED_COUNT;
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+    @Value("${cloud.aws.s3.view-endpoint}")
+    private String viewEndpoint;
+
+    @Override
+    public String uploadLogo(String clubId, MultipartFile file) {
+        Club club = getClub(clubId);
+
+        if (club.getClubRecruitmentInformation().getLogo() != null) {
+            deleteFile(club, club.getClubRecruitmentInformation().getLogo());
+        }
+
+        String filePath = uploadFile(clubId, file, FileType.LOGO);
+        club.updateLogo(filePath);
+        clubRepository.save(club);
+        return filePath;
+    }
+
+    @Override
+    public void deleteLogo(String clubId) {
+        Club club = getClub(clubId);
+
+        if (club.getClubRecruitmentInformation().getLogo() != null) {
+            deleteFile(club, club.getClubRecruitmentInformation().getLogo());
+        }
+        club.updateLogo(null);
+        clubRepository.save(club);
+    }
+
+    @Override
+    public String uploadFeed(String clubId, MultipartFile file) {
+        int feedImagesCount = getClub(clubId).getClubRecruitmentInformation().getFeedImages().size();
+
+        if (feedImagesCount + 1 > MAX_FEED_COUNT) {
+            throw new RestApiException(ErrorCode.TOO_MANY_FILES);
+        }
+        return uploadFile(clubId, file, FileType.FEED);
+    }
+
+    @Override
+    public void updateFeeds(String clubId, List<String> newFeedImageList) {
+        Club club = getClub(clubId);
+
+        if (newFeedImageList.size() > MAX_FEED_COUNT) {
+            throw new RestApiException(ErrorCode.TOO_MANY_FILES);
+        }
+
+        List<String> feedImages = club.getClubRecruitmentInformation().getFeedImages();
+        if (feedImages != null  && !feedImages.isEmpty()) {
+            deleteFeedImages(club, feedImages, newFeedImageList);
+        }
+        club.updateFeedImages(newFeedImageList);
+        clubRepository.save(club);
+
+    }
+
+    private Club getClub(String clubId) {
+        ObjectId objectId = ObjectIdConverter.convertString(clubId);
+        return clubRepository.findClubById(objectId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.CLUB_NOT_FOUND));
+    }
+
+    private void deleteFeedImages(Club club, List<String> feedImages, List<String> newFeedImages) {
+        for (String feedsImage : feedImages) {
+            if (!newFeedImages.contains(feedsImage)) {
+                deleteFile(club, feedsImage);
+            }
+        }
+    }
+
+    @Override
+    public void deleteFile(Club club, String filePath) {
+        // https://pub-8655aea549d544239ad12d0385aa98aa.r2.dev/{key} -> {key}
+        String key = filePath.substring(viewEndpoint.length()+1);
+
+        DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .build();
+
+        s3Client.deleteObject(deleteRequest);
+    }
+
+    private String uploadFile(String clubId, MultipartFile file, FileType fileType) {
+        if (file == null || file.isEmpty()) {
+            throw new RestApiException(ErrorCode.FILE_NOT_FOUND);
+        }
+
+        // 파일명 처리
+        String fileName = file.getOriginalFilename();
+        if (containsKoreanOrBlank(fileName)) {
+            fileName = RandomStringUtil.generateRandomString(10);
+        }
+
+        // S3에 저장할 key 경로 생성
+        String key = clubId + "/" + fileType + "/" + fileName;
+
+        // S3 업로드 요청
+        try {
+            PutObjectRequest putRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .contentType(file.getContentType())
+                    .acl(ObjectCannedACL.PUBLIC_READ)  // 공개 URL 용도
+                    .build();
+
+            s3Client.putObject(putRequest, RequestBody.fromInputStream(
+                    file.getInputStream(),
+                    file.getSize()
+            ));
+
+        } catch (IOException e) {
+            throw new RestApiException(ErrorCode.FILE_TRANSFER_ERROR);
+        } catch (Exception e) {
+            throw new RestApiException(ErrorCode.IMAGE_UPLOAD_FAILED);
+        }
+
+        // 공유 가능한 공개 URL 반환
+        return viewEndpoint + "/" + key;
+    }
+}

--- a/backend/src/main/java/moadong/media/service/GcsClubImageService.java
+++ b/backend/src/main/java/moadong/media/service/GcsClubImageService.java
@@ -1,6 +1,6 @@
 package moadong.media.service;
 
-import static moadong.media.util.ClubImageUtil.containsKoreanOrBlank;
+import static moadong.media.util.ClubImageUtil.containsInvalidChars;
 
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
@@ -140,7 +140,7 @@ public class GcsClubImageService implements ClubImageService {
         String originalFileName = file.getOriginalFilename();
         String contentType = file.getContentType().split("/")[1];
 
-        if (containsKoreanOrBlank(originalFileName)) {
+        if (containsInvalidChars(originalFileName)) {
             originalFileName = RandomStringUtil.generateRandomString(10) + "." + contentType;
         }
 

--- a/backend/src/main/java/moadong/media/service/GcsClubImageService.java
+++ b/backend/src/main/java/moadong/media/service/GcsClubImageService.java
@@ -1,6 +1,6 @@
 package moadong.media.service;
 
-import static moadong.media.util.ClubImageUtil.containsKorean;
+import static moadong.media.util.ClubImageUtil.containsKoreanOrBlank;
 
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
@@ -16,7 +16,6 @@ import moadong.global.util.RandomStringUtil;
 import moadong.media.domain.FileType;
 import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 //@Service
@@ -141,7 +140,7 @@ public class GcsClubImageService implements ClubImageService {
         String originalFileName = file.getOriginalFilename();
         String contentType = file.getContentType().split("/")[1];
 
-        if (containsKorean(originalFileName)) {
+        if (containsKoreanOrBlank(originalFileName)) {
             originalFileName = RandomStringUtil.generateRandomString(10) + "." + contentType;
         }
 

--- a/backend/src/main/java/moadong/media/service/GoogleDriveClubImageService.java
+++ b/backend/src/main/java/moadong/media/service/GoogleDriveClubImageService.java
@@ -1,6 +1,6 @@
 package moadong.media.service;
 
-import static moadong.media.util.ClubImageUtil.containsKoreanOrBlank;
+import static moadong.media.util.ClubImageUtil.containsInvalidChars;
 
 import com.google.api.client.http.FileContent;
 import com.google.api.services.drive.Drive;
@@ -135,7 +135,7 @@ public class GoogleDriveClubImageService implements ClubImageService {
         // 메타데이터 생성
         File fileMetadata = new File();
         String fileName = file.getOriginalFilename();
-        if (containsKoreanOrBlank(fileName)) {
+        if (containsInvalidChars(fileName)) {
             fileName = RandomStringUtil.generateRandomString(10);
         }
 

--- a/backend/src/main/java/moadong/media/service/GoogleDriveClubImageService.java
+++ b/backend/src/main/java/moadong/media/service/GoogleDriveClubImageService.java
@@ -1,6 +1,6 @@
 package moadong.media.service;
 
-import static moadong.media.util.ClubImageUtil.containsKorean;
+import static moadong.media.util.ClubImageUtil.containsKoreanOrBlank;
 
 import com.google.api.client.http.FileContent;
 import com.google.api.services.drive.Drive;
@@ -22,7 +22,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-@Service
+@Service("googleDrive")
 @RequiredArgsConstructor
 public class GoogleDriveClubImageService implements ClubImageService {
 
@@ -135,7 +135,7 @@ public class GoogleDriveClubImageService implements ClubImageService {
         // 메타데이터 생성
         File fileMetadata = new File();
         String fileName = file.getOriginalFilename();
-        if (containsKorean(fileName)) {
+        if (containsKoreanOrBlank(fileName)) {
             fileName = RandomStringUtil.generateRandomString(10);
         }
 

--- a/backend/src/main/java/moadong/media/util/ClubImageUtil.java
+++ b/backend/src/main/java/moadong/media/util/ClubImageUtil.java
@@ -34,7 +34,6 @@ public class ClubImageUtil {
 
         while (true) {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
             Thumbnails.of(file.getInputStream())
                     .size(maxDim, maxDim)
                     .outputQuality(quality)
@@ -43,14 +42,11 @@ public class ClubImageUtil {
 
             result = baos.toByteArray();
 
-
             if (result.length <= maxSizeBytes || (quality <= 0.3 && maxDim <= 800)) {
                 break;
             }
-
             quality -= 0.1;
             maxDim -= 200;
-
             file = new MockMultipartFile(file.getName(), file.getOriginalFilename(),
                     file.getContentType(), new ByteArrayInputStream(file.getBytes()));
         }

--- a/backend/src/main/java/moadong/media/util/ClubImageUtil.java
+++ b/backend/src/main/java/moadong/media/util/ClubImageUtil.java
@@ -1,12 +1,66 @@
 package moadong.media.util;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.text.Normalizer;
+import java.util.Set;
 import java.util.regex.Pattern;
+import net.coobird.thumbnailator.Thumbnails;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
 
 public class ClubImageUtil {
 
-    public static boolean containsKoreanOrBlank(String text) {
+    private static final Set<String> ALLOWED_IMAGE_EXTENSIONS = Set.of("jpg", "jpeg", "png", "gif", "bmp", "webp");
+
+    public static boolean containsInvalidChars(String text) {
         text = Normalizer.normalize(text, Normalizer.Form.NFC);
-        return Pattern.matches(".*([ㄱ-ㅎㅏ-ㅣ가-힣]|\\s)+.*", text);
+        return Pattern.matches(".*(%[0-9A-Fa-f]{2}|[ㄱ-ㅎㅏ-ㅣ가-힣]|\\s).*", text);
     }
+
+    public static boolean isImageExtension(String originalFilename) {
+        if (originalFilename == null || !originalFilename.contains(".")) {
+            return false;
+        }
+        String extension = originalFilename.substring(originalFilename.lastIndexOf(".") + 1).toLowerCase();
+        return ALLOWED_IMAGE_EXTENSIONS.contains(extension);
+    }
+
+    public static MultipartFile resizeImage(MultipartFile file, long maxSizeBytes) throws IOException {
+        double quality = 0.9;
+        int maxDim = 2000;
+        byte[] result;
+
+        while (true) {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+            Thumbnails.of(file.getInputStream())
+                    .size(maxDim, maxDim)
+                    .outputQuality(quality)
+                    .outputFormat("jpg") // 용량 줄이기 좋음
+                    .toOutputStream(baos);
+
+            result = baos.toByteArray();
+
+
+            if (result.length <= maxSizeBytes || (quality <= 0.3 && maxDim <= 800)) {
+                break;
+            }
+
+            quality -= 0.1;
+            maxDim -= 200;
+
+            file = new MockMultipartFile(file.getName(), file.getOriginalFilename(),
+                    file.getContentType(), new ByteArrayInputStream(file.getBytes()));
+        }
+
+        return new MockMultipartFile(
+                file.getName(),
+                file.getOriginalFilename(),
+                "image/jpeg",
+                new ByteArrayInputStream(result)
+        );
+    }
+
 }

--- a/backend/src/main/java/moadong/media/util/ClubImageUtil.java
+++ b/backend/src/main/java/moadong/media/util/ClubImageUtil.java
@@ -5,8 +5,8 @@ import java.util.regex.Pattern;
 
 public class ClubImageUtil {
 
-    public static boolean containsKorean(String text) {
+    public static boolean containsKoreanOrBlank(String text) {
         text = Normalizer.normalize(text, Normalizer.Form.NFC);
-        return Pattern.matches(".*[ㄱ-ㅎㅏ-ㅣ가-힣]+.*", text);
+        return Pattern.matches(".*([ㄱ-ㅎㅏ-ㅣ가-힣]|\\s)+.*", text);
     }
 }

--- a/backend/src/main/java/moadong/media/util/S3Config.java
+++ b/backend/src/main/java/moadong/media/util/S3Config.java
@@ -1,0 +1,40 @@
+package moadong.media.util;
+
+import com.google.storage.v2.ListBucketsResponse;
+import jakarta.annotation.PostConstruct;
+import java.net.URI;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.s3.endpoint}")
+    private String endpoint;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
+                .endpointOverride(URI.create(endpoint))
+                .region(Region.US_EAST_1) // Region은 아무거나 넣어도 되지만 필수
+                .serviceConfiguration(S3Configuration.builder()
+                        .pathStyleAccessEnabled(true) // Cloudflare R2에서 필수
+                        .build())
+                .build();
+    }
+
+}
+

--- a/backend/src/test/java/moadong/media/service/GoogleDriveClubImageServiceFeedTest.java
+++ b/backend/src/test/java/moadong/media/service/GoogleDriveClubImageServiceFeedTest.java
@@ -17,6 +17,7 @@ import moadong.club.entity.ClubRecruitmentInformation;
 import moadong.club.repository.ClubRepository;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
+import moadong.util.annotations.UnitTest;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 @ExtendWith(MockitoExtension.class)
+@UnitTest
 class GoogleDriveClubImageServiceFeedTest {
 
     @Spy

--- a/backend/src/test/java/moadong/media/service/GoogleDriveClubImageServiceLogoTest.java
+++ b/backend/src/test/java/moadong/media/service/GoogleDriveClubImageServiceLogoTest.java
@@ -35,7 +35,6 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
 @ExtendWith(MockitoExtension.class)
-@UnitTest
 class GoogleDriveClubImageServiceLogoTest {
 
     @Spy

--- a/backend/src/test/java/moadong/media/service/GoogleDriveClubImageServiceLogoTest.java
+++ b/backend/src/test/java/moadong/media/service/GoogleDriveClubImageServiceLogoTest.java
@@ -1,8 +1,10 @@
 package moadong.media.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
@@ -18,6 +20,8 @@ import moadong.club.repository.ClubRepository;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
 import moadong.media.domain.FileType;
+import moadong.media.util.ClubImageUtil;
+import moadong.util.annotations.UnitTest;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,6 +35,7 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
 @ExtendWith(MockitoExtension.class)
+@UnitTest
 class GoogleDriveClubImageServiceLogoTest {
 
     @Spy
@@ -123,5 +128,25 @@ class GoogleDriveClubImageServiceLogoTest {
         RestApiException exception = assertThrows(RestApiException.class,
                 () -> clubImageService.deleteLogo(objectId.toHexString()));
         assertEquals(ErrorCode.CLUB_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    void 파일명에_적절하지않은_기호나_한글이_포함되어있으면_true를_반환한다(){
+        // 정상 케이스
+        assertFalse(ClubImageUtil.containsInvalidChars("normal-file.jpg"));
+
+        // 한글 포함
+        assertTrue(ClubImageUtil.containsInvalidChars("file 이름.png"));
+
+        // 퍼센트 인코딩 포함
+        assertTrue(ClubImageUtil.containsInvalidChars("file%20name.png"));
+        assertTrue(ClubImageUtil.containsInvalidChars("%3Ahidden.jpg"));
+
+        // 공백 포함
+        assertTrue(ClubImageUtil.containsInvalidChars("file name.png"));
+        assertTrue(ClubImageUtil.containsInvalidChars(" tab\tname.png"));
+
+        // 여러 조건 섞인 경우
+        assertTrue(ClubImageUtil.containsInvalidChars("%22한글 space.png"));
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #424

## 📝작업 내용

> cloudflare 이미지 업로드 기능을 구현했습니다
저장소가 s3랑 연결되어있어서 S3 sdk를 통해서 구현할 수 있다는 장점 있답니다~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 클럽 이미지를 Cloudflare에 업로드, 삭제 및 피드 이미지 관리가 가능한 REST API가 추가되었습니다.
    - Cloudflare(R2) 연동을 위한 AWS S3 클라이언트 설정 및 서비스가 도입되었습니다.
    - 이미지 크기 조절, 확장자 검증 기능과 최대 피드 이미지 개수 제한이 추가되어 업로드 이미지 품질과 용량 관리가 강화되었습니다.

- **버그 수정**
    - 파일명에 한글, 공백, 퍼센트 인코딩 등의 부적절한 문자가 포함된 경우 무작위 문자열로 대체하는 로직이 개선되었습니다.

- **리팩터**
    - Google Drive 이미지 서비스 및 컨트롤러의 의존성 주입 방식이 명확히 지정되었습니다.

- **기타**
    - AWS S3 연동 라이브러리 및 빌드 설정이 추가되었습니다.
    - S3 클라이언트에 경로 스타일 액세스가 활성화되어 Cloudflare R2 호환성이 향상되었습니다.
    - 파일 확장자 유효성 검사 및 이미지 리사이징 유틸리티가 도입되었습니다.
    - 신규 에러 코드(지원하지 않는 파일 형식)가 추가되었습니다.
    - 관련 유닛 테스트가 추가되어 파일명 유효성 검사 기능이 검증되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->