### PR TITLE
[hotfix] 지원자 응답 순서 보장

### DIFF
--- a/backend/src/main/java/moadong/club/entity/ClubApplication.java
+++ b/backend/src/main/java/moadong/club/entity/ClubApplication.java
@@ -39,8 +39,16 @@ public class ClubApplication {
     @Builder.Default
     LocalDateTime createdAt = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime();
 
-    public void updateDetail(String memo, ApplicationStatus status) {
+    public void updateMemo(String memo) {
         this.memo = memo;
+    }
+
+    public void updateStatus(ApplicationStatus status) {
         this.status = status;
+    }
+
+    public void updateAnswers(List<ClubQuestionAnswer> answers) {
+        this.answers.clear();
+        this.answers.addAll(answers);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

지원자의 응답을 지원서의 순서에 맞게 정렬하여 응답해줍니다.
이를통해 프론트에서 이름을 가져오는 부분에 문제가 생기지않도록 보장합니다

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항