### PR TITLE
[refactor] 카테고리 버튼 클릭 로깅 통일

### DIFF
--- a/frontend/src/pages/MainPage/components/CategoryButtonList/CategoryButtonList.tsx
+++ b/frontend/src/pages/MainPage/components/CategoryButtonList/CategoryButtonList.tsx
@@ -1,4 +1,4 @@
-import mixpanel from 'mixpanel-browser';
+import useMixpanelTrack from '@/hooks/useMixpanelTrack';
 import * as Styled from './CategoryButtonList.styles';
 import iconAll from '@/assets/images/icons/category_button/category_all_button_icon.svg';
 import iconVolunteer from '@/assets/images/icons/category_button/category_volunteer_button_icon.svg';
@@ -14,59 +14,27 @@ interface Category {
   id: string;
   name: string;
   icon: string;
-  eventName: string;
 }
 
 const clubCategories: Category[] = [
-  { id: 'all', name: '전체', icon: iconAll, eventName: 'Category_All_Clicked' },
-  {
-    id: '봉사',
-    name: '봉사',
-    icon: iconVolunteer,
-    eventName: 'Category_Volunteering_Clicked',
-  },
-  {
-    id: '종교',
-    name: '종교',
-    icon: iconReligion,
-    eventName: 'Category_Religion_Clicked',
-  },
-  {
-    id: '취미교양',
-    name: '취미교양',
-    icon: iconHobby,
-    eventName: 'Category_Hobby_Clicked',
-  },
-  {
-    id: '학술',
-    name: '학술',
-    icon: iconStudy,
-    eventName: 'Category_Study_Clicked',
-  },
-  {
-    id: '운동',
-    name: '운동',
-    icon: iconSport,
-    eventName: 'Category_Sport_Clicked',
-  },
-  {
-    id: '공연',
-    name: '공연',
-    icon: iconPerformance,
-    eventName: 'Category_Performance_Clicked',
-  },
+  { id: 'all', name: '전체', icon: iconAll },
+  { id: '봉사', name: '봉사', icon: iconVolunteer },
+  { id: '종교', name: '종교', icon: iconReligion },
+  { id: '취미교양', name: '취미교양', icon: iconHobby },
+  { id: '학술', name: '학술', icon: iconStudy },
+  { id: '운동', name: '운동', icon: iconSport },
+  { id: '공연', name: '공연', icon: iconPerformance },
 ];
 
 const CategoryButtonList = () => {
   const { setKeyword, setInputValue, setIsSearching } = useSearch();
   const { setSelectedCategory } = useCategory();
+  const trackEvent = useMixpanelTrack();
 
   const handleCategoryClick = (category: Category) => {
-    mixpanel.track(category.eventName, {
+    trackEvent('categoryButton Clicked', {
       category_id: category.id,
       category_name: category.name,
-      timestamp: Date.now(),
-      url: window.location.href,
     });
 
     setKeyword('');


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #637 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지/동영상 첨부 가능)

## 퍼널

<img width="699" height="489" alt="스크린샷 2025-08-12 01 37 35" src="https://github.com/user-attachments/assets/d07cd71e-ed73-4840-b002-fb78d0ac2258" />

- 믹스패널에 `퍼널`을 사용하면, 단계별로 사용자 전환율을 확인할 수 있습니다.
- eventName을 한 번 더 추상화하여 전체적인 전환율 파악을 위해서 변경했습니다.


## 이전 로그

<img width="373" height="491" alt="스크린샷 2025-08-12 01 33 23" src="https://github.com/user-attachments/assets/ee9438d0-587e-4fdb-b7f7-2d9669c5fe38" />

- eventName에 분과가 포함되었다.

## 변경 후

<img width="375" height="470" alt="스크린샷 2025-08-12 01 34 11" src="https://github.com/user-attachments/assets/a438872f-7a57-4878-a48f-eaa8b0afd134" />

- useMixpanelTrack (기존 믹스패널 hook)로 공통 속성 자동 포함
- eventName은 `CategoryButton Clicked`로 설정



## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * 카테고리 버튼 클릭 이벤트 추적을 통합해 데이터 일관성을 개선했습니다.
  * 이벤트 페이로드를 간소화하여 카테고리 ID/이름만 전송합니다.
  * 사용자 경험 변화 없음: 검색어 초기화 및 카테고리 선택 동작은 기존과 동일합니다.
* Refactor
  * 추적 로직을 공용 유틸로 일원화해 유지보수성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->