### PR TITLE
[feature] 지원서 질문 추가/삭제 및 장문형 질문 타입 구현

### DIFF
--- a/frontend/src/components/common/CustomTextArea/CustomTextArea.styles.ts
+++ b/frontend/src/components/common/CustomTextArea/CustomTextArea.styles.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-export const InputContainer = styled.div<{ width: string }>`
+export const TextAreaContainer = styled.div<{ width: string }>`
   width: ${(props) => props.width};
   min-width: 385px;
   display: flex;
@@ -13,7 +13,7 @@ export const Label = styled.label`
   font-weight: 600;
 `;
 
-export const InputWrapper = styled.div`
+export const TextAreaWrapper = styled.div`
   position: relative;
   display: flex;
   align-items: center;
@@ -22,13 +22,15 @@ export const InputWrapper = styled.div`
 export const TextArea = styled.textarea<{ hasError?: boolean }>`
   flex: 1;
   height: 45px;
-  padding: 12px 80px 12px 18px;
+  padding: 12px 18px;
   border: 1px solid ${({ hasError }) => (hasError ? 'red' : '#c5c5c5')};
   border-radius: 6px;
   outline: none;
   font-size: 1.125rem;
   letter-spacing: 0;
   color: rgba(0, 0, 0, 0.8);
+  overflow: hidden;
+  resize: none;
 
   &:focus {
     border-color: ${({ hasError }) => (hasError ? 'red' : '#007bff')};
@@ -37,11 +39,9 @@ export const TextArea = styled.textarea<{ hasError?: boolean }>`
         hasError ? 'rgba(255, 0, 0, 0.5)' : 'rgba(0, 123, 255, 0.5)'};
   }
 
-  ${({ disabled }) =>
-    disabled &&
-    `
-    background-color: rgba(0, 0, 0, 0.05); 
-  `}
+  &:disabled {
+    background-color: rgba(0, 0, 0, 0.05);
+  }
   &::placeholder {
     color: rgba(0, 0, 0, 0.3);
   }

--- a/frontend/src/components/common/CustomTextArea/CustomTextArea.styles.ts
+++ b/frontend/src/components/common/CustomTextArea/CustomTextArea.styles.ts
@@ -1,5 +1,7 @@
 import styled from 'styled-components';
 
+//Todo : InputField 컴포넌트와 중복되는 부분이 많아 추후 리팩토링 검토
+
 export const TextAreaContainer = styled.div<{ width: string }>`
   width: ${(props) => props.width};
   min-width: 385px;

--- a/frontend/src/components/common/CustomTextArea/CustomTextArea.styles.ts
+++ b/frontend/src/components/common/CustomTextArea/CustomTextArea.styles.ts
@@ -1,0 +1,69 @@
+import styled from 'styled-components';
+
+export const InputContainer = styled.div<{ width: string }>`
+  width: ${(props) => props.width};
+  min-width: 385px;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const Label = styled.label`
+  font-size: 1.125rem;
+  margin-bottom: 12px;
+  font-weight: 600;
+`;
+
+export const InputWrapper = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+`;
+
+export const TextArea = styled.textarea<{ hasError?: boolean }>`
+  flex: 1;
+  height: 45px;
+  padding: 12px 80px 12px 18px;
+  border: 1px solid ${({ hasError }) => (hasError ? 'red' : '#c5c5c5')};
+  border-radius: 6px;
+  outline: none;
+  font-size: 1.125rem;
+  letter-spacing: 0;
+  color: rgba(0, 0, 0, 0.8);
+
+  &:focus {
+    border-color: ${({ hasError }) => (hasError ? 'red' : '#007bff')};
+    box-shadow: 0 0 3px
+      ${({ hasError }) =>
+        hasError ? 'rgba(255, 0, 0, 0.5)' : 'rgba(0, 123, 255, 0.5)'};
+  }
+
+  ${({ disabled }) =>
+    disabled &&
+    `
+    background-color: rgba(0, 0, 0, 0.05); 
+  `}
+  &::placeholder {
+    color: rgba(0, 0, 0, 0.3);
+  }
+`;
+
+export const CharCount = styled.span`
+  position: absolute;
+  color: #c5c5c5;
+  right: 0;
+  top: 100%;
+  font-size: 16px;
+  letter-spacing: -0.96px;
+`;
+
+export const HelperText = styled.div`
+  position: absolute;
+  left: 0;
+  top: 100%;
+  font-size: 0.75rem;
+  color: red;
+  margin-top: 4px;
+  pointer-events: none;
+  white-space: nowrap;
+  z-index: 1;
+`;

--- a/frontend/src/components/common/CustomTextArea/CustomTextArea.tsx
+++ b/frontend/src/components/common/CustomTextArea/CustomTextArea.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef } from 'react';
 import * as Styled from './CustomTextArea.styles';
 
+//Todo : InputField 컴포넌트와 중복되는 부분이 많아 추후 리팩토링 검토
+
 interface CustomTextAreaProps {
   placeholder?: string;
   width?: string;

--- a/frontend/src/components/common/CustomTextArea/CustomTextArea.tsx
+++ b/frontend/src/components/common/CustomTextArea/CustomTextArea.tsx
@@ -12,7 +12,6 @@ interface CustomTextAreaProps {
   disabled?: boolean;
   value?: string;
   onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
-  onClear?: () => void;
   isError?: boolean;
   helperText?: string;
 }

--- a/frontend/src/components/common/CustomTextArea/CustomTextArea.tsx
+++ b/frontend/src/components/common/CustomTextArea/CustomTextArea.tsx
@@ -1,0 +1,63 @@
+import * as Styled from './CustomTextArea.styles';
+
+interface CustomInputProps {
+  placeholder?: string;
+  width?: string;
+  maxLength?: number;
+  label?: string;
+  showMaxChar?: boolean;
+  disabled?: boolean;
+  value?: string;
+  onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onClear?: () => void;
+  isError?: boolean;
+  helperText?: string;
+}
+
+const CustomTextArea = ({
+  placeholder = '입력하세요',
+  width = '100%',
+  maxLength,
+  label,
+  showMaxChar = false,
+  disabled = false,
+  value = '',
+  onChange,
+  isError,
+  helperText,
+}: CustomInputProps) => {
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const inputValue = e.target.value;
+    if (maxLength !== undefined && inputValue.length > maxLength) {
+      return;
+    }
+    onChange?.(e);
+  };
+
+  return (
+    <Styled.InputContainer width={width}>
+      {label && <Styled.Label>{label}</Styled.Label>}
+      <Styled.InputWrapper>
+        <Styled.TextArea
+          onChange={handleChange}
+          placeholder={placeholder}
+          maxLength={maxLength}
+          disabled={disabled}
+          hasError={isError}
+        >
+          {value}
+        </Styled.TextArea>
+        {showMaxChar && maxLength !== undefined && (
+          <Styled.CharCount>
+            {value.length}/{maxLength}
+          </Styled.CharCount>
+        )}
+      </Styled.InputWrapper>
+      {isError && helperText && (
+        <Styled.HelperText>{helperText}</Styled.HelperText>
+      )}
+    </Styled.InputContainer>
+  );
+};
+
+export default CustomTextArea;

--- a/frontend/src/components/common/CustomTextArea/CustomTextArea.tsx
+++ b/frontend/src/components/common/CustomTextArea/CustomTextArea.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import * as Styled from './CustomTextArea.styles';
 
-interface CustomInputProps {
+interface CustomTextAreaProps {
   placeholder?: string;
   width?: string;
   maxLength?: number;
@@ -26,7 +26,7 @@ const CustomTextArea = ({
   onChange,
   isError,
   helperText,
-}: CustomInputProps) => {
+}: CustomTextAreaProps) => {
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {

--- a/frontend/src/components/common/CustomTextArea/CustomTextArea.tsx
+++ b/frontend/src/components/common/CustomTextArea/CustomTextArea.tsx
@@ -44,9 +44,8 @@ const CustomTextArea = ({
           maxLength={maxLength}
           disabled={disabled}
           hasError={isError}
-        >
-          {value}
-        </Styled.TextArea>
+          value={value}
+        />
         {showMaxChar && maxLength !== undefined && (
           <Styled.CharCount>
             {value.length}/{maxLength}

--- a/frontend/src/components/common/CustomTextArea/CustomTextArea.tsx
+++ b/frontend/src/components/common/CustomTextArea/CustomTextArea.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import * as Styled from './CustomTextArea.styles';
 
 interface CustomInputProps {
@@ -26,6 +27,19 @@ const CustomTextArea = ({
   isError,
   helperText,
 }: CustomInputProps) => {
+  const textAreaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (disabled) {
+      return;
+    }
+    const el = textAreaRef.current;
+    if (el) {
+      el.style.height = 'auto'; // 초기화
+      el.style.height = `${el.scrollHeight}px`;
+    }
+  }, [value]);
+
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const inputValue = e.target.value;
     if (maxLength !== undefined && inputValue.length > maxLength) {
@@ -35,10 +49,11 @@ const CustomTextArea = ({
   };
 
   return (
-    <Styled.InputContainer width={width}>
+    <Styled.TextAreaContainer width={width}>
       {label && <Styled.Label>{label}</Styled.Label>}
-      <Styled.InputWrapper>
+      <Styled.TextAreaWrapper>
         <Styled.TextArea
+          ref={textAreaRef}
           onChange={handleChange}
           placeholder={placeholder}
           maxLength={maxLength}
@@ -51,11 +66,11 @@ const CustomTextArea = ({
             {value.length}/{maxLength}
           </Styled.CharCount>
         )}
-      </Styled.InputWrapper>
+      </Styled.TextAreaWrapper>
       {isError && helperText && (
         <Styled.HelperText>{helperText}</Styled.HelperText>
       )}
-    </Styled.InputContainer>
+    </Styled.TextAreaContainer>
   );
 };
 

--- a/frontend/src/components/common/InputField/InputField.styles.ts
+++ b/frontend/src/components/common/InputField/InputField.styles.ts
@@ -37,11 +37,9 @@ export const Input = styled.input<{ hasError?: boolean }>`
         hasError ? 'rgba(255, 0, 0, 0.5)' : 'rgba(0, 123, 255, 0.5)'};
   }
 
-  ${({ disabled }) =>
-    disabled &&
-    `
-    background-color: rgba(0, 0, 0, 0.05); 
-  `}
+  &:disabled {
+    background-color: rgba(0, 0, 0, 0.05);
+  }
   &::placeholder {
     color: rgba(0, 0, 0, 0.3);
   }

--- a/frontend/src/constants/APPLICATION_FORM.ts
+++ b/frontend/src/constants/APPLICATION_FORM.ts
@@ -1,12 +1,15 @@
 const APPLICATION_FORM = {
   SHORT_TEXT: {
     placeholder: '답변입력란(최대 20자)',
+    maxLength: 20,
   },
   LONG_TEXT: {
     placeholder: '답변입력란(최대 500자)',
+    maxLength: 500,
   },
   CHOICE: {
     placeholder: '항목(최대 20자)',
+    maxLength: 20,
   },
 } as const;
 export default APPLICATION_FORM;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -13,7 +13,7 @@ initializeSentry();
 
 async function startApp() {
   if (process.env.NODE_ENV === 'development') {
-    const { worker } = await import('./mocks/mswDevSetup');
+    const { worker } = await import('./mocks/mswDevSetup');
     await worker.start({
       onUnhandledRequest: 'bypass',
     });

--- a/frontend/src/mocks/mswDevSetup.ts
+++ b/frontend/src/mocks/mswDevSetup.ts
@@ -1,5 +1,0 @@
-import { setupWorker } from 'msw/browser';
-import { handlers } from './api';
-import { RequestHandler } from 'msw/lib/core/handlers/RequestHandler.mjs';
-
-export const worker = setupWorker(...(handlers as unknown as RequestHandler[]));

--- a/frontend/src/mocks/mswDevSetup.ts
+++ b/frontend/src/mocks/mswDevSetup.ts
@@ -1,0 +1,5 @@
+import { setupWorker } from 'msw/browser';
+import { handlers } from './api';
+import { RequestHandler } from 'msw/lib/core/handlers/RequestHandler.mjs';
+
+export const worker = setupWorker(...(handlers as unknown as RequestHandler[]));

--- a/frontend/src/pages/AdminPage/application/CreateApplicationForm.styles.ts
+++ b/frontend/src/pages/AdminPage/application/CreateApplicationForm.styles.ts
@@ -22,3 +22,15 @@ export const QuestionContainer = styled.div`
   flex-direction: column;
   gap: 83px;
 `;
+
+export const AddQuestionButton = styled.button`
+  padding: 8px 12px;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+  font-size: 0.875rem;
+  font-weight: 500;
+  background: white;
+  color: #555;
+  margin-top: 8px;
+  cursor: pointer;
+`;

--- a/frontend/src/pages/AdminPage/application/CreateApplicationForm.tsx
+++ b/frontend/src/pages/AdminPage/application/CreateApplicationForm.tsx
@@ -15,10 +15,16 @@ const CreateApplicationForm = () => {
   const [formData, setFormData] = useState<ApplicationFormData>(
     mockData ?? INITIAL_FORM_DATA,
   );
+  const [nextId, setNextId] = useState(() => {
+    const questions = mockData?.questions ?? INITIAL_FORM_DATA.questions;
+    if (questions.length === 0) return 1;
+    const maxId = Math.max(...questions.map((q) => q.id));
+    return maxId + 1;
+  });
 
   const addQuestion = () => {
     const newQuestion: Question = {
-      id: formData.questions.length + 1,
+      id: nextId,
       title: '',
       description: '',
       type: 'SHORT_TEXT',
@@ -28,6 +34,7 @@ const CreateApplicationForm = () => {
       ...prev,
       questions: [...prev.questions, newQuestion],
     }));
+    setNextId((currentId) => currentId + 1);
   };
 
   const removeQuestion = (id: number) => {

--- a/frontend/src/pages/AdminPage/application/CreateApplicationForm.tsx
+++ b/frontend/src/pages/AdminPage/application/CreateApplicationForm.tsx
@@ -16,6 +16,27 @@ const CreateApplicationForm = () => {
     mockData ?? INITIAL_FORM_DATA,
   );
 
+  const addQuestion = () => {
+    const newQuestion: Question = {
+      id: formData.questions.length + 1,
+      title: '',
+      description: '',
+      type: 'SHORT_TEXT',
+      options: { required: false },
+    };
+    setFormData((prev) => ({
+      ...prev,
+      questions: [...prev.questions, newQuestion],
+    }));
+  };
+
+  const removeQuestion = (id: number) => {
+    setFormData((prev) => ({
+      ...prev,
+      questions: prev.questions.filter((q) => q.id !== id),
+    }));
+  };
+
   const updateQuestionField = <K extends keyof Question>(
     id: number,
     key: K,
@@ -97,9 +118,13 @@ const CreateApplicationForm = () => {
               onItemsChange={handleItemsChange(question.id)}
               onTypeChange={handleTypeChange(question.id)}
               onRequiredChange={handleRequiredChange(question.id)}
+              onRemoveQuestion={() => removeQuestion(question.id)}
             />
           ))}
         </Styled.QuestionContainer>
+        <Styled.AddQuestionButton onClick={addQuestion}>
+          질문 추가 +
+        </Styled.AddQuestionButton>
       </PageContainer>
     </>
   );

--- a/frontend/src/pages/AdminPage/application/components/QuestionBuilder/QuestionBuilder.styles.ts
+++ b/frontend/src/pages/AdminPage/application/components/QuestionBuilder/QuestionBuilder.styles.ts
@@ -2,7 +2,8 @@ import styled from 'styled-components';
 
 export const QuestionMenu = styled.div`
   display: flex;
-  width: 140px;
+  max-width: 140px;
+  width: 100%;
   flex-direction: column;
   gap: 4px;
 `;

--- a/frontend/src/pages/AdminPage/application/components/QuestionBuilder/QuestionBuilder.tsx
+++ b/frontend/src/pages/AdminPage/application/components/QuestionBuilder/QuestionBuilder.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
 import ShortText from '@/pages/AdminPage/application/fields/ShortText';
-import dropdown_icon from '@/assets/images/icons/drop_button_icon.svg';
 import Choice from '@/pages/AdminPage/application/fields/Choice';
-import * as Styled from './QuestionBuilder.styles';
+import LongText from '@/pages/AdminPage/application/fields/LongText';
 import { QuestionType } from '@/types/application';
 import { QuestionBuilderProps } from '@/types/application';
 import { QUESTION_TYPE_LIST } from '@/types/application';
+import dropdown_icon from '@/assets/images/icons/drop_button_icon.svg';
+import * as Styled from './QuestionBuilder.styles';
 
 const QuestionBuilder = ({
   id,
@@ -43,9 +44,20 @@ const QuestionBuilder = ({
       case 'NAME':
       case 'EMAIL':
       case 'PHONE_NUMBER':
-      case 'LONG_TEXT':
         return (
           <ShortText
+            id={id}
+            title={title}
+            required={options?.required}
+            description={description}
+            mode='builder'
+            onTitleChange={onTitleChange}
+            onDescriptionChange={onDescriptionChange}
+          />
+        );
+      case 'LONG_TEXT':
+        return (
+          <LongText
             id={id}
             title={title}
             required={options?.required}
@@ -125,8 +137,9 @@ const QuestionBuilder = ({
               onTypeChange?.(selectedType);
             }}
           >
-            <option value='CHOICE'>객관식</option>
+            <option value='LONG_TEXT'>장문형</option>
             <option value='SHORT_TEXT'>단답형</option>
+            <option value='CHOICE'>객관식</option>
           </Styled.Dropdown>
         </Styled.DropDownWrapper>
         {renderSelectionToggle()}

--- a/frontend/src/pages/AdminPage/application/components/QuestionBuilder/QuestionBuilder.tsx
+++ b/frontend/src/pages/AdminPage/application/components/QuestionBuilder/QuestionBuilder.tsx
@@ -19,6 +19,7 @@ const QuestionBuilder = ({
   onDescriptionChange,
   onTypeChange,
   onRequiredChange,
+  onRemoveQuestion,
 }: QuestionBuilderProps) => {
   if (!QUESTION_TYPE_LIST.includes(type as QuestionType)) {
     return null;
@@ -129,6 +130,7 @@ const QuestionBuilder = ({
           </Styled.Dropdown>
         </Styled.DropDownWrapper>
         {renderSelectionToggle()}
+        <button onClick={() => onRemoveQuestion()}>삭제</button>
       </Styled.QuestionMenu>
       <Styled.QuestionFieldContainer>
         {renderFieldByQuestionType()}

--- a/frontend/src/pages/AdminPage/application/components/QuestionBuilder/QuestionBuilder.tsx
+++ b/frontend/src/pages/AdminPage/application/components/QuestionBuilder/QuestionBuilder.tsx
@@ -67,7 +67,6 @@ const QuestionBuilder = ({
             onDescriptionChange={onDescriptionChange}
           />
         );
-      // Todo case 'LONG_TEXT': 와 같은 다른 케이스도 여기서 렌더링 가능
       case 'CHOICE':
       case 'MULTI_CHOICE':
         return (

--- a/frontend/src/pages/AdminPage/application/fields/LongText.tsx
+++ b/frontend/src/pages/AdminPage/application/fields/LongText.tsx
@@ -1,0 +1,46 @@
+import QuestionTitle from '@/pages/AdminPage/application/components/QuestionTitle/QuestionTitle';
+import QuestionDescription from '@/pages/AdminPage/application/components/QuestionDescription/QuestionDescription';
+import APPLICATION_FORM from '@/constants/APPLICATION_FORM';
+import { TextProps } from '@/types/application';
+import CustomTextArea from '@/components/common/CustomTextArea/CustomTextArea';
+
+const LongText = ({
+  id,
+  title,
+  description,
+  required,
+  answer,
+  mode,
+  onAnswerChange,
+  onTitleChange,
+  onDescriptionChange,
+}: TextProps) => {
+  return (
+    <div>
+      <QuestionTitle
+        id={id}
+        title={title}
+        required={required}
+        mode={mode}
+        onTitleChange={onTitleChange}
+      />
+      <QuestionDescription
+        description={description}
+        mode={mode}
+        onDescriptionChange={onDescriptionChange}
+      />
+      <CustomTextArea
+        value={answer}
+        onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+          onAnswerChange?.(e.target.value)
+        }
+        placeholder={APPLICATION_FORM.LONG_TEXT.placeholder}
+        disabled={mode === 'builder'}
+        showMaxChar={mode === 'answer'}
+        maxLength={APPLICATION_FORM.LONG_TEXT.maxLength}
+      />
+    </div>
+  );
+};
+
+export default LongText;

--- a/frontend/src/pages/AdminPage/application/fields/LongText.tsx
+++ b/frontend/src/pages/AdminPage/application/fields/LongText.tsx
@@ -31,9 +31,7 @@ const LongText = ({
       />
       <CustomTextArea
         value={answer}
-        onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-          onAnswerChange?.(e.target.value)
-        }
+        onChange={(e) => onAnswerChange?.(e.target.value)}
         placeholder={APPLICATION_FORM.LONG_TEXT.placeholder}
         disabled={mode === 'builder'}
         showMaxChar={mode === 'answer'}

--- a/frontend/src/pages/AdminPage/application/fields/ShortText.tsx
+++ b/frontend/src/pages/AdminPage/application/fields/ShortText.tsx
@@ -2,7 +2,7 @@ import QuestionTitle from '@/pages/AdminPage/application/components/QuestionTitl
 import QuestionDescription from '@/pages/AdminPage/application/components/QuestionDescription/QuestionDescription';
 import InputField from '@/components/common/InputField/InputField';
 import APPLICATION_FORM from '@/constants/APPLICATION_FORM';
-import { ShortTextProps } from '@/types/application';
+import { TextProps } from '@/types/application';
 
 const ShortText = ({
   id,
@@ -14,7 +14,7 @@ const ShortText = ({
   onAnswerChange,
   onTitleChange,
   onDescriptionChange,
-}: ShortTextProps) => {
+}: TextProps) => {
   return (
     <div>
       <QuestionTitle

--- a/frontend/src/types/application.ts
+++ b/frontend/src/types/application.ts
@@ -29,6 +29,7 @@ export interface QuestionBuilderProps extends Question {
   onItemsChange?: (newItems: { value: string }[]) => void;
   onTypeChange?: (type: QuestionType) => void;
   onRequiredChange?: (required: boolean) => void;
+  onRemoveQuestion: () => void;
 }
 
 interface QuestionComponentProps {

--- a/frontend/src/types/application.ts
+++ b/frontend/src/types/application.ts
@@ -41,7 +41,7 @@ interface QuestionComponentProps {
   onDescriptionChange?: (value: string) => void;
 }
 
-export interface ShortTextProps extends QuestionComponentProps {
+export interface TextProps extends QuestionComponentProps {
   answer?: string;
   onAnswerChange?: (value: string) => void;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #453

## 📝작업 내용
### 주요 기능
![image](https://github.com/user-attachments/assets/9e0dbcbd-ffcf-419f-9fbb-6c8a27d5c591)
- **질문 추가/삭제**: 질문을 실시간으로 추가하고 삭제할 수 있는 기능
- **장문형 질문**: CustomTextArea를 활용한 LongText 질문 타입 추가  
- **UI 개선**: 질문 추가 버튼 스타일링 및 사용자 경험 향상

<br />

### 새로 추가된 컴포넌트
- `CustomTextArea`: 장문 텍스트 입력용 TextArea 컴포넌트
- `LongText`: 장문형 질문 전용 컴포넌트

<br />

### 기타 개선사항  
- ShortText → Text로 타입명 통일
- APPLICATION_FORM 상수에 maxLength 속성 추가

<br />

## 🫡 참고사항
- 성원님과 2시간 진행한 페어프로그래밍입니다~ 수고많으셨습니다~~
- Co-Authored-By: Seongwon Seo <seongwon0903@gmail.com>
- **트러블슈팅**: mswDevSetup 파일명 앞에 의문의 숫자가 포함되어 Windows 환경에서 git checkout이 불가능한 이슈 발생
  - 해당 숫자를 제거하고 mswDevSetup을 정상화하여 해결 (커밋: `8b37602`, `c1afb35`)

![image](https://github.com/user-attachments/assets/92d30289-acb3-4c00-be28-20bcb9bddb41)

<br />

## 🐰 토끼 리뷰 후 수정부분
### 1. 중복 id의 질문 생성 트러블 슈팅
#### 문제점
기존에는 `formData.questions.length + 1` 방식으로 질문 ID를 생성하고 있었습니다.  
하지만 질문을 삭제할 경우, 예를 들어 ID가 1, 2, 3 → 2 삭제 시 → 남은 ID: 1, 3  
이 상태에서 새 질문을 추가하면 다시 ID가 3이 되어 ID 중복 문제가 발생합니다.

#### 해결 방법
현재 존재하는 질문들 중 가장 큰 ID 값을 구한 뒤,  그 값에 +1을 더한 값을 새로운 질문의 ID로 할당하도록 변경
즉, 위 예시에서는 다음 질문의 ID가 4가 되어 1, 3, 4 형태로 유지됩니다.

#### 그럼 지원서 제출 시에는 ID가 어떻게 해야하나요?
제출 시에는 배열의 순서에 맞춰 `id`를 다시 1부터 재정렬해 백엔드에 전송합니다.  
즉, 프론트는 고유 ID만 유지하고, 실제 저장은 순서 기준으로 처리됩니다.

<br />

### 2. 짜잘한 리펙토링
- **textarea 입력 불가 문제 해결**: React textarea의 value를 children에서 prop으로 변경하여 controlled component 동작 보장 ff1ddbb
- **QuestionMenu width 불일치 문제**: 질문 타입별로 너비가 달라지는 문제를 max-width와 width 조합으로 해결 96eabfd

#### ✨ **기능 추가**
- **CustomTextArea 자동 높이 조절**: 입력 내용에 따라 텍스트 영역 높이가 자동으로 조정되는 기능 추가 b373166

#### 🔧 **리팩토링**
- **타입 및 네이밍 정리**: CustomInputProps → CustomTextAreaProps, Input* → TextArea* 컴포넌트명 통일 8ab82cb, cedced4
- **불필요한 props 제거**: 사용되지 않는 onClear 프로퍼티 제거 1a80126
- **스타일 개선**: disabled 스타일을 pseudo-selector로 변경, padding 및 resize 설정 최적화 312d784, cedced4
- **타입 추론 활용**: LongText에서 불필요한 명시적 타입 제거 770153e
- **Todo 주석 정리**: InputField와의 중복 코드 리팩토링 필요성 명시, 불필요한 주석 제거 8f8a8a9, b94ba42



<br />
<br />
<br />

# 버그 사항
단답형, 장문형 질문 교체시 textarea의 placeholder의 폰트스타일이 사라집니다... 이거 못고치겄음 뭥미
![image](https://github.com/user-attachments/assets/e6f645c0-0c14-4d0f-aab3-ff0215abfb0d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 커스텀 텍스트 영역 컴포넌트와 스타일이 추가되었습니다.
  - 지원서 양식에 질문 추가 및 삭제 기능이 도입되었습니다.
  - 긴 텍스트(LONG_TEXT) 질문 유형이 지원됩니다.

- **버그 수정**
  - 개발 환경에서 모듈 임포트 경로 오류가 수정되었습니다.

- **스타일**
  - 입력 필드 및 질문 메뉴의 스타일이 개선되어, 비활성화 및 반응형 동작이 향상되었습니다.
  - 지원서 작성 페이지에 질문 추가 버튼 스타일이 추가되었습니다.

- **기타**
  - 각 질문 유형에 최대 글자 수 제한이 적용되었습니다.
  - 일부 타입 및 인터페이스 명칭이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->