### PR TITLE
[fix] FE-119 SNS 링크 입력 기능 임시 비활성화

### DIFF
--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTab.styles.ts
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTab.styles.ts
@@ -10,7 +10,7 @@ export const InfoTitle = styled.h2`
   font-size: 1.5rem;
   font-weight: bold;
   letter-spacing: 0;
-  margin-bottom: 46px;
+  margin-bottom: 30px;
 `;
 
 export const InfoGroup = styled.div`

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTab.tsx
@@ -183,31 +183,31 @@ const ClubInfoEditTab = () => {
         <MakeTags value={clubTags} onChange={setClubTags} />
       </Styled.TagEditGroup>
 
-      <Styled.InfoTitle>동아리 SNS 링크</Styled.InfoTitle>
-      <p>현재 준비 중인 기능입니다. 조금만 기다려 주세요!</p>
-      <Styled.SNSInputGroup>
-        {Object.entries(SNS_CONFIG).map(([rawKey, { label, placeholder }]) => {
-          const key = rawKey as SNSPlatform;
+      {/*<Styled.InfoTitle>동아리 SNS 링크</Styled.InfoTitle>*/}
+      {/*<p>현재 준비 중인 기능입니다. 조금만 기다려 주세요!</p>*/}
+      {/*<Styled.SNSInputGroup>*/}
+      {/*  {Object.entries(SNS_CONFIG).map(([rawKey, { label, placeholder }]) => {*/}
+      {/*    const key = rawKey as SNSPlatform;*/}
 
-          return (
-            <Styled.SNSRow key={key}>
-              <Styled.SNSCheckboxLabel>{label}</Styled.SNSCheckboxLabel>
-              <InputField
-                placeholder={placeholder}
-                value={socialLinks[key]}
-                onChange={(e) => handleSocialLinkChange(key, e.target.value)}
-                onClear={() => {
-                  setSocialLinks((prev) => ({ ...prev, [key]: '' }));
-                  setSnsErrors((prev) => ({ ...prev, [key]: '' }));
-                }}
-                isError={snsErrors[key] !== ''}
-                helperText={snsErrors[key]}
-                disabled={true}
-              />
-            </Styled.SNSRow>
-          );
-        })}
-      </Styled.SNSInputGroup>
+      {/*    return (*/}
+      {/*      <Styled.SNSRow key={key}>*/}
+      {/*        <Styled.SNSCheckboxLabel>{label}</Styled.SNSCheckboxLabel>*/}
+      {/*        <InputField*/}
+      {/*          placeholder={placeholder}*/}
+      {/*          value={socialLinks[key]}*/}
+      {/*          onChange={(e) => handleSocialLinkChange(key, e.target.value)}*/}
+      {/*          onClear={() => {*/}
+      {/*            setSocialLinks((prev) => ({ ...prev, [key]: '' }));*/}
+      {/*            setSnsErrors((prev) => ({ ...prev, [key]: '' }));*/}
+      {/*          }}*/}
+      {/*          isError={snsErrors[key] !== ''}*/}
+      {/*          helperText={snsErrors[key]}*/}
+      {/*          disabled={true}*/}
+      {/*        />*/}
+      {/*      </Styled.SNSRow>*/}
+      {/*    );*/}
+      {/*  })}*/}
+      {/*</Styled.SNSInputGroup>*/}
     </>
   );
 };

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTab.tsx
@@ -201,6 +201,7 @@ const ClubInfoEditTab = () => {
                 }}
                 isError={snsErrors[key] !== ''}
                 helperText={snsErrors[key]}
+                disabled={true}
               />
             </Styled.SNSRow>
           );

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTab.tsx
@@ -184,6 +184,7 @@ const ClubInfoEditTab = () => {
       </Styled.TagEditGroup>
 
       <Styled.InfoTitle>동아리 SNS 링크</Styled.InfoTitle>
+      <p>현재 준비 중인 기능입니다. 조금만 기다려 주세요!</p>
       <Styled.SNSInputGroup>
         {Object.entries(SNS_CONFIG).map(([rawKey, { label, placeholder }]) => {
           const key = rawKey as SNSPlatform;

--- a/frontend/src/pages/ClubDetailPage/components/InfoBox/InfoBox.styles.ts
+++ b/frontend/src/pages/ClubDetailPage/components/InfoBox/InfoBox.styles.ts
@@ -16,7 +16,7 @@ export const InfoBoxWrapper = styled.div`
 
 export const InfoBox = styled.div`
   width: 573px;
-  height: 197px;
+  height: 164px; //todo 추후 197로 수정 필요
   border-radius: 18px;
   border: 1px solid #dcdcdc;
   padding: 30px;

--- a/frontend/src/pages/ClubDetailPage/components/InfoBox/InfoBox.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/InfoBox/InfoBox.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import * as Styled from './InfoBox.styles';
 import { ClubDetail } from '@/types/club';
 import { INFOTABS_SCROLL_INDEX } from '@/constants/scrollSections';
-import SnsLinkIcons from '@/pages/ClubDetailPage/components/SnsLinkIcons/SnsLinkIcons';
+//import SnsLinkIcons from '@/pages/ClubDetailPage/components/SnsLinkIcons/SnsLinkIcons';
 
 interface ClubInfoItem {
   label: string;
@@ -39,10 +39,10 @@ const InfoBox = ({ sectionRefs, clubDetail }: InfoBoxProps) => {
       descriptions: [
         { label: '회장이름', value: clubDetail.presidentName },
         { label: '전화번호', value: clubDetail.presidentPhoneNumber },
-        {
-          label: 'SNS',
-          render: <SnsLinkIcons apiSocialLinks={clubDetail.socialLinks} />,
-        },
+        // {
+        //   label: 'SNS',
+        //   render: <SnsLinkIcons apiSocialLinks={clubDetail.socialLinks} />,
+        // },
       ],
       refIndex: INFOTABS_SCROLL_INDEX.CLUB_INFO_TAB,
     },


### PR DESCRIPTION
## #️⃣연관된 이슈

> #427

## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지/동영상 첨부 가능)
![image](https://github.com/user-attachments/assets/eec2680a-d27f-48cd-b1a7-9ba8010efc22)
- SNS 링크 입력 기능 아직 배포되지 않은 상태로, 입력 필드 전체를 disabled 처리했습니다.
- 사용자를 위한 안내 문구(현재 준비 중인 기능입니다. 조금만 기다려 주세요!)를 추가했습니다.
- 안내 문구 하단 여백(margin)을 조정해 간격을 자연스럽게 정리했습니다.




## 🫡 참고사항
백엔드 테스트 서버에서는 기능이 완료된 상태이며 메인 서버 배포 이후 해당 기능은 다시 활성화될 예정입니다.
현재 비활성화는 일시적인 조치입니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **스타일**
  - "동아리 SNS 링크" 제목의 하단 여백이 줄어들었습니다.
  - 동아리 정보 박스 높이가 일시적으로 축소되었습니다.
- **기능 변경**
  - 동아리 SNS 링크 관련 입력란 및 아이콘이 화면에서 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->