### PR TITLE
[feature] 통합테스트 및 몽고디비 컨테이너 테스트 준비

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -52,6 +52,8 @@ dependencies {
 	implementation 'com.google.api-client:google-api-client:2.0.0'
 	implementation 'com.google.oauth-client:google-oauth-client-jetty:1.34.1'
 	implementation 'com.google.apis:google-api-services-drive:v3-rev20220815-2.0.0'
+	testImplementation 'org.testcontainers:testcontainers'
+	testImplementation 'org.testcontainers:mongodb:1.19.0'
 }
 
 //전체 테스트

--- a/backend/src/test/java/moadong/unit/db/MongoTest.java
+++ b/backend/src/test/java/moadong/unit/db/MongoTest.java
@@ -1,0 +1,31 @@
+package moadong.unit.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+import moadong.club.entity.Club;
+import moadong.club.repository.ClubRepository;
+import moadong.util.annotations.IntegrationTest;
+import moadong.util.annotations.MongoTestContainerSupport;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@IntegrationTest
+public class MongoTest extends MongoTestContainerSupport {
+
+    @Autowired
+    private ClubRepository clubRepository;
+
+    @Test
+    public void testMongoDBConnection() {
+
+        assertNotNull(clubRepository);
+
+        Club club = new Club();
+        clubRepository.save(club);
+        List<Club> all = clubRepository.findAll();
+        assertEquals( 1, all.size());
+        assertEquals( club.getId(), all.get(0).getId());
+    }
+}

--- a/backend/src/test/java/moadong/unit/media/GoogleDriveClubImageServiceFeedTest.java
+++ b/backend/src/test/java/moadong/unit/media/GoogleDriveClubImageServiceFeedTest.java
@@ -1,4 +1,4 @@
-package moadong.media.service;
+package moadong.unit.media;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
@@ -17,6 +17,8 @@ import moadong.club.entity.ClubRecruitmentInformation;
 import moadong.club.repository.ClubRepository;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
+import moadong.media.service.GoogleDriveClubImageService;
+import moadong.util.annotations.UnitTest;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,12 +27,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 @ExtendWith(MockitoExtension.class)
+@UnitTest
 class GoogleDriveClubImageServiceFeedTest {
 
     @Spy

--- a/backend/src/test/java/moadong/unit/media/GoogleDriveClubImageServiceLogoTest.java
+++ b/backend/src/test/java/moadong/unit/media/GoogleDriveClubImageServiceLogoTest.java
@@ -1,23 +1,20 @@
-package moadong.media.service;
+package moadong.unit.media;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import com.google.api.services.drive.Drive;
-import java.lang.reflect.Method;
 import java.util.Optional;
 import moadong.club.entity.Club;
 import moadong.club.entity.ClubRecruitmentInformation;
 import moadong.club.repository.ClubRepository;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
-import moadong.media.domain.FileType;
+import moadong.media.service.GoogleDriveClubImageService;
+import moadong.util.annotations.UnitTest;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,11 +23,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
 @ExtendWith(MockitoExtension.class)
+@UnitTest
 class GoogleDriveClubImageServiceLogoTest {
 
     @Spy

--- a/backend/src/test/java/moadong/util/annotations/MongoTestContainerSupport.java
+++ b/backend/src/test/java/moadong/util/annotations/MongoTestContainerSupport.java
@@ -1,0 +1,24 @@
+package moadong.util.annotations;
+
+import java.time.Duration;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class MongoTestContainerSupport {
+
+    static MongoDBContainer mongoDBContainer = new MongoDBContainer(DockerImageName.parse("mongo:6.0"))
+            .withStartupTimeout(Duration.ofSeconds(60));
+
+    static {
+        mongoDBContainer.start();
+    }
+
+    @DynamicPropertySource
+    static void mongoProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #396 

## 📝작업 내용

> 통합테스트 및 몽고디비 컨테이너 테스트 준비 완료했습니다.
1. 도커 실행
2. @IntegrationTest어노테이션 추가
3. 몽고디비 테스트의 경우 MongoTestContainerSupport 추상클래스 상속
<img width="570" alt="image" src="https://github.com/user-attachments/assets/7f11d179-b3ca-43b4-9dd7-288d1d291bf6" />