### PR TITLE
[feature] debounce 유틸함수 단위 테스트 추가

### DIFF
--- a/frontend/src/utils/debounce.test.ts
+++ b/frontend/src/utils/debounce.test.ts
@@ -1,0 +1,50 @@
+import debounce from './debounce';
+
+describe('debounce 함수 테스트', () => {
+  let mockfn: jest.Mock;
+  let debouncedFn: ReturnType<typeof debounce>;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockfn = jest.fn();
+    debouncedFn = debounce(mockfn, 1000);
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('지정된 시간 후에 함수가 한 번만 호출된다.', () => {
+    debouncedFn();
+    debouncedFn();
+    debouncedFn();
+
+    expect(mockfn).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1000);
+
+    expect(mockfn).toHaveBeenCalledTimes(1);
+  });
+
+  it('지정된 시간 내에 함수가 다시 호출되면 타이머가 리셋된다.', () => {
+    debouncedFn();
+    jest.advanceTimersByTime(500);
+
+    debouncedFn();
+    jest.advanceTimersByTime(500);
+
+    expect(mockfn).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(500);
+
+    expect(mockfn).toHaveBeenCalledTimes(1);
+  });
+
+  it('함수에 전달된 인자가 올바르게 전달된다.', () => {
+    debouncedFn('test', 1, 2, 3);
+    jest.advanceTimersByTime(1000);
+
+    expect(mockfn).toHaveBeenCalledWith('test', 1, 2, 3);
+  });
+});


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #443 

## 📝작업 내용
> [Jest Mock 타이머 적용하기](https://haeguri.github.io/2020/01/12/jest-mock-timer/)
[Timer Mocks](https://jestjs.io/docs/timer-mocks) 를 참고하였습니다.

- 연속된 함수 호출을 제어하는 `debounce` 유틸리티 함수에 대한 단위 테스트를 추가했습니다.
- 지정된 시간(delay) 동안 마지막 호출만 실행되도록 하였습니다.
- 함수 인자 전달 기능을 지원합니다.
- 테스트 시 타이머가 자동 리셋됩니다. 


## 테스트
- 지정된 시간 후 함수가 한 번만 호출되는지 검증
- 타이머 리셋 기능 검증
- 함수 인자 전달 검증

## 사용 예시
```typescript
const debouncedFn = debounce((value: string) => {
  console.log(value);
}, 1000);

// 연속 호출 시 마지막 호출만 실행됨
debouncedFn('test1');
debouncedFn('test2');
debouncedFn('test3');
// 1초 후 'test3'만 출력
```

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항