### PR TITLE
[fix] 동아리 SNS 링크 관련 전체 기능 재활성화

### DIFF
--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTab.tsx
@@ -184,7 +184,6 @@ const ClubInfoEditTab = () => {
       </Styled.TagEditGroup>
 
       <Styled.InfoTitle>동아리 SNS 링크</Styled.InfoTitle>
-      <p>현재 준비 중인 기능입니다. 조금만 기다려 주세요!</p>
       <Styled.SNSInputGroup>
         {Object.entries(SNS_CONFIG).map(([rawKey, { label, placeholder }]) => {
           const key = rawKey as SNSPlatform;
@@ -202,7 +201,6 @@ const ClubInfoEditTab = () => {
                 }}
                 isError={snsErrors[key] !== ''}
                 helperText={snsErrors[key]}
-                disabled={true}
               />
             </Styled.SNSRow>
           );

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTab.tsx
@@ -183,31 +183,31 @@ const ClubInfoEditTab = () => {
         <MakeTags value={clubTags} onChange={setClubTags} />
       </Styled.TagEditGroup>
 
-      {/*<Styled.InfoTitle>동아리 SNS 링크</Styled.InfoTitle>*/}
-      {/*<p>현재 준비 중인 기능입니다. 조금만 기다려 주세요!</p>*/}
-      {/*<Styled.SNSInputGroup>*/}
-      {/*  {Object.entries(SNS_CONFIG).map(([rawKey, { label, placeholder }]) => {*/}
-      {/*    const key = rawKey as SNSPlatform;*/}
+      <Styled.InfoTitle>동아리 SNS 링크</Styled.InfoTitle>
+      <p>현재 준비 중인 기능입니다. 조금만 기다려 주세요!</p>
+      <Styled.SNSInputGroup>
+        {Object.entries(SNS_CONFIG).map(([rawKey, { label, placeholder }]) => {
+          const key = rawKey as SNSPlatform;
 
-      {/*    return (*/}
-      {/*      <Styled.SNSRow key={key}>*/}
-      {/*        <Styled.SNSCheckboxLabel>{label}</Styled.SNSCheckboxLabel>*/}
-      {/*        <InputField*/}
-      {/*          placeholder={placeholder}*/}
-      {/*          value={socialLinks[key]}*/}
-      {/*          onChange={(e) => handleSocialLinkChange(key, e.target.value)}*/}
-      {/*          onClear={() => {*/}
-      {/*            setSocialLinks((prev) => ({ ...prev, [key]: '' }));*/}
-      {/*            setSnsErrors((prev) => ({ ...prev, [key]: '' }));*/}
-      {/*          }}*/}
-      {/*          isError={snsErrors[key] !== ''}*/}
-      {/*          helperText={snsErrors[key]}*/}
-      {/*          disabled={true}*/}
-      {/*        />*/}
-      {/*      </Styled.SNSRow>*/}
-      {/*    );*/}
-      {/*  })}*/}
-      {/*</Styled.SNSInputGroup>*/}
+          return (
+            <Styled.SNSRow key={key}>
+              <Styled.SNSCheckboxLabel>{label}</Styled.SNSCheckboxLabel>
+              <InputField
+                placeholder={placeholder}
+                value={socialLinks[key]}
+                onChange={(e) => handleSocialLinkChange(key, e.target.value)}
+                onClear={() => {
+                  setSocialLinks((prev) => ({ ...prev, [key]: '' }));
+                  setSnsErrors((prev) => ({ ...prev, [key]: '' }));
+                }}
+                isError={snsErrors[key] !== ''}
+                helperText={snsErrors[key]}
+                disabled={true}
+              />
+            </Styled.SNSRow>
+          );
+        })}
+      </Styled.SNSInputGroup>
     </>
   );
 };

--- a/frontend/src/pages/ClubDetailPage/components/InfoBox/InfoBox.styles.ts
+++ b/frontend/src/pages/ClubDetailPage/components/InfoBox/InfoBox.styles.ts
@@ -16,7 +16,7 @@ export const InfoBoxWrapper = styled.div`
 
 export const InfoBox = styled.div`
   width: 573px;
-  height: 164px; //todo 추후 197로 수정 필요
+  height: 197px;
   border-radius: 18px;
   border: 1px solid #dcdcdc;
   padding: 30px;

--- a/frontend/src/pages/ClubDetailPage/components/InfoBox/InfoBox.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/InfoBox/InfoBox.tsx
@@ -1,7 +1,7 @@
 import * as Styled from './InfoBox.styles';
 import { ClubDetail } from '@/types/club';
 import { INFOTABS_SCROLL_INDEX } from '@/constants/scrollSections';
-//import SnsLinkIcons from '@/pages/ClubDetailPage/components/SnsLinkIcons/SnsLinkIcons';
+import SnsLinkIcons from '@/pages/ClubDetailPage/components/SnsLinkIcons/SnsLinkIcons';
 
 interface ClubInfoItem {
   label: string;
@@ -38,10 +38,10 @@ const InfoBox = ({ sectionRefs, clubDetail }: InfoBoxProps) => {
       descriptions: [
         { label: '회장이름', value: clubDetail.presidentName },
         { label: '전화번호', value: clubDetail.presidentPhoneNumber },
-        // {
-        //   label: 'SNS',
-        //   render: <SnsLinkIcons apiSocialLinks={clubDetail.socialLinks} />,
-        // },
+        {
+          label: 'SNS',
+          render: <SnsLinkIcons apiSocialLinks={clubDetail.socialLinks} />,
+        },
       ],
       refIndex: INFOTABS_SCROLL_INDEX.CLUB_INFO_TAB,
     },


### PR DESCRIPTION
## #️⃣연관된 이슈

> #501 

## 📝작업 내용

### 🚀 동아리 SNS 링크 기능 구현

#### 재활성화된 기능:
**1. 클럽 상세 페이지 SNS 링크 표시 재활성화**
- Instagram, YouTube, X 링크 표시 기능 복구
- SNS 아이콘과 함께 링크 표시 UI 정상화

**2. 관리자 페이지 SNS 링크 입력 기능 재활성화**
- 동아리 정보 수정 시 SNS 링크 편집 기능 복구
- 유효성 검증 및 에러 처리 로직 정상화

**3. 레이아웃 최적화**
- InfoBox 높이값 조정으로 UI 안정성 확보


## 🫡 참고사항
- TypeScript 타입 안정성을 위해 타입 활용 `SNSPlatform`
- 기존 코드의 일관성을 유지하며 새로운 기능 통합
- 모든 변경사항은 기존 기능에 영향을 주지 않도록 구현
