### PR TITLE
[fix] 질문 제목 반응형 레이아웃 변경

### DIFF
--- a/frontend/src/components/application/QuestionTitle/QuestionTitle.styles.ts
+++ b/frontend/src/components/application/QuestionTitle/QuestionTitle.styles.ts
@@ -30,11 +30,13 @@ export const QuestionTitleTextContainer = styled.div`
   gap: 4px;
   width: fit-content;
   max-width: calc(100% - 20px);
+  flex: 1;
 `;
 
 export const QuestionTitleText = styled.textarea`
   display: inline-block;
   min-width: 100px;
+  width: 100%;
   resize: none;
   border: none;
   outline: none;

--- a/frontend/src/components/application/QuestionTitle/QuestionTitle.tsx
+++ b/frontend/src/components/application/QuestionTitle/QuestionTitle.tsx
@@ -1,6 +1,7 @@
 import * as Styled from './QuestionTitle.styles';
 import { APPLICATION_FORM } from '@/constants/APPLICATION_FORM';
 import useIsMobile from '@/hooks/useIsMobile';
+import { useEffect, useLayoutEffect, useRef } from 'react';
 
 interface QuestionTitleProps {
   id: number;
@@ -18,6 +19,18 @@ const QuestionTitle = ({
   onTitleChange,
 }: QuestionTitleProps) => {
   const isMobile = useIsMobile();
+  const textAreaRef = useRef<HTMLTextAreaElement>(null);
+
+  useLayoutEffect(() => {
+    if (textAreaRef.current) {
+      const el = textAreaRef.current;
+      if (mode === 'answer') {
+        el.style.width = el.value.length + "ch";
+      }
+      el.style.height = '0px';
+      el.style.height = `${el.scrollHeight}px`;
+    }
+  }, [title]);
   
   return (
     <Styled.QuestionTitleRow>
@@ -26,6 +39,8 @@ const QuestionTitle = ({
       )}
       <Styled.QuestionTitleTextContainer>
         <Styled.QuestionTitleText
+          ref={textAreaRef}
+          rows={1}
           readOnly={mode === 'answer'}
           suppressContentEditableWarning={true}
           onChange={(e) => {


### PR DESCRIPTION
## #️⃣연관된 이슈

#687

## 📝작업 내용

```js
  useLayoutEffect(() => {
    if (textAreaRef.current) {
      const el = textAreaRef.current;
      if (mode === 'answer') {
        el.style.width = el.value.length + "ch";
      }
      el.style.height = '0px';
      el.style.height = `${el.scrollHeight}px`;
    }
  }, [title]);
```
지원서 입력모드에서 textarea의 너비를 ch로 텍스트 크기에 맞게 변경되도록 합니다.

QuestionTitleTextContainer은 flex:1;
QuestionTitleText는 width: 100%을 이용해 지원서 제작시에 너비가 부모에 맞게 설정되도록 변경하여 모든브라우저에서 표시되는 화면을 통일했습니다.

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 질문 제목 입력창이 내용에 맞춰 자동으로 크기(높이, 일부 모드에서 너비 포함)가 조절되어 가독성과 사용성이 향상되었습니다.
* 스타일
  * 제목 영역의 레이아웃을 개선하여 컨테이너가 공간을 적절히 채우고, 입력창이 가로폭을 안정적으로 활용하도록 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->