### PR TITLE
[fix] 관리자 페이지에서 지원서 제작 시 글자 수 제한 수정

### DIFF
--- a/frontend/src/constants/APPLICATION_FORM.ts
+++ b/frontend/src/constants/APPLICATION_FORM.ts
@@ -1,11 +1,11 @@
 export const APPLICATION_FORM = {
   QUESTION_TITLE: {
     placeholder: '질문 제목을 입력해주세요(최대 20자)',
-    maxLength: 20,
+    maxLength: 50,
   },
   QUESTION_DESCRIPTION: {
     placeholder: '질문 설명을 입력해주세요(최대 300자)',
-    maxLength: 300,
+    maxLength: 200,
   },
   SHORT_TEXT: {
     placeholder: '답변입력란(최대 20자)',

--- a/frontend/src/constants/APPLICATION_FORM.ts
+++ b/frontend/src/constants/APPLICATION_FORM.ts
@@ -1,23 +1,27 @@
 export const APPLICATION_FORM = {
+  APPLICATION_DESCRIPTION: {
+    placeholder: '지원서 설명을 입력해주세요 (최대 3000자)',
+    maxLength: 3000,
+  },
   QUESTION_TITLE: {
-    placeholder: '질문 제목을 입력해주세요(최대 20자)',
+    placeholder: '질문 제목을 입력해주세요(최대 50자)',
     maxLength: 50,
   },
   QUESTION_DESCRIPTION: {
-    placeholder: '질문 설명을 입력해주세요(최대 300자)',
+    placeholder: '질문 설명을 입력해주세요(최대 200자)',
     maxLength: 200,
   },
   SHORT_TEXT: {
-    placeholder: '답변입력란(최대 20자)',
+    placeholder: '답변입력란(최대 30자)',
     maxLength: 30,
   },
   LONG_TEXT: {
-    placeholder: '답변입력란(최대 500자)',
+    placeholder: '답변입력란(최대 1000자)',
     maxLength: 1000,
   },
   CHOICE: {
     placeholder: '항목(최대 20자)',
-    maxLength: 30,
+    maxLength: 20,
   },
 } as const;
 

--- a/frontend/src/constants/APPLICATION_FORM.ts
+++ b/frontend/src/constants/APPLICATION_FORM.ts
@@ -9,15 +9,15 @@ export const APPLICATION_FORM = {
   },
   SHORT_TEXT: {
     placeholder: '답변입력란(최대 20자)',
-    maxLength: 20,
+    maxLength: 30,
   },
   LONG_TEXT: {
     placeholder: '답변입력란(최대 500자)',
-    maxLength: 500,
+    maxLength: 1000,
   },
   CHOICE: {
     placeholder: '항목(최대 20자)',
-    maxLength: 20,
+    maxLength: 30,
   },
 } as const;
 

--- a/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.styles.ts
+++ b/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.styles.ts
@@ -17,34 +17,10 @@ export const FormTitle = styled.input`
   }
 `;
 
-export const FormDescription = styled.textarea`
-  width: 100%;
-  min-height: 120px;
-  height: auto;
-  resize: none;
-  overflow: hidden;
-  border: none;
-  outline: none;
-  margin-bottom: 24px;
-  padding: 12px;
-
-  &::placeholder {
-    color: #c5c5c5;
-    transition: opacity 0.15s;
-  }
-
-  &:focus::placeholder {
-    opacity: 0;
-  }
-
-  &:hover {
-    border: 1px solid #ccc;
-  }
-`;
-
 export const QuestionContainer = styled.div`
   display: flex;
   flex-direction: column;
+  margin-top : 40px;
   gap: 83px;
 `;
 

--- a/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.tsx
@@ -11,6 +11,8 @@ import { useAdminClubContext } from '@/context/AdminClubContext';
 import { useGetApplication } from '@/hooks/queries/application/useGetApplication';
 import createApplication from '@/apis/application/createApplication';
 import updateApplication from '@/apis/application/updateApplication';
+import CustomTextArea from '@/components/common/CustomTextArea/CustomTextArea';
+import { APPLICATION_FORM } from '@/constants/APPLICATION_FORM';
 
 const ApplicationEditTab = () => {
   const { clubId } = useAdminClubContext();
@@ -20,8 +22,8 @@ const ApplicationEditTab = () => {
 
   const [formData, setFormData] =
     useState<ApplicationFormData>(INITIAL_FORM_DATA);
+  const [descriptionError, setDescriptionError] = useState<string | null>(null);
 
-  const descriptionRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
     if (data) {
@@ -84,11 +86,6 @@ const ApplicationEditTab = () => {
       ...prev,
       description: value,
     }));
-    if (descriptionRef.current) {
-      descriptionRef.current.style.height = 'auto';
-      descriptionRef.current.style.height =
-        descriptionRef.current.scrollHeight + 'px';
-    }
   };
 
   const handleTitleChange = (id: number) => (value: string) =>
@@ -162,13 +159,16 @@ const ApplicationEditTab = () => {
           onChange={(e) => handleFormTitleChange(e.target.value)}
           placeholder='지원서 제목을 입력하세요'
         ></Styled.FormTitle>
-        <Styled.FormDescription
-          ref={descriptionRef}
+        <CustomTextArea
+          label="지원서 설명"
           value={formData.description}
-          onInput={(e) => handleFormDescriptionChange(e.currentTarget.value)}
-          placeholder='지원서 설명을 입력하세요'
-        ></Styled.FormDescription>
-        <Styled.QuestionContainer>
+          onChange={(e) => handleFormDescriptionChange(e.target.value)}
+          placeholder={APPLICATION_FORM.APPLICATION_DESCRIPTION.placeholder}
+          maxLength={APPLICATION_FORM.APPLICATION_DESCRIPTION.maxLength}
+          showMaxChar
+          width="100%"
+        />
+        <Styled.QuestionContainer  >
           {formData.questions.map((question, index) => (
             <QuestionBuilder
               key={question.id}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #566

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지/동영상 첨부 가능)

- 기존 글자 수 제한 로직으로 인해 프론트에서 임시로 제한을 해제하고 WAP 지원서를 작성했었는데,  
  이번에 **필드별 최대 글자 수 및 placeholder를 명확히 지정**하여 근본적으로 수정했습니다.


- `지원서 설명` 입력란에 **글자 수 제한(최대 3000자)**을 적용하고, `CustomTextArea` 컴포넌트로 대체하여 UI/UX를 개선했습니다.


- 글자 수 초과 방지를 위한 `maxLength` 및 실시간 카운팅(`showMaxChar`) 기능을 적용했습니다.