### PR TITLE
[feature] 소개페이지 컴포넌트 테스트 코드 작성

### DIFF
--- a/frontend/src/pages/IntroducePage/IntroducePage.test.tsx
+++ b/frontend/src/pages/IntroducePage/IntroducePage.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import IntroducePage from './IntroducePage';
+
+jest.mock('@/components/common/Header/Header', () => ({
+  __esModule: true,
+  default: () => <div data-testid='mock-header'>Header</div>,
+}));
+
+jest.mock('@/components/common/Footer/Footer', () => ({
+  __esModule: true,
+  default: () => <div data-testid='mock-footer'>Footer</div>,
+}));
+
+jest.mock('@/components/common/Spinner/Spinner', () => ({
+  __esModule: true,
+  default: () => <div data-testid='mock-spinner'>Loading...</div>,
+}));
+
+jest.mock('@/assets/images/introduce/Introduce.png', () => 'mocked-image-path');
+
+describe('IntroducePage 컴포넌트', () => {
+  it('초기 상태에서는 스피너가 표시되고 이미지는 숨겨진다', () => {
+    render(<IntroducePage />);
+
+    expect(screen.getByTestId('mock-spinner')).toBeInTheDocument();
+
+    const image = screen.getByAltText('소개 이미지');
+    expect(image).toHaveStyle({ display: 'none' });
+  });
+
+  it('이미지 로드가 완료되면 스피너가 사라지고 이미지가 표시된다', () => {
+    render(<IntroducePage />);
+
+    const image = screen.getByAltText('소개 이미지');
+    fireEvent.load(image);
+
+    expect(screen.queryByTestId('mock-spinner')).not.toBeInTheDocument();
+    expect(image).toHaveStyle({ display: 'block' });
+  });
+
+  it('Header와 Footer가 올바르게 렌더링된다', () => {
+    render(<IntroducePage />);
+
+    expect(screen.getByTestId('mock-header')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-footer')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #447 

## 📝작업 내용
- 초기 로딩 상태에서 스피너 표시 여부 테스트
- 이미지 로드 완료 후 UI 상태 변경 테스트
- Header, Footer 컴포넌트 렌더링 테스트
- 외부 컴포넌트(Header, Footer, Spinner) 모킹 설정

## 테스트 케이스
### 1. 초기 상태 테스트
  - 스피너가 표시되는지 확인
  - 이미지가 숨겨진 상태인지 확인

### 2. 이미지 로드 완료 테스트
 - 스피너가 사라지는지 확인
 - 이미지가 표시되는지 확인

### 3. 레이아웃 컴포넌트 테스트
  - Header 컴포넌트 렌더링 확인
  - Footer 컴포넌트 렌더링 확인

[testing-library 메서드 정리](https://www.notion.so/react-testing-library-201aad23209680f5a42df55a7ef6b4ad?pvs=4)


## 테스트의 필요성
오늘 태규님에게 테스트에 대한 얘기를 듣고 왔습니다!  단위 테스트든 UI테스트든 가장 중요한 건 
`1. 공통적으로 쓰이는 로직일 때`
`2. 내부 구현 로직이 복잡하거나 상태 변화가 많을 때`


라고 하셨습니다. 1번은 여러 기능에 영향을 미치므로 이 로직이 망가지면 여러 손해가 발생할 수 있습니다.
2번은 에러를 던질 가능성이 많다는 것으로 해석할 수 있습니다.

### 도입했던 이유
저는 `1. 커버리지 높이기`, `2. react-testing-library공부`를 목적으로 했는데,
1번은 단위 테스트에서 지양해야 할 점이라고 합니다. 

### 유틸함수 테스트
단위테스트 중 유틸 함수는 `util`이라는 이름처럼 여러 곳에서 쓰이므로 적합합니다. 
하지만 이전에 올렸던 `stringToDate`에 대한 단위 테스트([해당 pr](https://github.com/Moadong/moadong/pull/442))는, 테스트의 용이성을 위해 기존 함수를 분리했기에 
테스트에 대한 의존성만 높아진 것입니다. 추가로 테스트가 필요한 점 2번 또한 간과한 것이 될 수 있겠네요. 

### UI 테스트 
이것도 비즈니스 로직이 있다면 사용자 흐름을 테스트할 수 있어서 용이할 수 있습니다. 하지만 제가 올린 pr은 
공통적으로 쓰이지도 않고 비즈니스적인 흐름도 없어, "굳이" 할 이유는 없던 것 같습니다.
혹여나 다른 로직이 추가되면 테스트를 바꾸는 데에도 리소스가 발생하기 때문이며, ci/cd에도 영향을 줄 수 있습니다.

## 결론
공부할 목적으로 하면 좋은 것 같습니다. 다만, 테스트를 한다고 무조건 좋은 것은 아니라는 것을 알게 되었습니다.
단위테스트와 커버리지에 대한 얘기가 부족했던 것 같아서 이 부분 꼭 같이 얘기해보는 게 좋을 것 같아요 ㅎㅎ

[단위테스트](https://product.kyobobook.co.kr/detail/S000001805070) 이 책도 추천해주셨습니다 ~

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)


## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - `IntroducePage` 컴포넌트에 대한 새로운 테스트가 추가되어, 로딩 스피너와 이미지 표시, Header 및 Footer 렌더링이 올바르게 동작하는지 검증합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->