### PR TITLE
[fix] 클럽 지원서 조회 시 오류 해결 및 Spinner 적용 및 예외 메시지 개선

### DIFF
--- a/frontend/src/pages/AdminPage/application/answer/AnswerApplicationForm.tsx
+++ b/frontend/src/pages/AdminPage/application/answer/AnswerApplicationForm.tsx
@@ -8,25 +8,30 @@ import { useAnswers } from '@/hooks/useAnswers';
 import QuestionAnswerer from '@/pages/AdminPage/application/components/QuestionAnswerer/QuestionAnswerer';
 import { useGetApplication } from '@/hooks/queries/application/useGetApplication';
 import { Question } from '@/types/application';
+import Spinner from '@/components/common/Spinner/Spinner';
 
 const AnswerApplicationForm = () => {
   const { clubId } = useParams<{ clubId: string }>();
-  const { data: clubDetail, error } = useGetClubDetail(clubId || '');
-  const {
-    data: formData,
-    isLoading,
-    isError,
-  } = useGetApplication(clubId || '');
   if (!clubId) return null;
-  if (!clubDetail) return null;
+
+  const { data: clubDetail, error } = useGetClubDetail(clubId);
+  const { data: formData, isLoading, isError } = useGetApplication(clubId);
+
   const { onAnswerChange, getAnswersById } = useAnswers();
 
-  if (!clubId || isLoading || !formData || !clubDetail) {
-    return <div>로딩 중...</div>;
+  if (isLoading) return <Spinner />;
+
+  if (error || isError) {
+    return <div>문제가 발생했어요. 잠시 후 다시 시도해 주세요.</div>;
   }
 
-  if (error) {
-    return <div>에러가 발생했습니다.</div>;
+  if (!formData || !clubDetail) {
+    return (
+      <div>
+        지원서 정보를 불러오지 못했어요. 새로고침하거나 잠시 후 다시 시도해
+        주세요.
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
## #️⃣연관된 이슈

> #498 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지/동영상 첨부 가능)
-  useAnswers();훅이 return문보다 뒤에서 호출되어 React 훅 규칙을 위반한 문제가 있었고, 이를 뒤로 이동시켜 해결했습니다
![image](https://github.com/user-attachments/assets/d0c66eb5-38c6-4d5b-bc56-af65b4960c7d)



- 클럽 상세 정보(clubDetail) 또는 지원서 데이터(formData)가 없을 때 null 참조로 인한 오류 방지

- 로딩 시 "로딩 중..." 텍스트를 Spinner 컴포넌트로 교체하여 UX 개선

- 지원서가 없거나 불러오지 못했을 경우 사용자에게 구체적인 예외 메시지를 안내

### ✅ 확인 사항
- 데이터가 정상적으로 없을 경우에도 예외 메시지로 안내됨

- 잘못된 접근 시 무한 스피너 발생하지 않음

- 기존 정상 흐름(form 출력)은 그대로 유지됨



## 🫡 참고사항
https://velog.io/@sinf/Rendered-more-hooks-than-during-the-previous-render

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 로딩 중일 때 "로딩 중..." 텍스트 대신 스피너가 표시됩니다.
  - 오류 발생 시 통합된 오류 메시지가 보여집니다.
  - 신청서 정보를 불러오지 못할 경우 명확한 안내 메시지가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->