### PR TITLE
[fix] 관리자 지원서 작성 기능 배포 전 임시 차단

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,8 +14,9 @@ import AccountEditTab from '@/pages/AdminPage/tabs/AccountEditTab/AccountEditTab
 import LoginTab from '@/pages/AdminPage/auth/LoginTab/LoginTab';
 import PrivateRoute from '@/pages/AdminPage/auth/PrivateRoute/PrivateRoute';
 import PhotoEditTab from '@/pages/AdminPage/tabs/PhotoEditTab/PhotoEditTab';
-import AnswerApplicationForm from '@/pages/AdminPage/application/answer/AnswerApplicationForm';
-import CreateApplicationForm from '@/pages/AdminPage/application/CreateApplicationForm';
+// TODO: 지원서 개발 완료 후 활성화
+// import AnswerApplicationForm from '@/pages/AdminPage/application/answer/AnswerApplicationForm';
+// import CreateApplicationForm from '@/pages/AdminPage/application/CreateApplicationForm';
 
 const queryClient = new QueryClient();
 
@@ -65,20 +66,24 @@ const App = () => {
                           path='account-edit'
                           element={<AccountEditTab />}
                         />
-                        <Route
-                          path='application-edit'
-                          element={<CreateApplicationForm />}
-                        />
+                        {/*🔒 메인 브랜치에서는 접근 차단 (배포용 차단 목적)*/}
+                        {/*develop-fe 브랜치에서는 접근 가능하도록 풀고 개발 예정*/}
+                        {/*<Route*/}
+                        {/*  path='application-edit'*/}
+                        {/*  element={<CreateApplicationForm />}*/}
+                        {/*/>*/}
                       </Route>
                     </Routes>
                   </PrivateRoute>
                 </AdminClubProvider>
               }
             />
-            <Route
-              path='/application/:clubId'
-              element={<AnswerApplicationForm />}
-            />
+            {/*🔒 사용자용 지원서 작성 페이지도 메인에서는 비활성화 처리 */}
+            {/*🛠 develop-fe에서는 다시 노출 예정*/}
+            {/*<Route*/}
+            {/*  path='/application/:clubId'*/}
+            {/*  element={<AnswerApplicationForm />}*/}
+            {/*/>*/}
             <Route path='*' element={<Navigate to='/' replace />} />
           </Routes>
         </BrowserRouter>

--- a/frontend/src/pages/AdminPage/components/SideBar/SideBar.tsx
+++ b/frontend/src/pages/AdminPage/components/SideBar/SideBar.tsx
@@ -14,7 +14,7 @@ const tabs = [
   { label: '기본 정보 수정', path: '/admin/club-info' },
   { label: '모집 정보 수정', path: '/admin/recruit-edit' },
   { label: '활동 사진 수정', path: '/admin/photo-edit' },
-  { label: '지원서 관리', path: '/admin/application-edit' },
+  { label: '지원 관리', path: '/admin/application-edit' },
   { label: '계정 관리', path: '/admin/account-edit' },
 ];
 
@@ -29,7 +29,10 @@ const SideBar = ({ clubLogo, clubName }: SideBarProps) => {
 
   const handleTabClick = (tab: (typeof tabs)[number]) => {
     if (tab.label === '계정 관리') {
-      alert('계정 관리 탭은 준비 중입니다☺️');
+      alert('계정 관리 기능은 아직 준비 중이에요. ☺️');
+      return;
+    } else if (tab.label === '지원 관리') {
+      alert('동아리 지원 관리 기능은 곧 오픈돼요!\n조금만 기다려주세요 🚀');
       return;
     }
     navigate(tab.path);


### PR DESCRIPTION
## #️⃣연관된 이슈

> #506 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지/동영상 첨부 가능)
- 클럽 지원서 기능 관련 컴포넌트와 라우트를 메인 브랜치에서 임시 비활성화
- /admin/application-edit, /application/:clubId 접근 제거 또는 차단
- 사이드바 내 안내 메시지 문구 개선
- '지원 관리' 탭 클릭 시 친근한 문구로 안내
- 추후 기능 완성 시 재활성화 예정

## 🫡 참고사항
해당 기능은 develop-fe 브랜치에서 계속 개발 중입니다
develop에서 다시 주석 해제 예정