### PR TITLE
[feature] 카테고리 선택 상태 Context 전역 관리로 변경 및 페이지 이동 시 상태 유지

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { Suspense } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { SearchProvider } from '@/context/SearchContext';
+import { CategoryProvider } from '@/context/CategoryContext';
 import { AdminClubProvider } from '@/context/AdminClubContext';
 import GlobalStyles from '@/styles/Global.styles';
 import MainPage from '@/pages/MainPage/MainPage';
@@ -24,69 +25,74 @@ const App = () => {
   return (
     <QueryClientProvider client={queryClient}>
       <SearchProvider>
-        <BrowserRouter>
-          <GlobalStyles />
-          <Routes>
-            <Route
-              path='/'
-              element={
-                <Suspense fallback={null}>
-                  <MainPage />
-                </Suspense>
-              }
-            />
-            <Route
-              path='/club/:clubId'
-              element={
-                <Suspense fallback={null}>
-                  <ClubDetailPage />
-                </Suspense>
-              }
-            />
-            <Route path='/introduce' element={<IntroducePage />} />
-            <Route path='/admin/login' element={<LoginTab />} />
-            <Route
-              path='/admin/*'
-              element={
-                <AdminClubProvider>
-                  <PrivateRoute>
-                    <Routes>
-                      <Route path='' element={<AdminPage />}>
-                        <Route
-                          index
-                          element={<Navigate to='club-info' replace />}
-                        />
-                        <Route path='club-info' element={<ClubInfoEditTab />} />
-                        <Route
-                          path='recruit-edit'
-                          element={<RecruitEditTab />}
-                        />
-                        <Route path='photo-edit' element={<PhotoEditTab />} />
-                        <Route
-                          path='account-edit'
-                          element={<AccountEditTab />}
-                        />
-                        {/*🔒 메인 브랜치에서는 접근 차단 (배포용 차단 목적)*/}
-                        {/*develop-fe 브랜치에서는 접근 가능하도록 풀고 개발 예정*/}
-                        {/*<Route*/}
-                        {/*  path='application-edit'*/}
-                        {/*  element={<CreateApplicationForm />}*/}
-                        {/*/>*/}
-                      </Route>
-                    </Routes>
-                  </PrivateRoute>
-                </AdminClubProvider>
-              }
-            />
-            {/*🔒 사용자용 지원서 작성 페이지도 메인에서는 비활성화 처리 */}
-            {/*🛠 develop-fe에서는 다시 노출 예정*/}
-            {/*<Route*/}
-            {/*  path='/application/:clubId'*/}
-            {/*  element={<AnswerApplicationForm />}*/}
-            {/*/>*/}
-            <Route path='*' element={<Navigate to='/' replace />} />
-          </Routes>
-        </BrowserRouter>
+        <CategoryProvider>
+          <BrowserRouter>
+            <GlobalStyles />
+            <Routes>
+              <Route
+                path='/'
+                element={
+                  <Suspense fallback={null}>
+                    <MainPage />
+                  </Suspense>
+                }
+              />
+              <Route
+                path='/club/:clubId'
+                element={
+                  <Suspense fallback={null}>
+                    <ClubDetailPage />
+                  </Suspense>
+                }
+              />
+              <Route path='/introduce' element={<IntroducePage />} />
+              <Route path='/admin/login' element={<LoginTab />} />
+              <Route
+                path='/admin/*'
+                element={
+                  <AdminClubProvider>
+                    <PrivateRoute>
+                      <Routes>
+                        <Route path='' element={<AdminPage />}>
+                          <Route
+                            index
+                            element={<Navigate to='club-info' replace />}
+                          />
+                          <Route
+                            path='club-info'
+                            element={<ClubInfoEditTab />}
+                          />
+                          <Route
+                            path='recruit-edit'
+                            element={<RecruitEditTab />}
+                          />
+                          <Route path='photo-edit' element={<PhotoEditTab />} />
+                          <Route
+                            path='account-edit'
+                            element={<AccountEditTab />}
+                          />
+                          {/*🔒 메인 브랜치에서는 접근 차단 (배포용 차단 목적)*/}
+                          {/*develop-fe 브랜치에서는 접근 가능하도록 풀고 개발 예정*/}
+                          {/*<Route*/}
+                          {/*  path='application-edit'*/}
+                          {/*  element={<CreateApplicationForm />}*/}
+                          {/*/>*/}
+                        </Route>
+                      </Routes>
+                    </PrivateRoute>
+                  </AdminClubProvider>
+                }
+              />
+              {/*🔒 사용자용 지원서 작성 페이지도 메인에서는 비활성화 처리 */}
+              {/*🛠 develop-fe에서는 다시 노출 예정*/}
+              {/*<Route*/}
+              {/*  path='/application/:clubId'*/}
+              {/*  element={<AnswerApplicationForm />}*/}
+              {/*/>*/}
+              <Route path='*' element={<Navigate to='/' replace />} />
+            </Routes>
+          </BrowserRouter>
+        </CategoryProvider>
       </SearchProvider>
     </QueryClientProvider>
   );

--- a/frontend/src/context/CategoryContext.tsx
+++ b/frontend/src/context/CategoryContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
 
 const CategoryContext = createContext<{
   selectedCategory: string;
@@ -22,7 +22,25 @@ export const CategoryProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const [selectedCategory, setSelectedCategory] = useState('all');
+  const [selectedCategory, setSelectedCategoryState] = useState(() => {
+    return localStorage.getItem('selectedCategory') || 'all';
+  });
+
+  const setSelectedCategory = (category: string) => {
+    setSelectedCategoryState(category);
+    localStorage.setItem('selectedCategory', category);
+  };
+
+  useEffect(() => {
+    const handler = () => {
+      setSelectedCategoryState(
+        localStorage.getItem('selectedCategory') || 'all',
+      );
+    };
+    window.addEventListener('storage', handler);
+    return () => window.removeEventListener('storage', handler);
+  }, []);
+
   return (
     <CategoryContext.Provider value={{ selectedCategory, setSelectedCategory }}>
       {children}

--- a/frontend/src/context/CategoryContext.tsx
+++ b/frontend/src/context/CategoryContext.tsx
@@ -38,7 +38,16 @@ export const CategoryProvider = ({
       );
     };
     window.addEventListener('storage', handler);
-    return () => window.removeEventListener('storage', handler);
+
+    const handleBeforeUnload = () => {
+      localStorage.removeItem('selectedCategory');
+    };
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener('storage', handler);
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
   }, []);
 
   return (

--- a/frontend/src/context/CategoryContext.tsx
+++ b/frontend/src/context/CategoryContext.tsx
@@ -23,24 +23,24 @@ export const CategoryProvider = ({
   children: React.ReactNode;
 }) => {
   const [selectedCategory, setSelectedCategoryState] = useState(() => {
-    return localStorage.getItem('selectedCategory') || 'all';
+    return sessionStorage.getItem('selectedCategory') || 'all';
   });
 
   const setSelectedCategory = (category: string) => {
     setSelectedCategoryState(category);
-    localStorage.setItem('selectedCategory', category);
+    sessionStorage.setItem('selectedCategory', category);
   };
 
   useEffect(() => {
     const handler = () => {
       setSelectedCategoryState(
-        localStorage.getItem('selectedCategory') || 'all',
+        sessionStorage.getItem('selectedCategory') || 'all',
       );
     };
     window.addEventListener('storage', handler);
 
     const handleBeforeUnload = () => {
-      localStorage.removeItem('selectedCategory');
+      sessionStorage.removeItem('selectedCategory');
     };
     window.addEventListener('beforeunload', handleBeforeUnload);
 

--- a/frontend/src/context/CategoryContext.tsx
+++ b/frontend/src/context/CategoryContext.tsx
@@ -39,14 +39,8 @@ export const CategoryProvider = ({
     };
     window.addEventListener('storage', handler);
 
-    const handleBeforeUnload = () => {
-      sessionStorage.removeItem('selectedCategory');
-    };
-    window.addEventListener('beforeunload', handleBeforeUnload);
-
     return () => {
       window.removeEventListener('storage', handler);
-      window.removeEventListener('beforeunload', handleBeforeUnload);
     };
   }, []);
 

--- a/frontend/src/context/CategoryContext.tsx
+++ b/frontend/src/context/CategoryContext.tsx
@@ -8,7 +8,14 @@ const CategoryContext = createContext<{
   setSelectedCategory: () => {},
 });
 
-export const useCategory = () => useContext(CategoryContext);
+export const useCategory = () => {
+  const context = useContext(CategoryContext);
+  if (!context)
+    throw new Error(
+      'useCategory는 CategoryProvider 내부에서만 사용할 수 있습니다',
+    );
+  return context;
+};
 
 export const CategoryProvider = ({
   children,

--- a/frontend/src/context/CategoryContext.tsx
+++ b/frontend/src/context/CategoryContext.tsx
@@ -1,0 +1,24 @@
+import { createContext, useContext, useState } from 'react';
+
+const CategoryContext = createContext<{
+  selectedCategory: string;
+  setSelectedCategory: (category: string) => void;
+}>({
+  selectedCategory: 'all',
+  setSelectedCategory: () => {},
+});
+
+export const useCategory = () => useContext(CategoryContext);
+
+export const CategoryProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [selectedCategory, setSelectedCategory] = useState('all');
+  return (
+    <CategoryContext.Provider value={{ selectedCategory, setSelectedCategory }}>
+      {children}
+    </CategoryContext.Provider>
+  );
+};

--- a/frontend/src/pages/MainPage/MainPage.tsx
+++ b/frontend/src/pages/MainPage/MainPage.tsx
@@ -50,7 +50,7 @@ const MainPage = () => {
         mobileBanners={MobileBannerImageList}
       />
       <Styled.PageContainer>
-        <CategoryButtonList onCategorySelect={setSelectedCategory} />
+        <CategoryButtonList />
         <Styled.FilterWrapper>
           <StatusRadioButton onChange={setIsFilterActive} />
         </Styled.FilterWrapper>

--- a/frontend/src/pages/MainPage/MainPage.tsx
+++ b/frontend/src/pages/MainPage/MainPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react';
 import { useSearch } from '@/context/SearchContext';
+import { useCategory } from '@/context/CategoryContext';
 import useTrackPageView from '@/hooks/useTrackPageView';
 import { useGetCardList } from '@/hooks/queries/club/useGetCardList';
 import CategoryButtonList from '@/pages/MainPage/components/CategoryButtonList/CategoryButtonList';
@@ -18,7 +19,7 @@ const MainPage = () => {
   useTrackPageView('MainPage');
 
   const [isFilterActive, setIsFilterActive] = useState(false);
-  const [selectedCategory, setSelectedCategory] = useState('all');
+  const { selectedCategory, setSelectedCategory } = useCategory();
 
   const { keyword } = useSearch();
   const recruitmentStatus = isFilterActive ? 'OPEN' : 'all';

--- a/frontend/src/pages/MainPage/components/CategoryButtonList/CategoryButtonList.tsx
+++ b/frontend/src/pages/MainPage/components/CategoryButtonList/CategoryButtonList.tsx
@@ -8,6 +8,7 @@ import iconStudy from '@/assets/images/icons/category_button/category_study_butt
 import iconSport from '@/assets/images/icons/category_button/category_sport_button_icon.svg';
 import iconPerformance from '@/assets/images/icons/category_button/category_performance_button_icon.svg';
 import { useSearch } from '@/context/SearchContext';
+import { useCategory } from '@/context/CategoryContext';
 
 interface Category {
   id: string;
@@ -62,6 +63,7 @@ const clubCategories: Category[] = [
 
 const CategoryButtonList = ({ onCategorySelect }: CategoryButtonListProps) => {
   const { setKeyword, setInputValue } = useSearch();
+  const { selectedCategory, setSelectedCategory } = useCategory();
 
   const handleCategoryClick = (category: Category) => {
     mixpanel.track(category.eventName, {
@@ -74,6 +76,7 @@ const CategoryButtonList = ({ onCategorySelect }: CategoryButtonListProps) => {
     setKeyword('');
     setInputValue('');
 
+    setSelectedCategory(category.id);
     onCategorySelect(category.id);
   };
 
@@ -82,7 +85,8 @@ const CategoryButtonList = ({ onCategorySelect }: CategoryButtonListProps) => {
       {clubCategories.map((category) => (
         <Styled.CategoryButton
           key={category.id}
-          onClick={() => handleCategoryClick(category)}>
+          onClick={() => handleCategoryClick(category)}
+        >
           <img src={category.icon} alt={category.name} />
           <span>{category.name}</span>
         </Styled.CategoryButton>

--- a/frontend/src/pages/MainPage/components/CategoryButtonList/CategoryButtonList.tsx
+++ b/frontend/src/pages/MainPage/components/CategoryButtonList/CategoryButtonList.tsx
@@ -17,10 +17,6 @@ interface Category {
   eventName: string;
 }
 
-interface CategoryButtonListProps {
-  onCategorySelect: (division: string) => void;
-}
-
 const clubCategories: Category[] = [
   { id: 'all', name: '전체', icon: iconAll, eventName: 'Category_All_Clicked' },
   {
@@ -61,7 +57,7 @@ const clubCategories: Category[] = [
   },
 ];
 
-const CategoryButtonList = ({ onCategorySelect }: CategoryButtonListProps) => {
+const CategoryButtonList = () => {
   const { setKeyword, setInputValue } = useSearch();
   const { setSelectedCategory } = useCategory();
 
@@ -77,7 +73,7 @@ const CategoryButtonList = ({ onCategorySelect }: CategoryButtonListProps) => {
     setInputValue('');
 
     setSelectedCategory(category.id);
-    onCategorySelect(category.id);
+
   };
 
   return (

--- a/frontend/src/pages/MainPage/components/CategoryButtonList/CategoryButtonList.tsx
+++ b/frontend/src/pages/MainPage/components/CategoryButtonList/CategoryButtonList.tsx
@@ -63,7 +63,7 @@ const clubCategories: Category[] = [
 
 const CategoryButtonList = ({ onCategorySelect }: CategoryButtonListProps) => {
   const { setKeyword, setInputValue } = useSearch();
-  const { selectedCategory, setSelectedCategory } = useCategory();
+  const { setSelectedCategory } = useCategory();
 
   const handleCategoryClick = (category: Category) => {
     mixpanel.track(category.eventName, {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #511

## 📝작업 내용

### ContextAPI로 카테고리 상태 관리하기
- 카테고리 상태를 전역으로 관리할 수 있는`CategoryContext.tsx` 컨텍스트 제작 79a5637aaec2c4ef040b5df9ef3c20ffc454d168
- `MainPage.tsx`의 카테고리 로컬 상태를 `useCategory()` 로 대체하여 전역 상태로 변경 65a5cff24824952261e35e60f854d629fcabb230
- `App.tsx`에 CategoryProvider 추가 9c5d471be95b0ad7a3dac5bc6225c5200c87acc9
- `CategoryButtonList.tsx`에서 카테고리 버튼 클릭시 전역으로 전달 58d9e8fb345e7245fc690f5053fce563d85c3052
- prop 전달 제거 [65db40c](https://github.com/Moadong/moadong/pull/512/commits/65db40cb7f76b186c249031697c40e28ca6d7579)

### 7.6 추가 변경
- 창닫거나 언마운트 시 localstorage 데이터 제거

### 관리자 페이지에서도 상태 유지하기
- localStorage에 카테고리명 저장
- 저장된 게 있으면 가져오고, 아니면 'all'로 유지 [cfaf4a5](https://github.com/Moadong/moadong/pull/512/commits/cfaf4a54e47a81e1a511a039129339230ab2f444)

### 동작 화면

https://github.com/user-attachments/assets/076890a2-71cb-4e42-9f8e-16d524112844



## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - 카테고리 선택 상태를 전역적으로 관리할 수 있는 카테고리 컨텍스트가 추가되었습니다.
- **Refactor**
  - 메인 페이지와 카테고리 버튼 리스트에서 카테고리 상태 관리를 컨텍스트 기반으로 변경하여, 여러 컴포넌트에서 카테고리 선택 정보를 공유할 수 있도록 개선되었습니다.
  - 전체 라우팅 구조가 카테고리 컨텍스트 프로바이더로 감싸져, 모든 라우트와 컴포넌트에서 카테고리 상태에 접근 가능해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->