### PR TITLE
[refactor] 지원서 길이 제한 변경

### DIFF
--- a/backend/src/main/java/moadong/club/payload/request/ClubApplicationCreateRequest.java
+++ b/backend/src/main/java/moadong/club/payload/request/ClubApplicationCreateRequest.java
@@ -13,7 +13,7 @@ public record ClubApplicationCreateRequest(
         String title,
 
         @NotBlank
-        @Size(max = 500)
+        @Size(max = 3000)
         String description,
 
         @NotNull

--- a/backend/src/main/java/moadong/club/payload/request/ClubApplicationEditRequest.java
+++ b/backend/src/main/java/moadong/club/payload/request/ClubApplicationEditRequest.java
@@ -13,7 +13,7 @@ public record ClubApplicationEditRequest(
         String title,
 
         @NotBlank
-        @Size(max = 500)
+        @Size(max = 3000)
         String description,
 
         @NotNull

--- a/backend/src/main/java/moadong/club/service/ClubApplyService.java
+++ b/backend/src/main/java/moadong/club/service/ClubApplyService.java
@@ -156,12 +156,12 @@ public class ClubApplyService {
     private void validateAnswerLength(String value, ClubApplicationQuestionType type) {
         switch (type) {
             case SHORT_TEXT -> {
-                if (value.length() > 30) {
+                if (value.length() > 100) {
                     throw new RestApiException(ErrorCode.SHORT_EXCEED_LENGTH);
                 }
             }
             case LONG_TEXT -> {
-                if (value.length() > 500) {
+                if (value.length() > 1000) {
                     throw new RestApiException(ErrorCode.LONG_EXCEED_LENGTH);
                 }
             }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #565 

## 📝작업 내용

지원서 설명 제한 500자 -> 3000자
지원 응답 각 30, 100 -> 100, 1000자 변경

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 동아리 지원서 및 수정 시 설명란에 입력 가능한 최대 글자 수가 500자에서 3000자로 확대되었습니다.
  * 지원서 문항 답변 시 단답형은 최대 100자, 장문형은 최대 1000자까지 입력할 수 있도록 확장되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->