### PR TITLE
[setting] MOA-84 백엔드 서버 오라클 클라우드로 이전

### DIFF
--- a/.github/workflows/oracle_server_cd_develop.yml
+++ b/.github/workflows/oracle_server_cd_develop.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - 'develop/be'
-      - 'setting/#542-oracle_cloud'
     paths:
       - 'backend/**'
 

--- a/.github/workflows/oracle_server_cd_develop.yml
+++ b/.github/workflows/oracle_server_cd_develop.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           context: ./backend
           file: ./backend/Dockerfile
-          platforms: linux/arm64
+          platforms: linux/arm64,linux/amd64
           push: true
           tags: |
             ${{ secrets.DOCKER_IMAGE_DEV }}:latest
@@ -105,7 +105,7 @@ jobs:
           script: |
             docker pull ${{ secrets.DOCKER_IMAGE_DEV }}:latest
 
-            echo whoami
+            echo $(whoami)
             export USERNAME=${{ secrets.ORACLE_INSTANCE_USER }}
             export DOCKER_APP_IMAGE=${{ secrets.DOCKER_IMAGE_DEV }}:latest
             sudo chmod +x /home/${{ secrets.ORACLE_INSTANCE_USER }}/deploy.sh

--- a/.github/workflows/oracle_server_cd_develop.yml
+++ b/.github/workflows/oracle_server_cd_develop.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches:
       - 'develop/be'
-      - 'feature/#517-oracle-cicd'
+      - "setting/#542-oracle_cloud"
     paths:
       - 'backend/**'
       - '.github/workflows/**'
@@ -32,12 +32,15 @@ jobs:
         uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
 
       - name: Cache Gradle dependencies
-        uses: actions/cache@v4  # Gradle 의존성 캐시 설정
+        uses: actions/cache@v4
         with:
-          path: ~/.gradle/caches  # Gradle 캐시 경로
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}  # Gradle 파일 해시값 기반 키
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+
 
       - name: make application.properties
         run: |
@@ -51,31 +54,13 @@ jobs:
         run: |
           cd backend
           ./gradlew clean build -x test
-
-      - id: 'auth'
-        uses: 'google-github-actions/auth@v2'
+          
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
         with:
-          credentials_json: ${{ secrets.GCE_SA_KEY }}
+          username: ${{ secrets.SERVER_DOCKER_USERNAME }}
+          password: ${{ secrets.SERVER_DOCKER_PASSWORD }}
 
-      # GCloud SDK 캐시 설정
-      - name: Cache Google Cloud SDK
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache
-          key: gcloud-sdk-${{ runner.os }}
-          restore-keys: |
-            gcloud-sdk-
-
-      # Google Cloud CLI 설정
-      - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          project_id: ${{ secrets.GCE_PROJECT }}
-
-      # Docker 인증
-      - name: Authenticate Docker to Google Cloud Container Registry (GCR)
-        run: |
-          gcloud auth configure-docker asia-northeast3-docker.pkg.dev
 
       # Docker 이미지 빌드 및 GCR 업로드
       # ARM 전용 이미지 배포
@@ -103,17 +88,11 @@ jobs:
     
     steps:
 
-      # gcloud-setup workflow 호출
-      - id: 'auth'
-        uses: 'google-github-actions/auth@v2'
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
         with:
-          credentials_json: ${{ secrets.GCE_SA_KEY }}
-
-      # Google Cloud CLI 설정
-      - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          project_id: ${{ secrets.GCE_PROJECT }}
+          username: ${{ secrets.SERVER_DOCKER_USERNAME }}
+          password: ${{ secrets.SERVER_DOCKER_PASSWORD }}
 
       # oracle ssh 접속 후 배포
       - name: Update Container on VM
@@ -124,13 +103,6 @@ jobs:
           key: ${{ secrets.ORACLE_INSTANCE_DEV_PRIVATE_KEY }}
           port: ${{ secrets.ORACLE_INSTANCE_DEV_PORT }}
           script: |
-            gcloud auth activate-service-account --key-file=/home/${{ secrets.ORACLE_INSTANCE_USER }}/gce_sa_key.json
-            ACCESS_TOKEN=$(gcloud auth print-access-token)
-            docker login -u oauth2accesstoken --password-stdin https://asia-northeast3-docker.pkg.dev
-            docker pull asia-northeast3-docker.pkg.dev/pristine-valve-457508-k7/moadong/moadong-dev:latest
-  
-            sudo usermod -aG docker $USER
-            newgrp docker
             docker pull ${{ secrets.DOCKER_IMAGE_DEV }}:latest
 
             export USERNAME=${{ secrets.ORACLE_INSTANCE_USER }}

--- a/.github/workflows/oracle_server_cd_develop.yml
+++ b/.github/workflows/oracle_server_cd_develop.yml
@@ -8,7 +8,6 @@ on:
       - 'develop/be'
     paths:
       - 'backend/**'
-      - '.github/workflows/**'
 
 jobs:
 
@@ -85,12 +84,6 @@ jobs:
     
     steps:
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.SERVER_DOCKER_USERNAME }}
-          password: ${{ secrets.SERVER_DOCKER_PASSWORD }}
-
       # oracle ssh 접속 후 배포
       - name: Update Container on VM
         uses: appleboy/ssh-action@master
@@ -102,7 +95,6 @@ jobs:
           script: |
             docker pull ${{ secrets.DOCKER_IMAGE_DEV }}:latest
 
-            echo $(whoami)
             export USERNAME=${{ secrets.ORACLE_INSTANCE_USER }}
             export DOCKER_APP_IMAGE=${{ secrets.DOCKER_IMAGE_DEV }}:latest
             sudo chmod +x /home/${{ secrets.ORACLE_INSTANCE_USER }}/deploy.sh

--- a/.github/workflows/oracle_server_cd_develop.yml
+++ b/.github/workflows/oracle_server_cd_develop.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - 'develop/be'
-      - "setting/#542-oracle_cloud"
     paths:
       - 'backend/**'
       - '.github/workflows/**'
@@ -62,8 +61,6 @@ jobs:
           password: ${{ secrets.SERVER_DOCKER_PASSWORD }}
 
 
-      # Docker 이미지 빌드 및 GCR 업로드
-      # ARM 전용 이미지 배포
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/oracle_server_cd_develop.yml
+++ b/.github/workflows/oracle_server_cd_develop.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - 'develop/be'
+      - 'setting/#542-oracle_cloud'
     paths:
       - 'backend/**'
 

--- a/.github/workflows/oracle_server_cd_develop.yml
+++ b/.github/workflows/oracle_server_cd_develop.yml
@@ -105,6 +105,7 @@ jobs:
           script: |
             docker pull ${{ secrets.DOCKER_IMAGE_DEV }}:latest
 
+            echo whoami
             export USERNAME=${{ secrets.ORACLE_INSTANCE_USER }}
             export DOCKER_APP_IMAGE=${{ secrets.DOCKER_IMAGE_DEV }}:latest
             sudo chmod +x /home/${{ secrets.ORACLE_INSTANCE_USER }}/deploy.sh

--- a/.github/workflows/server_cd_release.yml
+++ b/.github/workflows/server_cd_release.yml
@@ -84,12 +84,6 @@ jobs:
     
     steps:
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.SERVER_DOCKER_USERNAME }}
-          password: ${{ secrets.SERVER_DOCKER_PASSWORD }}
-
       # oracle ssh 접속 후 배포
       - name: Update Container on VM
         uses: appleboy/ssh-action@master
@@ -99,7 +93,7 @@ jobs:
           key: ${{ secrets.ORACLE_INSTANCE_RELEASE_PRIVATE_KEY }}
           port: ${{ secrets.ORACLE_INSTANCE_RELEASE_PORT }}
           script: |
-            echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+            echo "${{ secrets.DOCKER_PASSWORD }}" | docker login --username "${{ secrets.DOCKER_USERNAME }}" --password-stdin
             
             docker pull ${{ secrets.DOCKER_IMAGE_RELEASE }}:latest
             

--- a/.github/workflows/server_cd_release.yml
+++ b/.github/workflows/server_cd_release.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - 'main'
-      - "setting/#542-oracle_cloud"
     paths:
       - 'backend/**'
       - '.github/workflows/**'
@@ -93,11 +92,9 @@ jobs:
           key: ${{ secrets.ORACLE_INSTANCE_RELEASE_PRIVATE_KEY }}
           port: ${{ secrets.ORACLE_INSTANCE_RELEASE_PORT }}
           script: |
-            echo "${{ secrets.DOCKER_PASSWORD }}" | docker login --username "${{ secrets.DOCKER_USERNAME }}" --password-stdin
             
             docker pull ${{ secrets.DOCKER_IMAGE_RELEASE }}:latest
             
-            echo $(whoami)
             export USERNAME=${{ secrets.ORACLE_INSTANCE_USER }}
             export DOCKER_APP_IMAGE=${{ secrets.DOCKER_IMAGE_RELEASE }}:latest
             sudo chmod +x /home/${{ secrets.ORACLE_INSTANCE_USER }}/deploy.sh

--- a/.github/workflows/server_cd_release.yml
+++ b/.github/workflows/server_cd_release.yml
@@ -99,6 +99,8 @@ jobs:
           key: ${{ secrets.ORACLE_INSTANCE_RELEASE_PRIVATE_KEY }}
           port: ${{ secrets.ORACLE_INSTANCE_RELEASE_PORT }}
           script: |
+            echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+            
             docker pull ${{ secrets.DOCKER_IMAGE_RELEASE }}:latest
             
             echo $(whoami)

--- a/.github/workflows/server_cd_release.yml
+++ b/.github/workflows/server_cd_release.yml
@@ -1,4 +1,3 @@
-# .github/workflows/server_cd_develop.yml
 
 name: Release Server CD
 
@@ -6,6 +5,7 @@ on:
   push:
     branches:
       - 'main'
+      - "setting/#542-oracle_cloud"
     paths:
       - 'backend/**'
       - '.github/workflows/**'
@@ -31,10 +31,12 @@ jobs:
         uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
 
       - name: Cache Gradle dependencies
-        uses: actions/cache@v4  # Gradle 의존성 캐시 설정
+        uses: actions/cache@v4
         with:
-          path: ~/.gradle/caches  # Gradle 캐시 경로
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}  # Gradle 파일 해시값 기반 키
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
 
@@ -51,37 +53,26 @@ jobs:
           cd backend
           ./gradlew clean build -x test
 
-      - id: 'auth'
-        uses: 'google-github-actions/auth@v2'
-        with:
-          credentials_json: ${{ secrets.GCE_SA_KEY }}
-
-      # GCloud SDK 캐시 설정
-      - name: Cache Google Cloud SDK
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache
-          key: gcloud-sdk-${{ runner.os }}
-          restore-keys: |
-            gcloud-sdk-
-
-      # Google Cloud CLI 설정
-      - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          project_id: ${{ secrets.GCE_PROJECT }}
-
       # Docker 인증
-      - name: Authenticate Docker to Google Cloud Container Registry (GCR)
-        run: |
-          gcloud auth configure-docker asia-northeast3-docker.pkg.dev
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.SERVER_DOCKER_USERNAME }}
+          password: ${{ secrets.SERVER_DOCKER_PASSWORD }}
 
-      # Docker 이미지 빌드 및 GCR 업로드
-      - name: Build and Push Docker Image
-        run: |
-          cd backend
-          docker build -t ${{ secrets.DOCKER_IMAGE_RELEASE }}:${{ github.sha }} -t ${{ secrets.DOCKER_IMAGE_DEV }}:latest .
-          docker push -a ${{ secrets.DOCKER_IMAGE_RELEASE }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and Push ARM64 Docker Image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          platforms: linux/arm64,linux/amd64
+          push: true
+          tags: |
+            ${{ secrets.DOCKER_IMAGE_RELEASE }}:latest
+            ${{ secrets.DOCKER_IMAGE_RELEASE }}:${{ github.sha }}
 
   deploy:
     name: Deploy
@@ -93,33 +84,27 @@ jobs:
     
     steps:
 
-      # gcloud-setup workflow 호출
-      - id: 'auth'
-        uses: 'google-github-actions/auth@v2'
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
         with:
-          credentials_json: ${{ secrets.GCE_SA_KEY }}
+          username: ${{ secrets.SERVER_DOCKER_USERNAME }}
+          password: ${{ secrets.SERVER_DOCKER_PASSWORD }}
 
-      # Google Cloud CLI 설정
-      - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          project_id: ${{ secrets.GCE_PROJECT }}
-
+      # oracle ssh 접속 후 배포
       - name: Update Container on VM
-        run: |
-          gcloud compute ssh ${{ secrets.GCE_INSTANCE_RELEASE }} --zone=${{ secrets.GCP_REGION }} --command="
-          gcloud auth configure-docker asia-northeast3-docker.pkg.dev
-          gcloud auth activate-service-account --key-file=/home/${{ secrets.GCE_INSTANCE_USER }}/gce_sa_key.json
-          
-          sudo usermod -aG docker $USER
-          newgrp docker
-          
-          docker pull ${{ secrets.DOCKER_IMAGE_RELEASE }}:latest
-          
-          export USERNAME=${{ secrets.GCE_INSTANCE_USER }} # docker compose 파일에서 사용할 변수명 설정
-          export DOCKER_APP_IMAGE=${{ secrets.DOCKER_IMAGE_RELEASE }}:latest
-          sudo chmod +x /home/${{ secrets.GCE_INSTANCE_USER }}/deploy.sh # 실행 권한 부여
-          sudo -E /home/${{ secrets.GCE_INSTANCE_USER }}/deploy.sh # su권한으로 환경 변수 유지 및 실행
-          
-          docker image prune -af
-          docker ps -a"
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.ORACLE_INSTANCE_RELEASE_IP }}
+          username: ${{ secrets.ORACLE_INSTANCE_USER }}
+          key: ${{ secrets.ORACLE_INSTANCE_RELEASE_PRIVATE_KEY }}
+          port: ${{ secrets.ORACLE_INSTANCE_RELEASE_PORT }}
+          script: |
+            docker pull ${{ secrets.DOCKER_IMAGE_RELEASE }}:latest
+            
+            echo $(whoami)
+            export USERNAME=${{ secrets.ORACLE_INSTANCE_USER }}
+            export DOCKER_APP_IMAGE=${{ secrets.DOCKER_IMAGE_RELEASE }}:latest
+            sudo chmod +x /home/${{ secrets.ORACLE_INSTANCE_USER }}/deploy.sh
+            sudo -E /home/${{ secrets.ORACLE_INSTANCE_USER }}/deploy.sh
+            
+            docker image prune -af

--- a/.github/workflows/server_cd_release.yml
+++ b/.github/workflows/server_cd_release.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'setting/#542-oracle_cloud'
     paths:
       - 'backend/**'
       - '.github/workflows/**'

--- a/backend/src/main/java/moadong/global/config/SecurityConfig.java
+++ b/backend/src/main/java/moadong/global/config/SecurityConfig.java
@@ -40,8 +40,8 @@ public class SecurityConfig {
 
     private final JwtProvider jwtProvider;
     private final CustomUserDetailService userDetailsService;
-    @Value("${spring.cloud.gcp.credentials.location}")
-    private String credentialsLocation;
+//    @Value("${spring.cloud.gcp.credentials.location}")
+//    private String credentialsLocation;
 
     public SecurityConfig(JwtProvider jwtProvider, CustomUserDetailService userDetailsService) {
         this.jwtProvider = jwtProvider;
@@ -62,14 +62,14 @@ public class SecurityConfig {
         return http.build();
     }
 
-    @Bean
-    public Storage storage() throws IOException {
-        InputStream keyFile = ResourceUtils.getURL(credentialsLocation).openStream();
-        return StorageOptions.newBuilder()
-                .setCredentials(GoogleCredentials.fromStream(keyFile))
-                .build()
-                .getService();
-    }
+//    @Bean
+//    public Storage storage() throws IOException {
+//        InputStream keyFile = ResourceUtils.getURL(credentialsLocation).openStream();
+//        return StorageOptions.newBuilder()
+//                .setCredentials(GoogleCredentials.fromStream(keyFile))
+//                .build()
+//                .getService();
+//    }
 
     @Bean
     public PasswordEncoder passwordEncoder() {

--- a/backend/src/main/java/moadong/media/util/GoogleDriveConfig.java
+++ b/backend/src/main/java/moadong/media/util/GoogleDriveConfig.java
@@ -1,41 +1,41 @@
-package moadong.media.util;
-
-import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
-import com.google.api.client.json.jackson2.JacksonFactory;
-import com.google.api.services.drive.Drive;
-import com.google.api.services.drive.DriveScopes;
-import com.google.auth.http.HttpCredentialsAdapter;
-import com.google.auth.oauth2.GoogleCredentials;
-import java.io.InputStream;
-import java.util.Collections;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.util.ResourceUtils;
-
-@Configuration
-public class GoogleDriveConfig {
-
-    @Value("${spring.cloud.gcp.credentials.location}")
-    private String credentialsLocation;
-
-    @Value("${google.application.name}")
-    private String applicationName;
-
-    @Bean
-    public Drive googleDriveService() throws Exception {
-        InputStream in = ResourceUtils.getURL(credentialsLocation).openStream();
-        GoogleCredentials credentials = GoogleCredentials.fromStream(in)
-                .createScoped(Collections.singleton(DriveScopes.DRIVE));
-
-        return new Drive.Builder(
-                GoogleNetHttpTransport.newTrustedTransport(),
-                JacksonFactory.getDefaultInstance(),
-                new HttpCredentialsAdapter(credentials))
-                .setApplicationName(applicationName)
-                .build();
-
-    }
-
-
-}
+//package moadong.media.util;
+//
+//import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+//import com.google.api.client.json.jackson2.JacksonFactory;
+//import com.google.api.services.drive.Drive;
+//import com.google.api.services.drive.DriveScopes;
+//import com.google.auth.http.HttpCredentialsAdapter;
+//import com.google.auth.oauth2.GoogleCredentials;
+//import java.io.InputStream;
+//import java.util.Collections;
+//import org.springframework.beans.factory.annotation.Value;
+//import org.springframework.context.annotation.Bean;
+//import org.springframework.context.annotation.Configuration;
+//import org.springframework.util.ResourceUtils;
+//
+//@Configuration
+//public class GoogleDriveConfig {
+//
+//    @Value("${spring.cloud.gcp.credentials.location}")
+//    private String credentialsLocation;
+//
+//    @Value("${google.application.name}")
+//    private String applicationName;
+//
+//    @Bean
+//    public Drive googleDriveService() throws Exception {
+//        InputStream in = ResourceUtils.getURL(credentialsLocation).openStream();
+//        GoogleCredentials credentials = GoogleCredentials.fromStream(in)
+//                .createScoped(Collections.singleton(DriveScopes.DRIVE));
+//
+//        return new Drive.Builder(
+//                GoogleNetHttpTransport.newTrustedTransport(),
+//                JacksonFactory.getDefaultInstance(),
+//                new HttpCredentialsAdapter(credentials))
+//                .setApplicationName(applicationName)
+//                .build();
+//
+//    }
+//
+//
+//}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #542 

## 📝작업 내용

> 백엔드 서버 오라클 클라우드로 이전
> 개발섭, 배포섭 모두 이전

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD 워크플로우가 Google Cloud에서 Docker Hub 및 Oracle VM 기반 배포로 전환되었습니다.
  * Docker 이미지는 이제 ARM64와 AMD64 아키텍처 모두에 대해 빌드 및 배포됩니다.
  * Google Cloud 인증 및 관련 설정 단계가 제거되었습니다.

* **Refactor**
  * Google Cloud Storage 및 Google Drive 관련 설정 코드가 비활성화(주석 처리)되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->