### PR TITLE
[feature] 비참여 동아리 상세페이지 접근 시 alert 처리

### DIFF
--- a/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
@@ -14,6 +14,48 @@ import useTrackPageView from '@/hooks/useTrackPageView';
 import useAutoScroll from '@/hooks/InfoTabs/useAutoScroll';
 import { useGetClubDetail } from '@/hooks/queries/club/useGetClubDetail';
 
+const notJoinedClubNames = [
+  'PKNUO',
+  'UCDC',
+  '울림',
+  '쇳물결',
+  '한누리',
+  '씨사운드',
+  '백경클래식기타연구회',
+  '남천로타렉트',
+  '동반',
+  '민심사랑',
+  '절영회',
+  '청심회',
+  '피어드림',
+  '버드',
+  '모비딕',
+  '후라',
+  '어택',
+  '홍백',
+  '바구니',
+  '산악부',
+  '한판',
+  '리얼겟',
+  '조정부',
+  '조나단',
+  '불교학생회',
+  'JDM',
+  'SFC',
+  '가톨릭학생회',
+  'CCC',
+  'PAS',
+  '300',
+  '백경 유스호스텔',
+  '짚신 유스호스텔',
+  '수석회',
+  '포시즌',
+  'O.S.T',
+  'SIC',
+  'CERT-IS',
+  'testaa',
+];
+
 const ClubDetailPage = () => {
   const { clubId } = useParams<{ clubId: string }>();
   const { sectionRefs, scrollToSection } = useAutoScroll();

--- a/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import * as Styled from '@/styles/PageContainer.styles';
 import Header from '@/components/common/Header/Header';
 import BackNavigationBar from '@/pages/ClubDetailPage/components/BackNavigationBar/BackNavigationBar';
@@ -61,7 +61,23 @@ const ClubDetailPage = () => {
   const { sectionRefs, scrollToSection } = useAutoScroll();
   const [showHeader, setShowHeader] = useState(window.innerWidth > 500);
 
+  const navigate = useNavigate();
+  const [blockState, setBlockState] = useState<
+    'checking' | 'blocked' | 'allowed'
+  >('checking');
   const { data: clubDetail, error } = useGetClubDetail(clubId || '');
+
+  useEffect(() => {
+    if (!clubDetail) return;
+
+    if (notJoinedClubNames.includes(clubDetail?.name || '')) {
+      setBlockState('blocked');
+      alert('참여하지 않는 동아리입니다.');
+      navigate('/', { replace: true });
+    } else {
+      setBlockState('allowed');
+    }
+  }, [clubDetail, navigate]);
 
   useEffect(() => {
     const handleResize = () => {
@@ -74,7 +90,7 @@ const ClubDetailPage = () => {
 
   useTrackPageView(`ClubDetailPage`, clubDetail?.name);
 
-  if (!clubDetail) {
+  if (!clubDetail || blockState !== 'allowed') {
     return null;
   }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #547

## 📝작업 내용

- 비참여 동아리 정적 데이터 정의 1f33deaf18e9d62dfc0d85f688c38ba04a2b577d
- 비참여 동아리 리다이렉션 및 alert처리 b5d1343cc438aa6dccb1d44265f837b41ee52b8f


## 고민한 부분

```
1. clubId리스트를 만들고 router에서 미리 걸러주기 
2. 상세페이지에서 clubName기준으로 리다이렉션
```

1번으로 하면 clubId를 상수로 관리해야 하는데 혹시 모를 보안문제가 생길 수도 있다고 판단했습니다. 
추가로 커스텀 훅을 구현해야 하는 번거로움도 있을 것 같네요.


## 구현방식

```
1. clubName이 비참여 동아리인지 확인한다
2. 비참여 동아리라면 alert를 띄운다
3. 홈으로 리다이렉션을 한다
```

### ✔️ 로딩 상태가 필요한 이유

- `clubDetailPage.tsx`에서 렌더링 전에 (tanstack으로) clubDetail 값을 받기 떄문입니다.

### 발생하는 문제

(1) mount
    ↓
(2) fetch clubDetail
    ↓
(3) clubDetail 도착
    ↓
(4) 렌더링 발생
    ↓
(5) useEffect → alert → navigate('/')

=> 렌더링 후 다시 리다이렉션되기에 깜빡거림이 발생합니다.

### 로딩 상태 추가
```typescript
 const [blockState, setBlockState] = useState<
    'checking' | 'blocked' | 'allowed'
  >('checking');
```

- clubDetail 도착 전 → 'checking' 상태 → 렌더링 안 함

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 가입하지 않은 동아리의 상세 페이지 접근 시, 접근이 차단되고 홈 화면으로 자동 이동됩니다.  
  * 차단된 동아리 접근 시 안내 알림이 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->