### PR TITLE
[feature] 지원서 작성/편집 기능 구현 및 질문 컴포넌트 구조화

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -72,6 +72,7 @@ const App = () => {
               }
             />
             <Route path='view-application' element={<ApplicationForm />} />
+            {/*TODO: CreateForm은 관리자 기능이므로 추후 /admin/* 경로 안으로 이동 필요*/}
             <Route path='create-application' element={<CreateForm />} />
             <Route path='*' element={<Navigate to='/' replace />} />
           </Routes>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,8 @@ import AccountEditTab from '@/pages/AdminPage/tabs/AccountEditTab/AccountEditTab
 import LoginTab from '@/pages/AdminPage/auth/LoginTab/LoginTab';
 import PrivateRoute from '@/pages/AdminPage/auth/PrivateRoute/PrivateRoute';
 import PhotoEditTab from '@/pages/AdminPage/tabs/PhotoEditTab/PhotoEditTab';
+import ApplicationForm from '@/pages/AdminPage/application/ApplicationForm';
+import CreateForm from '@/pages/AdminPage/application/CreateForm';
 
 const queryClient = new QueryClient();
 
@@ -69,6 +71,8 @@ const App = () => {
                 </AdminClubProvider>
               }
             />
+            <Route path='view-application' element={<ApplicationForm />} />
+            <Route path='create-application' element={<CreateForm />} />
             <Route path='*' element={<Navigate to='/' replace />} />
           </Routes>
         </BrowserRouter>

--- a/frontend/src/assets/images/icons/drop_button_icon.svg
+++ b/frontend/src/assets/images/icons/drop_button_icon.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="8" viewBox="0 0 14 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1.3335 0.58317L7.16683 6.4165L13.0002 0.58317" stroke="#787878"/>
+</svg>

--- a/frontend/src/constants/APPLICATION_FORM.ts
+++ b/frontend/src/constants/APPLICATION_FORM.ts
@@ -3,7 +3,7 @@ const APPLICATION_FORM = {
     placeholder: '답변입력란(최대 20자)',
   },
   LONG_TEXT: {
-    placeholder: '답변입력란(최대 20자)',
+    placeholder: '답변입력란(최대 500자)',
   },
   CHOICE: {
     placeholder: '항목(최대 20자)',

--- a/frontend/src/constants/APPLICATION_FORM.ts
+++ b/frontend/src/constants/APPLICATION_FORM.ts
@@ -1,0 +1,12 @@
+const APPLICATION_FORM = {
+  SHORT_TEXT: {
+    placeholder: '답변입력란(최대 20자)',
+  },
+  LONG_TEXT: {
+    placeholder: '답변입력란(최대 20자)',
+  },
+  CHOICE: {
+    placeholder: '항목(최대 20자)',
+  },
+} as const;
+export default APPLICATION_FORM;

--- a/frontend/src/pages/AdminPage/application/ApplicationForm.tsx
+++ b/frontend/src/pages/AdminPage/application/ApplicationForm.tsx
@@ -1,0 +1,71 @@
+// 지원하기 : 지원서 입력 컴포넌트
+// 특정 지원서를 사용자들이 입력할 수 있는 지원서 작성 부분
+// Todo 추후 특정 지원서를 받아서 answer 모드로 렌더링
+import { useState } from 'react';
+import ShortText from '@/pages/AdminPage/application/fields/ShortText';
+import Choice from '@/pages/AdminPage/application/fields/Choice';
+
+interface QuestionData {
+  title: string;
+  description: string;
+  items?: { value: string }[];
+}
+
+interface AnswerData {
+  [id: number]: string;
+}
+
+const ApplicationForm = () => {
+  const [questions] = useState<Record<number, QuestionData>>({
+    1: {
+      title: '이름을 입력해주세요',
+      description: '본명을 입력해 주세요',
+    },
+    2: {
+      title: '자기소개를 해주세요',
+      description: '300자 이내로 입력해주세요',
+    },
+    3: {
+      title: '지원 분야를 선택해주세요',
+      description: '중복 선택은 불가능합니다',
+      items: [
+        { value: '프론트엔드' },
+        { value: '백엔드' },
+        { value: '디자인' },
+      ],
+    },
+    4: {
+      title: '희망하는 활동 시간을 선택해주세요',
+      description: '가장 편한 시간을 골라주세요',
+      items: [],
+    },
+    5: {
+      title: '이전에 프로젝트 경험이 있나요?',
+      description: '간단하게 작성해주세요',
+      items: [{ value: 'React' }],
+    },
+    6: {
+      title: '사용 가능한 기술 스택을 선택해주세요',
+      description: '복수 선택 가능',
+      items: [
+        { value: 'React' },
+        { value: 'Node.js' },
+        { value: 'Python' },
+        { value: 'Figma' },
+      ],
+    },
+  });
+
+  const [answers, setAnswers] = useState<AnswerData>({});
+
+  const handleAnswerChange = (id: number) => (value: string) => {
+    setAnswers((prev) => ({
+      ...prev,
+      [id]: value,
+    }));
+  };
+
+  return <></>;
+};
+
+export default ApplicationForm;

--- a/frontend/src/pages/AdminPage/application/CreateForm.tsx
+++ b/frontend/src/pages/AdminPage/application/CreateForm.tsx
@@ -83,7 +83,10 @@ const CreateForm = () => {
       ...prev,
       [id]: {
         ...prev[id],
-        type: newType,
+        options: {
+          ...prev[id].options,
+          required: value,
+        },
       },
     }));
   };
@@ -102,6 +105,7 @@ const CreateForm = () => {
           onDescriptionChange={handleDescriptionChange(Number(id))}
           onItemsChange={handleItemsChange(Number(id))}
           onTypeChange={handleTypeChange(Number(id))}
+          onRequiredChange={handleRequiredChange(Number(id))}
           type={question.type}
         />
       ))}

--- a/frontend/src/pages/AdminPage/application/CreateForm.tsx
+++ b/frontend/src/pages/AdminPage/application/CreateForm.tsx
@@ -16,8 +16,11 @@ type QuestionType =
 type Question = {
   title: string;
   description: string;
-  items?: { value: string }[];
   type: QuestionType;
+  options: {
+    required: boolean;
+  };
+  items?: { value: string }[];
 };
 
 const CreateForm = () => {
@@ -25,12 +28,17 @@ const CreateForm = () => {
     1: {
       title: '이름을 입력해주세요',
       description: '본명을 입력해 주세요',
+      options: {
+        required: true,
+      },
       type: 'SHORT_TEXT',
-      items: [],
     },
     2: {
       title: '지원 분야를 선택해주세요',
       description: '중복 선택은 불가능합니다',
+      options: {
+        required: false,
+      },
       items: [
         { value: '프론트엔드' },
         { value: '백엔드' },
@@ -88,7 +96,7 @@ const CreateForm = () => {
           id={Number(id)}
           title={question.title}
           description={question.description}
-          required={true}
+          required={question.options?.required ?? false}
           options={question.items}
           onTitleChange={handleTitleChange(Number(id))}
           onDescriptionChange={handleDescriptionChange(Number(id))}

--- a/frontend/src/pages/AdminPage/application/CreateForm.tsx
+++ b/frontend/src/pages/AdminPage/application/CreateForm.tsx
@@ -1,0 +1,102 @@
+// 지원서 제작하기 : 지원서 제작 컴포넌트
+import { useState } from 'react';
+import QuestionBuilder from '@/pages/AdminPage/application/components/QuestionBuilder/QuestionBuilder';
+
+type QuestionType =
+  | 'SHORT_TEXT'
+  | 'LONG_TEXT'
+  | 'CHOICE'
+  | 'MULTI_CHOICE'
+  | 'EMAIL'
+  | 'PHONE_NUMBER'
+  | 'NAME';
+
+type Question = {
+  title: string;
+  description: string;
+  items?: { value: string }[];
+  type: QuestionType;
+};
+
+const CreateForm = () => {
+  const [questions, setQuestions] = useState<Record<number, Question>>({
+    1: {
+      title: '이름을 입력해주세요',
+      description: '본명을 입력해 주세요',
+      type: 'SHORT_TEXT',
+      items: [],
+    },
+    2: {
+      title: '지원 분야를 선택해주세요',
+      description: '중복 선택은 불가능합니다',
+      items: [
+        { value: '프론트엔드' },
+        { value: '백엔드' },
+        { value: '디자인' },
+      ],
+      type: 'MULTI_CHOICE',
+    },
+  });
+
+  const handleTitleChange = (id: number) => (value: string) => {
+    setQuestions((prev) => ({
+      ...prev,
+      [id]: {
+        ...prev[id],
+        title: value,
+      },
+    }));
+  };
+
+  const handleDescriptionChange = (id: number) => (value: string) => {
+    setQuestions((prev) => ({
+      ...prev,
+      [id]: {
+        ...prev[id],
+        description: value,
+      },
+    }));
+  };
+
+  const handleItemsChange = (id: number) => (newItems: { value: string }[]) => {
+    setQuestions((prev) => ({
+      ...prev,
+      [id]: {
+        ...prev[id],
+        items: newItems,
+      },
+    }));
+  };
+
+  const handleTypeChange = (id: number) => (newType: QuestionType) => {
+    setQuestions((prev) => ({
+      ...prev,
+      [id]: {
+        ...prev[id],
+        type: newType,
+      },
+    }));
+  };
+
+  return (
+    <>
+      {Object.entries(questions).map(([id, question]) => (
+        <QuestionBuilder
+          key={id}
+          id={Number(id)}
+          title={question.title}
+          description={question.description}
+          required={true}
+          options={question.items}
+          onTitleChange={handleTitleChange(Number(id))}
+          onDescriptionChange={handleDescriptionChange(Number(id))}
+          onItemsChange={handleItemsChange(Number(id))}
+          onTypeChange={handleTypeChange(Number(id))}
+          type={question.type}
+        />
+      ))}
+    </>
+  );
+};
+
+export default CreateForm;

--- a/frontend/src/pages/AdminPage/application/CreateForm.tsx
+++ b/frontend/src/pages/AdminPage/application/CreateForm.tsx
@@ -79,6 +79,32 @@ const CreateForm = () => {
   };
 
   const handleTypeChange = (id: number) => (newType: QuestionType) => {
+    setQuestions((prev) => {
+      const prevQuestion = prev[id];
+      const isChoiceType = newType === 'CHOICE' || newType === 'MULTI_CHOICE';
+
+      const updatedQuestion: Question = {
+        ...prevQuestion,
+        type: newType,
+      };
+
+      if (isChoiceType) {
+        updatedQuestion.items =
+          !prevQuestion.items || prevQuestion.items.length < 2
+            ? [{ value: '' }, { value: '' }]
+            : prevQuestion.items;
+      } else {
+        delete updatedQuestion.items;
+      }
+
+      return {
+        ...prev,
+        [id]: updatedQuestion,
+      };
+    });
+  };
+
+  const handleRequiredChange = (id: number) => (value: boolean) => {
     setQuestions((prev) => ({
       ...prev,
       [id]: {

--- a/frontend/src/pages/AdminPage/application/CreateForm.tsx
+++ b/frontend/src/pages/AdminPage/application/CreateForm.tsx
@@ -97,7 +97,7 @@ const CreateForm = () => {
           title={question.title}
           description={question.description}
           required={question.options?.required ?? false}
-          options={question.items}
+          items={question.items}
           onTitleChange={handleTitleChange(Number(id))}
           onDescriptionChange={handleDescriptionChange(Number(id))}
           onItemsChange={handleItemsChange(Number(id))}

--- a/frontend/src/pages/AdminPage/application/CreateForm.tsx
+++ b/frontend/src/pages/AdminPage/application/CreateForm.tsx
@@ -35,7 +35,7 @@ const CreateForm = () => {
     },
     2: {
       title: '지원 분야를 선택해주세요',
-      description: '중복 선택은 불가능합니다',
+      description: '중복 선택 가능합니다',
       options: {
         required: false,
       },

--- a/frontend/src/pages/AdminPage/application/CreateForm.tsx
+++ b/frontend/src/pages/AdminPage/application/CreateForm.tsx
@@ -1,4 +1,6 @@
 // 지원서 제작하기 : 지원서 제작 컴포넌트
+// 지원서 수정과 제작을 맡을 컴포넌트
+// Todo: 질문 삭제 및 질문 추가 기능 구현
 import { useState } from 'react';
 import QuestionBuilder from '@/pages/AdminPage/application/components/QuestionBuilder/QuestionBuilder';
 

--- a/frontend/src/pages/AdminPage/application/components/QuestionBuilder/QuestionBuilder.styles.ts
+++ b/frontend/src/pages/AdminPage/application/components/QuestionBuilder/QuestionBuilder.styles.ts
@@ -1,0 +1,101 @@
+import styled from 'styled-components';
+
+export const QuestionMenu = styled.div`
+  display: flex;
+  width: 140px;
+  flex-direction: column;
+  gap: 4px;
+`;
+
+export const RequiredToggleButton = styled.div`
+  display: flex;
+  border: none;
+  padding: 12px 16px;
+  justify-content: space-between;
+  align-items: center;
+  border-radius: 0.375rem;
+  background: #f5f5f5;
+  cursor: pointer;
+  margin: 0;
+  color: #787878;
+  font-size: 0.875rem;
+  font-weight: 600;
+`;
+
+export const RequiredToggleCircle = styled.span<{ active?: boolean }>`
+  position: relative;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 1px solid ${(props) => (props.active ? '#ff5000' : '#ccc')};
+  background-color: ${(props) => (props.active ? '#ff5000' : 'white')};
+
+  ${({ active }) =>
+    active &&
+    `
+    background-color: #fff;
+    &::after {
+      content: '';
+      width: 10px;
+      height: 10px;
+      background-color: #ff5000;
+      border-radius: 50%;
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+    }
+  `}
+`;
+
+export const DropDownWrapper = styled.div`
+  position: relative;
+  width: 100%;
+`;
+
+export const Dropdown = styled.select`
+  display: flex;
+  width: 100%;
+  border: none;
+  padding: 12px 16px;
+  border-radius: 0.375rem;
+  background: #f5f5f5;
+  color: #787878;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  appearance: none;
+`;
+
+export const DropdownIcon = styled.img`
+  position: absolute;
+  top: 50%;
+  right: 19px;
+  transform: translateY(-50%);
+  pointer-events: none;
+`;
+
+export const SelectionToggleWrapper = styled.div`
+  display: flex;
+  background-color: #f7f7f7;
+  border-radius: 0.375rem;
+  padding: 2px;
+`;
+
+export const SelectionToggleButton = styled.button<{ active: boolean }>`
+  border: none;
+  background-color: ${(props) => (props.active ? '#ddd' : 'transparent')};
+  color: #787878;
+  font-size: 0.875rem;
+  border-radius: 0.375rem;
+  padding: 10px;
+  font-weight: 600;
+  cursor: pointer;
+  letter-spacing: -0.42px;
+  white-space: nowrap;
+`;
+
+export const QuestionWrapper = styled.div`
+  display: flex;
+  gap: 36px;
+`;

--- a/frontend/src/pages/AdminPage/application/components/QuestionBuilder/QuestionBuilder.tsx
+++ b/frontend/src/pages/AdminPage/application/components/QuestionBuilder/QuestionBuilder.tsx
@@ -24,6 +24,7 @@ interface QuestionBuilderProps {
   onDescriptionChange: (value: string) => void;
   onItemsChange?: (newItems: { value: string }[]) => void;
   onTypeChange?: (type: QuestionType) => void;
+  onRequiredChange?: (required: boolean) => void;
 }
 
 const QuestionBuilder = ({
@@ -37,8 +38,8 @@ const QuestionBuilder = ({
   onItemsChange,
   onDescriptionChange,
   onTypeChange,
+  onRequiredChange,
 }: QuestionBuilderProps) => {
-  const [isRequired, setIsRequired] = useState(required);
   const [selectionType, setSelectionType] = useState<'single' | 'multi'>(
     type === 'MULTI_CHOICE' ? 'multi' : 'single',
   );
@@ -62,7 +63,7 @@ const QuestionBuilder = ({
           <ShortText
             id={id}
             title={title}
-            required={isRequired}
+            required={required}
             description={description}
             mode='builder'
             onTitleChange={onTitleChange}
@@ -76,7 +77,7 @@ const QuestionBuilder = ({
           <Choice
             id={id}
             title={title}
-            required={isRequired}
+            required={required}
             description={description}
             mode='builder'
             items={items}
@@ -124,9 +125,11 @@ const QuestionBuilder = ({
   return (
     <Styled.QuestionWrapper>
       <Styled.QuestionMenu>
-        <Styled.RequiredToggleButton onClick={() => setIsRequired(!isRequired)}>
+        <Styled.RequiredToggleButton
+          onClick={() => onRequiredChange?.(!required)}
+        >
           답변 필수
-          <Styled.RequiredToggleCircle active={isRequired} />
+          <Styled.RequiredToggleCircle active={required} />
         </Styled.RequiredToggleButton>
         <Styled.DropDownWrapper>
           <Styled.DropdownIcon
@@ -138,7 +141,7 @@ const QuestionBuilder = ({
             onChange={(e) => {
               const selectedType = e.target.value as QuestionType;
               setQuestionType(selectedType);
-              onTypeChange?.(selectedType); // 상위 상태도 업데이트
+              onTypeChange?.(selectedType);
             }}
           >
             <option value='CHOICE'>객관식</option>

--- a/frontend/src/pages/AdminPage/application/components/QuestionBuilder/QuestionBuilder.tsx
+++ b/frontend/src/pages/AdminPage/application/components/QuestionBuilder/QuestionBuilder.tsx
@@ -17,7 +17,7 @@ interface QuestionBuilderProps {
   id: number;
   title: string;
   description: string;
-  options?: { value: string }[];
+  items?: { value: string }[];
   type: QuestionType;
   required: boolean;
   onTitleChange: (value: string) => void;
@@ -31,7 +31,7 @@ const QuestionBuilder = ({
   title,
   description,
   required,
-  options,
+  items,
   type,
   onTitleChange,
   onItemsChange,
@@ -79,7 +79,7 @@ const QuestionBuilder = ({
             required={isRequired}
             description={description}
             mode='builder'
-            items={options}
+            items={items}
             onTitleChange={onTitleChange}
             onDescriptionChange={onDescriptionChange}
             onItemsChange={onItemsChange}

--- a/frontend/src/pages/AdminPage/application/components/QuestionBuilder/QuestionBuilder.tsx
+++ b/frontend/src/pages/AdminPage/application/components/QuestionBuilder/QuestionBuilder.tsx
@@ -1,0 +1,259 @@
+import styled from 'styled-components';
+import { useEffect, useState } from 'react';
+import ShortText from '@/pages/AdminPage/application/fields/ShortText';
+import dropdown_icon from '@/assets/images/icons/drop_button_icon.svg';
+import Choice from '@/pages/AdminPage/application/fields/Choice';
+
+type QuestionType =
+  | 'CHOICE'
+  | 'MULTI_CHOICE'
+  | 'SHORT_TEXT'
+  | 'LONG_TEXT'
+  | 'PHONE_NUMBER'
+  | 'EMAIL'
+  | 'NAME';
+
+interface QuestionBuilderProps {
+  id: number;
+  title: string;
+  description: string;
+  options?: { value: string }[];
+  type: QuestionType;
+  required: boolean;
+  onTitleChange: (value: string) => void;
+  onDescriptionChange: (value: string) => void;
+  onItemsChange?: (newItems: { value: string }[]) => void;
+  onTypeChange?: (type: QuestionType) => void;
+}
+
+const QuestionMenu = styled.div`
+  display: flex;
+  width: 140px;
+  flex-direction: column;
+  gap: 4px;
+`;
+
+const RequiredToggleButton = styled.div`
+  display: flex;
+  border: none;
+  padding: 12px 16px;
+  justify-content: space-between;
+  align-items: center;
+  border-radius: 0.375rem;
+  background: #f5f5f5;
+  cursor: pointer;
+  margin: 0;
+
+  color: #787878;
+  font-size: 0.875rem;
+  font-style: normal;
+  font-weight: 600;
+  line-height: normal;
+`;
+
+const RequiredToggleCircle = styled.span<{ active?: boolean }>`
+  position: relative;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 1px solid ${(props) => (props.active ? '#ff5000' : '#ccc')};
+  background-color: ${(props) => (props.active ? '#ff5000' : 'white')};
+
+  ${({ active }) =>
+    active &&
+    `
+    background-color: #fff;
+    &::after {
+      content: '';
+      width: 10px;
+      height: 10px;
+      background-color: #ff5000;
+      border-radius: 50%;
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+    }
+  `}
+`;
+
+const DropDownWrapper = styled.div`
+  position: relative;
+  width: 100%;
+`;
+
+const Dropdown = styled.select`
+  display: flex;
+  width: 100%;
+  border: none;
+  padding: 12px 16px;
+  border-radius: 0.375rem;
+  background: #f5f5f5;
+  color: #787878;
+  font-size: 0.875rem;
+  font-style: normal;
+  font-weight: 600;
+  cursor: pointer;
+  appearance: none;
+`;
+
+const DropdownIcon = styled.img`
+  position: absolute;
+  top: 50%;
+  right: 19px;
+  transform: translateY(-50%);
+  pointer-events: none;
+`;
+
+const SelectionToggleWrapper = styled.div`
+  display: flex;
+  background-color: #f7f7f7;
+  border-radius: 0.375rem;
+  padding: 2px;
+`;
+
+const SelectionToggleButton = styled.button<{ active: boolean }>`
+  border: none;
+  background-color: ${(props) => (props.active ? '#ddd' : 'transparent')};
+  color: #787878;
+  font-size: 0.875rem;
+  border-radius: 0.375rem;
+  padding: 10px;
+  font-weight: 600;
+  cursor: pointer;
+  letter-spacing: -0.42px;
+  white-space: nowrap;
+`;
+
+const QuestionWrapper = styled.div`
+  display: flex;
+  gap: 36px;
+`;
+
+const QuestionBuilder = ({
+  id,
+  title,
+  description,
+  required,
+  options,
+  type,
+  onTitleChange,
+  onItemsChange,
+  onDescriptionChange,
+  onTypeChange,
+}: QuestionBuilderProps) => {
+  const [isRequired, setIsRequired] = useState(required);
+  const [selectionType, setSelectionType] = useState<'single' | 'multi'>(
+    type === 'MULTI_CHOICE' ? 'multi' : 'single',
+  );
+  const [questionType, setQuestionType] = useState<QuestionType>(type);
+
+  useEffect(() => {
+    if (type === 'MULTI_CHOICE') {
+      setSelectionType('multi');
+    } else if (type === 'CHOICE') {
+      setSelectionType('single');
+    }
+  }, [type]);
+
+  const renderFieldByQuestionType = () => {
+    switch (questionType) {
+      case 'SHORT_TEXT':
+      case 'NAME':
+      case 'EMAIL':
+      case 'PHONE_NUMBER':
+        return (
+          <ShortText
+            id={id}
+            title={title}
+            required={isRequired}
+            description={description}
+            mode='builder'
+            onTitleChange={onTitleChange}
+            onDescriptionChange={onDescriptionChange}
+          />
+        );
+      // Todo case 'LONG_TEXT': 와 같은 다른 케이스도 여기서 렌더링 가능
+      case 'CHOICE':
+      case 'MULTI_CHOICE':
+        return (
+          <Choice
+            id={id}
+            title={title}
+            required={isRequired}
+            description={description}
+            mode='builder'
+            items={options}
+            onTitleChange={onTitleChange}
+            onDescriptionChange={onDescriptionChange}
+            onItemsChange={onItemsChange}
+            isMulti={questionType === 'MULTI_CHOICE'}
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
+  const renderSelectionToggle = () => {
+    if (questionType !== 'CHOICE' && questionType !== 'MULTI_CHOICE')
+      return null;
+
+    return (
+      <SelectionToggleWrapper>
+        <SelectionToggleButton
+          active={selectionType === 'single'}
+          onClick={() => {
+            setSelectionType('single');
+            setQuestionType('CHOICE');
+            onTypeChange?.('CHOICE');
+          }}
+        >
+          단일선택
+        </SelectionToggleButton>
+        <SelectionToggleButton
+          active={selectionType === 'multi'}
+          onClick={() => {
+            setSelectionType('multi');
+            setQuestionType('MULTI_CHOICE');
+            onTypeChange?.('MULTI_CHOICE');
+          }}
+        >
+          다중선택
+        </SelectionToggleButton>
+      </SelectionToggleWrapper>
+    );
+  };
+
+  return (
+    <QuestionWrapper>
+      <QuestionMenu>
+        <RequiredToggleButton onClick={() => setIsRequired(!isRequired)}>
+          답변 필수
+          <RequiredToggleCircle active={isRequired} />
+        </RequiredToggleButton>
+        <DropDownWrapper>
+          <DropdownIcon
+            src={dropdown_icon}
+            alt={'질문 타입 선택하기'}
+          ></DropdownIcon>
+          <Dropdown
+            value={questionType}
+            onChange={(e) => {
+              const selectedType = e.target.value as QuestionType;
+              setQuestionType(selectedType);
+              onTypeChange?.(selectedType); // 상위 상태도 업데이트
+            }}
+          >
+            <option value='CHOICE'>객관식</option>
+            <option value='SHORT_TEXT'>단답형</option>
+          </Dropdown>
+        </DropDownWrapper>
+        {renderSelectionToggle()}
+      </QuestionMenu>
+      {renderFieldByQuestionType()}
+    </QuestionWrapper>
+  );
+};
+
+export default QuestionBuilder;

--- a/frontend/src/pages/AdminPage/application/components/QuestionBuilder/QuestionBuilder.tsx
+++ b/frontend/src/pages/AdminPage/application/components/QuestionBuilder/QuestionBuilder.tsx
@@ -1,8 +1,8 @@
-import styled from 'styled-components';
 import { useEffect, useState } from 'react';
 import ShortText from '@/pages/AdminPage/application/fields/ShortText';
 import dropdown_icon from '@/assets/images/icons/drop_button_icon.svg';
 import Choice from '@/pages/AdminPage/application/fields/Choice';
+import * as Styled from './QuestionBuilder.styles';
 
 type QuestionType =
   | 'CHOICE'
@@ -25,110 +25,6 @@ interface QuestionBuilderProps {
   onItemsChange?: (newItems: { value: string }[]) => void;
   onTypeChange?: (type: QuestionType) => void;
 }
-
-const QuestionMenu = styled.div`
-  display: flex;
-  width: 140px;
-  flex-direction: column;
-  gap: 4px;
-`;
-
-const RequiredToggleButton = styled.div`
-  display: flex;
-  border: none;
-  padding: 12px 16px;
-  justify-content: space-between;
-  align-items: center;
-  border-radius: 0.375rem;
-  background: #f5f5f5;
-  cursor: pointer;
-  margin: 0;
-
-  color: #787878;
-  font-size: 0.875rem;
-  font-style: normal;
-  font-weight: 600;
-  line-height: normal;
-`;
-
-const RequiredToggleCircle = styled.span<{ active?: boolean }>`
-  position: relative;
-  width: 16px;
-  height: 16px;
-  border-radius: 50%;
-  border: 1px solid ${(props) => (props.active ? '#ff5000' : '#ccc')};
-  background-color: ${(props) => (props.active ? '#ff5000' : 'white')};
-
-  ${({ active }) =>
-    active &&
-    `
-    background-color: #fff;
-    &::after {
-      content: '';
-      width: 10px;
-      height: 10px;
-      background-color: #ff5000;
-      border-radius: 50%;
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-    }
-  `}
-`;
-
-const DropDownWrapper = styled.div`
-  position: relative;
-  width: 100%;
-`;
-
-const Dropdown = styled.select`
-  display: flex;
-  width: 100%;
-  border: none;
-  padding: 12px 16px;
-  border-radius: 0.375rem;
-  background: #f5f5f5;
-  color: #787878;
-  font-size: 0.875rem;
-  font-style: normal;
-  font-weight: 600;
-  cursor: pointer;
-  appearance: none;
-`;
-
-const DropdownIcon = styled.img`
-  position: absolute;
-  top: 50%;
-  right: 19px;
-  transform: translateY(-50%);
-  pointer-events: none;
-`;
-
-const SelectionToggleWrapper = styled.div`
-  display: flex;
-  background-color: #f7f7f7;
-  border-radius: 0.375rem;
-  padding: 2px;
-`;
-
-const SelectionToggleButton = styled.button<{ active: boolean }>`
-  border: none;
-  background-color: ${(props) => (props.active ? '#ddd' : 'transparent')};
-  color: #787878;
-  font-size: 0.875rem;
-  border-radius: 0.375rem;
-  padding: 10px;
-  font-weight: 600;
-  cursor: pointer;
-  letter-spacing: -0.42px;
-  white-space: nowrap;
-`;
-
-const QuestionWrapper = styled.div`
-  display: flex;
-  gap: 36px;
-`;
 
 const QuestionBuilder = ({
   id,
@@ -200,8 +96,8 @@ const QuestionBuilder = ({
       return null;
 
     return (
-      <SelectionToggleWrapper>
-        <SelectionToggleButton
+      <Styled.SelectionToggleWrapper>
+        <Styled.SelectionToggleButton
           active={selectionType === 'single'}
           onClick={() => {
             setSelectionType('single');
@@ -210,8 +106,8 @@ const QuestionBuilder = ({
           }}
         >
           단일선택
-        </SelectionToggleButton>
-        <SelectionToggleButton
+        </Styled.SelectionToggleButton>
+        <Styled.SelectionToggleButton
           active={selectionType === 'multi'}
           onClick={() => {
             setSelectionType('multi');
@@ -220,24 +116,24 @@ const QuestionBuilder = ({
           }}
         >
           다중선택
-        </SelectionToggleButton>
-      </SelectionToggleWrapper>
+        </Styled.SelectionToggleButton>
+      </Styled.SelectionToggleWrapper>
     );
   };
 
   return (
-    <QuestionWrapper>
-      <QuestionMenu>
-        <RequiredToggleButton onClick={() => setIsRequired(!isRequired)}>
+    <Styled.QuestionWrapper>
+      <Styled.QuestionMenu>
+        <Styled.RequiredToggleButton onClick={() => setIsRequired(!isRequired)}>
           답변 필수
-          <RequiredToggleCircle active={isRequired} />
-        </RequiredToggleButton>
-        <DropDownWrapper>
-          <DropdownIcon
+          <Styled.RequiredToggleCircle active={isRequired} />
+        </Styled.RequiredToggleButton>
+        <Styled.DropDownWrapper>
+          <Styled.DropdownIcon
             src={dropdown_icon}
             alt={'질문 타입 선택하기'}
-          ></DropdownIcon>
-          <Dropdown
+          ></Styled.DropdownIcon>
+          <Styled.Dropdown
             value={questionType}
             onChange={(e) => {
               const selectedType = e.target.value as QuestionType;
@@ -247,12 +143,12 @@ const QuestionBuilder = ({
           >
             <option value='CHOICE'>객관식</option>
             <option value='SHORT_TEXT'>단답형</option>
-          </Dropdown>
-        </DropDownWrapper>
+          </Styled.Dropdown>
+        </Styled.DropDownWrapper>
         {renderSelectionToggle()}
-      </QuestionMenu>
+      </Styled.QuestionMenu>
       {renderFieldByQuestionType()}
-    </QuestionWrapper>
+    </Styled.QuestionWrapper>
   );
 };
 

--- a/frontend/src/pages/AdminPage/application/components/QuestionBuilder/QuestionBuilder.tsx
+++ b/frontend/src/pages/AdminPage/application/components/QuestionBuilder/QuestionBuilder.tsx
@@ -43,7 +43,6 @@ const QuestionBuilder = ({
   const [selectionType, setSelectionType] = useState<'single' | 'multi'>(
     type === 'MULTI_CHOICE' ? 'multi' : 'single',
   );
-  const [questionType, setQuestionType] = useState<QuestionType>(type);
 
   useEffect(() => {
     if (type === 'MULTI_CHOICE') {
@@ -54,7 +53,7 @@ const QuestionBuilder = ({
   }, [type]);
 
   const renderFieldByQuestionType = () => {
-    switch (questionType) {
+    switch (type) {
       case 'SHORT_TEXT':
       case 'NAME':
       case 'EMAIL':
@@ -84,7 +83,7 @@ const QuestionBuilder = ({
             onTitleChange={onTitleChange}
             onDescriptionChange={onDescriptionChange}
             onItemsChange={onItemsChange}
-            isMulti={questionType === 'MULTI_CHOICE'}
+            isMulti={type === 'MULTI_CHOICE'}
           />
         );
       default:
@@ -93,8 +92,7 @@ const QuestionBuilder = ({
   };
 
   const renderSelectionToggle = () => {
-    if (questionType !== 'CHOICE' && questionType !== 'MULTI_CHOICE')
-      return null;
+    if (type !== 'CHOICE' && type !== 'MULTI_CHOICE') return null;
 
     return (
       <Styled.SelectionToggleWrapper>
@@ -102,7 +100,6 @@ const QuestionBuilder = ({
           active={selectionType === 'single'}
           onClick={() => {
             setSelectionType('single');
-            setQuestionType('CHOICE');
             onTypeChange?.('CHOICE');
           }}
         >
@@ -112,7 +109,6 @@ const QuestionBuilder = ({
           active={selectionType === 'multi'}
           onClick={() => {
             setSelectionType('multi');
-            setQuestionType('MULTI_CHOICE');
             onTypeChange?.('MULTI_CHOICE');
           }}
         >
@@ -137,10 +133,9 @@ const QuestionBuilder = ({
             alt={'질문 타입 선택하기'}
           ></Styled.DropdownIcon>
           <Styled.Dropdown
-            value={questionType}
+            value={type}
             onChange={(e) => {
               const selectedType = e.target.value as QuestionType;
-              setQuestionType(selectedType);
               onTypeChange?.(selectedType);
             }}
           >

--- a/frontend/src/pages/AdminPage/application/components/QuestionDescription/QuestionDescription.tsx
+++ b/frontend/src/pages/AdminPage/application/components/QuestionDescription/QuestionDescription.tsx
@@ -1,0 +1,35 @@
+import styled from 'styled-components';
+
+interface QuestionDescriptionProps {
+  description: string;
+  mode: 'builder' | 'answer';
+  onChange?: (value: string) => void;
+}
+
+const QuestionDescriptionText = styled.input`
+  border: none;
+  outline: none;
+  color: #c5c5c5;
+  font-size: 0.8125rem;
+  font-weight: 400;
+  line-height: normal;
+  letter-spacing: -0.26px;
+`;
+
+const QuestionDescription = ({
+  description,
+  mode,
+  onChange,
+}: QuestionDescriptionProps) => {
+  return (
+    <div>
+      <QuestionDescriptionText
+        value={description}
+        readOnly={mode === 'answer'}
+        onChange={(e) => onChange?.(e.target.value)}
+      />
+    </div>
+  );
+};
+
+export default QuestionDescription;

--- a/frontend/src/pages/AdminPage/application/components/QuestionDescription/QuestionDescription.tsx
+++ b/frontend/src/pages/AdminPage/application/components/QuestionDescription/QuestionDescription.tsx
@@ -22,13 +22,15 @@ const QuestionDescription = ({
   onChange,
 }: QuestionDescriptionProps) => {
   return (
-    <div>
+    <>
       <QuestionDescriptionText
         value={description}
+        placeholder='질문에 대한 설명을 입력하세요'
+        aria-label='질문 설명'
         readOnly={mode === 'answer'}
         onChange={(e) => onChange?.(e.target.value)}
       />
-    </div>
+    </>
   );
 };
 

--- a/frontend/src/pages/AdminPage/application/components/QuestionTitle/QuestionTitle.tsx
+++ b/frontend/src/pages/AdminPage/application/components/QuestionTitle/QuestionTitle.tsx
@@ -1,0 +1,62 @@
+import styled from 'styled-components';
+
+const QuestionTitleContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+`;
+
+const QuestionTitleId = styled.p`
+  color: #ff5414;
+  font-size: 1.25rem;
+  font-weight: 700;
+  line-height: normal;
+`;
+
+const QuestionTitleText = styled.input`
+  border: none;
+  outline: none;
+  color: #111;
+  font-size: 1.25rem;
+  font-weight: 700;
+  line-height: normal;
+`;
+
+const QuestionRequired = styled.div`
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: #ff5414;
+  margin-left: 14px;
+`;
+
+interface QuestionTitleProps {
+  id: number;
+  title: string;
+  required?: boolean;
+  mode: 'builder' | 'answer';
+  onChange?: (value: string) => void;
+}
+
+const QuestionTitle = ({
+  id,
+  title,
+  required,
+  mode,
+  onChange,
+}: QuestionTitleProps) => {
+  return (
+    <QuestionTitleContainer>
+      {id && <QuestionTitleId>{id}.</QuestionTitleId>}
+      <QuestionTitleText
+        type='text'
+        value={title}
+        readOnly={mode === 'answer'}
+        onChange={(e) => onChange?.(e.target.value)}
+      />
+      {mode === 'answer' && required && <QuestionRequired />}
+    </QuestionTitleContainer>
+  );
+};
+
+export default QuestionTitle;

--- a/frontend/src/pages/AdminPage/application/components/QuestionTitle/QuestionTitle.tsx
+++ b/frontend/src/pages/AdminPage/application/components/QuestionTitle/QuestionTitle.tsx
@@ -51,6 +51,8 @@ const QuestionTitle = ({
       <QuestionTitleText
         type='text'
         value={title}
+        placeholder='질문 제목을 입력하세요'
+        aria-label='질문 제목'
         readOnly={mode === 'answer'}
         onChange={(e) => onChange?.(e.target.value)}
       />

--- a/frontend/src/pages/AdminPage/application/fields/Choice.tsx
+++ b/frontend/src/pages/AdminPage/application/fields/Choice.tsx
@@ -1,0 +1,130 @@
+import styled from 'styled-components';
+import QuestionTitle from '@/pages/AdminPage/application/components/QuestionTitle/QuestionTitle';
+import QuestionDescription from '@/pages/AdminPage/application/components/QuestionDescription/QuestionDescription';
+import InputField from '@/components/common/InputField/InputField';
+import APPLICATION_FORM from '@/constants/APPLICATION_FORM';
+
+interface ChoiceProps {
+  id: number;
+  title: string;
+  description: string;
+  required: boolean;
+  mode: 'builder' | 'answer';
+  onTitleChange?: (value: string) => void;
+  onDescriptionChange?: (value: string) => void;
+  items?: { value: string }[];
+  answer?: string;
+  isMulti?: boolean;
+  onItemsChange?: (newItems: { value: string }[]) => void;
+}
+
+const AddItemButton = styled.button`
+  padding: 8px 12px;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+  font-size: 0.875rem;
+  font-weight: 500;
+  background: white;
+  color: #555;
+  margin-top: 8px;
+  cursor: pointer;
+`;
+
+const ItemWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+`;
+
+const DeleteButton = styled.button`
+  font-size: 0.75rem;
+  padding: 4px 8px;
+  border-radius: 4px;
+  background-color: #ffecec;
+  color: #e33;
+  border: 1px solid #f99;
+  cursor: pointer;
+`;
+
+const MIN_ITEMS = 2;
+const MAX_ITEMS = 6;
+
+//todo isMulti나 질문 타입을 props로 받아서 다중 선택이 가능하도록 기능 추가 필요
+const Choice = ({
+  id,
+  title,
+  description,
+  required,
+  mode,
+  onTitleChange,
+  onDescriptionChange,
+  items = [],
+  isMulti,
+  onItemsChange,
+}: ChoiceProps) => {
+  const filledItems =
+    items.length >= MIN_ITEMS
+      ? items
+      : [
+          ...items,
+          ...Array.from({ length: MIN_ITEMS - items.length }, () => ({
+            value: '',
+          })),
+        ];
+
+  const handleItemChange = (index: number, newValue: string) => {
+    const updated = [...items];
+    updated[index].value = newValue;
+    onItemsChange?.(updated);
+  };
+
+  const handleAddItem = () => {
+    if (items.length >= MAX_ITEMS) return;
+    onItemsChange?.([...items, { value: '' }]);
+  };
+
+  const handleDeleteItem = (index: number) => {
+    if (items.length <= MIN_ITEMS) return;
+    const updated = items.filter((_, i) => i !== index);
+    onItemsChange?.(updated);
+  };
+
+  return (
+    <div>
+      <QuestionTitle
+        id={id}
+        title={title}
+        required={required}
+        mode={mode}
+        onChange={onTitleChange}
+      />
+      <QuestionDescription
+        description={description}
+        mode={mode}
+        onChange={onDescriptionChange}
+      />
+      {filledItems.map((item, index) => (
+        <ItemWrapper key={index}>
+          <InputField
+            value={item.value}
+            onChange={(e) => handleItemChange(index, e.target.value)}
+            placeholder={APPLICATION_FORM.CHOICE.placeholder}
+            disabled={mode === 'answer'}
+          />
+          {mode === 'builder' && items.length > MIN_ITEMS && (
+            <DeleteButton onClick={() => handleDeleteItem(index)}>
+              삭제
+            </DeleteButton>
+          )}
+        </ItemWrapper>
+      ))}
+
+      {mode === 'builder' && items.length < MAX_ITEMS && (
+        <AddItemButton onClick={handleAddItem}>+ 추가항목</AddItemButton>
+      )}
+    </div>
+  );
+};
+
+export default Choice;

--- a/frontend/src/pages/AdminPage/application/fields/Choice.tsx
+++ b/frontend/src/pages/AdminPage/application/fields/Choice.tsx
@@ -63,19 +63,10 @@ const Choice = ({
   isMulti,
   onItemsChange,
 }: ChoiceProps) => {
-  const filledItems =
-    items.length >= MIN_ITEMS
-      ? items
-      : [
-          ...items,
-          ...Array.from({ length: MIN_ITEMS - items.length }, () => ({
-            value: '',
-          })),
-        ];
-
   const handleItemChange = (index: number, newValue: string) => {
-    const updated = [...items];
-    updated[index].value = newValue;
+    const updated = items.map((item, i) =>
+      i === index ? { ...item, value: newValue } : item,
+    );
     onItemsChange?.(updated);
   };
 
@@ -104,7 +95,7 @@ const Choice = ({
         mode={mode}
         onChange={onDescriptionChange}
       />
-      {filledItems.map((item, index) => (
+      {items.map((item, index) => (
         <ItemWrapper key={index}>
           <InputField
             value={item.value}

--- a/frontend/src/pages/AdminPage/application/fields/ShortText.tsx
+++ b/frontend/src/pages/AdminPage/application/fields/ShortText.tsx
@@ -1,0 +1,53 @@
+import QuestionTitle from '@/pages/AdminPage/application/components/QuestionTitle/QuestionTitle';
+import QuestionDescription from '@/pages/AdminPage/application/components/QuestionDescription/QuestionDescription';
+import InputField from '@/components/common/InputField/InputField';
+import APPLICATION_FORM from '@/constants/APPLICATION_FORM';
+
+interface ShortTextProps {
+  id: number;
+  title: string;
+  description: string;
+  required: boolean;
+  mode: 'builder' | 'answer';
+  answer?: string;
+  onChange?: (value: string) => void;
+  onTitleChange?: (value: string) => void;
+  onDescriptionChange?: (value: string) => void;
+}
+
+const ShortText = ({
+  id,
+  title,
+  description,
+  required,
+  answer,
+  mode,
+  onChange,
+  onTitleChange,
+  onDescriptionChange,
+}: ShortTextProps) => {
+  return (
+    <div>
+      <QuestionTitle
+        id={id}
+        title={title}
+        required={required}
+        mode={mode}
+        onChange={onTitleChange}
+      />
+      <QuestionDescription
+        description={description}
+        mode={mode}
+        onChange={onDescriptionChange}
+      />
+      <InputField
+        value={answer}
+        onChange={(e) => onChange?.(e.target.value)}
+        placeholder={APPLICATION_FORM.SHORT_TEXT.placeholder}
+        disabled={mode === 'builder'}
+      />
+    </div>
+  );
+};
+
+export default ShortText;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #440

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지/동영상 첨부 가능)

성원님과 함께 3일간 짝 프로그래밍하며 진행한 PR입니다. 수고 많으셨습니다! 😄
이번 작업은 지원서 컴포넌트를 재사용 가능하도록 설계하는 데 중점을 두었습니다.


개발 순서에 따라 작업 내역을 정리하면 다음과 같습니다:
### 1.QuestionTitle 및 QuestionDescription 컴포넌트 추가
- 질문 제목 및 설명을 표시/수정하는 컴포넌트입니다.
mode에 따라 편집 가능 여부가 달라집니다.
builder 모드: 제목/설명 수정 가능
answer 모드: 읽기 전용


<br/>

### 2. 폼 질문 유형별 컴포넌트를 구현하였습니다.
1️⃣  선택형 질문: Choice
- 옵션 항목 추가/삭제 가능
- 단일/다중 선택 모드 지원
- 모드(builder, answer)에 따른 동작 분기
<img src="https://github.com/user-attachments/assets/651373d9-4bce-4a8a-a7a4-b84e9d181e78" width="300"/>

2️⃣ 단답형 질문: ShortText
- 입력 필드 및 제목/설명 편집 기능 포함
<img src="https://github.com/user-attachments/assets/2830e0e2-9153-482d-b0a3-e94f85cfd4e1" width="300"/>

+ 추후 long text와 같은 추가 타입도 필요합니다.



<br/>

### 3. 질문 빌더: QuestionBuilder 컴포넌트 구현
- 질문 유형 선택 드롭다운 제공
- 필수 여부 토글
- 선택형 질문일 경우, 단일/다중 선택 전환 가능
- 선택된 질문 유형에 따라 적절한 컴포넌트 렌더링

<img src="https://github.com/user-attachments/assets/a669d672-dff9-47ee-9aee-7e02cba5b3c3" width="200"/>
<img src="https://github.com/user-attachments/assets/b87c3f7b-c6fd-43bf-9744-e9db436f4b50" width="200"/>


<br/>

### 4. 지원서 생성: CreateForm 컴포넌트 구현
관리자가 새로운 질문을 추가하거나, 기존 질문을 편집할 수 있는 페이지
각 질문을 유연하게 구성할 수 있도록 상태 관리 및 동적 렌더링 구현
해당 페이지에 추후 api 데이터에 맞게 제작, 수정 폼을 띄워야합니다.
질문 삭제, 추가 버튼도 필요합니다.


<br/>

### 5. 지원서 뷰 및 작성 페이지로 이동할 수 있는 라우팅 추가


## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

주말 일정으로 인해 PR이 다소 늦어진 점 양해 부탁드립니다.. 기다려주셔서 감사합니다 🙇‍♂️

혼자 진행한 작업은 아래와 같습니다:
- QuestionBuilder의 스타일을 분리해두었습니다.
- 아직 개발 예정인 부분은 TODO: 주석으로 표시해두었습니다.
추가하고 싶은 내용이 있으시다면 자유롭게 커밋 부탁드립니다!


## 🫡 참고사항

- Select태그 드랍다운 아이콘 리소스(SVG) 추가  
- 질문 입력 필드에 placeholder 상수 활용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **신규 기능**
    - 지원서 작성 및 생성 폼 페이지에 새 라우트가 추가되어, 사용자와 관리자 모두가 신청서 양식을 볼 수 있는 페이지에 접근 가능해졌습니다.
    - 관리자 페이지에 신청서 양식을 생성하고 편집할 수 있는 `CreateForm`과 `ApplicationForm` 컴포넌트가 도입되어, 질문 항목을 동적으로 관리할 수 있습니다.
    - 질문 유형 선택, 제목, 설명, 필수 여부, 선택지 항목 등을 설정하는 기능이 포함되어 있습니다.
    - 질문 편집 UI와 답변 모드에 따른 입력 필드, 선택지 관리, 질문 제목 및 설명 수정 기능이 제공됩니다.

- **스타일**
    - 질문 편집 인터페이스용 스타일이 새롭게 적용되어, 사용자 친화적이고 일관된 UI를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



## 🔧 리뷰로 인한 수정사항들 🔧
1. 질문 제목, 설명 컴포넌트에 placeholder와 접근성 속성 추가
→ 6b14dc9

2. LONG_TEXT placeholder 상수 값이 최대 20자로 되어 있어 500자로 수정
→ a6fae14

3. App.tsx CreateForm 경로 이동 필요 TODO 주석 추가
→ b64e5e1

4. CreateForm에서 QuestionBuilder에 required가 항상 true로 하드코딩 되어 있던 문제 해결
→ 30fb4a2

5. mock 데이터 안내 문구 수정
→ ecd73a3

6. QuestionBuilder의 잘못된 props명 options를 items로 변경
→ 4906413

