### PR TITLE
[feature] CustomDropdown 컴포넌트 구현 및 질문 입력 필드 UX 개선

### DIFF
--- a/frontend/src/components/common/CustomDropDown/CustomDropDown.styles.ts
+++ b/frontend/src/components/common/CustomDropDown/CustomDropDown.styles.ts
@@ -1,0 +1,60 @@
+import styled from 'styled-components';
+
+export const DropDownWrapper = styled.div`
+  position: relative;
+  width: 100%;
+`;
+
+export const Selected = styled.div<{ open: boolean }>`
+  padding: 12px 16px;
+  border-radius: 0.375rem;
+  background: ${({ open }) => (open ? '#fff' : '#f5f5f5')};
+  color: #787878;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid ${({ open }) => (open ? '#c5c5c5' : 'transparent')};
+  transition:
+    border-color 0.2s ease,
+    background-color 0.2s ease;
+
+  user-select: none;
+`;
+
+export const OptionList = styled.ul`
+  position: absolute;
+  top: 100%;
+  left: 0;
+  width: 100%;
+  background: #fff;
+  border-radius: 6px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
+  z-index: 10;
+  list-style: none;
+`;
+
+export const OptionItem = styled.li<{ isSelected: boolean }>`
+  text-align: center;
+  padding: 10px;
+  margin: 4px;
+  font-weight: 600;
+  border-radius: 6px;
+  color: #787878;
+  background-color: ${({ isSelected }) => (isSelected ? '#DCDCDC' : '#fff')};
+  cursor: pointer;
+
+  &:hover {
+    background-color: #dcdcdc;
+  }
+
+  transition: background-color 0.2s ease;
+  user-select: none;
+`;
+
+export const Icon = styled.img`
+  position: absolute;
+  top: 50%;
+  right: 19px;
+  transform: translateY(-50%);
+  pointer-events: none;
+`;

--- a/frontend/src/components/common/CustomDropDown/CustomDropDown.tsx
+++ b/frontend/src/components/common/CustomDropDown/CustomDropDown.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import * as Styled from './CustomDropDown.styles';
+import dropdown_icon from '@/assets/images/icons/drop_button_icon.svg';
+
+interface DropdownOption {
+  label: string;
+  value: string;
+}
+
+interface DropdownProps {
+  options: DropdownOption[];
+  selected: string;
+  onSelect: (value: string) => void;
+}
+
+const CustomDropdown = ({ options, selected, onSelect }: DropdownProps) => {
+  const [open, setOpen] = useState(false);
+
+  const handleSelect = (value: string) => {
+    onSelect(value);
+    setOpen(false);
+  };
+
+  const selectedLabel =
+    options.find((option) => option.value === selected)?.label || '선택하세요';
+
+  return (
+    <Styled.DropDownWrapper>
+      <Styled.Selected onClick={() => setOpen((prev) => !prev)} open={open}>
+        <span>{selectedLabel}</span>
+        <Styled.Icon src={dropdown_icon} alt='드롭다운 버튼' />
+      </Styled.Selected>
+      {open && (
+        <Styled.OptionList>
+          {options.map(({ label, value }) => (
+            <Styled.OptionItem
+              key={value}
+              isSelected={value === selected}
+              onClick={() => handleSelect(value)}
+            >
+              {label}
+            </Styled.OptionItem>
+          ))}
+        </Styled.OptionList>
+      )}
+    </Styled.DropDownWrapper>
+  );
+};
+
+export default CustomDropdown;

--- a/frontend/src/components/common/InputField/InputField.styles.ts
+++ b/frontend/src/components/common/InputField/InputField.styles.ts
@@ -82,10 +82,9 @@ export const ToggleButton = styled.button`
 export const CharCount = styled.span`
   position: absolute;
   color: #c5c5c5;
-  transform: translateY(-50%);
-  top: 50%;
-  right: 44px;
-  font-size: 12px;
+  top: 110%;
+  right: 0;
+  font-size: 14px;
   letter-spacing: -0.96px;
 `;
 

--- a/frontend/src/constants/APPLICATION_FORM.ts
+++ b/frontend/src/constants/APPLICATION_FORM.ts
@@ -20,4 +20,20 @@ export const APPLICATION_FORM = {
     maxLength: 20,
   },
 } as const;
-export default APPLICATION_FORM;
+
+export const QUESTION_LABEL_MAP = {
+  SHORT_TEXT: '단답형',
+  LONG_TEXT: '장문형',
+  CHOICE: '객관식',
+  MULTI_CHOICE: '객관식',
+  EMAIL: '이메일',
+  PHONE_NUMBER: '전화번호',
+  NAME: '이름',
+} as const;
+
+const DROPDOWN_QUESTION_TYPES = ['LONG_TEXT', 'SHORT_TEXT', 'CHOICE'] as const;
+
+export const DROPDOWN_OPTIONS = DROPDOWN_QUESTION_TYPES.map((type) => ({
+  value: type,
+  label: QUESTION_LABEL_MAP[type],
+}));

--- a/frontend/src/constants/APPLICATION_FORM.ts
+++ b/frontend/src/constants/APPLICATION_FORM.ts
@@ -1,4 +1,12 @@
-const APPLICATION_FORM = {
+export const APPLICATION_FORM = {
+  QUESTION_TITLE: {
+    placeholder: '질문 제목을 입력해주세요(최대 20자)',
+    maxLength: 20,
+  },
+  QUESTION_DESCRIPTION: {
+    placeholder: '질문 설명을 입력해주세요(최대 300자)',
+    maxLength: 300,
+  },
   SHORT_TEXT: {
     placeholder: '답변입력란(최대 20자)',
     maxLength: 20,

--- a/frontend/src/pages/AdminPage/application/CreateApplicationForm.styles.ts
+++ b/frontend/src/pages/AdminPage/application/CreateApplicationForm.styles.ts
@@ -31,6 +31,13 @@ export const AddQuestionButton = styled.button`
   font-weight: 500;
   background: white;
   color: #555;
-  margin-top: 8px;
+  margin-bottom: 200px;
   cursor: pointer;
+`;
+
+export const QuestionDivider = styled.hr`
+  margin-top: 40px;
+  margin-bottom: 40px;
+  border: none;
+  border-top: 1px solid #ddd;
 `;

--- a/frontend/src/pages/AdminPage/application/CreateApplicationForm.tsx
+++ b/frontend/src/pages/AdminPage/application/CreateApplicationForm.tsx
@@ -10,6 +10,7 @@ import { ApplicationFormData } from '@/types/application';
 import { PageContainer } from '@/styles/PageContainer.styles';
 import * as Styled from './CreateApplicationForm.styles';
 import INITIAL_FORM_DATA from '@/constants/INITIAL_FORM_DATA';
+import { QuestionDivider } from './CreateApplicationForm.styles';
 
 const CreateApplicationForm = () => {
   const [formData, setFormData] = useState<ApplicationFormData>(
@@ -129,6 +130,7 @@ const CreateApplicationForm = () => {
             />
           ))}
         </Styled.QuestionContainer>
+        <QuestionDivider />
         <Styled.AddQuestionButton onClick={addQuestion}>
           질문 추가 +
         </Styled.AddQuestionButton>

--- a/frontend/src/pages/AdminPage/application/CreateApplicationForm.tsx
+++ b/frontend/src/pages/AdminPage/application/CreateApplicationForm.tsx
@@ -112,10 +112,10 @@ const CreateApplicationForm = () => {
           placeholder='지원서 제목을 입력하세요'
         ></Styled.FormTitle>
         <Styled.QuestionContainer>
-          {formData.questions.map((question) => (
+          {formData.questions.map((question, index) => (
             <QuestionBuilder
               key={question.id}
-              id={question.id}
+              id={index + 1}
               title={question.title}
               description={question.description}
               options={question.options}

--- a/frontend/src/pages/AdminPage/application/components/QuestionBuilder/QuestionBuilder.styles.ts
+++ b/frontend/src/pages/AdminPage/application/components/QuestionBuilder/QuestionBuilder.styles.ts
@@ -25,6 +25,7 @@ export const RequiredToggleButton = styled.div`
   color: #787878;
   font-size: 0.875rem;
   font-weight: 600;
+  user-select: none;
 `;
 
 export const RequiredToggleCircle = styled.span<{ active?: boolean }>`
@@ -32,30 +33,23 @@ export const RequiredToggleCircle = styled.span<{ active?: boolean }>`
   width: 16px;
   height: 16px;
   border-radius: 50%;
-  border: 1px solid ${(props) => (props.active ? '#ff5000' : '#ccc')};
-  background-color: ${(props) => (props.active ? '#ff5000' : 'white')};
+  border: 1px solid ${({ active }) => (active ? '#ff5000' : '#ccc')};
+  background-color: #fff;
+  transition: background-color 0.2s ease;
 
-  ${({ active }) =>
-    active &&
-    `
-    background-color: #fff;
-    &::after {
-      content: '';
-      width: 10px;
-      height: 10px;
-      background-color: #ff5000;
-      border-radius: 50%;
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-    }
-  `}
-`;
-
-export const DropDownWrapper = styled.div`
-  position: relative;
-  width: 100%;
+  &::after {
+    content: '';
+    width: 10px;
+    height: 10px;
+    background-color: #ff5000;
+    border-radius: 50%;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    opacity: ${({ active }) => (active ? 1 : 0)};
+    transition: opacity 0.1s ease;
+  }
 `;
 
 export const SelectionToggleWrapper = styled.div`
@@ -76,6 +70,9 @@ export const SelectionToggleButton = styled.button<{ active: boolean }>`
   cursor: pointer;
   letter-spacing: -0.42px;
   white-space: nowrap;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease;
 `;
 
 export const QuestionWrapper = styled.div`

--- a/frontend/src/pages/AdminPage/application/components/QuestionBuilder/QuestionBuilder.styles.ts
+++ b/frontend/src/pages/AdminPage/application/components/QuestionBuilder/QuestionBuilder.styles.ts
@@ -58,28 +58,6 @@ export const DropDownWrapper = styled.div`
   width: 100%;
 `;
 
-export const Dropdown = styled.select`
-  display: flex;
-  width: 100%;
-  border: none;
-  padding: 12px 16px;
-  border-radius: 0.375rem;
-  background: #f5f5f5;
-  color: #787878;
-  font-size: 0.875rem;
-  font-weight: 600;
-  cursor: pointer;
-  appearance: none;
-`;
-
-export const DropdownIcon = styled.img`
-  position: absolute;
-  top: 50%;
-  right: 19px;
-  transform: translateY(-50%);
-  pointer-events: none;
-`;
-
 export const SelectionToggleWrapper = styled.div`
   display: flex;
   background-color: #f7f7f7;

--- a/frontend/src/pages/AdminPage/application/components/QuestionBuilder/QuestionBuilder.tsx
+++ b/frontend/src/pages/AdminPage/application/components/QuestionBuilder/QuestionBuilder.tsx
@@ -4,8 +4,8 @@ import Choice from '@/pages/AdminPage/application/fields/Choice';
 import LongText from '@/pages/AdminPage/application/fields/LongText';
 import { QuestionType } from '@/types/application';
 import { QuestionBuilderProps } from '@/types/application';
-import { QUESTION_TYPE_LIST } from '@/types/application';
-import dropdown_icon from '@/assets/images/icons/drop_button_icon.svg';
+import { QUESTION_LABEL_MAP } from '@/constants/APPLICATION_FORM';
+import { DROPDOWN_OPTIONS } from '@/constants/APPLICATION_FORM';
 import * as Styled from './QuestionBuilder.styles';
 
 const QuestionBuilder = ({

--- a/frontend/src/pages/AdminPage/application/components/QuestionBuilder/QuestionBuilder.tsx
+++ b/frontend/src/pages/AdminPage/application/components/QuestionBuilder/QuestionBuilder.tsx
@@ -7,6 +7,7 @@ import { QuestionBuilderProps } from '@/types/application';
 import { QUESTION_LABEL_MAP } from '@/constants/APPLICATION_FORM';
 import { DROPDOWN_OPTIONS } from '@/constants/APPLICATION_FORM';
 import * as Styled from './QuestionBuilder.styles';
+import CustomDropdown from '@/components/common/CustomDropDown/CustomDropDown';
 
 const QuestionBuilder = ({
   id,
@@ -22,7 +23,7 @@ const QuestionBuilder = ({
   onRequiredChange,
   onRemoveQuestion,
 }: QuestionBuilderProps) => {
-  if (!QUESTION_TYPE_LIST.includes(type as QuestionType)) {
+  if (!(type in QUESTION_LABEL_MAP)) {
     return null;
   }
 
@@ -124,23 +125,13 @@ const QuestionBuilder = ({
           답변 필수
           <Styled.RequiredToggleCircle active={options?.required} />
         </Styled.RequiredToggleButton>
-        <Styled.DropDownWrapper>
-          <Styled.DropdownIcon
-            src={dropdown_icon}
-            alt={'질문 타입 선택하기'}
-          ></Styled.DropdownIcon>
-          <Styled.Dropdown
-            value={type}
-            onChange={(e) => {
-              const selectedType = e.target.value as QuestionType;
-              onTypeChange?.(selectedType);
-            }}
-          >
-            <option value='LONG_TEXT'>장문형</option>
-            <option value='SHORT_TEXT'>단답형</option>
-            <option value='CHOICE'>객관식</option>
-          </Styled.Dropdown>
-        </Styled.DropDownWrapper>
+        <CustomDropdown
+          selected={type === 'MULTI_CHOICE' ? 'CHOICE' : type}
+          options={DROPDOWN_OPTIONS}
+          onSelect={(value) => {
+            onTypeChange?.(value as QuestionType);
+          }}
+        />
         {renderSelectionToggle()}
         <button onClick={() => onRemoveQuestion()}>삭제</button>
       </Styled.QuestionMenu>

--- a/frontend/src/pages/AdminPage/application/components/QuestionDescription/QuestionDescription.tsx
+++ b/frontend/src/pages/AdminPage/application/components/QuestionDescription/QuestionDescription.tsx
@@ -8,7 +8,7 @@ interface QuestionDescriptionProps {
   onDescriptionChange?: (value: string) => void;
 }
 
-const QuestionDescriptionText = styled.input`
+const QuestionDescriptionText = styled.textarea`
   border: none;
   outline: none;
   color: #c5c5c5;
@@ -53,10 +53,16 @@ const QuestionDescription = ({
       <QuestionDescriptionText
         ref={textAreaRef}
         value={description}
-        placeholder='질문에 대한 설명을 입력하세요'
+        maxLength={APPLICATION_FORM.QUESTION_DESCRIPTION.maxLength}
+        placeholder={APPLICATION_FORM.QUESTION_DESCRIPTION.placeholder}
         aria-label='질문 설명'
         readOnly={mode === 'answer'}
-        onChange={(e) => onDescriptionChange?.(e.target.value)}
+        onChange={(e) => {
+          const value = e.target.value;
+          if (value.length <= APPLICATION_FORM.QUESTION_DESCRIPTION.maxLength) {
+            onDescriptionChange?.(value);
+          }
+        }}
       />
     </>
   );

--- a/frontend/src/pages/AdminPage/application/components/QuestionDescription/QuestionDescription.tsx
+++ b/frontend/src/pages/AdminPage/application/components/QuestionDescription/QuestionDescription.tsx
@@ -1,4 +1,6 @@
 import styled from 'styled-components';
+import { APPLICATION_FORM } from '@/constants/APPLICATION_FORM';
+import { useEffect, useRef } from 'react';
 
 interface QuestionDescriptionProps {
   description: string;
@@ -14,6 +16,18 @@ const QuestionDescriptionText = styled.input`
   font-weight: 400;
   line-height: normal;
   letter-spacing: -0.26px;
+  width: 100%;
+  overflow: hidden;
+  resize: none;
+
+  &::placeholder {
+    color: #c5c5c5;
+    transition: opacity 0.15s;
+  }
+
+  &:focus::placeholder {
+    opacity: 0;
+  }
 `;
 
 const QuestionDescription = ({
@@ -21,9 +35,23 @@ const QuestionDescription = ({
   mode,
   onDescriptionChange,
 }: QuestionDescriptionProps) => {
+  const textAreaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (mode === 'answer') {
+      return;
+    }
+    const el = textAreaRef.current;
+    if (el) {
+      el.style.height = 'auto';
+      el.style.height = `${el.scrollHeight}px`;
+    }
+  }, [description]);
+
   return (
     <>
       <QuestionDescriptionText
+        ref={textAreaRef}
         value={description}
         placeholder='질문에 대한 설명을 입력하세요'
         aria-label='질문 설명'

--- a/frontend/src/pages/AdminPage/application/components/QuestionTitle/QuestionTitle.styles.ts
+++ b/frontend/src/pages/AdminPage/application/components/QuestionTitle/QuestionTitle.styles.ts
@@ -20,6 +20,16 @@ export const QuestionTitleText = styled.input`
   font-size: 1.25rem;
   font-weight: 700;
   line-height: normal;
+  width: 100%;
+
+  &::placeholder {
+    color: #c5c5c5;
+    transition: opacity 0.15s;
+  }
+
+  &:focus::placeholder {
+    opacity: 0;
+  }
 `;
 
 export const QuestionRequired = styled.div`

--- a/frontend/src/pages/AdminPage/application/components/QuestionTitle/QuestionTitle.tsx
+++ b/frontend/src/pages/AdminPage/application/components/QuestionTitle/QuestionTitle.tsx
@@ -1,4 +1,5 @@
 import * as Styled from './QuestionTitle.styles';
+import { APPLICATION_FORM } from '@/constants/APPLICATION_FORM';
 
 interface QuestionTitleProps {
   id: number;
@@ -21,10 +22,16 @@ const QuestionTitle = ({
       <Styled.QuestionTitleText
         type='text'
         value={title}
-        placeholder='질문 제목을 입력하세요'
+        maxLength={APPLICATION_FORM.QUESTION_TITLE.maxLength}
+        placeholder={APPLICATION_FORM.QUESTION_TITLE.placeholder}
         aria-label='질문 제목'
         readOnly={mode === 'answer'}
-        onChange={(e) => onTitleChange?.(e.target.value)}
+        onChange={(e) => {
+          const value = e.target.value;
+          if (value.length <= APPLICATION_FORM.QUESTION_TITLE.maxLength) {
+            onTitleChange?.(value);
+          }
+        }}
       />
       {mode === 'answer' && required && <Styled.QuestionRequired />}
     </Styled.QuestionTitleContainer>

--- a/frontend/src/pages/AdminPage/application/fields/Choice.tsx
+++ b/frontend/src/pages/AdminPage/application/fields/Choice.tsx
@@ -8,7 +8,11 @@ import { ChoiceProps } from '@/types/application';
 const MIN_ITEMS = 2;
 const MAX_ITEMS = 6;
 
-//todo isMulti나 질문 타입을 props로 받아서 다중 선택이 가능하도록 기능 추가 필요
+// todo inputField clear 버튼 빼기
+// todo 입력 필드안에 항목 삭제 아이콘 추가
+// todo mode : answer일때 다중, 단일 조건에 따라 선택 가능하도록 UI 및 기능 추가 필요
+// todo isMulti나 질문 타입을 props로 받아서 단일 / 다중 판단 하면 될듯
+
 const Choice = ({
   id,
   title,
@@ -60,6 +64,7 @@ const Choice = ({
             onChange={(e) => handleItemChange(index, e.target.value)}
             placeholder={APPLICATION_FORM.CHOICE.placeholder}
             disabled={mode === 'answer'}
+            showClearButton={false}
           />
           {mode === 'builder' && items.length > MIN_ITEMS && (
             <Styled.DeleteButton onClick={() => handleDeleteItem(index)}>

--- a/frontend/src/pages/AdminPage/application/fields/Choice.tsx
+++ b/frontend/src/pages/AdminPage/application/fields/Choice.tsx
@@ -2,7 +2,7 @@ import * as Styled from './Choice.styles';
 import QuestionTitle from '@/pages/AdminPage/application/components/QuestionTitle/QuestionTitle';
 import QuestionDescription from '@/pages/AdminPage/application/components/QuestionDescription/QuestionDescription';
 import InputField from '@/components/common/InputField/InputField';
-import APPLICATION_FORM from '@/constants/APPLICATION_FORM';
+import { APPLICATION_FORM } from '@/constants/APPLICATION_FORM';
 import { ChoiceProps } from '@/types/application';
 
 const MIN_ITEMS = 2;

--- a/frontend/src/pages/AdminPage/application/fields/LongText.tsx
+++ b/frontend/src/pages/AdminPage/application/fields/LongText.tsx
@@ -1,6 +1,6 @@
 import QuestionTitle from '@/pages/AdminPage/application/components/QuestionTitle/QuestionTitle';
 import QuestionDescription from '@/pages/AdminPage/application/components/QuestionDescription/QuestionDescription';
-import APPLICATION_FORM from '@/constants/APPLICATION_FORM';
+import { APPLICATION_FORM } from '@/constants/APPLICATION_FORM';
 import { TextProps } from '@/types/application';
 import CustomTextArea from '@/components/common/CustomTextArea/CustomTextArea';
 

--- a/frontend/src/pages/AdminPage/application/fields/ShortText.tsx
+++ b/frontend/src/pages/AdminPage/application/fields/ShortText.tsx
@@ -34,6 +34,10 @@ const ShortText = ({
         onChange={(e) => onAnswerChange?.(e.target.value)}
         placeholder={APPLICATION_FORM.SHORT_TEXT.placeholder}
         disabled={mode === 'builder'}
+        showMaxChar={mode === 'answer'}
+        maxLength={APPLICATION_FORM.SHORT_TEXT.maxLength}
+        showClearButton={false}
+        width={'60%'}
       />
     </div>
   );

--- a/frontend/src/pages/AdminPage/application/fields/ShortText.tsx
+++ b/frontend/src/pages/AdminPage/application/fields/ShortText.tsx
@@ -1,7 +1,7 @@
 import QuestionTitle from '@/pages/AdminPage/application/components/QuestionTitle/QuestionTitle';
 import QuestionDescription from '@/pages/AdminPage/application/components/QuestionDescription/QuestionDescription';
 import InputField from '@/components/common/InputField/InputField';
-import APPLICATION_FORM from '@/constants/APPLICATION_FORM';
+import { APPLICATION_FORM } from '@/constants/APPLICATION_FORM';
 import { TextProps } from '@/types/application';
 
 const ShortText = ({

--- a/frontend/src/styles/Global.styles.ts
+++ b/frontend/src/styles/Global.styles.ts
@@ -6,7 +6,9 @@ const GlobalStyles = createGlobalStyle`
     padding: 0;
     box-sizing: border-box;
   }
-  
+  textarea {
+    font-family: 'Pretendard', sans-serif;
+  }
   body {
     font-family: 'Pretendard', -apple-system, BlinkMacSystemFont, 'Segoe UI',
     Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue',

--- a/frontend/src/types/application.ts
+++ b/frontend/src/types/application.ts
@@ -1,16 +1,6 @@
-// types/application.ts
+import { QUESTION_LABEL_MAP } from '@/constants/APPLICATION_FORM';
 
-export const QUESTION_TYPE_LIST = [
-  'SHORT_TEXT',
-  'CHOICE',
-  'LONG_TEXT',
-  'MULTI_CHOICE',
-  'EMAIL',
-  'PHONE_NUMBER',
-  'NAME',
-] as const;
-
-export type QuestionType = (typeof QUESTION_TYPE_LIST)[number];
+export type QuestionType = keyof typeof QUESTION_LABEL_MAP;
 
 export interface Question {
   id: number;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #465 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지/동영상 첨부 가능)


### 🎨 CustomDropdown 컴포넌트 개발
- 재사용 가능한 드롭다운 컴포넌트 신규 구현
- 기존 QuestionBuilder의 select → CustomDropdown 교체
- 드롭다운 열림/닫힘 상태별 스타일링 적용
![image](https://github.com/user-attachments/assets/1cd67bba-b1d2-4cc4-ae54-15dfeaf252b8)


### ✏️ 질문 입력 필드 UX 개선
- **질문 제목/설명 입력**: placeholder, maxLength 동적 설정
- **Auto-resize**: 설명 입력 시 텍스트에 맞춰 높이 자동 조정
- **Placeholder 효과**: 포커스 시 투명도 애니메이션 추가
- **ShortText 개선**: 문자 수 제한 및 UI 정렬 개선




### 🔧 코드 구조 개선
- **상수 통합 관리**: `APPLICATION_FORM`, `QUESTION_LABEL_MAP` 추가
- **타입 정의 개선**: QuestionType을 QUESTION_LABEL_MAP 기반으로 변경
- **Import 통일**: named export 방식으로 일관성 확보

### 🐛 버그 수정
- textarea 폰트 미적용 문제 해결
- 사용자 선택 방지 기능 추가
- 중복 코드 정리 및 불필요한 props 제거


## 🫡 참고사항
성원님과 2시간 짝프로그래밍 진행
공동 작성자 표시를 깜박해서 뒤늦게 rebase로 커밋 메세지 수정했습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 추가 수정 사항

1️⃣ 질문 번호 렌더링 개선
[기존 문제]
- 내부 식별자(question.id)를 그대로 UI에 렌더링에 사용하고 있었음
- 그 결과, 화면에 질문 1, 질문 3, 질문 105처럼 불연속적인 번호가 표시되는 문제가 발생했음

[개선 사항]
- QuestionBuilder에 전달하는 id 값을 question.id → index + 1로 수정
- 이 id는 UI에서 번호를 순차적으로 보여주기 위한 용도로만 사용
- 내부 로직에서 사용하는 key나 삭제/수정 등의 식별에는 기존 question.id를 그대로 유지함

https://github.com/user-attachments/assets/622d1823-9839-4e02-8d2b-3a8db779f8a9



2️⃣ 질문 구분선 및 마진 추가
구분선 상하 마진(40px)을 적용하여 질문 간격을 명확하게 조절

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 커스텀 드롭다운 컴포넌트가 추가되어 질문 유형 선택 UI가 개선되었습니다.
    - 지원서 질문 구분선(QuestionDivider) 컴포넌트가 도입되었습니다.

- **기능 개선**
    - 질문 제목, 설명, 선택지 입력란이 중앙 관리되는 상수의 최대 길이 및 플레이스홀더를 사용하도록 변경되었습니다.
    - 질문 설명 입력란이 textarea로 변경되어 내용에 따라 높이가 자동 조절됩니다.
    - 입력란의 글자 수 표시 위치와 스타일이 개선되었습니다.
    - 질문 유형 선택 UI가 기존 select에서 커스텀 드롭다운으로 변경되었습니다.
    - 입력란의 기본 스타일 및 폰트가 통일되었습니다.

- **버그 수정**
    - 입력란에서 최대 글자 수를 초과 입력할 수 없도록 수정되었습니다.
    - 선택지 입력란에서 지우기 버튼이 비활성화되었습니다.

- **스타일**
    - 드롭다운, 토글 버튼 등 주요 UI 컴포넌트의 스타일이 개선되었습니다.
    - 전역 textarea 폰트가 Pretendard로 통일되었습니다.

- **리팩터**
    - 질문 유형 관련 상수 및 타입 관리 방식이 개선되어 유지보수성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->