### PR TITLE
[hotfix] 지원서 제목이 정상적으로 바뀌지않는 오류 수정

### DIFF
--- a/frontend/src/components/application/QuestionTitle/QuestionTitle.styles.ts
+++ b/frontend/src/components/application/QuestionTitle/QuestionTitle.styles.ts
@@ -32,18 +32,20 @@ export const QuestionTitleTextContainer = styled.div`
   max-width: calc(100% - 20px);
 `;
 
-export const QuestionTitleText = styled.div`
+export const QuestionTitleText = styled.textarea`
   display: inline-block;
   min-width: 100px;
   resize: none;
-  overflow-wrap: break-word;
-  white-space: pre-wrap;
   border: none;
   outline: none;
   font-size: 1.25rem;
   font-weight: 700;
   line-height: 1.5;
   color: #111;
+  field-sizing: content;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  overflow: hidden;
 
   &:empty:before {
     content: attr(data-placeholder);

--- a/frontend/src/components/application/QuestionTitle/QuestionTitle.tsx
+++ b/frontend/src/components/application/QuestionTitle/QuestionTitle.tsx
@@ -26,17 +26,17 @@ const QuestionTitle = ({
       )}
       <Styled.QuestionTitleTextContainer>
         <Styled.QuestionTitleText
-          contentEditable={mode !== 'answer'}
+          readOnly={mode === 'answer'}
           suppressContentEditableWarning={true}
           onChange={(e) => {
-            const value = e.currentTarget.textContent || '';
+            const value = e.target.value || '';
             if (value.length <= APPLICATION_FORM.QUESTION_TITLE.maxLength) {
               onTitleChange?.(value);
             }
           }}
+          value={title}
           data-placeholder={title ? '' : APPLICATION_FORM.QUESTION_TITLE.placeholder}
         >
-          {title}
         </Styled.QuestionTitleText>
         {mode === 'answer' && required && <Styled.QuestionRequired />}
       </Styled.QuestionTitleTextContainer>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

저번에 이벤트를 바꾸어 해결했던건 onInput이 contenteditable div에 적용되는 이벤트가 아니여서 state가 변경되지않음에 따라 정상적으로 된것처럼 보인것입니다.
따라서 div태그대신 textarea로 변경하여 오류를 수정하였습니다

## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 질문 제목 편집을 contentEditable div에서 제어형 textarea로 전환하여 입력 동작의 일관성 및 접근성을 개선했습니다. 보기 모드에서는 읽기 전용, 빌더 모드에서 편집 가능합니다.
- Style
  - textarea 스타일을 적용해 줄바꿈/오버플로 처리를 최적화하고 콘텐츠 크기 자동 맞춤을 도입했습니다. 긴 제목 입력 시 자동 줄바꿈되고 스크롤 없이 자연스럽게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->