### PR TITLE
[fix] 질문 번호 글꼴 크기 조정으로 정렬 불일치 해결

### DIFF
--- a/frontend/src/components/application/QuestionTitle/QuestionTitle.styles.ts
+++ b/frontend/src/components/application/QuestionTitle/QuestionTitle.styles.ts
@@ -14,7 +14,7 @@ export const QuestionTitleRow = styled.div`
 
 export const QuestionTitleId = styled.p`
   color: #ff5414;
-  font-size: 1.125rem;
+  font-size: 1.25rem;
   font-weight: 700;
   margin: 0;
   line-height: 1.5;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #594

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지/동영상 첨부 가능)
## 📝작업 내용  
- 질문 번호(`QuestionTitleId`)의 글꼴 크기를 1.125rem → 1.25rem으로 조정  
- 질문 번호와 텍스트 간 수평 정렬 불일치 문제 해결

<img width="544" height="214" alt="image" src="https://github.com/user-attachments/assets/244bc6b0-8cdc-4213-b4b1-921ad74ffa22" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * QuestionTitleId의 글꼴 크기가 더 크게 조정되어 가독성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->