### PR TITLE
[feature] stringToDate 유틸리티 함수 단위 테스트 추가

### DIFF
--- a/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.tsx
@@ -5,7 +5,7 @@ import Calendar from '@/pages/AdminPage/tabs/RecruitEditTab/components/Calendar/
 import Button from '@/components/common/Button/Button';
 import InputField from '@/components/common/InputField/InputField';
 import { useUpdateClubDescription } from '@/hooks/queries/club/useUpdateClubDescription';
-import { parseRecruitmentPeriod } from '@/utils/stringToDate';
+import { parseRecruitmentPeriod } from '@/utils/recruitmentPeriodParser.ts';
 import { ClubDetail } from '@/types/club';
 import { useQueryClient } from '@tanstack/react-query';
 import MarkdownEditor from '@/pages/AdminPage/tabs/RecruitEditTab/components/MarkdownEditor/MarkdownEditor';

--- a/frontend/src/pages/ClubDetailPage/components/ClubDetailFooter/ClubDetailFooter.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubDetailFooter/ClubDetailFooter.tsx
@@ -1,7 +1,7 @@
 import * as Styled from './ClubDetailFooter.styles';
 import DeadlineBadge from '@/pages/ClubDetailPage/components/DeadlineBadge/DeadlineBadge';
 import ClubApplyButton from '@/pages/ClubDetailPage/components/ClubApplyButton/ClubApplyButton';
-import { parseRecruitmentPeriod } from '@/utils/stringToDate';
+import { parseRecruitmentPeriod } from '@/utils/recruitmentPeriodParser.ts';
 import getDeadlineText from '@/utils/getDeadLineText';
 
 interface ClubDetailFooterProps {

--- a/frontend/src/pages/ClubDetailPage/components/ClubDetailHeader/ClubDetailHeader.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubDetailHeader/ClubDetailHeader.tsx
@@ -1,7 +1,7 @@
 import * as Styled from './ClubDetailHeader.styles';
 import ClubProfile from '@/pages/ClubDetailPage/components/ClubProfile/ClubProfile';
 import ClubApplyButton from '@/pages/ClubDetailPage/components/ClubApplyButton/ClubApplyButton';
-import { parseRecruitmentPeriod } from '@/utils/stringToDate';
+import { parseRecruitmentPeriod } from '@/utils/recruitmentPeriodParser.ts';
 import getDeadlineText from '@/utils/getDeadLineText';
 interface ClubDetailHeaderProps {
   name: string;

--- a/frontend/src/utils/parseRecruitmentPeriod.test.ts
+++ b/frontend/src/utils/parseRecruitmentPeriod.test.ts
@@ -1,0 +1,35 @@
+import { parseRecruitmentPeriod } from './stringToDate';
+
+describe('parseRecruitmentPeriod 함수 테스트', () => {
+  it('올바른 형식의 날짜를 파싱한다.', () => {
+    const input = '2024.03.20 14:00 ~ 2024.03.25 18:00';
+    const result = parseRecruitmentPeriod(input);
+
+    expect(result.recruitmentStart).toEqual(new Date('2024-03-20T14:00:00'));
+    expect(result.recruitmentEnd).toEqual(new Date('2024-03-25T18:00:00'));
+  });
+
+  it('날짜가 기간형식이 아닌 단일 날짜 형식인 경우 null을 반환한다.', () => {
+    const input = '2024.03.20 14:00';
+    const result = parseRecruitmentPeriod(input);
+
+    expect(result.recruitmentStart).toBeNull();
+    expect(result.recruitmentEnd).toBeNull();
+  });
+
+  it('빈 문자열이라면 null을 반환한다.', () => {
+    const input = '';
+    const result = parseRecruitmentPeriod(input);
+
+    expect(result.recruitmentStart).toBeNull();
+    expect(result.recruitmentEnd).toBeNull();
+  });
+
+  it('날짜 사이 ~가 없다면 null을 반환한다.', () => {
+    const input = '2024.03.20 14:00 - 2024.03.25 18:00';
+    const result = parseRecruitmentPeriod(input);
+
+    expect(result.recruitmentStart).toBeNull();
+    expect(result.recruitmentEnd).toBeNull();
+  });
+});

--- a/frontend/src/utils/parseRecruitmentPeriod.test.ts
+++ b/frontend/src/utils/parseRecruitmentPeriod.test.ts
@@ -1,4 +1,4 @@
-import { parseRecruitmentPeriod } from './stringToDate';
+import { parseRecruitmentPeriod } from './recruitmentPeriodParser.ts';
 
 describe('parseRecruitmentPeriod 함수 테스트', () => {
   it('올바른 형식의 날짜를 파싱한다.', () => {

--- a/frontend/src/utils/recruitmentPeriodParser.test.ts
+++ b/frontend/src/utils/recruitmentPeriodParser.test.ts
@@ -1,49 +1,49 @@
-import { stringToDate } from './stringToDate';
+import { parseRecruitmentDateString } from './recruitmentPeriodParser.ts';
 
-describe('stringToDate 함수 테스트', () => {
+describe('parseRecruitmentPeriod 함수 테스트', () => {
   it('날짜와 시간이 포함된 문자열을 Date 객체로 정확히 바꾼다', () => {
     const input = '2025.05.25 13:45';
     const result = new Date('2025-05-25T13:45:00');
-    expect(stringToDate(input)).toEqual(result);
+    expect(parseRecruitmentDateString(input)).toEqual(result);
   });
 
   it('자정 시간 "YYYY.MM.DD 00:00" 형식을 올바르게 Date 객체로 변환한다', () => {
     const input = '2025.05.25 00:00';
     const result = new Date('2025-05-25T00:00:00');
-    expect(stringToDate(input)).toEqual(result);
+    expect(parseRecruitmentDateString(input)).toEqual(result);
   });
 
   it('공백이 없는 문자열이라면 예외가 발생한다.', () => {
     const input = '2025.05.2513:45';
-    expect(() => stringToDate(input)).toThrow(
+    expect(() => parseRecruitmentDateString(input)).toThrow(
       '유효하지 않은 날짜 형식입니다. 형식은 "YYYY.MM.DD HH:mm" 이어야 합니다.',
     );
   });
 
   it('시간 부분이 누락된 경우 예외가 발생한다', () => {
     const input = '2025.05.25 ';
-    expect(() => stringToDate(input)).toThrow(
+    expect(() => parseRecruitmentDateString(input)).toThrow(
       '유효하지 않은 날짜 형식입니다. 형식은 "YYYY.MM.DD HH:mm" 이어야 합니다.',
     );
   });
 
   it('날짜 부분이 누락된 경우 예외가 발생한다', () => {
     const input = ' 13:45';
-    expect(() => stringToDate(input)).toThrow(
+    expect(() => parseRecruitmentDateString(input)).toThrow(
       '유효하지 않은 날짜 형식입니다. 형식은 "YYYY.MM.DD HH:mm" 이어야 합니다.',
     );
   });
 
   it('빈 문자열이 주어지면 예외가 발생한다', () => {
     const input = '';
-    expect(() => stringToDate(input)).toThrow(
+    expect(() => parseRecruitmentDateString(input)).toThrow(
       '유효하지 않은 날짜 형식입니다. 형식은 "YYYY.MM.DD HH:mm" 이어야 합니다.',
     );
   });
 
   it('YYYY.MM.DD HH:mm 형식이 아닌 입력에 대해 에러를 던진다', () => {
     const input = '1.1.1 1:1';
-    expect(() => stringToDate(input)).toThrow(
+    expect(() => parseRecruitmentDateString(input)).toThrow(
       '유효하지 않은 날짜 형식입니다. 형식은 "YYYY.MM.DD HH:mm" 이어야 합니다.',
     );
   });

--- a/frontend/src/utils/recruitmentPeriodParser.ts.ts
+++ b/frontend/src/utils/recruitmentPeriodParser.ts.ts
@@ -1,6 +1,6 @@
 import { parse, isValid } from 'date-fns';
 
-export const stringToDate = (s: string): Date => {
+export const parseRecruitmentDateString = (s: string): Date => {
   const regex = /^\d{4}\.\d{2}\.\d{2} \d{2}:\d{2}$/;
   if (!regex.test(s)) {
     throw new Error(
@@ -25,7 +25,7 @@ export const parseRecruitmentPeriod = (
   }
 
   return {
-    recruitmentStart: stringToDate(parts[0]),
-    recruitmentEnd: stringToDate(parts[1]),
+    recruitmentStart: parseRecruitmentDateString(parts[0]),
+    recruitmentEnd: parseRecruitmentDateString(parts[1]),
   };
 };

--- a/frontend/src/utils/stringToDate.test.ts
+++ b/frontend/src/utils/stringToDate.test.ts
@@ -1,0 +1,29 @@
+import { stringToDate } from './stringToDate';
+
+describe('stringToDate 함수 테스트', () => {
+  it('날짜와 시간이 포함된 문자열을 Date 객체로 정확히 바꾼다', () => {
+    const input = '2025.05.25 13:45';
+    const result = new Date('2025-05-25T13:45:00');
+    expect(stringToDate(input)).toEqual(result);
+  });
+
+  it('자정 시간 "YYYY.MM.DD 00:00" 형식을 올바르게 Date 객체로 변환한다', () => {
+    const input = '2025.05.25 00:00';
+    const result = new Date('2025-05-25T00:00:00');
+    expect(stringToDate(input)).toEqual(result);
+  });
+
+  it('공백이 없는 문자열이 주어지면 예외를 발생시킨다.', () => {
+    const input = '2025.05.2513:45';
+    expect(() => stringToDate(input)).toThrow(
+      '유효하지 않은 날짜 형식입니다. 형식은 "YYYY.MM.DD HH:mm" 이어야 합니다.',
+    );
+  });
+
+  it('시간 형식이 누락된 경우 예외가 발생한다', () => {
+    const input = '2025.05.25 ';
+    expect(() => stringToDate(input)).toThrow(
+      '유효하지 않은 날짜 형식입니다. 형식은 "YYYY.MM.DD HH:mm" 이어야 합니다.',
+    );
+  });
+});

--- a/frontend/src/utils/stringToDate.test.ts
+++ b/frontend/src/utils/stringToDate.test.ts
@@ -13,15 +13,29 @@ describe('stringToDate 함수 테스트', () => {
     expect(stringToDate(input)).toEqual(result);
   });
 
-  it('공백이 없는 문자열이 주어지면 예외를 발생시킨다.', () => {
+  it('공백이 없는 문자열이라면 예외가 발생한다.', () => {
     const input = '2025.05.2513:45';
     expect(() => stringToDate(input)).toThrow(
       '유효하지 않은 날짜 형식입니다. 형식은 "YYYY.MM.DD HH:mm" 이어야 합니다.',
     );
   });
 
-  it('시간 형식이 누락된 경우 예외가 발생한다', () => {
+  it('시간 부분이 누락된 경우 예외가 발생한다', () => {
     const input = '2025.05.25 ';
+    expect(() => stringToDate(input)).toThrow(
+      '유효하지 않은 날짜 형식입니다. 형식은 "YYYY.MM.DD HH:mm" 이어야 합니다.',
+    );
+  });
+
+  it('날짜 부분이 누락된 경우 예외가 발생한다', () => {
+    const input = ' 13:45';
+    expect(() => stringToDate(input)).toThrow(
+      '유효하지 않은 날짜 형식입니다. 형식은 "YYYY.MM.DD HH:mm" 이어야 합니다.',
+    );
+  });
+
+  it('빈 문자열이 주어지면 예외가 발생한다', () => {
+    const input = '';
     expect(() => stringToDate(input)).toThrow(
       '유효하지 않은 날짜 형식입니다. 형식은 "YYYY.MM.DD HH:mm" 이어야 합니다.',
     );

--- a/frontend/src/utils/stringToDate.test.ts
+++ b/frontend/src/utils/stringToDate.test.ts
@@ -40,4 +40,11 @@ describe('stringToDate 함수 테스트', () => {
       '유효하지 않은 날짜 형식입니다. 형식은 "YYYY.MM.DD HH:mm" 이어야 합니다.',
     );
   });
+
+  it('YYYY.MM.DD HH:mm 형식이 아닌 입력에 대해 에러를 던진다', () => {
+    const input = '1.1.1 1:1';
+    expect(() => stringToDate(input)).toThrow(
+      '유효하지 않은 날짜 형식입니다. 형식은 "YYYY.MM.DD HH:mm" 이어야 합니다.',
+    );
+  });
 });

--- a/frontend/src/utils/stringToDate.ts
+++ b/frontend/src/utils/stringToDate.ts
@@ -1,20 +1,19 @@
-export function parseRecruitmentPeriod(periodStr: string): {
-  recruitmentStart: Date | null;
-  recruitmentEnd: Date | null;
-} {
+export const stringToDate = (s: string): Date => {
+  const [datePart, timePart] = s.split(' ');
+  const isoDate = datePart.replace(/\./g, '-');
+  return new Date(`${isoDate}T${timePart}:00`);
+};
+
+export const parseRecruitmentPeriod = (
+  periodStr: string,
+): { recruitmentStart: Date | null; recruitmentEnd: Date | null } => {
   const parts = periodStr.split('~').map((s) => s.trim());
   if (parts.length !== 2) {
     return { recruitmentStart: null, recruitmentEnd: null };
   }
 
-  const convertToDate = (s: string): Date => {
-    const [datePart, timePart] = s.split(' ');
-    const isoDate = datePart.replace(/\./g, '-');
-    return new Date(`${isoDate}T${timePart}:00`);
-  };
-
   return {
-    recruitmentStart: convertToDate(parts[0]),
-    recruitmentEnd: convertToDate(parts[1]),
+    recruitmentStart: stringToDate(parts[0]),
+    recruitmentEnd: stringToDate(parts[1]),
   };
-}
+};

--- a/frontend/src/utils/stringToDate.ts
+++ b/frontend/src/utils/stringToDate.ts
@@ -1,7 +1,20 @@
 export const stringToDate = (s: string): Date => {
   const [datePart, timePart] = s.split(' ') as [string, string];
+  if (!datePart || !timePart) {
+    throw new Error(
+      '유효하지 않은 날짜 형식입니다. 형식은 "YYYY.MM.DD HH:mm" 이어야 합니다.',
+    );
+  }
+
   const isoDate = datePart.replace(/\./g, '-');
-  return new Date(`${isoDate}T${timePart}:00`);
+  const date = new Date(`${isoDate}T${timePart}:00`);
+
+  if (isNaN(date.getTime())) {
+    throw new Error(
+      '유효하지 않은 날짜 형식입니다. 형식은 "YYYY.MM.DD HH:mm" 이어야 합니다.',
+    );
+  }
+  return date;
 };
 
 export const parseRecruitmentPeriod = (

--- a/frontend/src/utils/stringToDate.ts
+++ b/frontend/src/utils/stringToDate.ts
@@ -9,11 +9,6 @@ export const stringToDate = (s: string): Date => {
   const isoDate = datePart.replace(/\./g, '-');
   const date = new Date(`${isoDate}T${timePart}:00`);
 
-  if (isNaN(date.getTime())) {
-    throw new Error(
-      '유효하지 않은 날짜 형식입니다. 형식은 "YYYY.MM.DD HH:mm" 이어야 합니다.',
-    );
-  }
   return date;
 };
 

--- a/frontend/src/utils/stringToDate.ts
+++ b/frontend/src/utils/stringToDate.ts
@@ -1,14 +1,12 @@
+import { parse, isValid } from 'date-fns';
+
 export const stringToDate = (s: string): Date => {
-  const [datePart, timePart] = s.split(' ') as [string, string];
-  if (!datePart || !timePart) {
+  const date = parse(s, 'yyyy.MM.dd HH:mm', new Date());
+  if (!isValid(date)) {
     throw new Error(
       '유효하지 않은 날짜 형식입니다. 형식은 "YYYY.MM.DD HH:mm" 이어야 합니다.',
     );
   }
-
-  const isoDate = datePart.replace(/\./g, '-');
-  const date = new Date(`${isoDate}T${timePart}:00`);
-
   return date;
 };
 

--- a/frontend/src/utils/stringToDate.ts
+++ b/frontend/src/utils/stringToDate.ts
@@ -1,6 +1,12 @@
 import { parse, isValid } from 'date-fns';
 
 export const stringToDate = (s: string): Date => {
+  const regex = /^\d{4}\.\d{2}\.\d{2} \d{2}:\d{2}$/;
+  if (!regex.test(s)) {
+    throw new Error(
+      '유효하지 않은 날짜 형식입니다. 형식은 "YYYY.MM.DD HH:mm" 이어야 합니다.',
+    );
+  }
   const date = parse(s, 'yyyy.MM.dd HH:mm', new Date());
   if (!isValid(date)) {
     throw new Error(

--- a/frontend/src/utils/stringToDate.ts
+++ b/frontend/src/utils/stringToDate.ts
@@ -1,5 +1,5 @@
 export const stringToDate = (s: string): Date => {
-  const [datePart, timePart] = s.split(' ');
+  const [datePart, timePart] = s.split(' ') as [string, string];
   const isoDate = datePart.replace(/\./g, '-');
   return new Date(`${isoDate}T${timePart}:00`);
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #441 

## 📝작업 내용

>[코드와 함께 살펴보는 프론트엔드 단위 테스트 – Part 1. 이론 편](https://techblog.woowahan.com/17404/)

## 유틸리티 함수 분리
`parseRecruitmentPeriod` 하나로 구성된 날짜변환 유틸함수를 2개의 유틸함수로 분리했습니다.
- `parseRecruitmentPeriod` 유지
- `convertToDate` 를 `stringToDate`로 이름을 바꾸고 분리했습니다.

## 이유
✔️유틸함수가 두 번의 과정을 거칩니다.
1. ~로 이어진 기간을 파싱
2. 파싱된 날짜 유효성 검사

이 과정에서 같은 변수를 사용하기에 의존적입니다. 또한, 단위테스트 작성이 어렵습니다.

### 독립 테스트 필요
- `parseRecruitmentPeriod`테스트 실패 시 원인이 `stringToDate`인지 추적하기 어렵습니다.
- 나중에 `stringToDate` 구현이 바뀔 시 `parseRecruitmentPeriod`테스트가 통과해도 `stringToDate`가 제대로 동작하는지 알기 어렵습니다. 
- 재사용성이 떨어집니다.

## 단위테스트 작성하기

- parseRecruitmentPeriod c0de6abf1ae8dbdf24ffd5acb280b1c39faa0a8b
- stringToDate f41a55c59435776a9d93d41f0283cc33809b315e
- 에러 테스트를 위해 stringToDate에 `throw Error`추가 24930ef0b46c5362185c56b16fc14b6f66e71716

## 중점적으로 리뷰받고 싶은 부분(선택)

## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 모집 기간 문자열을 "YYYY.MM.DD HH:mm ~ YYYY.MM.DD HH:mm" 형식으로 입력하면 정확하게 시작 및 종료 날짜를 파싱하는 기능이 추가되었습니다.
  * 개별 날짜 문자열("YYYY.MM.DD HH:mm")을 엄격하게 검증 및 파싱하는 기능이 도입되었습니다.

* **버그 수정**
  * 잘못된 날짜 형식 입력 시 오류 메시지를 명확하게 안내하도록 개선되었습니다.

* **테스트**
  * 모집 기간 파싱 함수와 날짜 파싱 함수에 대한 테스트가 추가되어 입력 형식에 대한 검증이 강화되었습니다.

* **리팩터**
  * 날짜 파싱 로직이 분리되어 코드 구조가 개선되었습니다.

* **기타**
  * 관련 유틸 함수의 import 경로가 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->