### PR TITLE
[feature] 동아리 지원서 페이지 방문, 체류시간 로깅한다

### DIFF
--- a/frontend/src/hooks/queries/application/useGetApplication.ts
+++ b/frontend/src/hooks/queries/application/useGetApplication.ts
@@ -6,5 +6,6 @@ export const useGetApplication = (clubId: string) => {
     queryKey: ['applicationForm', clubId],
     queryFn: () => getApplication(clubId),
     retry: false,
+    enabled: !!clubId,
   });
 };

--- a/frontend/src/hooks/useTrackPageView.ts
+++ b/frontend/src/hooks/useTrackPageView.ts
@@ -39,7 +39,7 @@ const useTrackPageView = (pageName: string, clubName?: string) => {
       window.removeEventListener('beforeunload', trackPageDuration);
       document.removeEventListener('visibilitychange', trackPageDuration);
     };
-  }, [location.pathname, clubName]);
+  }, [location.pathname]);
 };
 
 export default useTrackPageView;

--- a/frontend/src/pages/ApplicationFormPage/ApplicationFormPage.tsx
+++ b/frontend/src/pages/ApplicationFormPage/ApplicationFormPage.tsx
@@ -21,6 +21,16 @@ const ApplicationFormPage = () => {
   const questionRefs = useRef<Array<HTMLDivElement | null>>([]);
   const [invalidQuestionIds, setInvalidQuestionIds] = useState<number[]>([]);
 
+  const { data: clubDetail, error: clubError } = useGetClubDetail(clubId!);
+  const {
+    data: formData,
+    isLoading,
+    isError,
+    error: applicationError,
+  } = useGetApplication(clubId!);
+
+  useTrackPageView('ApplicationFormPage', clubDetail?.name);
+
   if (!clubId) return null;
 
   const STORAGE_KEY = `applicationAnswers_${clubId}`;
@@ -32,16 +42,6 @@ const ApplicationFormPage = () => {
     getAnswersById,
     answers,
   } = useAnswers(initialAnswers);
-
-  const { data: clubDetail, error: clubError } = useGetClubDetail(clubId);
-  const {
-    data: formData,
-    isLoading,
-    isError,
-    error: applicationError,
-  } = useGetApplication(clubId);
-
-  useTrackPageView('ApplicationFormPage', clubDetail?.name);
 
   useEffect(() => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(answers));

--- a/frontend/src/pages/ApplicationFormPage/ApplicationFormPage.tsx
+++ b/frontend/src/pages/ApplicationFormPage/ApplicationFormPage.tsx
@@ -3,6 +3,7 @@ import { PageContainer } from '@/styles/PageContainer.styles';
 import Header from '@/components/common/Header/Header';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useGetClubDetail } from '@/hooks/queries/club/useGetClubDetail';
+import useTrackPageView from '@/hooks/useTrackPageView';
 import { useAnswers } from '@/hooks/useAnswers';
 import QuestionAnswerer from '@/pages/ApplicationFormPage/components/QuestionAnswerer/QuestionAnswerer';
 import { useGetApplication } from '@/hooks/queries/application/useGetApplication';
@@ -39,6 +40,8 @@ const ApplicationFormPage = () => {
     isError,
     error: applicationError,
   } = useGetApplication(clubId);
+
+  useTrackPageView('ApplicationFormPage', clubDetail?.name);
 
   useEffect(() => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(answers));

--- a/frontend/src/pages/ApplicationFormPage/ApplicationFormPage.tsx
+++ b/frontend/src/pages/ApplicationFormPage/ApplicationFormPage.tsx
@@ -29,7 +29,10 @@ const ApplicationFormPage = () => {
     error: applicationError,
   } = useGetApplication(clubId!);
 
-  useTrackPageView('ApplicationFormPage', clubDetail?.name);
+  useTrackPageView(
+    'ApplicationFormPage',
+    clubDetail?.name ?? `club:${clubId ?? 'unknown'}`,
+  );
 
   if (!clubId) return null;
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #681 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지/동영상 첨부 가능)

- `useTrackPageView`에서 clubName을 의존성배열에서 제거 -> 중복 트래킹 방지
- 동아리 지원서 페이지 트래킹 추가
- 훅 호출 순서 변경 8a3113d2a830e3a7c82f337bb1b1b09961850fe9

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 신청서 페이지에 페이지뷰 분석 계측을 추가해 방문 및 체류 시간을 기록합니다.
* 개선
  * 페이지뷰 이벤트가 경로(pathname) 변경 시에만 재전송되도록 조정해 중복 계측을 줄였습니다.
  * 클럽 식별자(clubId)가 없을 때 관련 데이터 조회가 자동 실행되지 않도록 제어해 불필요한 요청을 방지합니다.
* 참고
  * 클럽명 변경만으로는 기존 페이지뷰 이벤트가 재전송되지 않습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->