### PR TITLE
[feautre] 지원서 관리 API

### DIFF
--- a/backend/src/main/java/moadong/club/controller/ClubApplyController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubApplyController.java
@@ -4,11 +4,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AllArgsConstructor;
-import moadong.club.entity.ClubApplication;
+import moadong.club.payload.request.ClubApplicantEditRequest;
 import moadong.club.payload.request.ClubApplicationCreateRequest;
 import moadong.club.payload.request.ClubApplicationEditRequest;
 import moadong.club.payload.request.ClubApplyRequest;
-import moadong.club.payload.response.ClubApplicationResponse;
 import moadong.club.service.ClubApplyService;
 import moadong.global.payload.Response;
 import moadong.user.annotation.CurrentUser;
@@ -17,8 +16,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/club/{clubId}")
@@ -71,6 +68,21 @@ public class ClubApplyController {
     public ResponseEntity<?> getApplyInfo(@PathVariable String clubId,
                                           @CurrentUser CustomUserDetails user) {
         return Response.ok(clubApplyService.getClubApplyInfo(clubId, user));
+    }
+
+    @PutMapping("/apply/{appId}")
+    @Operation(summary = "지원서 변경",
+            description = "클럽 자원자의 지원서 정보를 수정합니다.<br>"
+        + "appId - 지원서 아이디"
+    )
+    @PreAuthorize("isAuthenticated()")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> editApplicantDetail(@PathVariable String clubId,
+                                                 @PathVariable String appId,
+                                                 @RequestBody @Validated ClubApplicantEditRequest request,
+                                                 @CurrentUser CustomUserDetails user) {
+        clubApplyService.editApplicantDetail(clubId, appId, request, user);
+        return Response.ok("success edit applicant");
     }
 
 }

--- a/backend/src/main/java/moadong/club/controller/ClubApplyController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubApplyController.java
@@ -73,7 +73,7 @@ public class ClubApplyController {
     @PutMapping("/apply/{appId}")
     @Operation(summary = "지원서 변경",
             description = "클럽 자원자의 지원서 정보를 수정합니다.<br>"
-        + "appId - 지원서 아이디"
+                    + "appId - 지원서 아이디"
     )
     @PreAuthorize("isAuthenticated()")
     @SecurityRequirement(name = "BearerAuth")
@@ -83,6 +83,20 @@ public class ClubApplyController {
                                                  @CurrentUser CustomUserDetails user) {
         clubApplyService.editApplicantDetail(clubId, appId, request, user);
         return Response.ok("success edit applicant");
+    }
+
+    @DeleteMapping("/apply/{appId}")
+    @Operation(summary = "지원서 삭제",
+            description = "클럽 자원자의 지원서를 삭제합니다.<br>"
+                    + "appId - 지원서 아이디"
+    )
+    @PreAuthorize("isAuthenticated()")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> removeApplicant(@PathVariable String clubId,
+                                             @PathVariable String appId,
+                                             @CurrentUser CustomUserDetails user) {
+        clubApplyService.deleteApplicant(clubId, appId, user);
+        return Response.ok("success delete applicant");
     }
 
 }

--- a/backend/src/main/java/moadong/club/entity/ClubApplication.java
+++ b/backend/src/main/java/moadong/club/entity/ClubApplication.java
@@ -31,8 +31,16 @@ public class ClubApplication {
     ApplicationStatus status = ApplicationStatus.SUBMITTED;
 
     @Builder.Default
+    private String memo = "";
+
+    @Builder.Default
     private List<ClubQuestionAnswer> answers = new ArrayList<>();
 
     @Builder.Default
     LocalDateTime createdAt = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime();
+
+    public void updateDetail(String memo, ApplicationStatus status) {
+        this.memo = memo;
+        this.status = status;
+    }
 }

--- a/backend/src/main/java/moadong/club/payload/dto/ClubApplicantsResult.java
+++ b/backend/src/main/java/moadong/club/payload/dto/ClubApplicantsResult.java
@@ -9,15 +9,17 @@ import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
 import moadong.global.util.AESCipher;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 @Builder
 @Slf4j
 public record ClubApplicantsResult(
-        String questionId,
+        String id,
         ApplicationStatus status,
-        List<ClubQuestionAnswer> answers
+        List<ClubQuestionAnswer> answers,
+        LocalDateTime createdAt
 ) {
     public static ClubApplicantsResult of(ClubApplication application, AESCipher cipher) {
         List<ClubQuestionAnswer> decryptedAnswers = new ArrayList<>();
@@ -35,9 +37,10 @@ public record ClubApplicantsResult(
         }
 
         return ClubApplicantsResult.builder()
-                .questionId(application.getQuestionId())
+                .id(application.getId())
                 .status(application.getStatus())
                 .answers(decryptedAnswers)
+                .createdAt(application.getCreatedAt())
                 .build();
     }
 }

--- a/backend/src/main/java/moadong/club/payload/request/ClubApplicantEditRequest.java
+++ b/backend/src/main/java/moadong/club/payload/request/ClubApplicantEditRequest.java
@@ -1,0 +1,14 @@
+package moadong.club.payload.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import moadong.club.enums.ApplicationStatus;
+
+public record ClubApplicantEditRequest(
+        @NotNull
+        @Size(max = 500)
+        String memo,
+
+        ApplicationStatus status
+) {
+}

--- a/backend/src/main/java/moadong/club/payload/request/ClubApplicantEditRequest.java
+++ b/backend/src/main/java/moadong/club/payload/request/ClubApplicantEditRequest.java
@@ -9,6 +9,7 @@ public record ClubApplicantEditRequest(
         @Size(max = 500)
         String memo,
 
+        @NotNull
         ApplicationStatus status
 ) {
 }

--- a/backend/src/main/java/moadong/club/repository/ClubApplicationRepository.java
+++ b/backend/src/main/java/moadong/club/repository/ClubApplicationRepository.java
@@ -5,8 +5,11 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ClubApplicationRepository extends MongoRepository<ClubApplication, String> {
     @Query("{ 'questionId': ?0, 'status': { $exists: true, $ne: 'DRAFT' } }")
     List<ClubApplication> findAllByQuestionId(String questionId);
+
+    Optional<ClubApplication> findByIdAndQuestionId(String id, String questionId);
 }

--- a/backend/src/main/java/moadong/club/service/ClubApplyService.java
+++ b/backend/src/main/java/moadong/club/service/ClubApplyService.java
@@ -142,6 +142,21 @@ public class ClubApplyService {
         clubApplicationRepository.save(application);
     }
 
+    @Transactional
+    public void deleteApplicant(String clubId, String appId, CustomUserDetails user) {
+        Club club = clubRepository.findById(clubId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.CLUB_NOT_FOUND));
+
+        if (!user.getId().equals(club.getUserId())) {
+            throw new RestApiException(ErrorCode.USER_UNAUTHORIZED);
+        }
+
+        ClubApplication application = clubApplicationRepository.findByIdAndQuestionId(appId, clubId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.APPLICANT_NOT_FOUND));
+
+        clubApplicationRepository.delete(application);
+    }
+
     private void validateAnswers(List<ClubApplyRequest.Answer> answers, ClubQuestion clubQuestion) {
         // 미리 질문과 응답 id 만들어두기
         Map<Long, ClubApplicationQuestion> questionMap = clubQuestion.getQuestions().stream()

--- a/backend/src/main/java/moadong/club/service/ClubApplyService.java
+++ b/backend/src/main/java/moadong/club/service/ClubApplyService.java
@@ -1,10 +1,12 @@
 package moadong.club.service;
 
+import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import moadong.club.entity.*;
 import moadong.club.enums.ClubApplicationQuestionType;
 import moadong.club.payload.dto.ClubApplicantsResult;
+import moadong.club.payload.request.ClubApplicantEditRequest;
 import moadong.club.payload.request.ClubApplicationCreateRequest;
 import moadong.club.payload.request.ClubApplicationEditRequest;
 import moadong.club.payload.request.ClubApplyRequest;
@@ -121,6 +123,23 @@ public class ClubApplyService {
                 .accepted(accepted)
                 .applicants(applications)
                 .build();
+    }
+
+    @Transactional
+    public void editApplicantDetail(String clubId, String appId, ClubApplicantEditRequest request, CustomUserDetails user) {
+        Club club = clubRepository.findById(clubId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.CLUB_NOT_FOUND));
+
+        if (!user.getId().equals(club.getUserId())) {
+            throw new RestApiException(ErrorCode.USER_UNAUTHORIZED);
+        }
+
+        ClubApplication application = clubApplicationRepository.findByIdAndQuestionId(appId, clubId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.APPLICANT_NOT_FOUND));
+
+        application.updateDetail(request.memo(), request.status());
+
+        clubApplicationRepository.save(application);
     }
 
     private void validateAnswers(List<ClubApplyRequest.Answer> answers, ClubQuestion clubQuestion) {

--- a/backend/src/main/java/moadong/global/exception/ErrorCode.java
+++ b/backend/src/main/java/moadong/global/exception/ErrorCode.java
@@ -39,7 +39,8 @@ public enum ErrorCode {
     QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "800-4", "존재하지 않은 질문입니다."),
     REQUIRED_QUESTION_MISSING(HttpStatus.BAD_REQUEST, "800-5", "필수 응답 질문이 누락되었습니다."),
 
-    AES_CIPHER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "900-1", "암호화 중 오류가 발생했습니다.")
+    AES_CIPHER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "900-1", "암호화 중 오류가 발생했습니다."),
+    APPLICANT_NOT_FOUND(HttpStatus.NOT_FOUND, "900-2", "지원서가 존재하지 않습니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## #️⃣연관된 이슈

#619, #618, #617

## 📝작업 내용

- 지원서 메모 API
- 지원서 상태 API
- 지원서 삭제 API

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 동아리 지원자 개별 정보(메모, 상태)를 수정할 수 있는 기능이 추가되었습니다.
  * 동아리 지원자 개별 지원서를 삭제할 수 있는 기능이 추가되었습니다.

* **버그 수정**
  * 지원서가 존재하지 않을 때의 오류 메시지가 개선되었습니다.

* **기타**
  * 지원자 정보에 메모 및 생성일 표시가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->