### PR TITLE
[hotfix] 지원서의 질문 제목을 정상적으로 변경할수 없는 오류 수정

### DIFF
--- a/frontend/src/components/application/QuestionTitle/QuestionTitle.tsx
+++ b/frontend/src/components/application/QuestionTitle/QuestionTitle.tsx
@@ -28,7 +28,7 @@ const QuestionTitle = ({
         <Styled.QuestionTitleText
           contentEditable={mode !== 'answer'}
           suppressContentEditableWarning={true}
-          onInput={(e) => {
+          onChange={(e) => {
             const value = e.currentTarget.textContent || '';
             if (value.length <= APPLICATION_FORM.QUESTION_TITLE.maxLength) {
               onTitleChange?.(value);


### PR DESCRIPTION
이게왜?????

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지/동영상 첨부 가능)

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 질문 제목 입력 시 변경 사항이 이제 입력 중 실시간 반영이 아닌 편집 완료(포커스 해제 등) 시점에 반영됩니다. 이로써 타이핑 중 불필요한 업데이트나 깜빡임이 줄어들고 안정적으로 제목이 저장됩니다. 플레이스홀더, 필수 표시, 편집 가능 상태 등 기존 동작은 그대로 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->