### PR TITLE
[fix] 질문 제목 줄바꿈, 설명 커서 노출, 객관식 선택 해제 등 지원서 폼 UI/UX 개선

### DIFF
--- a/frontend/src/components/application/QuestionDescription/QuestionDescription.tsx
+++ b/frontend/src/components/application/QuestionDescription/QuestionDescription.tsx
@@ -30,6 +30,16 @@ const QuestionDescriptionText = styled.textarea`
   }
 `;
 
+const AnswerText = styled.p`
+  color: #787878;
+  font-size: 0.8125rem;
+  font-weight: 400;
+  line-height: normal;
+  letter-spacing: -0.26px;
+  white-space: pre-wrap;
+  margin-bottom: 10px;
+`;
+
 const QuestionDescription = ({
   description,
   mode,
@@ -38,33 +48,32 @@ const QuestionDescription = ({
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
-    if (mode === 'answer') {
-      return;
-    }
-    const el = textAreaRef.current;
-    if (el) {
+    if (mode === 'builder' && textAreaRef.current) {
+      const el = textAreaRef.current;
       el.style.height = 'auto';
       el.style.height = `${el.scrollHeight}px`;
     }
-  }, [description]);
+  }, [description, mode]);
+
+  if (mode === 'answer') {
+    if (!description) return null;
+    return <AnswerText>{description}</AnswerText>;
+  }
 
   return (
-    <>
-      <QuestionDescriptionText
-        ref={textAreaRef}
-        value={description}
-        maxLength={APPLICATION_FORM.QUESTION_DESCRIPTION.maxLength}
-        placeholder={APPLICATION_FORM.QUESTION_DESCRIPTION.placeholder}
-        aria-label='질문 설명'
-        readOnly={mode === 'answer'}
-        onChange={(e) => {
-          const value = e.target.value;
-          if (value.length <= APPLICATION_FORM.QUESTION_DESCRIPTION.maxLength) {
-            onDescriptionChange?.(value);
-          }
-        }}
-      />
-    </>
+    <QuestionDescriptionText
+      ref={textAreaRef}
+      value={description}
+      maxLength={APPLICATION_FORM.QUESTION_DESCRIPTION.maxLength}
+      placeholder={APPLICATION_FORM.QUESTION_DESCRIPTION.placeholder}
+      aria-label='질문 설명'
+      onChange={(e) => {
+        const value = e.target.value;
+        if (value.length <= APPLICATION_FORM.QUESTION_DESCRIPTION.maxLength) {
+          onDescriptionChange?.(value);
+        }
+      }}
+    />
   );
 };
 

--- a/frontend/src/components/application/QuestionTitle/QuestionTitle.styles.ts
+++ b/frontend/src/components/application/QuestionTitle/QuestionTitle.styles.ts
@@ -2,13 +2,12 @@ import styled from 'styled-components';
 import { media } from '@/styles/mediaQuery';
 
 export const QuestionTitleContainer = styled.div`
-  display: flex;
+  display: inline-flex;
   flex-direction: column;
 `;
 
 export const QuestionTitleRow = styled.div`
   display: flex;
-  align-items: flex-start;
   gap: 6px;
   width: 100%;
 `;
@@ -25,8 +24,17 @@ export const QuestionTitleId = styled.p`
   }
 `;
 
-export const QuestionTitleText = styled.textarea`
-  flex: 1;
+export const QuestionTitleTextContainer = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: 4px;
+  width: fit-content;
+  max-width: calc(100% - 20px);
+`;
+
+export const QuestionTitleText = styled.div`
+  display: inline-block;
+  min-width: 100px;
   resize: none;
   overflow-wrap: break-word;
   white-space: pre-wrap;
@@ -36,14 +44,13 @@ export const QuestionTitleText = styled.textarea`
   font-weight: 700;
   line-height: 1.5;
   color: #111;
-  field-sizing: content;
 
-  &::placeholder {
+  &:empty:before {
+    content: attr(data-placeholder);
     color: #c5c5c5;
-    transition: opacity 0.15s;
   }
 
-  &:focus::placeholder {
+  &:focus:before {
     opacity: 0;
   }
 
@@ -56,7 +63,9 @@ export const QuestionTitleText = styled.textarea`
 export const QuestionRequired = styled.div`
   width: 8px;
   height: 8px;
-  margin-top: 4px;
+  margin-top: 10px;
+  margin-left: 10px;
   border-radius: 50%;
   background-color: #ff5414;
+  flex-shrink: 0;
 `;

--- a/frontend/src/components/application/QuestionTitle/QuestionTitle.styles.ts
+++ b/frontend/src/components/application/QuestionTitle/QuestionTitle.styles.ts
@@ -1,25 +1,41 @@
 import styled from 'styled-components';
+import { media } from '@/styles/mediaQuery';
 
 export const QuestionTitleContainer = styled.div`
   display: flex;
-  align-items: center;
-  gap: 4px;
+  flex-direction: column;
+`;
+
+export const QuestionTitleRow = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  width: 100%;
 `;
 
 export const QuestionTitleId = styled.p`
   color: #ff5414;
-  font-size: 1.25rem;
+  font-size: 1.125rem;
   font-weight: 700;
-  line-height: normal;
+  margin: 0;
+  line-height: 1.5;
+  ${media.mobile} {
+    font-size: 1.05rem;
+    line-height: 1.4;
+  }
 `;
 
-export const QuestionTitleText = styled.input`
+export const QuestionTitleText = styled.textarea`
+  flex: 1;
+  resize: none;
+  overflow-wrap: break-word;
+  white-space: pre-wrap;
   border: none;
   outline: none;
-  color: #111;
   font-size: 1.25rem;
   font-weight: 700;
-  line-height: normal;
+  line-height: 1.5;
+  color: #111;
   field-sizing: content;
 
   &::placeholder {
@@ -30,12 +46,18 @@ export const QuestionTitleText = styled.input`
   &:focus::placeholder {
     opacity: 0;
   }
+
+  ${media.mobile} {
+    font-size: 1.05rem;
+    line-height: 1.4;
+  }
 `;
 
 export const QuestionRequired = styled.div`
   width: 8px;
   height: 8px;
+  margin-top: 4px;
   border-radius: 50%;
   background-color: #ff5414;
-  margin-left: 14px;
 `;
+

--- a/frontend/src/components/application/QuestionTitle/QuestionTitle.styles.ts
+++ b/frontend/src/components/application/QuestionTitle/QuestionTitle.styles.ts
@@ -60,4 +60,3 @@ export const QuestionRequired = styled.div`
   border-radius: 50%;
   background-color: #ff5414;
 `;
-

--- a/frontend/src/components/application/QuestionTitle/QuestionTitle.tsx
+++ b/frontend/src/components/application/QuestionTitle/QuestionTitle.tsx
@@ -1,5 +1,6 @@
 import * as Styled from './QuestionTitle.styles';
 import { APPLICATION_FORM } from '@/constants/APPLICATION_FORM';
+import useIsMobile from '@/hooks/useIsMobile';
 
 interface QuestionTitleProps {
   id: number;
@@ -16,16 +17,17 @@ const QuestionTitle = ({
   mode,
   onTitleChange,
 }: QuestionTitleProps) => {
+  const isMobile = useIsMobile();
   return (
-    <Styled.QuestionTitleContainer>
-      {id && <Styled.QuestionTitleId>{id}.</Styled.QuestionTitleId>}
+    <Styled.QuestionTitleRow>
+      {!isMobile && id && <Styled.QuestionTitleId>{id}.</Styled.QuestionTitleId>}
       <Styled.QuestionTitleText
-        type='text'
+        as="textarea"
         value={title}
-        maxLength={APPLICATION_FORM.QUESTION_TITLE.maxLength}
-        placeholder={APPLICATION_FORM.QUESTION_TITLE.placeholder}
-        aria-label='질문 제목'
+        rows={1}
         readOnly={mode === 'answer'}
+        placeholder={APPLICATION_FORM.QUESTION_TITLE.placeholder}
+        maxLength={APPLICATION_FORM.QUESTION_TITLE.maxLength}
         onChange={(e) => {
           const value = e.target.value;
           if (value.length <= APPLICATION_FORM.QUESTION_TITLE.maxLength) {
@@ -34,7 +36,8 @@ const QuestionTitle = ({
         }}
       />
       {mode === 'answer' && required && <Styled.QuestionRequired />}
-    </Styled.QuestionTitleContainer>
+    </Styled.QuestionTitleRow>
+
   );
 };
 

--- a/frontend/src/components/application/QuestionTitle/QuestionTitle.tsx
+++ b/frontend/src/components/application/QuestionTitle/QuestionTitle.tsx
@@ -20,9 +20,11 @@ const QuestionTitle = ({
   const isMobile = useIsMobile();
   return (
     <Styled.QuestionTitleRow>
-      {!isMobile && id && <Styled.QuestionTitleId>{id}.</Styled.QuestionTitleId>}
+      {!isMobile && id && (
+        <Styled.QuestionTitleId>{id}.</Styled.QuestionTitleId>
+      )}
       <Styled.QuestionTitleText
-        as="textarea"
+        as='textarea'
         value={title}
         rows={1}
         readOnly={mode === 'answer'}
@@ -37,7 +39,6 @@ const QuestionTitle = ({
       />
       {mode === 'answer' && required && <Styled.QuestionRequired />}
     </Styled.QuestionTitleRow>
-
   );
 };
 

--- a/frontend/src/components/application/QuestionTitle/QuestionTitle.tsx
+++ b/frontend/src/components/application/QuestionTitle/QuestionTitle.tsx
@@ -18,26 +18,28 @@ const QuestionTitle = ({
   onTitleChange,
 }: QuestionTitleProps) => {
   const isMobile = useIsMobile();
+  
   return (
     <Styled.QuestionTitleRow>
       {!isMobile && id && (
         <Styled.QuestionTitleId>{id}.</Styled.QuestionTitleId>
       )}
-      <Styled.QuestionTitleText
-        as='textarea'
-        value={title}
-        rows={1}
-        readOnly={mode === 'answer'}
-        placeholder={APPLICATION_FORM.QUESTION_TITLE.placeholder}
-        maxLength={APPLICATION_FORM.QUESTION_TITLE.maxLength}
-        onChange={(e) => {
-          const value = e.target.value;
-          if (value.length <= APPLICATION_FORM.QUESTION_TITLE.maxLength) {
-            onTitleChange?.(value);
-          }
-        }}
-      />
-      {mode === 'answer' && required && <Styled.QuestionRequired />}
+      <Styled.QuestionTitleTextContainer>
+        <Styled.QuestionTitleText
+          contentEditable={mode !== 'answer'}
+          suppressContentEditableWarning={true}
+          onInput={(e) => {
+            const value = e.currentTarget.textContent || '';
+            if (value.length <= APPLICATION_FORM.QUESTION_TITLE.maxLength) {
+              onTitleChange?.(value);
+            }
+          }}
+          data-placeholder={title ? '' : APPLICATION_FORM.QUESTION_TITLE.placeholder}
+        >
+          {title}
+        </Styled.QuestionTitleText>
+        {mode === 'answer' && required && <Styled.QuestionRequired />}
+      </Styled.QuestionTitleTextContainer>
     </Styled.QuestionTitleRow>
   );
 };

--- a/frontend/src/components/application/questionTypes/Choice.tsx
+++ b/frontend/src/components/application/questionTypes/Choice.tsx
@@ -57,10 +57,13 @@ const Choice = ({
           onAnswerChange?.([...answer, value]);
         }
       }
-      // 다중 선택: 이미 포함되어 있으면 제거, 아니면 추가
     } else {
-      // 단일 선택: 클릭된 값만 넘김
-      onAnswerChange?.(value);
+      // 단일 선택일 때 선택/해제 가능하게 처리
+      if (String(answer) === value) {
+        onAnswerChange?.('');
+      } else {
+        onAnswerChange?.(value);
+      }
     }
   };
 
@@ -80,7 +83,11 @@ const Choice = ({
       />
 
       {items.map((item, index) => {
-        const isSelected = mode === 'answer' && answer.includes(item.value);
+        const isSelected =
+          mode === 'answer' &&
+          (isMulti
+            ? Array.isArray(answer) && answer.includes(item.value)
+            : String(answer) === item.value);
 
         return (
           <Styled.ItemWrapper key={index}>

--- a/frontend/src/components/application/questionTypes/Choice.tsx
+++ b/frontend/src/components/application/questionTypes/Choice.tsx
@@ -120,8 +120,6 @@ const Choice = ({
         );
       })}
 
-
-
       {mode === 'builder' && items.length < MAX_ITEMS && (
         <Styled.AddItemButton onClick={handleAddItem}>
           + 추가항목

--- a/frontend/src/components/common/Footer/Footer.styles.ts
+++ b/frontend/src/components/common/Footer/Footer.styles.ts
@@ -25,7 +25,17 @@ export const FooterContent = styled.div`
   }
 `;
 
-export const PolicyText = styled.p``;
+export const PolicyLink = styled.a`
+  color: #787878;
+  font-size: 0.75rem;
+  text-decoration: underline;
+  cursor: pointer;
+
+  &:hover {
+    opacity: 0.8;
+  }
+`;
+
 
 export const CopyRightText = styled.p``;
 

--- a/frontend/src/components/common/Footer/Footer.tsx
+++ b/frontend/src/components/common/Footer/Footer.tsx
@@ -6,7 +6,13 @@ const Footer = () => {
       <Styled.FooterContainer>
         <Styled.Divider />
         <Styled.FooterContent>
-          <Styled.PolicyText>개인정보 처리방침</Styled.PolicyText>
+                  <Styled.PolicyLink
+          href='https://honorable-cough-8f9.notion.site/232aad23209680f2a2cadb146eff81cd?pvs=74'
+          target='_blank'
+          rel='noopener noreferrer'
+        >
+          개인정보 처리방침
+        </Styled.PolicyLink>
           <Styled.CopyRightText>
             Copyright © moodong. All Rights Reserved
           </Styled.CopyRightText>

--- a/frontend/src/constants/APPLICATION_FORM.ts
+++ b/frontend/src/constants/APPLICATION_FORM.ts
@@ -8,8 +8,8 @@ export const APPLICATION_FORM = {
     maxLength: 50,
   },
   QUESTION_DESCRIPTION: {
-    placeholder: '질문 설명을 입력해주세요(최대 200자)',
-    maxLength: 200,
+    placeholder: '질문 설명을 입력해주세요(최대 300자)',
+    maxLength: 300,
   },
   SHORT_TEXT: {
     placeholder: '답변입력란(최대 100자)',

--- a/frontend/src/pages/ApplicationFormPage/ApplicationFormPage.styles.ts
+++ b/frontend/src/pages/ApplicationFormPage/ApplicationFormPage.styles.ts
@@ -21,11 +21,10 @@ export const FormDescription = styled.div`
   padding: 0 15px;
 
   ${media.mobile} {
-      font-size: 0.95rem;
+    font-size: 0.95rem;
     line-height: 1.5;
   }
 `;
-
 
 export const QuestionsWrapper = styled.div`
   display: flex;
@@ -35,7 +34,6 @@ export const QuestionsWrapper = styled.div`
   ${media.mobile} {
     gap: 10px;
   }
-
 `;
 
 export const ButtonWrapper = styled.div`

--- a/frontend/src/pages/ApplicationFormPage/ApplicationFormPage.tsx
+++ b/frontend/src/pages/ApplicationFormPage/ApplicationFormPage.tsx
@@ -15,124 +15,131 @@ import { parseDescriptionWithLinks } from '@/utils/parseDescriptionWithLinks';
 import { validateAnswers } from '@/hooks/useValidateAnswers';
 import * as Styled from './ApplicationFormPage.styles';
 
-
-
 const AnswerApplicationForm = () => {
-    const { clubId } = useParams<{ clubId: string }>();
-    const navigate = useNavigate();
-    const questionRefs = useRef<Array<HTMLDivElement | null>>([]);
-    const [invalidQuestionIds, setInvalidQuestionIds] = useState<number[]>([]);
+  const { clubId } = useParams<{ clubId: string }>();
+  const navigate = useNavigate();
+  const questionRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const [invalidQuestionIds, setInvalidQuestionIds] = useState<number[]>([]);
 
-    const { onAnswerChange: rawOnAnswerChange, getAnswersById, answers } = useAnswers();
-    const {
-        data: clubDetail,
-        error: clubError,
-    } = useGetClubDetail(clubId ?? '');
+  const {
+    onAnswerChange: rawOnAnswerChange,
+    getAnswersById,
+    answers,
+  } = useAnswers();
+  const { data: clubDetail, error: clubError } = useGetClubDetail(clubId ?? '');
 
-    const {
-        data: formData,
-        isLoading,
-        isError,
-        error: applicationError,
-    } = useGetApplication(clubId ?? '');
+  const {
+    data: formData,
+    isLoading,
+    isError,
+    error: applicationError,
+  } = useGetApplication(clubId ?? '');
 
-    if (!clubId) return null;
-    if (isLoading) return <Spinner />;
+  if (!clubId) return null;
+  if (isLoading) return <Spinner />;
 
-    const onAnswerChange = (id: number, value: string | string[]) => {
-        rawOnAnswerChange(id, value);
+  const onAnswerChange = (id: number, value: string | string[]) => {
+    rawOnAnswerChange(id, value);
 
-        // 입력이 생겼다면 해당 질문의 오류 제거
-        const isEmpty =
-            (Array.isArray(value) && value.every(v => v.trim() === '')) ||
-            (!Array.isArray(value) && value.trim() === '');
+    // 입력이 생겼다면 해당 질문의 오류 제거
+    const isEmpty =
+      (Array.isArray(value) && value.every((v) => v.trim() === '')) ||
+      (!Array.isArray(value) && value.trim() === '');
 
-        if (!isEmpty && invalidQuestionIds.includes(id)) {
-            setInvalidQuestionIds(prev => prev.filter(qid => qid !== id));
-        }
-    };
-
-    const handleScrollToInvalid = (invalidIds: number[]) => {
-        const firstInvalidIndex = formData?.questions.findIndex((q: Question) => invalidIds.includes(q.id));
-        const targetEl = firstInvalidIndex !== undefined ? questionRefs.current[firstInvalidIndex] : null;
-        targetEl?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    };
-
-
-    const handleSubmit = async () => {
-        if (!formData) return;
-
-        const invalidIds = validateAnswers(formData.questions, getAnswersById);
-
-        if (invalidIds.length > 0) {
-            setInvalidQuestionIds(invalidIds);
-            handleScrollToInvalid(invalidIds);
-            return;
-        }
-
-        try {
-            await applyToClub(clubId!, answers);
-            alert('답변이 성공적으로 제출되었습니다.');
-        } catch {
-            alert('답변 제출에 실패했습니다. 잠시 후 다시 시도해 주세요.');
-        }
-    };
-
-    if (!clubId) return null;
-    if (isLoading) return <Spinner />;
-    if (isError || clubError) {
-        alert(applicationError?.message || '문제가 발생했어요.');
-        navigate(`/club/${clubId}`);
-        return <div>문제가 발생했어요. 잠시 후 다시 시도해 주세요.</div>;
+    if (!isEmpty && invalidQuestionIds.includes(id)) {
+      setInvalidQuestionIds((prev) => prev.filter((qid) => qid !== id));
     }
-    if (!formData || !clubDetail) {
-        return <div>지원서 정보를 불러오지 못했어요. 새로고침하거나 잠시 후 다시 시도해 주세요.</div>;
+  };
+
+  const handleScrollToInvalid = (invalidIds: number[]) => {
+    const firstInvalidIndex = formData?.questions.findIndex((q: Question) =>
+      invalidIds.includes(q.id),
+    );
+    const targetEl =
+      firstInvalidIndex !== undefined
+        ? questionRefs.current[firstInvalidIndex]
+        : null;
+    targetEl?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
+  const handleSubmit = async () => {
+    if (!formData) return;
+
+    const invalidIds = validateAnswers(formData.questions, getAnswersById);
+
+    if (invalidIds.length > 0) {
+      setInvalidQuestionIds(invalidIds);
+      handleScrollToInvalid(invalidIds);
+      return;
     }
 
+    try {
+      await applyToClub(clubId!, answers);
+      alert('답변이 성공적으로 제출되었습니다.');
+    } catch {
+      alert('답변 제출에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+    }
+  };
+
+  if (!clubId) return null;
+  if (isLoading) return <Spinner />;
+  if (isError || clubError) {
+    alert(applicationError?.message || '문제가 발생했어요.');
+    navigate(`/club/${clubId}`);
+    return <div>문제가 발생했어요. 잠시 후 다시 시도해 주세요.</div>;
+  }
+  if (!formData || !clubDetail) {
     return (
-        <>
-            <Header />
-            <PageContainer style={{ paddingTop: '80px' }}>
-                {/* <ClubProfile
+      <div>
+        지원서 정보를 불러오지 못했어요. 새로고침하거나 잠시 후 다시 시도해
+        주세요.
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Header />
+      <PageContainer style={{ paddingTop: '80px' }}>
+        {/* <ClubProfile
                     name={clubDetail.name}
                     logo={clubDetail.logo}
                     division={clubDetail.division}
                     category={clubDetail.category}
                     tags={clubDetail.tags}
                 /> */}
-                <Styled.FormTitle>{formData.title}</Styled.FormTitle>
-                {formData.description && (
-                    <Styled.FormDescription>
-                        {parseDescriptionWithLinks(formData.description)}
-                    </Styled.FormDescription>
+        <Styled.FormTitle>{formData.title}</Styled.FormTitle>
+        {formData.description && (
+          <Styled.FormDescription>
+            {parseDescriptionWithLinks(formData.description)}
+          </Styled.FormDescription>
+        )}
+        <Styled.QuestionsWrapper>
+          {formData.questions.map((q: Question, i: number) => (
+            <QuestionContainer
+              key={q.id}
+              hasError={invalidQuestionIds.includes(q.id)}
+              ref={(el: HTMLDivElement | null) => {
+                questionRefs.current[i] = el;
+              }}
+            >
+              <QuestionAnswerer
+                question={q}
+                selectedAnswers={getAnswersById(q.id)}
+                onChange={onAnswerChange}
+              />
+            </QuestionContainer>
+          ))}
+        </Styled.QuestionsWrapper>
 
-                )}
-                <Styled.QuestionsWrapper>
-                    {formData.questions.map((q: Question, i: number) => (
-                        <QuestionContainer
-                            key={q.id}
-                            hasError={invalidQuestionIds.includes(q.id)}
-                            ref={(el: HTMLDivElement | null) => {
-                                questionRefs.current[i] = el;
-                            }}
-                        >
-                            <QuestionAnswerer
-                                question={q}
-                                selectedAnswers={getAnswersById(q.id)}
-                                onChange={onAnswerChange}
-                            />
-                        </QuestionContainer>
-                    ))}
-                </Styled.QuestionsWrapper>
-
-
-                <Styled.ButtonWrapper>
-                    <Styled.submitButton onClick={handleSubmit}>제출하기</Styled.submitButton>
-                </Styled.ButtonWrapper>
-            </PageContainer>
-        </>
-    );
-
+        <Styled.ButtonWrapper>
+          <Styled.submitButton onClick={handleSubmit}>
+            제출하기
+          </Styled.submitButton>
+        </Styled.ButtonWrapper>
+      </PageContainer>
+    </>
+  );
 };
 
 export default AnswerApplicationForm;

--- a/frontend/src/pages/ApplicationFormPage/components/ChoiceItem/ChoiceItem.styles.ts
+++ b/frontend/src/pages/ApplicationFormPage/components/ChoiceItem/ChoiceItem.styles.ts
@@ -1,16 +1,19 @@
 import styled from 'styled-components';
 
-export const ItemWrapper = styled.div<{ 'data-selected'?: string }>`
+export const ItemWrapper = styled.div`
   flex: 1;
   height: 45px;
   padding: 12px 18px;
   border: none;
   border-radius: 6px;
   font-size: 1.125rem;
-  background-color: ${({ 'data-selected': selected }) =>
-        selected === 'true' ? '#FFECE5' : '#F5F5F5'};
-  color: ${({ 'data-selected': selected }) =>
-        selected === 'true' ? '#111111' : '#818181'};
+  background-color: #f5f5f5;
+  color: #818181;
+
+  &[data-selected='true'] {
+    background-color: #FFD9CB;
+    color: #111111;
+  }
   cursor: pointer;
   transition: background-color 0.2s, border-color 0.2s;
 `;

--- a/frontend/src/pages/ApplicationFormPage/components/ChoiceItem/ChoiceItem.styles.ts
+++ b/frontend/src/pages/ApplicationFormPage/components/ChoiceItem/ChoiceItem.styles.ts
@@ -11,11 +11,13 @@ export const ItemWrapper = styled.div`
   color: #818181;
 
   &[data-selected='true'] {
-    background-color: #FFD9CB;
+    background-color: #ffd9cb;
     color: #111111;
   }
   cursor: pointer;
-  transition: background-color 0.2s, border-color 0.2s;
+  transition:
+    background-color 0.2s,
+    border-color 0.2s;
 `;
 
 export const Label = styled.span`

--- a/frontend/src/pages/ApplicationFormPage/components/ChoiceItem/ChoiceItem.tsx
+++ b/frontend/src/pages/ApplicationFormPage/components/ChoiceItem/ChoiceItem.tsx
@@ -1,17 +1,20 @@
 import * as Styled from './ChoiceItem.styles';
 
 interface ChoiceItemProps {
-    label: string;
-    selected: boolean;
-    onClick: () => void;
+  label: string;
+  selected: boolean;
+  onClick: () => void;
 }
 
 const ChoiceItem = ({ label, selected, onClick }: ChoiceItemProps) => {
-    return (
-        <Styled.ItemWrapper onClick={onClick} data-selected={selected ? 'true' : undefined}>
-            <Styled.Label>{label || '(빈 항목)'}</Styled.Label>
-        </Styled.ItemWrapper>
-    );
+  return (
+    <Styled.ItemWrapper
+      onClick={onClick}
+      data-selected={selected ? 'true' : undefined}
+    >
+      <Styled.Label>{label || '(빈 항목)'}</Styled.Label>
+    </Styled.ItemWrapper>
+  );
 };
 
 export default ChoiceItem;

--- a/frontend/src/pages/ApplicationFormPage/components/QuestionContainer/QuestionContainer.tsx
+++ b/frontend/src/pages/ApplicationFormPage/components/QuestionContainer/QuestionContainer.tsx
@@ -11,26 +11,26 @@ const Container = styled.div<{ hasError?: boolean }>`
 `;
 
 const ErrorText = styled.div`
-  color: #FF5414;
+  color: #ff5414;
   font-size: 0.9rem;
   font-weight: 600;
   margin-bottom: 8px;
 `;
 
 interface Props {
-    hasError?: boolean;
-    children: React.ReactNode;
+  hasError?: boolean;
+  children: React.ReactNode;
 }
 
 const QuestionContainer = forwardRef<HTMLDivElement, Props>(
-    ({ hasError, children }, ref) => {
-        return (
-            <Container hasError={hasError} ref={ref}>
-                {hasError && <ErrorText>‼️ 필수 입력 문항입니다</ErrorText>}
-                {children}
-            </Container>
-        );
-    }
+  ({ hasError, children }, ref) => {
+    return (
+      <Container hasError={hasError} ref={ref}>
+        {hasError && <ErrorText>‼️ 필수 입력 문항입니다</ErrorText>}
+        {children}
+      </Container>
+    );
+  },
 );
 
 export default QuestionContainer;

--- a/frontend/src/pages/ClubDetailPage/components/ClubApplyButton/ClubApplyButton.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubApplyButton/ClubApplyButton.tsx
@@ -36,9 +36,7 @@ const Button = styled.button`
   }
 `;
 
-const ClubApplyButton = ({
-  isRecruiting
-}: ButtonProps) => {
+const ClubApplyButton = ({ isRecruiting }: ButtonProps) => {
   const { clubId } = useParams<{ clubId: string }>();
   const trackEvent = useMixpanelTrack();
   const navigate = useNavigate();
@@ -48,7 +46,7 @@ const ClubApplyButton = ({
 
     //TODO: 지원서를 작성한 동아리의 경우에만 리다이렉트
     if (!isRecruiting) {
-      alert('지원모집이 마감되었습니다. 다음에 지원해 주세요.')
+      alert('지원모집이 마감되었습니다. 다음에 지원해 주세요.');
       return;
     }
     navigate(`/application/${clubId}`);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

>  #572 

## 📝 작업 내용

사용자 지원서 폼과 관리자 페이지에서 다음과 같은 UI/UX 이슈를 수정했습니다.

### ✅ 사용자 FE

- **모바일 질문 제목이 UI를 벗어나는 현상 수정**
  - 모바일 환경에서 제목이 박스를 넘치던 문제 해결
  - 모바일에서는 질문 번호 비표시 처리 및 글자 수 축소
  -  적용 예시(훨씬 보기 좋아짐)
    <img width="397" height="483" alt="image" src="https://github.com/user-attachments/assets/a672d01e-4c09-4d89-8f0b-1e287fdd1c1e" />

- **단일 선택 객관식 선택 해제 기능 추가**
  - 동일 항목 재클릭 시 선택 해제되도록 UX 개선

- **설명 미입력 시 placeholder 커서 노출 문제 수정**
  - 설명이 비어 있을 경우 입력창 비노출 처리

- **질문 설명이 두 줄 이상일 경우 잘리는 문제 해결**
  - height를 builder 모드에서만 계산하던 기존 로직 → 글자 수 기반으로 항상 계산되도록 수정

- **객관식 항목 선택 시 색상 강조**
  - 선택된 항목 배경색을 더 명확하게 강조 (특히 야간모드 대응)


- 푸터에 개인정보취급방침 추가
---

### ✅ 관리자 FE

- **질문 설명 글자 수 제한 실수 수정**
  - 기존 200자로 잘못 줄였던 maxLength를 300자로 복구
  - `APPLICATION_FORM.ts` 상수 수정



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **신규 기능**
  * 단일 선택형 문항에서 이미 선택된 항목을 다시 클릭하면 선택이 해제되는 토글 기능이 추가되었습니다.

* **버그 수정**
  * 질문 설명 입력란의 최대 글자 수가 200자에서 300자로 늘어나고, 안내 문구도 이에 맞게 변경되었습니다.

* **스타일**
  * 질문 제목 및 설명, 선택 항목 등 여러 컴포넌트의 레이아웃과 스타일이 개선되어 모바일 환경에서 더 나은 가독성과 일관성을 제공합니다.
  * 푸터 개인정보 처리방침 텍스트가 클릭 가능한 링크로 변경되어 외부 페이지로 연결됩니다.
  * 일부 스타일 속성의 표기(예: 색상 코드 대소문자)가 통일되었습니다.

* **리팩터**
  * 질문 설명과 질문 제목 컴포넌트가 모드에 따라 적절한 입력/출력 UI를 제공하도록 개선되었습니다.
  * 코드 구조와 들여쓰기가 정리되어 가독성이 향상되었습니다.

* **사소한 작업**
  * 불필요한 공백 및 세미콜론 누락이 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->