### PR TITLE
[fix] 지원서 입력폼에서 단답형 입력 필드가 부모 너비를 초과하여 레이아웃 깨짐

### DIFF
--- a/frontend/src/components/common/CustomTextArea/CustomTextArea.styles.ts
+++ b/frontend/src/components/common/CustomTextArea/CustomTextArea.styles.ts
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 export const TextAreaContainer = styled.div<{ width: string }>`
   width: ${(props) => props.width};
-  min-width: 300px;
+  max-width: 100%;
   display: flex;
   flex-direction: column;
 `;

--- a/frontend/src/components/common/InputField/InputField.styles.ts
+++ b/frontend/src/components/common/InputField/InputField.styles.ts
@@ -2,12 +2,11 @@ import styled from 'styled-components';
 
 export const InputContainer = styled.div<{ width: string; readOnly?: boolean }>`
   width: ${(props) => props.width};
-  min-width: 300px;
+  max-width: 100%;
   display: flex;
   flex-direction: column;
 
   @media (max-width: 768px) {
-    min-width: 0;
     width: 100%;
   }
 `;
@@ -27,7 +26,7 @@ export const InputWrapper = styled.div`
 export const Input = styled.input<{ hasError?: boolean; readOnly?: boolean }>`
   flex: 1;
   height: 45px;
-  padding: 12px 80px 12px 18px;
+  padding: 12px 18px;
   border: 1px solid ${({ hasError }) => (hasError ? 'red' : '#c5c5c5')};
   background-color: transparent;
   border-radius: 6px;

--- a/frontend/src/pages/ApplicationFormPage/ApplicationFormPage.styles.ts
+++ b/frontend/src/pages/ApplicationFormPage/ApplicationFormPage.styles.ts
@@ -18,11 +18,15 @@ export const FormDescription = styled.div`
   color: #444;
   margin-top: -20px;
   margin-bottom: 48px;
-  padding: 0 15px;
+  padding: 12px 18px;
+  background-color: #f5f5f5;
+  border-radius: 6px;
 
   ${media.mobile} {
     font-size: 0.95rem;
     line-height: 1.5;
+
+    padding: 4px 6px;
   }
 `;
 


### PR DESCRIPTION
## #️⃣ 관련 이슈  
- #600

## 📝 작업 내용  
- `InputContainer`, `TextAreaContainer`에 `box-sizing: border-box`, `max-width: 100%` 추가  
- 모바일 환경에서 입력 필드 및 텍스트 영역이 부모를 넘치던 현상 해결  
- 상위 컨테이너에는 `max-width`를 적용하여 반응형 대응

## 🎯 문제 원인  
- `min-width: 300px`, `width: 60%` 설정이 모바일에서 비율 계산에 의해 실제 너비보다 커짐  
- `box-sizing` 미설정으로 padding 포함 계산 시 width 초과  
- 모바일 환경에서는 fixed width/percentage 조합이 깨지기 쉬움

---

## 📷 before | after 비교

| before | after |
|--------|-------|
| <img width="471" height="593" alt="image" src="https://github.com/user-attachments/assets/5ff60462-03dc-437f-b0ed-55b294dda3bf" />|<img width="491" height="594" alt="image" src="https://github.com/user-attachments/assets/05f3d66c-e0ab-451e-805a-7544d0037db1" />|



## 소개글 배경도 추가함
<img width="1270" height="817" alt="image" src="https://github.com/user-attachments/assets/ac5ff06a-9787-4f00-a9fa-945144dd356a" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * 입력 필드와 텍스트 영역의 최소 너비 제한을 제거하고, 최대 너비를 100%로 변경하여 레이아웃 유연성을 개선했습니다.
  * 입력 필드의 오른쪽 패딩을 줄여 입력 공간을 최적화했습니다.
  * 신청서 설명 영역에 여백과 배경색, 둥근 모서리를 추가하여 시각적 가독성을 향상시켰습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->