### PR TITLE
지원서 입력값을 localStorage에 저장하여 임시 보관 기능 구현

### DIFF
--- a/frontend/src/hooks/useAnswers.ts
+++ b/frontend/src/hooks/useAnswers.ts
@@ -1,13 +1,13 @@
 import { useState } from 'react';
 import { AnswerItem } from '@/types/application';
 
-export const useAnswers = () => {
-  const [answers, setAnswers] = useState<AnswerItem[]>([]);
+export const useAnswers = (initialAnswers: AnswerItem[] = []) => {
+  const [answers, setAnswers] = useState<AnswerItem[]>(initialAnswers);
 
   const updateSingleAnswer = (id: number, value: string) => {
     setAnswers((prev) => [
       ...prev.filter((a) => a.id !== id),
-      { id, value: value },
+      { id, value },
     ]);
   };
 
@@ -26,7 +26,7 @@ export const useAnswers = () => {
     }
   };
 
-  const getAnswersById = (id: number) =>
+  const getAnswersById = (id: number): string[] =>
     answers.filter((a) => a.id === id).map((a) => a.value);
 
   return { onAnswerChange, getAnswersById, answers };

--- a/frontend/src/pages/ApplicationFormPage/ApplicationFormPage.tsx
+++ b/frontend/src/pages/ApplicationFormPage/ApplicationFormPage.tsx
@@ -20,22 +20,18 @@ const AnswerApplicationForm = () => {
   const questionRefs = useRef<Array<HTMLDivElement | null>>([]);
   const [invalidQuestionIds, setInvalidQuestionIds] = useState<number[]>([]);
 
-  // ===== 1. 유효성: clubId가 없을 경우 =====
   if (!clubId) return null;
 
-  // ===== 2. 로컬스토리지 초기값 불러오기 =====
   const STORAGE_KEY = `applicationAnswers_${clubId}`;
   const saved = localStorage.getItem(STORAGE_KEY);
   const initialAnswers = saved ? JSON.parse(saved) : [];
 
-  // ===== 3. useAnswers 훅 =====
   const {
     onAnswerChange: rawOnAnswerChange,
     getAnswersById,
     answers,
   } = useAnswers(initialAnswers);
 
-  // ===== 4. 쿼리 호출 =====
   const { data: clubDetail, error: clubError } = useGetClubDetail(clubId);
   const {
     data: formData,
@@ -44,12 +40,10 @@ const AnswerApplicationForm = () => {
     error: applicationError,
   } = useGetApplication(clubId);
 
-  // ===== 5. 자동 저장 =====
   useEffect(() => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(answers));
   }, [answers]);
 
-  // ===== 6. 로딩/에러 처리 =====
   if (isLoading) return <Spinner />;
   if (isError || clubError) {
     alert(applicationError?.message || '문제가 발생했어요.');
@@ -65,7 +59,6 @@ const AnswerApplicationForm = () => {
     );
   }
 
-  // ===== 7. 핸들러 =====
   const onAnswerChange = (id: number, value: string | string[]) => {
     rawOnAnswerChange(id, value);
 
@@ -103,7 +96,6 @@ const AnswerApplicationForm = () => {
     }
   };
 
-  // ===== 8. 렌더 =====
   return (
     <>
       <Header />


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #581 


<br />

## 📝 작업 내용

### 1. useAnswers 훅 개선

- `useAnswers` 훅에 초기 답변 배열(`initialAnswers`)을 인자로 받을 수 있도록 개선했습니다.
  - 기존에는 항상 빈 배열에서 시작했지만, 로컬스토리지에 저장된 데이터를 초기값으로 받을 수 있도록 확장했습니다.

<br />

### 2. AnswerApplicationForm 임시 저장 기능 구현
- `AnswerApplicationForm`에서 임시 저장 기능을 구현했습니다.
  - 입력 중인 답변을 `localStorage`에 자동 저장합니다.
  - `clubId`를 기준으로 고유한 키(`applicationAnswers_${clubId}`)로 저장합니다.
  - 제출 성공 시 저장된 답변을 삭제합니다.

<br />

### 3. 코드 구조 개선
- 전체 코드 구조를 섹션별로 나누어 가독성을 높였습니다.
  - 쿼리, 핸들러, 렌더 로직 분리
  - 조건 분기 간소화

<br /><br />

## 🫡 참고사항

- `AnswerApplicationForm`에서 localStorage 관련 key는 `"applicationAnswers_${clubId}"` 형식을 사용했습니다.
- 기존 제출 흐름에는 영향이 없으며, 제출 성공 시에만 임시 저장 데이터가 삭제됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 사용자 답변이 세션 간에도 유지되도록 로컬 스토리지에 저장 및 불러오기 기능이 추가되었습니다.

* **버그 수정**
  * 데이터 로딩 및 오류 처리 방식이 개선되어, 오류 발생 시 알림과 함께 클럽 페이지로 이동하도록 변경되었습니다.
  * 불필요한 코드와 중복 처리가 제거되어 사용자 경험이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->