### PR TITLE
fix: 잘못된 비밀번호 검증 로직과 잘못된 비밀번호 테스트 수정

### DIFF
--- a/backend/src/main/java/moadong/global/validator/PasswordValidator.java
+++ b/backend/src/main/java/moadong/global/validator/PasswordValidator.java
@@ -7,13 +7,16 @@ import moadong.global.annotation.Password;
 import java.util.regex.Pattern;
 
 public class PasswordValidator implements ConstraintValidator<Password, String> {
-    // 8 ~ 20자이고, 반드시 한 개의 알파벳, 한 개의 숫자, !@#$%^ 중 한 개가 모두 들어 갔는지 확인
-    private static final Pattern PASSWORD_PATTERN = Pattern.compile("^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^]).{8,20}$");
+    private static final String REGEX = "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^])(?!.*\\s).{8,20}$";
+    private static final Pattern PASSWORD_PATTERN = Pattern.compile(REGEX);
+
     @Override
-    public boolean isValid(String s, ConstraintValidatorContext constraintValidatorContext) {
+    public boolean isValid(String s, ConstraintValidatorContext context) {
         if (s == null || s.isEmpty()) {
-            return true;
+            return false;
         }
         return PASSWORD_PATTERN.matcher(s).matches();
     }
+
 }
+

--- a/backend/src/test/java/moadong/unit/user/PasswordValidatorTest.java
+++ b/backend/src/test/java/moadong/unit/user/PasswordValidatorTest.java
@@ -1,0 +1,40 @@
+package moadong.unit.user;
+
+import moadong.fixture.UserFixture;
+import moadong.global.validator.PasswordValidator;
+import moadong.util.annotations.UnitTest;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@UnitTest
+public class PasswordValidatorTest {
+    private final PasswordValidator passwordValidator = new PasswordValidator();
+
+    @Test
+    void 유효한_비밀번호는_유효하다() {
+        boolean isValid = passwordValidator.isValid(UserFixture.collectPassword, null);
+        Assertions.assertThat(isValid).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "short1!",              // 7자 (길이 부족)
+            "longpassword1234567890!", // 21자 (길이 초과)
+            "abcdefgh",             // 영문 소문자만 (숫자 없음)
+            "ABCDEFGH",             // 영문 대문자만 (숫자 없음)
+            "12345678",             // 숫자만 (영문 없음)
+            "Abcdefgh",             // 영문만 (숫자 없음)
+            "abcd1234*",            // 허용되지 않은 특수문자 `*`
+            "abc def123!",          // 공백 포함
+            "passWord!",            // 특수문자 있음, 숫자 없음
+            "1234!@#$",             // 숫자 + 특수문자, 문자 없음
+            "Abcdef12()",           // 괄호 포함 (허용되지 않은 특수문자)
+            "ABCD1234~",            // `~` 특수문자 허용 안됨
+    })
+    void 유효하지_않은_비밀번호는_실패한다(String password) {
+        boolean isValid = passwordValidator.isValid(password, null);
+        Assertions.assertThat(isValid).isFalse();
+    }
+}

--- a/backend/src/test/java/moadong/unit/user/UserRegisterTest.java
+++ b/backend/src/test/java/moadong/unit/user/UserRegisterTest.java
@@ -153,7 +153,6 @@ class UserRegisterTest {
             "1234!@#$",             // 숫자 + 특수문자, 문자 없음
             "Abcdef12()",           // 괄호 포함 (허용되지 않은 특수문자)
             "ABCD1234~",            // `~` 특수문자 허용 안됨
-            "abc1234^",             // `^`는 허용되지만 문자 형식에 따라 위험성 있음
     })
     void 회원가입시_유저_비밀번호가_조건에_맞지_않으면_실패한다(String password) {
         String userId = UserFixture.collectUserId;


### PR DESCRIPTION
## #️⃣연관된 이슈

#455 

## 📝작업 내용

- 잘못된 비밀번호 테스트 코드 수정 : 올바른 비밀번호 테스트 케이스가 실패 케이스에 들어갔었습니다.
- 비밀번호 검증 개선 : 정규표현식을 더 직관적인 것으로 교체하였습니다.

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 비밀번호 유효성 검사에서 공백이 포함된 비밀번호를 허용하지 않도록 개선되었습니다.
  - 비밀번호가 비어있거나 null인 경우 유효하지 않도록 동작이 변경되었습니다.

- **테스트**
  - 비밀번호 유효성 검사를 위한 단위 테스트가 추가되어 다양한 비밀번호 조건에 대해 검증이 강화되었습니다.
  - 회원가입 시 비밀번호 조건 테스트 케이스 일부가 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->