### PR TITLE
[refactor] 지원서를 여러개 수정할 수 있다. -BE

### DIFF
--- a/backend/src/main/java/moadong/club/controller/ClubApplyController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubApplyController.java
@@ -69,7 +69,7 @@ public class ClubApplyController {
         return Response.ok(clubApplyService.getClubApplyInfo(clubId, user));
     }
 
-    @PutMapping("/apply/{appId}")
+    @PutMapping("/applicant")
     @Operation(summary = "지원자의 지원서 정보 변경",
             description = "클럽 지원자의 지원서 정보를 수정합니다.<br>"
                     + "appId - 지원서 아이디"

--- a/backend/src/main/java/moadong/club/controller/ClubApplyController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubApplyController.java
@@ -14,6 +14,8 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/club/{clubId}")
 @AllArgsConstructor
@@ -75,10 +77,9 @@ public class ClubApplyController {
     @PreAuthorize("isAuthenticated()")
     @SecurityRequirement(name = "BearerAuth")
     public ResponseEntity<?> editApplicantDetail(@PathVariable String clubId,
-                                                 @PathVariable String appId,
-                                                 @RequestBody @Validated ClubApplicantEditRequest request,
+                                                 @RequestBody @Validated List<ClubApplicantEditRequest> request,
                                                  @CurrentUser CustomUserDetails user) {
-        clubApplyService.editApplicantDetail(clubId, appId, request, user);
+        clubApplyService.editApplicantDetail(clubId, request, user);
         return Response.ok("success edit applicant");
     }
 

--- a/backend/src/main/java/moadong/club/controller/ClubApplyController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubApplyController.java
@@ -3,6 +3,8 @@ package moadong.club.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import moadong.club.payload.request.*;
 import moadong.club.service.ClubApplyService;
@@ -77,7 +79,7 @@ public class ClubApplyController {
     @PreAuthorize("isAuthenticated()")
     @SecurityRequirement(name = "BearerAuth")
     public ResponseEntity<?> editApplicantDetail(@PathVariable String clubId,
-                                                 @RequestBody @Validated List<ClubApplicantEditRequest> request,
+                                                 @RequestBody @Valid @NotEmpty List<ClubApplicantEditRequest> request,
                                                  @CurrentUser CustomUserDetails user) {
         clubApplyService.editApplicantDetail(clubId, request, user);
         return Response.ok("success edit applicant");

--- a/backend/src/main/java/moadong/club/controller/ClubApplyController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubApplyController.java
@@ -73,8 +73,8 @@ public class ClubApplyController {
 
     @PutMapping("/applicant")
     @Operation(summary = "지원자의 지원서 정보 변경",
-            description = "클럽 지원자의 지원서 정보를 수정합니다.<br>"
-                    + "appId - 지원서 아이디"
+            description = "여러 지원자의 지원서 정보를 일괄 수정합니다.<br>"
+                    + "요청 본문은 ClubApplicantEditRequest 객체의 배열이며, 각 원소는 applicantId, memo, status를 포함합니다."
     )
     @PreAuthorize("isAuthenticated()")
     @SecurityRequirement(name = "BearerAuth")

--- a/backend/src/main/java/moadong/club/payload/request/ClubApplicantEditRequest.java
+++ b/backend/src/main/java/moadong/club/payload/request/ClubApplicantEditRequest.java
@@ -1,10 +1,14 @@
 package moadong.club.payload.request;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import moadong.club.enums.ApplicationStatus;
 
 public record ClubApplicantEditRequest(
+        @NotBlank
+        String applicantId,
+
         @NotNull
         @Size(max = 500)
         String memo,

--- a/backend/src/main/java/moadong/club/service/ClubApplyService.java
+++ b/backend/src/main/java/moadong/club/service/ClubApplyService.java
@@ -159,9 +159,9 @@ public class ClubApplyService {
         }
 
         application.forEach(app -> {
-            ClubApplicantEditRequest _request = requestMap.get(app.getId());
-            app.updateMemo(_request.memo());
-            app.updateStatus(_request.status());
+            ClubApplicantEditRequest editRequest = requestMap.get(app.getId());
+            app.updateMemo(editRequest.memo());
+            app.updateStatus(editRequest.status());
         });
 
         clubApplicationRepository.saveAll(application);

--- a/backend/src/main/java/moadong/club/service/ClubApplyService.java
+++ b/backend/src/main/java/moadong/club/service/ClubApplyService.java
@@ -139,7 +139,7 @@ public class ClubApplyService {
     }
 
     @Transactional
-    public void editApplicantDetail(String clubId, String appId, ClubApplicantEditRequest request, CustomUserDetails user) {
+    public void editApplicantDetail(String clubId, List<ClubApplicantEditRequest> request, CustomUserDetails user) {
         Club club = clubRepository.findById(clubId)
                 .orElseThrow(() -> new RestApiException(ErrorCode.CLUB_NOT_FOUND));
 
@@ -147,13 +147,23 @@ public class ClubApplyService {
             throw new RestApiException(ErrorCode.USER_UNAUTHORIZED);
         }
 
-        ClubApplication application = clubApplicationRepository.findByIdAndQuestionId(appId, clubId)
-                .orElseThrow(() -> new RestApiException(ErrorCode.APPLICANT_NOT_FOUND));
+        Map<String, ClubApplicantEditRequest> requestMap = request.stream()
+                .collect(Collectors.toMap(ClubApplicantEditRequest::applicantId, Function.identity()));
 
-        application.updateMemo(request.memo());
-        application.updateStatus(request.status());
+        List<String> applicationIds = new ArrayList<>(requestMap.keySet());
+        List<ClubApplication> application = clubApplicationRepository.findAllByIdInAndQuestionId(applicationIds, clubId);
 
-        clubApplicationRepository.save(application);
+        if (application.size() != applicationIds.size()) {
+            throw new RestApiException(ErrorCode.APPLICANT_NOT_FOUND);
+        }
+
+        application.forEach(app -> {
+            ClubApplicantEditRequest _request = requestMap.get(app.getId());
+            app.updateMemo(_request.memo());
+            app.updateStatus(_request.status());
+        });
+
+        clubApplicationRepository.saveAll(application);
     }
 
     @Transactional

--- a/backend/src/main/java/moadong/club/service/ClubApplyService.java
+++ b/backend/src/main/java/moadong/club/service/ClubApplyService.java
@@ -148,7 +148,8 @@ public class ClubApplyService {
         }
 
         Map<String, ClubApplicantEditRequest> requestMap = request.stream()
-                .collect(Collectors.toMap(ClubApplicantEditRequest::applicantId, Function.identity()));
+                .collect(Collectors.toMap(ClubApplicantEditRequest::applicantId,
+                        Function.identity(), (prev, next) -> next));
 
         List<String> applicationIds = new ArrayList<>(requestMap.keySet());
         List<ClubApplication> application = clubApplicationRepository.findAllByIdInAndQuestionId(applicationIds, clubId);


### PR DESCRIPTION
## #️⃣연관된 이슈

#702 

## 📝작업 내용

- 요청 DTO를 리스트로 받게 변경. 664f8aad2a958f1b30b8978d093a5aa06c0e8033

``` java
Map<String, ClubApplicantEditRequest> requestMap = request.stream()
        .collect(Collectors.toMap(ClubApplicantEditRequest::applicantId, Function.identity()));

List<String> applicationIds = new ArrayList<>(requestMap.keySet());
List<ClubApplication> application = clubApplicationRepository.findAllByIdInAndQuestionId(applicationIds, clubId);

if (application.size() != applicationIds.size()) {
    throw new RestApiException(ErrorCode.APPLICANT_NOT_FOUND);
}

application.forEach(app -> {
    ClubApplicantEditRequest _request = requestMap.get(app.getId());
    app.updateMemo(_request.memo());
    app.updateStatus(_request.status());
});
```
list로 응답을 받고, 반복하여 수정하게 변경하였습니다

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 지원자 상세정보를 여러 명 대상으로 한 번에 수정하는 일괄 편집 기능을 추가했습니다(메모·상태).
  - 각 항목별 지원자 ID가 필수로 포함된 목록 형태의 페이로드를 지원합니다.

- **버그 수정**
  - 입력된 지원자 ID 목록과 실제 조회 대상 수가 일치하지 않을 경우 명확한 오류를 반환하도록 검증을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->