### PR TITLE
[fix] 지원서 미등록 시 alert 반복 버그 수정 및 외부 링크/지원서 분기 처리

### DIFF
--- a/frontend/src/pages/ClubDetailPage/components/ClubDetailFooter/ClubDetailFooter.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubDetailFooter/ClubDetailFooter.tsx
@@ -11,9 +11,7 @@ interface ClubDetailFooterProps {
 }
 
 const ClubDetailFooter = ({
-  recruitmentPeriod,
-  recruitmentForm,
-  presidentPhoneNumber,
+  recruitmentPeriod
 }: ClubDetailFooterProps) => {
   const { recruitmentStart, recruitmentEnd } =
     parseRecruitmentPeriod(recruitmentPeriod);
@@ -24,10 +22,10 @@ const ClubDetailFooter = ({
     new Date(),
   );
 
-  return (
+  return ( 
     <Styled.ClubDetailFooterContainer>
       <DeadlineBadge deadlineText={deadlineText} />
-      <ClubApplyButton isRecruiting={deadlineText !== '모집 마감'} />
+      <ClubApplyButton />
     </Styled.ClubDetailFooterContainer>
   );
 };

--- a/frontend/src/pages/ClubDetailPage/components/ClubDetailHeader/ClubDetailHeader.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubDetailHeader/ClubDetailHeader.tsx
@@ -1,8 +1,7 @@
 import * as Styled from './ClubDetailHeader.styles';
 import ClubProfile from '@/pages/ClubDetailPage/components/ClubProfile/ClubProfile';
 import ClubApplyButton from '@/pages/ClubDetailPage/components/ClubApplyButton/ClubApplyButton';
-import { parseRecruitmentPeriod } from '@/utils/recruitmentPeriodParser';
-import getDeadlineText from '@/utils/getDeadLineText';
+
 interface ClubDetailHeaderProps {
   name: string;
   category: string;
@@ -20,19 +19,7 @@ const ClubDetailHeader = ({
   division,
   tags,
   logo,
-  recruitmentPeriod,
-  recruitmentForm,
-  presidentPhoneNumber,
 }: ClubDetailHeaderProps) => {
-  const { recruitmentStart, recruitmentEnd } =
-    parseRecruitmentPeriod(recruitmentPeriod);
-
-  const deadlineText = getDeadlineText(
-    recruitmentStart,
-    recruitmentEnd,
-    new Date(),
-  );
-
   return (
     <Styled.ClubDetailHeaderContainer>
       <ClubProfile
@@ -42,7 +29,7 @@ const ClubDetailHeader = ({
         tags={tags}
         logo={logo}
       />
-      <ClubApplyButton isRecruiting={deadlineText !== '모집 마감'} />
+      <ClubApplyButton />
     </Styled.ClubDetailHeaderContainer>
   );
 };

--- a/frontend/src/types/club.ts
+++ b/frontend/src/types/club.ts
@@ -23,6 +23,7 @@ export interface ClubDetail extends Club {
   recruitmentPeriod: string;
   recruitmentTarget: string;
   socialLinks: Record<SNSPlatform, string>;
+  externalApplicationUrl?: string;
 }
 
 export interface ClubDescription {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #602 지원서 없는 경우 뒤로가기 시 alert 반복 발생 버그 수정


## 📝 작업 내용

### ✅ 문제 원인
- 기존에는 **모집 기간이 진행 중인지 여부만 확인한 뒤**, `/application/:id`로 바로 이동을 시도했습니다.
- 하지만 모집 중인 동아리라도 **모아동 지원서가 등록되지 않은 경우**, 해당 페이지에서 alert이 뜨고 다시 상세 페이지로 리디렉션되는 문제가 있었고,
- 이후 뒤로가기를 누르면 다시 `/application/:id`로 이동 → alert → 리디렉션이 반복되며  
  ❗ **alert이 무한 반복되는 UX 버그**가 발생했습니다.

<br />

### ✅ 개선 내용
- **입장 조건을 명확하게 분기**하도록 로직을 수정했습니다:

  1. 모집 마감 여부 확인  
     → 마감이면 alert 출력 후 상세페이지 유지

  2. 모아동 지원서 존재 여부 확인 (`getApplication`)
     → 존재하면 `/application/:id`로 이동

  3. 모아동 지원서가 없는 경우, 외부 지원 링크(`externalApplicationUrl`) 확인  
     → 존재하면 새 창으로 외부 폼 이동  
     → 없다면 안내 메시지 출력 후 상세페이지 유지

<br />


## 🫡 참고사항

- 외부 지원 링크는 `window.open(..., '_blank', 'noopener,noreferrer')` 방식으로 보안 대응했습니다.
