### PR TITLE
[refactor] 믹스패널 공통 이벤트 상수 도입

### DIFF
--- a/frontend/src/components/common/SearchBox/SearchBox.tsx
+++ b/frontend/src/components/common/SearchBox/SearchBox.tsx
@@ -5,6 +5,7 @@ import useMixpanelTrack from '@/hooks/useMixpanelTrack';
 import * as Styled from './SearchBox.styles';
 import SearchIcon from '@/assets/images/icons/search_button_icon.svg';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { EVENT_NAME } from '@/constants/eventName';
 
 const SearchBox = () => {
   const [isSearchBoxClicked, setIsSearchBoxClicked] = useState(false);
@@ -30,7 +31,7 @@ const SearchBox = () => {
 
     inputRef.current?.blur();
 
-    trackEvent('Search Executed', {
+    trackEvent(EVENT_NAME.SEARCH_BOX_CLICKED, {
       inputValue: inputValue,
       page: window.location.pathname,
     });

--- a/frontend/src/constants/eventName.ts
+++ b/frontend/src/constants/eventName.ts
@@ -1,0 +1,17 @@
+export const EVENT_NAME = {
+  CATEGORY_BUTTON_CLICKED: 'CategoryButton Clicked' as const,
+  SEARCH_BOX_CLICKED: 'SearchBox Clicked' as const,
+  PHOTO_NAVIGATION_CLICKED: 'Photo Navigation' as const,
+  BACK_BUTTON_CLICKED: 'Back Button Clicked' as const,
+  CLUB_APPLY_BUTTON_CLICKED: 'Club Apply Button Clicked' as const,
+  TAB_CLICKED: 'Tab Clicked' as const,
+  SHARE_BUTTON_CLICKED: '공유하기 버튼 클릭' as const,
+  SNS_LINK_CLICKED: 'sns링크 버튼 클릭' as const,
+  STATUS_RADIO_BUTTON_CLICKED: 'StatusRadioButton Clicked' as const,
+  HOME_BUTTON_CLICKED: 'Home Button Clicked' as const,
+  MOBILE_HOME_BUTTON_CLICKED: 'Mobile Home Button Clicked' as const,
+  INTRODUCE_BUTTON_CLICKED: 'Introduce Button Clicked' as const,
+  MOBILE_MENU_BUTTON_CLICKED: 'Mobile Menu Button Clicked' as const,
+  MOBILE_MENU_DELETE_BUTTON_CLICKED:
+    'Mobile Menubar delete Button Clicked' as const,
+} as const;

--- a/frontend/src/hooks/PhotoList/usePhotoNavigation.ts
+++ b/frontend/src/hooks/PhotoList/usePhotoNavigation.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect } from 'react';
 import useMixpanelTrack from '../useMixpanelTrack';
+import { EVENT_NAME } from '@/constants/eventName';
 
 export const usePhotoNavigation = ({
   currentIndex,
@@ -34,13 +35,19 @@ export const usePhotoNavigation = ({
     const nextIndex = currentIndex + 1;
     if (nextIndex >= photosLength) return;
     setCurrentIndex(nextIndex);
-    trackEvent('Photo Navigation', { action: 'next', index: nextIndex });
+    trackEvent(EVENT_NAME.PHOTO_NAVIGATION_CLICKED, {
+      action: 'next',
+      index: nextIndex,
+    });
   };
 
   const handlePrev = () => {
     if (currentIndex <= 0) return;
     setCurrentIndex(currentIndex - 1);
-    trackEvent('Photo Navigation', { action: 'prev', index: currentIndex - 1 });
+    trackEvent(EVENT_NAME.PHOTO_NAVIGATION_CLICKED, {
+      action: 'prev',
+      index: currentIndex - 1,
+    });
   };
 
   const canScrollLeft = currentIndex > 0 && photosLength > 1;

--- a/frontend/src/pages/ClubDetailPage/components/BackNavigationBar/BackNavigationBar.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/BackNavigationBar/BackNavigationBar.tsx
@@ -2,13 +2,14 @@ import useMixpanelTrack from '@/hooks/useMixpanelTrack';
 import { useNavigate } from 'react-router-dom';
 import * as Styled from './BackNavigationBar.styles';
 import BackIcon from '@/assets/images/icons/back_button_icon.svg';
+import { EVENT_NAME } from '@/constants/eventName';
 
 const BackNavigationBar = () => {
   const navigate = useNavigate();
   const trackEvent = useMixpanelTrack();
 
   const handleBackClick = () => {
-    trackEvent('Back Button Clicked');
+    trackEvent(EVENT_NAME.BACK_BUTTON_CLICKED);
     navigate('/');
   };
 

--- a/frontend/src/pages/ClubDetailPage/components/ClubApplyButton/ClubApplyButton.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubApplyButton/ClubApplyButton.tsx
@@ -5,6 +5,7 @@ import getApplication from '@/apis/application/getApplication';
 import { parseRecruitmentPeriod } from '@/utils/recruitmentPeriodParser';
 import getDeadlineText from '@/utils/getDeadLineText';
 import useMixpanelTrack from '@/hooks/useMixpanelTrack';
+import { EVENT_NAME } from '@/constants/eventName';
 
 const Button = styled.button`
   display: flex;
@@ -45,7 +46,7 @@ const ClubApplyButton = () => {
   const handleClick = async () => {
     if (!clubId || !clubDetail) return;
 
-    trackEvent('Club Apply Button Clicked');
+    trackEvent(EVENT_NAME.CLUB_APPLY_BUTTON_CLICKED);
 
     const { recruitmentStart, recruitmentEnd } = parseRecruitmentPeriod(
       clubDetail.recruitmentPeriod,

--- a/frontend/src/pages/ClubDetailPage/components/InfoTabs/InfoTabs.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/InfoTabs/InfoTabs.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import * as Styled from './InfoTabs.styles';
 import useMixpanelTrack from '@/hooks/useMixpanelTrack';
+import { EVENT_NAME } from '@/constants/eventName';
 
 const tabLabels = ['모집정보', '동아리정보', '소개글', '활동사진'];
 
@@ -12,7 +13,7 @@ const InfoTabs = ({ onTabClick }: { onTabClick: (index: number) => void }) => {
     setActiveTab(index);
     onTabClick(index);
 
-    trackEvent('Tab Clicked', {
+    trackEvent(EVENT_NAME.TAB_CLICKED, {
       tabName: tabLabels[index],
       tabIndex: index,
     });
@@ -24,7 +25,8 @@ const InfoTabs = ({ onTabClick }: { onTabClick: (index: number) => void }) => {
         <Styled.InfoTabButton
           key={label}
           className={activeTab === index ? 'active' : ''}
-          onClick={() => handleTabClick(index)}>
+          onClick={() => handleTabClick(index)}
+        >
           {label}
         </Styled.InfoTabButton>
       ))}

--- a/frontend/src/pages/ClubDetailPage/components/ShareButton/ShareButton.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ShareButton/ShareButton.tsx
@@ -3,6 +3,7 @@ import * as Styled from './ShareButton.styles';
 import { useGetClubDetail } from '@/hooks/queries/club/useGetClubDetail';
 import useMixpanelTrack from '@/hooks/useMixpanelTrack';
 import KakaoIcon from '@/assets/images/icons/kakaotalk_sharing_btn_small.png';
+import { EVENT_NAME } from '@/constants/eventName';
 
 interface ShareButtonProps {
   clubId: string;
@@ -43,7 +44,7 @@ const ShareButton = ({ clubId }: ShareButtonProps) => {
         },
       ],
     });
-    trackEvent('공유하기 버튼 클릭', { clubName: clubDetail.name });
+    trackEvent(EVENT_NAME.SHARE_BUTTON_CLICKED, { clubName: clubDetail.name });
   };
 
   return (

--- a/frontend/src/pages/ClubDetailPage/components/SnsLinkIcons/SnsLinkIcons.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/SnsLinkIcons/SnsLinkIcons.tsx
@@ -3,6 +3,7 @@ import * as Styled from './SnsLinkIcons.styles';
 import { SNS_CONFIG } from '@/constants/snsConfig';
 import { SNSPlatform } from '@/types/club';
 import useMixpanelTrack from '@/hooks/useMixpanelTrack';
+import { EVENT_NAME } from '@/constants/eventName';
 
 interface SnsLinkIconsProps {
   apiSocialLinks: Partial<Record<SNSPlatform, string>>;
@@ -26,7 +27,7 @@ const SnsLinkIcons = ({ apiSocialLinks, clubName }: SnsLinkIconsProps) => {
             target='_blank'
             rel='noreferrer'
             onClick={() =>
-              trackEvent('sns링크 버튼 클릭', {
+              trackEvent(EVENT_NAME.SNS_LINK_CLICKED, {
                 platform,
                 clubName,
               })

--- a/frontend/src/pages/MainPage/components/CategoryButtonList/CategoryButtonList.tsx
+++ b/frontend/src/pages/MainPage/components/CategoryButtonList/CategoryButtonList.tsx
@@ -9,6 +9,7 @@ import iconSport from '@/assets/images/icons/category_button/category_sport_butt
 import iconPerformance from '@/assets/images/icons/category_button/category_performance_button_icon.svg';
 import { useSearch } from '@/context/SearchContext';
 import { useCategory } from '@/context/CategoryContext';
+import { EVENT_NAME } from '@/constants/eventName';
 
 interface Category {
   id: string;
@@ -32,7 +33,7 @@ const CategoryButtonList = () => {
   const trackEvent = useMixpanelTrack();
 
   const handleCategoryClick = (category: Category) => {
-    trackEvent('categoryButton Clicked', {
+    trackEvent(EVENT_NAME.CATEGORY_BUTTON_CLICKED, {
       category_id: category.id,
       category_name: category.name,
     });

--- a/frontend/src/pages/MainPage/components/CategoryButtonList/CategoryButtonList.tsx
+++ b/frontend/src/pages/MainPage/components/CategoryButtonList/CategoryButtonList.tsx
@@ -1,4 +1,4 @@
-import mixpanel from 'mixpanel-browser';
+import useMixpanelTrack from '@/hooks/useMixpanelTrack';
 import * as Styled from './CategoryButtonList.styles';
 import iconAll from '@/assets/images/icons/category_button/category_all_button_icon.svg';
 import iconVolunteer from '@/assets/images/icons/category_button/category_volunteer_button_icon.svg';
@@ -14,59 +14,27 @@ interface Category {
   id: string;
   name: string;
   icon: string;
-  eventName: string;
 }
 
 const clubCategories: Category[] = [
-  { id: 'all', name: '전체', icon: iconAll, eventName: 'Category_All_Clicked' },
-  {
-    id: '봉사',
-    name: '봉사',
-    icon: iconVolunteer,
-    eventName: 'Category_Volunteering_Clicked',
-  },
-  {
-    id: '종교',
-    name: '종교',
-    icon: iconReligion,
-    eventName: 'Category_Religion_Clicked',
-  },
-  {
-    id: '취미교양',
-    name: '취미교양',
-    icon: iconHobby,
-    eventName: 'Category_Hobby_Clicked',
-  },
-  {
-    id: '학술',
-    name: '학술',
-    icon: iconStudy,
-    eventName: 'Category_Study_Clicked',
-  },
-  {
-    id: '운동',
-    name: '운동',
-    icon: iconSport,
-    eventName: 'Category_Sport_Clicked',
-  },
-  {
-    id: '공연',
-    name: '공연',
-    icon: iconPerformance,
-    eventName: 'Category_Performance_Clicked',
-  },
+  { id: 'all', name: '전체', icon: iconAll },
+  { id: '봉사', name: '봉사', icon: iconVolunteer },
+  { id: '종교', name: '종교', icon: iconReligion },
+  { id: '취미교양', name: '취미교양', icon: iconHobby },
+  { id: '학술', name: '학술', icon: iconStudy },
+  { id: '운동', name: '운동', icon: iconSport },
+  { id: '공연', name: '공연', icon: iconPerformance },
 ];
 
 const CategoryButtonList = () => {
   const { setKeyword, setInputValue, setIsSearching } = useSearch();
   const { setSelectedCategory } = useCategory();
+  const trackEvent = useMixpanelTrack();
 
   const handleCategoryClick = (category: Category) => {
-    mixpanel.track(category.eventName, {
+    trackEvent('categoryButton Clicked', {
       category_id: category.id,
       category_name: category.name,
-      timestamp: Date.now(),
-      url: window.location.href,
     });
 
     setKeyword('');

--- a/frontend/src/pages/MainPage/components/StatusRadioButton/StatusRadioButton.tsx
+++ b/frontend/src/pages/MainPage/components/StatusRadioButton/StatusRadioButton.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import useMixpanelTrack from '@/hooks/useMixpanelTrack';
 import * as Styled from './StatusRadioButton.styles';
+import { EVENT_NAME } from '@/constants/eventName';
 
 interface StatusRadioButtonProps {
   onChange: (selectedStatus: boolean) => void;
@@ -15,7 +16,7 @@ const StatusRadioButton = ({ onChange }: StatusRadioButtonProps) => {
       const newStatus = !prev;
       onChange(newStatus);
 
-      trackEvent('StatusRadioButton Clicked', {
+      trackEvent(EVENT_NAME.STATUS_RADIO_BUTTON_CLICKED, {
         new_status: newStatus ? 'OPEN' : 'ALL',
       });
 

--- a/frontend/src/services/header/useHeaderService.ts
+++ b/frontend/src/services/header/useHeaderService.ts
@@ -1,10 +1,11 @@
 import { useNavigate } from 'react-router-dom';
 import { useSearch } from '@/context/SearchContext';
 import useMixpanelTrack from '@/hooks/useMixpanelTrack';
+import { EVENT_NAME } from '@/constants/eventName';
 
 const trackEventNames = {
-  desktop: 'Home Button Clicked',
-  mobile: 'Mobile Home Button Clicked',
+  desktop: EVENT_NAME.HOME_BUTTON_CLICKED,
+  mobile: EVENT_NAME.MOBILE_HOME_BUTTON_CLICKED,
 } as const;
 
 const useHeaderService = () => {
@@ -21,11 +22,11 @@ const useHeaderService = () => {
 
   const goIntroducePage = () => {
     navigate('/introduce');
-    trackEvent('Introduce Button Clicked');
+    trackEvent(EVENT_NAME.INTRODUCE_BUTTON_CLICKED);
   };
 
   const handleMenuClick = () => {
-    trackEvent('Mobile Menu Button Clicked');
+    trackEvent(EVENT_NAME.MOBILE_MENU_BUTTON_CLICKED);
   };
 
   return {

--- a/frontend/src/services/header/useMobileMenu.ts
+++ b/frontend/src/services/header/useMobileMenu.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import useMixpanelTrack from '@/hooks/useMixpanelTrack';
+import { EVENT_NAME } from '@/constants/eventName';
 
 interface MobileMenuProp {
   handleMenuClick: () => void;
@@ -16,7 +17,7 @@ const useMobileMenu = ({ handleMenuClick }: MobileMenuProp) => {
 
   const closeMenu = useCallback(() => {
     setIsMenuOpen(false);
-    trackEvent('Mobile Menubar delete Button Clicked');
+    trackEvent(EVENT_NAME.MOBILE_MENU_DELETE_BUTTON_CLICKED);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #640 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지/동영상 첨부 가능)

- `여러 컴포넌트에서 하드코딩된 이벤트명을 EVENT_NAME 상수로 치환


## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 중앙화된 이벤트 상수 도입으로 사용자 행동 로그 명칭을 통일하고 관리 용이성 향상.
- Chores
  - 헤더 홈/소개/메뉴, 카테고리 버튼, 상태 라디오 버튼, SNS 링크, 뒤로가기, 동아리 신청/공유 버튼, 사진 내비게이션, 검색 상자 등 전반의 추적 호출 정리 및 임의 문자열 제거.
  - 일부 컴포넌트 속성 보강(SNS 링크의 clubName 옵션 추가).
  - 기능, UI, 사용자 흐름에는 변화 없음.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->