### PR TITLE
[fix] 모집기간 설정 시간 보정

### DIFF
--- a/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.tsx
@@ -35,13 +35,18 @@ const RecruitEditTab = () => {
     setDescription((prev) => prev || clubDetail.description || '');
   }, [clubDetail]);
 
+  const correctKoreanDate = (date: Date | null): string | undefined => {
+    if (!date) return undefined;
+    return new Date(date?.getTime() + 9 * 60 * 60 * 1000).toISOString();
+  }
+
   const handleUpdateClub = async () => {
     if (!clubDetail) return;
 
     const updatedData = {
       id: clubDetail.id,
-      recruitmentStart: recruitmentStart?.toISOString(),
-      recruitmentEnd: recruitmentEnd?.toISOString(),
+      recruitmentStart: correctKoreanDate(recruitmentStart),
+      recruitmentEnd: correctKoreanDate(recruitmentEnd),
       recruitmentTarget: recruitmentTarget,
       description: description,
       externalApplicationUrl: clubDetail.externalApplicationUrl ?? '',

--- a/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.tsx
@@ -29,15 +29,20 @@ const RecruitEditTab = () => {
 
     const now = new Date();
 
-    setRecruitmentStart((prev) => prev ?? initialStart ?? now);
-    setRecruitmentEnd((prev) => prev ?? initialEnd ?? now);
+    setRecruitmentStart((prev) => prev ?? correctResponseKoreanDate(initialStart) ?? now);
+    setRecruitmentEnd((prev) => prev ?? correctResponseKoreanDate(initialEnd) ?? now);
     setRecruitmentTarget((prev) => prev || clubDetail.recruitmentTarget || '');
     setDescription((prev) => prev || clubDetail.description || '');
   }, [clubDetail]);
 
-  const correctKoreanDate = (date: Date | null): string | undefined => {
-    if (!date) return undefined;
-    return new Date(date?.getTime() + 9 * 60 * 60 * 1000).toISOString();
+  const correctRequestKoreanDate = (date: Date | null): Date | null => {
+    if (!date) return null;
+    return new Date(date?.getTime() + 9 * 60 * 60 * 1000);
+  }
+
+  const correctResponseKoreanDate = (date: Date | null): Date | null => {
+    if (!date) return null;
+    return new Date(date?.getTime() - 9 * 60 * 60 * 1000);
   }
 
   const handleUpdateClub = async () => {
@@ -45,8 +50,8 @@ const RecruitEditTab = () => {
 
     const updatedData = {
       id: clubDetail.id,
-      recruitmentStart: correctKoreanDate(recruitmentStart),
-      recruitmentEnd: correctKoreanDate(recruitmentEnd),
+      recruitmentStart: correctRequestKoreanDate(recruitmentStart)?.toISOString(),
+      recruitmentEnd: correctRequestKoreanDate(recruitmentEnd)?.toISOString(),
       recruitmentTarget: recruitmentTarget,
       description: description,
       externalApplicationUrl: clubDetail.externalApplicationUrl ?? '',


### PR DESCRIPTION
## #️⃣연관된 이슈

#689

## 📝작업 내용

모집기간 변경 요청 -> be에서 저장시 -9시간이 되어 저장됨. -> 따라서 변경 요청시 +9 시간을 해어 보정해줌
모집기간 응답 요청 -> 보정된 +9시간을 다시 빼주어 정상적으로 표시되게 변경

# 임시조취
서버단에서 시간을 제대로 저장시키게 변경하는게아니라 임시로 조취한 방법입니다.
이대로 배포시 지금 (보정X)저장되어있는 시간을 불러올때 -9시간으로 표시되어 불편함 생길수도있음.

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항