### PR TITLE
[feature] 관리자 지원서 페이지에 설명을 추가한다

### DIFF
--- a/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.styles.ts
+++ b/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.styles.ts
@@ -17,6 +17,31 @@ export const FormTitle = styled.input`
   }
 `;
 
+export const FormDescription = styled.textarea`
+  width: 100%;
+  min-height: 120px;
+  height: auto;
+  resize: none;
+  overflow: hidden;
+  border: none;
+  outline: none;
+  margin-bottom: 24px;
+  padding: 12px;
+
+  &::placeholder {
+    color: #c5c5c5;
+    transition: opacity 0.15s;
+  }
+
+  &:focus::placeholder {
+    opacity: 0;
+  }
+
+  &:hover {
+    border: 1px solid #ccc;
+  }
+`;
+
 export const QuestionContainer = styled.div`
   display: flex;
   flex-direction: column;

--- a/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import QuestionBuilder from '@/pages/AdminPage/components/QuestionBuilder/QuestionBuilder';
 import { QuestionType } from '@/types/application';
 import { Question } from '@/types/application';
@@ -20,6 +20,9 @@ const ApplicationEditTab = () => {
 
   const [formData, setFormData] =
     useState<ApplicationFormData>(INITIAL_FORM_DATA);
+
+  const [description, setDescription] = useState('');
+  const descriptionRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
     if (data) {
@@ -75,6 +78,15 @@ const ApplicationEditTab = () => {
       ...prev,
       title: value,
     }));
+  };
+
+  const handleFormDescriptionChange = (value: string) => {
+    setDescription(value);
+    if (descriptionRef.current) {
+      descriptionRef.current.style.height = 'auto';
+      descriptionRef.current.style.height =
+        descriptionRef.current.scrollHeight + 'px';
+    }
   };
 
   const handleTitleChange = (id: number) => (value: string) =>
@@ -148,6 +160,12 @@ const ApplicationEditTab = () => {
           onChange={(e) => handleFormTitleChange(e.target.value)}
           placeholder='지원서 제목을 입력하세요'
         ></Styled.FormTitle>
+        <Styled.FormDescription
+          ref={descriptionRef}
+          value={description}
+          onInput={(e) => handleFormDescriptionChange(e.currentTarget.value)}
+          placeholder='지원서 설명을 입력하세요'
+        ></Styled.FormDescription>
         <Styled.QuestionContainer>
           {formData.questions.map((question, index) => (
             <QuestionBuilder


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #560

## 📝작업 내용

- 지원서 설명 스타일 추가 f3f658a43df18b28eb970a5e8dcac93cf40156ea
- 지원서 설명 필드 임시로 local State 추가 및 textArea 높이 자동 조절 b36f8ae6a380e91a73386d85ea6a64b3f9a5f66d

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항