### PR TITLE
[feature] 지원서 요약 API에 메모 필드추가

### DIFF
--- a/backend/src/main/java/moadong/club/payload/dto/ClubApplicantsResult.java
+++ b/backend/src/main/java/moadong/club/payload/dto/ClubApplicantsResult.java
@@ -19,6 +19,7 @@ public record ClubApplicantsResult(
         String id,
         ApplicationStatus status,
         List<ClubQuestionAnswer> answers,
+        String memo,
         LocalDateTime createdAt
 ) {
     public static ClubApplicantsResult of(ClubApplication application, AESCipher cipher) {
@@ -40,6 +41,7 @@ public record ClubApplicantsResult(
                 .id(application.getId())
                 .status(application.getStatus())
                 .answers(decryptedAnswers)
+                .memo(application.getMemo())
                 .createdAt(application.getCreatedAt())
                 .build();
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

#634

## 📝작업 내용

저번 작업에 빼먹었던 필드 추가했습니다 ㅜ

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 지원자 상세 정보에 메모 필드가 추가되었습니다. 이제 지원자 목록/상세 조회 시 메모 내용을 함께 확인할 수 있습니다.
  - API 응답에 memo 항목이 포함되어, 외부 연동 시 해당 정보를 활용할 수 있습니다.
- 기타
  - 기존 필드와 동작에는 영향이 없으며, 메모 필드 추가는 하위 호환을 유지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->