### PR TITLE
[refactor] 모바일 활동사진 UI 그리드 형태로 수정 및 반응형 개선 작업

### DIFF
--- a/frontend/src/components/common/Footer/Footer.styles.ts
+++ b/frontend/src/components/common/Footer/Footer.styles.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { media } from '@/styles/mediaQuery';
 
 export const FooterContainer = styled.footer`
   text-align: left;
@@ -18,7 +19,7 @@ export const FooterContent = styled.div`
   line-height: 1.25rem;
   color: #818181;
 
-  @media (max-width: 500px) {
+  ${media.mobile} {
     font-size: 0.625rem;
     padding: 20px 20px 30px 20px;
   }

--- a/frontend/src/pages/ClubDetailPage/components/InfoBox/InfoBox.styles.ts
+++ b/frontend/src/pages/ClubDetailPage/components/InfoBox/InfoBox.styles.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { media } from '@/styles/mediaQuery';
 
 export const InfoBoxWrapper = styled.div`
   display: flex;
@@ -7,7 +8,11 @@ export const InfoBoxWrapper = styled.div`
   gap: 34px;
   margin-top: 100px;
 
-  @media (max-width: 500px) {
+  @media (max-width: 800px) {
+    flex-direction: column;
+  }
+
+  ${media.mobile} {
     flex-direction: column;
     gap: 0;
     margin-top: 40px;
@@ -21,7 +26,11 @@ export const InfoBox = styled.div`
   border: 1px solid #dcdcdc;
   padding: 30px;
 
-  @media (max-width: 500px) {
+  @media (max-width: 800px) {
+    width: 100%;
+  }
+
+  ${media.mobile} {
     width: 100%;
     border: none;
     border-radius: 0;
@@ -52,7 +61,7 @@ export const DescriptionWrapper = styled.div`
   align-items: center;
   gap: 50px;
   font-size: 16px;
-  @media (max-width: 500px) {
+  ${media.mobile} {
     font-size: 14px;
     gap: 40px;
   }
@@ -72,7 +81,7 @@ export const RightText = styled.p`
     white-space: normal;
   }
 
-  @media (max-width: 500px) {
+  ${media.mobile} {
     white-space: nowrap;
   }
 `;

--- a/frontend/src/pages/ClubDetailPage/components/PhotoList/PhotoList.styles.ts
+++ b/frontend/src/pages/ClubDetailPage/components/PhotoList/PhotoList.styles.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { media } from '@/styles/mediaQuery';
 
 export const PhotoListTitle = styled.p`
   font-size: 20px;
@@ -15,7 +16,7 @@ export const PhotoListContainer = styled.div`
   padding: 30px;
   gap: 30px;
 
-  @media (max-width: 500px) {
+  ${media.mobile} {
     margin-top: 0;
     width: 100%;
     border: none;
@@ -44,6 +45,13 @@ export const PhotoList = styled.div<{
     photoCount <= 2 ? 'none' : `translateX(${translateX}px)`};
 
   user-select: none;
+
+  ${media.mobile} {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 12px;
+    transform: none !important;
+  }
 `;
 
 export const PhotoCard = styled.div`
@@ -65,9 +73,13 @@ export const PhotoCard = styled.div`
     -webkit-user-drag: none;
   }
 
-  @media (max-width: 500px) {
-    width: 350px;
-    height: 350px;
+  ${media.mobile} {
+    width: 100%;
+    aspect-ratio: 1 / 1;
+    height: auto;
+    min-width: 0;
+    min-height: 0;
+    border-radius: 8px;
   }
 `;
 
@@ -96,7 +108,7 @@ export const NavigationButton = styled.button<{ direction: 'left' | 'right' }>`
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
   }
 
-  @media (max-width: 500px) {
+  ${media.mobile} {
     width: 30px;
     height: 30px;
     font-size: 15px;

--- a/frontend/src/pages/ClubDetailPage/components/PhotoList/PhotoList.styles.ts
+++ b/frontend/src/pages/ClubDetailPage/components/PhotoList/PhotoList.styles.ts
@@ -50,7 +50,7 @@ export const PhotoList = styled.div<{
     display: grid;
     grid-template-columns: repeat(2, 1fr);
     gap: 12px;
-    transform: none !important;
+    transform: none;
   }
 `;
 

--- a/frontend/src/pages/ClubDetailPage/components/PhotoList/PhotoList.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/PhotoList/PhotoList.tsx
@@ -65,12 +65,12 @@ const PhotoList = ({ feeds, sectionRefs, clubName }: PhotoListProps) => {
             onImageError={handleImageError}
           />
         </Styled.PhotoList>
-        {canScrollLeft && (
+        {!isMobile && canScrollLeft && (
           <Styled.NavigationButton direction='left' onClick={handlePrev}>
             <img src={SlideButton[0]} alt='이전 사진' draggable={false} />
           </Styled.NavigationButton>
         )}
-        {canScrollRight && (
+        {!isMobile && canScrollRight && (
           <Styled.NavigationButton direction='right' onClick={handleNext}>
             <img src={SlideButton[1]} alt='다음 사진' draggable={false} />
           </Styled.NavigationButton>

--- a/frontend/src/pages/ClubDetailPage/components/PhotoList/PhotoModal/PhotoModal.styles.ts
+++ b/frontend/src/pages/ClubDetailPage/components/PhotoList/PhotoModal/PhotoModal.styles.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { media } from '@/styles/mediaQuery';
 
 export const ModalOverlay = styled.div`
   position: fixed;
@@ -39,7 +40,7 @@ export const ModalContent = styled.div`
   position: relative;
   overflow: hidden;
 
-  @media (max-width: 600px) {
+  ${media.mobile} {
     width: 100vw;
     height: 100vh;
     border-radius: 0;
@@ -100,7 +101,7 @@ export const ImageContainer = styled.div`
   align-items: center;
   padding: 0 60px;
 
-  @media (max-width: 600px) {
+  ${media.mobile} {
     padding: 0 16px;
   }
 `;
@@ -116,7 +117,7 @@ export const Image = styled.img`
   -webkit-user-drag: none;
   pointer-events: none;
 
-  @media (max-width: 600px) {
+  ${media.mobile} {
     max-height: 100%;
   }
 `;
@@ -155,7 +156,7 @@ export const NavButton = styled.button<{ position: 'left' | 'right' }>`
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
   }
 
-  @media (max-width: 600px) {
+  ${media.mobile} {
     ${({ position }) => (position === 'left' ? 'left: 8px;' : 'right: 8px;')}
     width: 38px;
     height: 38px;
@@ -176,7 +177,7 @@ export const ThumbnailContainer = styled.div`
   justify-content: center;
   background: linear-gradient(to top, rgba(0, 0, 0, 0.03), transparent);
 
-  @media (max-width: 600px) {
+  ${media.mobile} {
     height: 80px;
     padding: 0 15px;
   }
@@ -204,7 +205,7 @@ export const ThumbnailList = styled.div`
     border-radius: 4px;
   }
 
-  @media (max-width: 600px) {
+  ${media.mobile} {
     gap: 6px;
     padding: 8px;
   }
@@ -235,7 +236,7 @@ export const Thumbnail = styled.button<{ isActive: boolean }>`
     pointer-events: none;
   }
 
-  @media (max-width: 600px) {
+  ${media.mobile} {
     width: 36px;
     height: 36px;
   }

--- a/frontend/src/styles/mediaQuery.ts
+++ b/frontend/src/styles/mediaQuery.ts
@@ -1,0 +1,9 @@
+export const BREAKPOINT = {
+  mobile: 500,
+  tablet: 900,
+};
+
+export const media = {
+  mobile: `@media (max-width: ${BREAKPOINT.mobile}px)`,
+  tablet: `@media (max-width: ${BREAKPOINT.tablet}px)`,
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> #534 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지/동영상 첨부 가능)

https://github.com/user-attachments/assets/b860050c-82df-4145-a26b-cf1a7bba919d

<br />

### 1. 상세 페이지 반응형 UI 오류 수정
화면 너비가 900px에서 500px 사이로 변경될 때 발생하던 UI 깨짐 현상을 해결했습니다.
수정: 버튼을 아래로 자연스럽게 내려 배치했습니다


| 기존 문제 | 수정 후 |
|-----------|----------|
| <img width="350" src="https://github.com/user-attachments/assets/a3bc17e6-4a3e-4b43-891e-67f0fc076345" /> | <img width="350" src="https://github.com/user-attachments/assets/5f224881-be98-47d7-bd64-b75b34afde18" /> |

- (수정 후) 사진에 헤더는 인터넷 끊어져서 저렇게 보이는중..

<br />

### 2. 미디어 쿼리 분기점 상수화
중복되고 일관성 없는 분기점(490px, 500px, 550px 등)을 styles/mediaQuery에 전역 상수로 통합해두었습니다.

전 파일에 일괄 적용하고 싶었지만, 파일 수가 많고 충돌 가능성이 있어 눈에 보이는 일부 파일에만 우선 적용했습니다.

이후 작업 시 여유 있을 때 함께 적용 부탁드립니다.

### 사용법
```ts
import { media } from '@/styles/mediaQuery';

const Wrapper = styled.div`
  @media ${media.mobile} {
    /* 모바일 전용 스타일 */
  }
`;
```

<br />

### 3. '활동 사진' 모바일 UI 개선
> 모바일 사용성을 높이기 위해 '활동 사진' 영역을 그리드 형태의 피드 UI로 변경했습니다.

- 기존 슬라이드 방식은 활동 모달과 유사해 기능 중복이 있었고, 썸네일을 한눈에 여러 장 보여주는 방식이 더 효과적이라고 판단
-> 이에 따라 여러 이미지를 동시에 보여주는 그리드 UI를 적용하고, 모바일 화면에서는 좌우 탐색 버튼을 제거


<br />



## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 모바일 및 태블릿 반응형 스타일을 위한 미디어 쿼리 기준이 통일되어, 다양한 컴포넌트에서 일관된 화면 전환 및 레이아웃이 적용됩니다.
  * 일부 컴포넌트의 모바일 레이아웃 전환 기준이 500px에서 800px로 확대되어, 더 넓은 화면에서도 모바일 스타일이 적용됩니다.
  * 모바일 환경에서 사진 리스트의 네비게이션 버튼이 더 이상 표시되지 않습니다.
* **Chores**
  * 미디어 쿼리 기준을 중앙에서 관리할 수 있도록 설정이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->