### PR TITLE
[fix] 로그인 시 비밀번호 검증 오류 발생

### DIFF
--- a/backend/src/main/java/moadong/global/validator/PasswordValidator.java
+++ b/backend/src/main/java/moadong/global/validator/PasswordValidator.java
@@ -8,7 +8,7 @@ import java.util.regex.Pattern;
 
 public class PasswordValidator implements ConstraintValidator<Password, String> {
     // 8 ~ 20자이고, 반드시 한 개의 알파벳, 한 개의 숫자, !@#$%^ 중 한 개가 모두 들어 갔는지 확인
-    private static final Pattern PASSWORD_PATTERN = Pattern.compile("\"^(?=.*[a-zA-Z])(?=.*\\\\d)(?=.*[!@#$%^])[a-zA-Z\\\\d!@#$%^]{8,20}$\"\n");
+    private static final Pattern PASSWORD_PATTERN = Pattern.compile("^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^]).{8,20}$");
     @Override
     public boolean isValid(String s, ConstraintValidatorContext constraintValidatorContext) {
         if (s == null || s.isEmpty()) {


### PR DESCRIPTION
## #️⃣연관된 이슈

#455 

## 📝작업 내용
비밀번호 검증 시 정확한 비밀번호를 입력했음에도 검증 오류가 발생하는 상황

=> 이전 값으로 롤백처리

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 비밀번호 유효성 검사에서 일부 잘못된 문자 제한을 수정하여, 영문자, 숫자, 지정된 특수문자(!@#$%^)를 포함한 8~20자의 비밀번호를 올바르게 허용하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->