### PR TITLE
[fix] 로그아웃 안 되는 문제를 해결한다

### DIFF
--- a/frontend/src/apis/auth/logout.ts
+++ b/frontend/src/apis/auth/logout.ts
@@ -3,12 +3,13 @@ import API_BASE_URL from '@/constants/api';
 export const logout = async (): Promise<void> => {
   const accessToken = localStorage.getItem('accessToken');
 
+  if (!accessToken) {
+    return;
+  }
+
   const response = await fetch(`${API_BASE_URL}/auth/user/logout`, {
     method: 'GET',
     credentials: 'include',
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
   });
 
   if (!response.ok) {

--- a/frontend/src/apis/auth/logout.ts
+++ b/frontend/src/apis/auth/logout.ts
@@ -1,10 +1,14 @@
 import API_BASE_URL from '@/constants/api';
-import { secureFetch } from '@/apis/auth/secureFetch';
 
 export const logout = async (): Promise<void> => {
-  const response = await secureFetch(`${API_BASE_URL}/auth/user/logout`, {
+  const accessToken = localStorage.getItem('accessToken');
+
+  const response = await fetch(`${API_BASE_URL}/auth/user/logout`, {
     method: 'GET',
     credentials: 'include',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
   });
 
   if (!response.ok) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #628 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지/동영상 첨부 가능)

- logout 함수에서 secureFetch 대신 일반 fetch 사용
- 토큰 만료 시 자동 refresh 시도로 인한 find/club API 호출 방지

### 왜 안 될까

SideBar 컴포넌트 자체는 `useAuth`를 직접 사용하지 않고 있습니다. 문제는 **PrivateRoute에서 useAuth를 사용**하고 있고, 
이 훅이 AdminPage가 렌더링될 때마다 실행되기 때문입니다.

### 로그아웃 버튼을 클릭할 때 find/club API가 호출되는 이유

1. AdminPage가 렌더링됨
2. PrivateRoute에서 useAuth 훅이 실행됨
3. useAuth에서 getClubIdByToken() 호출
4. getClubIdByToken()에서 secureFetch 사용
5. secureFetch에서 /auth/user/find/club API 호출

### 해결 방법

logout 시 토큰 인증 부분을 건너뛰고, 바로 로그아웃 처리를 해야 합니다.

1. secureFetch가 아닌 fetch 사용하기

2. useAuth 에 초기화 함수 추가하기

3. 로그아웃 시 페이지 강제로 리로드하기

### 결론

2번은 useAuth를 고치면 여러 파일(PrivateRoute, AdminContext)을 수정해야 하고, 3번은 여전히 액세스토큰이 남습니다. 
그래서 api 파일만 수정해도 되고, fetch로만 바꾸면 되기 떄문에 1번으로 해결했습니다.


## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **버그 수정**
  * 로그아웃 요청 시 인증 토큰이 없으면 요청을 건너뛰도록 개선되었습니다.
  * 로그아웃 처리 방식이 안정적으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->