### PR TITLE
[feature]상세페이지에 동아리 추천 추가

### DIFF
--- a/frontend/config/webpack.dev.ts
+++ b/frontend/config/webpack.dev.ts
@@ -55,10 +55,10 @@ export default getAvailablePort(DEFAULT_PORT).then((port) => {
         {
           test: /\.css$/,
           use: ['style-loader', 'css-loader'],
-          include: path.resolve(
-            __dirname,
-            '../node_modules/react-datepicker/dist',
-          ),
+          include: [
+          path.resolve(__dirname, '../node_modules/react-datepicker/dist'),
+          path.resolve(__dirname, '../node_modules/swiper'),
+        ],
         },
         {
           test: /\.css$/,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,7 +26,8 @@
         "rehype-raw": "^7.0.0",
         "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.1",
-        "styled-components": "^6.1.14"
+        "styled-components": "^6.1.14",
+        "swiper": "^11.2.10"
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^3.2.4",
@@ -10478,14 +10479,12 @@
         "he": "bin/he"
       }
     },
-
     "node_modules/headers-polyfill": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
       "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
       "license": "MIT"
     },
-
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -17947,6 +17946,25 @@
       "peerDependencies": {
         "@swc/core": "^1.2.147",
         "webpack": ">=2"
+      }
+    },
+    "node_modules/swiper": {
+      "version": "11.2.10",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.2.10.tgz",
+      "integrity": "sha512-RMeVUUjTQH+6N3ckimK93oxz6Sn5la4aDlgPzB+rBrG/smPdCTicXyhxa+woIpopz+jewEloiEE3lKo1h9w2YQ==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.7.0"
       }
     },
     "node_modules/symbol-tree": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,8 @@
     "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
-    "styled-components": "^6.1.14"
+    "styled-components": "^6.1.14",
+    "swiper": "^11.2.10"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^3.2.4",

--- a/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
@@ -14,6 +14,8 @@ import useTrackPageView from '@/hooks/useTrackPageView';
 import useAutoScroll from '@/hooks/InfoTabs/useAutoScroll';
 import { useGetClubDetail } from '@/hooks/queries/club/useGetClubDetail';
 import ShareButton from '@/pages/ClubDetailPage/components/ShareButton/ShareButton';
+import RecommendedClubs from '@/pages/ClubDetailPage/components/RecommendedClubs/RecommendedClubs';
+import { Club } from '@/types/club';
 
 const ClubDetailPage = () => {
   const { clubId } = useParams<{ clubId: string }>();
@@ -68,6 +70,8 @@ const ClubDetailPage = () => {
           feeds={clubDetail.feeds}
           clubName={clubDetail.name}
         />
+        <RecommendedClubs clubs={(clubDetail.recommendClubs ?? []) as Club[]} />
+        
       </Styled.PageContainer>
       <Footer />
       <ClubDetailFooter

--- a/frontend/src/pages/ClubDetailPage/components/ClubCard/ClubCard.styles.ts
+++ b/frontend/src/pages/ClubDetailPage/components/ClubCard/ClubCard.styles.ts
@@ -1,0 +1,74 @@
+import styled from 'styled-components';
+
+const CardContainer = styled.div<{
+  $state: string;
+  $isClicked: boolean;
+}>`
+  display: flex;
+  flex-direction: column;
+  border-radius: 14px;
+  padding: 20px;
+  background-color: #fff;
+  width: 100%;
+  height: 170px;
+  border-radius: 18px;
+  border: 1px solid #dcdcdc;
+
+  transition:
+    transform 0.2s ease-in-out,
+
+  transform: ${({ $isClicked }) => ($isClicked ? 'scale(1.05)' : 'scale(1)')};
+  cursor: pointer;
+
+  &:hover {
+    transform: ${({ $isClicked }) =>
+      $isClicked ? 'scale(1.05)' : 'scale(1.03)'};
+  }
+
+  &:active {
+    transform: scale(0.98);
+  }
+
+  @media (max-width: 300px) {
+    height: auto;
+  }
+`;
+
+const CardHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const ClubProfile = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 18px;
+`;
+
+const ClubName = styled.h2`
+  font-size: 1.25rem;
+  font-weight: bold;
+`;
+
+const TagsContainer = styled.div`
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+`;
+
+const Introduction = styled.p`
+  font-size: 0.875rem;
+  margin: 22px 3px 22px 5px;
+  color: rgba(129, 129, 129, 1);
+  line-height: 16px;
+  white-space: nowrap;
+`;
+
+export {
+  CardContainer,
+  CardHeader,
+  ClubProfile,
+  ClubName,
+  TagsContainer,
+  Introduction,
+};

--- a/frontend/src/pages/ClubDetailPage/components/ClubCard/ClubCard.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubCard/ClubCard.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+import mixpanel from 'mixpanel-browser';
+import ClubTag from '@/components/ClubTag/ClubTag';
+import ClubLogo from '@/components/ClubLogo/ClubLogo';
+import ClubStateBox from '@/components/ClubStateBox/ClubStateBox';
+import * as Styled from './ClubCard.styles';
+import { Club } from '@/types/club';
+import { useNavigate } from 'react-router-dom';
+import default_profile_image from '@/assets/images/logos/default_profile_image.svg';
+
+const ClubCard = ({ club }: { club: Club }) => {
+  const navigate = useNavigate();
+  const [isClicked, setIsClicked] = useState(false);
+
+  const handleNavigate = () => {
+    setIsClicked(true);
+    mixpanel.track('Recommended ClubCard Clicked', {
+      club_id: club.id,
+      club_name: club.name,
+      recruitment_status: club.recruitmentStatus,
+    });
+
+    setTimeout(() => {
+      setIsClicked(false);
+      navigate(`/club/${club.id}`);
+    }, 150);
+  };
+
+  return (
+    <Styled.CardContainer
+      $state={club.recruitmentStatus}
+      $isClicked={isClicked}
+      onClick={handleNavigate}>
+      <Styled.CardHeader>
+        <Styled.ClubProfile>
+          <ClubLogo $imageSrc={club.logo || default_profile_image} />
+          <Styled.ClubName>{club.name}</Styled.ClubName>
+        </Styled.ClubProfile>
+        <ClubStateBox state={club.recruitmentStatus} />
+      </Styled.CardHeader>
+      <Styled.Introduction>{club.introduction}</Styled.Introduction>
+      <Styled.TagsContainer>
+        <ClubTag key={`division-${club.id}`} type={club.division} />
+        <ClubTag key={`category-${club.id}`} type={club.category} />
+        {club.tags
+          .filter((tag) => tag.trim())
+          .map((tag) => (
+            <ClubTag key={`tag-${club.id}-${tag}`} type={'자유'}>
+              {tag}
+            </ClubTag>
+          ))}
+      </Styled.TagsContainer>
+    </Styled.CardContainer>
+  );
+};
+
+export default ClubCard;

--- a/frontend/src/pages/ClubDetailPage/components/RecommendedClubs/RecommendedClubs.styles.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/RecommendedClubs/RecommendedClubs.styles.tsx
@@ -1,0 +1,34 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-top: 34px;
+  width: 100%;
+  border-radius: 18px;
+  border: 1px solid #dcdcdc;
+  padding: 30px;
+  gap: 30px;
+`;
+
+export const Title = styled.h2`
+  font-size: 1.25rem;
+  font-weight: bold;
+  margin-bottom: 16px;
+`;
+
+// 반응형 그리드 리스트
+export const GridList = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr); // 기본 2열
+  gap: 16px;
+
+  // 화면 넓이 600px 이하일 경우 1열로 변경
+  @media (max-width: 600px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+export const CardWrapper = styled.div`
+  width: 100%;
+`;

--- a/frontend/src/pages/ClubDetailPage/components/RecommendedClubs/RecommendedClubs.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/RecommendedClubs/RecommendedClubs.tsx
@@ -1,0 +1,65 @@
+import { useState, useEffect } from 'react';
+import * as Styled from './RecommendedClubs.styles';
+import ClubCard from '@/pages/ClubDetailPage/components/ClubCard/ClubCard';
+import { Club } from '@/types/club';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import 'swiper/css';
+
+interface RecommendedClubsProps {
+  clubs: Club[];
+}
+
+const getABGroup = (): 'A' | 'B' => {
+  const savedGroup = localStorage.getItem('recommendABGroup');
+  if (savedGroup === 'A' || savedGroup === 'B') return savedGroup;
+  const group = Math.random() < 0.5 ? 'A' : 'B';
+  localStorage.setItem('recommendABGroup', group);
+  return 'A';
+};
+
+const RecommendedClubs = ({ clubs }: RecommendedClubsProps) => {
+  const [abGroup, setAbGroup] = useState<'A' | 'B'>('A');
+
+  useEffect(() => {
+    const group = getABGroup();
+    setAbGroup(group);
+  }, []);
+
+  if (!clubs || clubs.length === 0) return null;
+
+  const displayClubs = clubs.slice(0, 6);
+
+  if (abGroup === 'A') {
+    // 기존 그리드 + 기존 문구
+    return (
+      <Styled.Container>
+        <Styled.Title>이런 동아리는 어때요? 지금 바로 확인! 🔥</Styled.Title>
+        <Styled.GridList>
+          {displayClubs.map((club) => (
+            <Styled.CardWrapper key={club.id}>
+              <ClubCard club={club} />
+            </Styled.CardWrapper>
+          ))}
+        </Styled.GridList>
+      </Styled.Container>
+    );
+  } else {
+    // B 그룹: 슬라이더 + 문구 변경
+    return (
+      <Styled.Container>
+        <Styled.Title>당신에게 맞는 동아리 안내드려요! ✨</Styled.Title>
+        <Swiper spaceBetween={16} slidesPerView={2} freeMode={true}>
+          {displayClubs.map((club) => (
+            <SwiperSlide key={club.id}>
+              <Styled.CardWrapper>
+                <ClubCard club={club} />
+              </Styled.CardWrapper>
+            </SwiperSlide>
+          ))}
+        </Swiper>
+      </Styled.Container>
+    );
+  }
+};
+
+export default RecommendedClubs;

--- a/frontend/src/types/club.ts
+++ b/frontend/src/types/club.ts
@@ -24,6 +24,7 @@ export interface ClubDetail extends Club {
   recruitmentTarget: string;
   socialLinks: Record<SNSPlatform, string>;
   externalApplicationUrl?: string;
+  recommendClubs?: Club
 }
 
 export interface ClubDescription {


### PR DESCRIPTION
## #️⃣연관된 이슈

#657 
#655 

## 📝작업 내용
<img width="453" height="5050" alt="image" src="https://github.com/user-attachments/assets/021136d0-6619-4a11-89f6-4d9c33481073" />

- 동아리 상세 페이지에 동아리 추천 섹션을 추가했습니다.
- 6개 중 4개는 같은 분과(카테고리)이고 나머지는 전체 랜덤으로 구성했습니다.
- 믹스패널 A/B테스트를 위한 더미 코드가 있습니다
  (다른 유저 그룹은 Swap할 수 있는 구조로 만들기 위한 Swiper 라이브러리를 추가했습니다)
- 버그로 인해 Swiper 개발이 늦어지는 관계로 대체제로 GridList로 올립니다.



## 중점적으로 리뷰받고 싶은 부분(선택)



## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항