### PR TITLE
[fix] jest.config.js 인식 위해 coverage 스크립트에 설정 파일 경로 추가

### DIFF
--- a/frontend/codecov.yml
+++ b/frontend/codecov.yml
@@ -1,0 +1,10 @@
+codecov:
+  require_ci_to_pass: yes
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: false
+  branches:
+    - develop-fe
+    - main

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,4 +1,5 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} **/
+
 module.exports = {
   setupFiles: ['<rootDir>/jest.setup.ts'],
   testEnvironment: 'jsdom',

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,5 +1,4 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} **/
-
 module.exports = {
   setupFiles: ['<rootDir>/jest.setup.ts'],
   testEnvironment: 'jsdom',

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "build-storybook": "storybook build",
     "chromatic": "chromatic --project-token=$CHROMATIC_PROJECT_TOKEN",
     "test": "jest",
-    "coverage": "jest --coverage"
+    "coverage": "jest --coverage --config jest.config.js"
   },
   "keywords": [],
   "author": "",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,8 +17,6 @@ import PhotoEditTab from '@/pages/AdminPage/tabs/PhotoEditTab/PhotoEditTab';
 
 const queryClient = new QueryClient();
 
-// [x]TODO: fallback component 추가
-
 const App = () => {
   return (
     <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #430

## 🐞 문제 발생 원인

- 이전 PR에서 `.svg` import 문제를 해결하기 위해 `jest.config.js`에 `jest-transform-stub`을 설정함
- `npm run test` 명령에서는 해당 설정이 정상 적용되어 문제가 발생하지 않음
- 그러나 `npm run coverage`에서는 동일한 `<` token 오류가 재발함
- 이는 Jest가 coverage 명령 실행 시 `jest.config.js`를 자동으로 인식하지 못해 설정이 적용되지 않았기 때문ㅁ

![image](https://github.com/user-attachments/assets/41f9f4a7-1f64-464b-a638-46465a1adf78)

## 🛠️ 해결 과정

- 문제의 원인을 분석한 결과, Jest가 coverage 실행 시 별도 설정을 요구한다는 점을 파악
- `package.json` 내 coverage 스크립트를  수정:
  ```json
  "coverage": "jest --coverage --config jest.config.js"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Jest 커버리지 스크립트가 명시적으로 설정 파일을 사용하도록 업데이트되었습니다.
  - Codecov 통합을 위한 새로운 설정 파일이 추가되어 CI 통과 후에만 리포트가 반영되고, PR 코멘트 레이아웃 및 브랜치 제한이 적용됩니다.

- **Style**
  - 불필요한 주석(TODO)이 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->