### PR TITLE
[fix] 인스타 프로필 공유하기 링크를 올릴 수 있다

### DIFF
--- a/frontend/src/constants/snsConfig.ts
+++ b/frontend/src/constants/snsConfig.ts
@@ -7,7 +7,8 @@ export const SNS_CONFIG = {
     label: '인스타그램',
     placeholder: 'https://www.instagram.com/id',
     // username 뒤에 슬래시 및 쿼리스트링(예: ?igsh=...&utm_source=...) 허용
-    regex: /^https:\/\/(www\.)?instagram\.com\/[A-Za-z0-9._%-]+\/?(\?.*)?$/,
+    regex:
+      /^https:\/\/(www\.)?instagram\.com\/(?!redirect(?:\/|\?|$))[A-Za-z0-9._%-]+\/?(?:\?.*)?$/,
     icon: instagram_icon,
   },
   youtube: {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #630

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지/동영상 첨부 가능)

### 인스타 링크 정규식 변경

정규식 허용: https://www.instagram.com/user, https://www.instagram.com/user/, https://www.instagram.com/user?igsh=...&utm_source=qr
차단: https://www.instagram.com/redirect?to=https://attacker.com/...

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 인스타그램 URL 검증을 개선했습니다. 사용자명이 포함된 링크에 트레일링 슬래시와 쿼리스트링(예: ?igsh=..., &utm_source=...)을 허용하고, redirect로 시작하는 잘못된 경로는 차단합니다. 이로써 유효한 링크가 불필요하게 거절되는 사례가 줄어들고, 프로필 연결·링크 공유·폼 제출 등에서 호환성과 성공률이 향상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->