### PR TITLE
[feature] 여러명의 지원상태를 변경할 수 있다.

### DIFF
--- a/frontend/src/apis/application/updateApplicantDetail.ts
+++ b/frontend/src/apis/application/updateApplicantDetail.ts
@@ -1,25 +1,20 @@
 import API_BASE_URL from '@/constants/api';
 import { secureFetch } from '@/apis/auth/secureFetch';
-import { ApplicationStatus } from '@/types/applicants';
+import { UpdateApplicantParams } from '@/types/applicants';
 
 export const updateApplicantDetail = async (
-  memo: string,
-  status: ApplicationStatus,
+  applicant: UpdateApplicantParams[],
   clubId: string,
-  applicantId: string,
 ) => {
   try {
     const response = await secureFetch(
-      `${API_BASE_URL}/api/club/${clubId}/apply/${applicantId}`,
+      `${API_BASE_URL}/api/club/${clubId}/applicant`,
       {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({
-          memo,
-          status
-        })
+        body: JSON.stringify(applicant),
       },
     );
 

--- a/frontend/src/hooks/queries/applicants/useUpdateApplicant.ts
+++ b/frontend/src/hooks/queries/applicants/useUpdateApplicant.ts
@@ -1,18 +1,18 @@
-import { updateApplicantDetail } from "@/apis/application/updateApplicantDetail";
-import { ApplicationStatus } from "@/types/applicants";
-import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { updateApplicantDetail } from '@/apis/application/updateApplicantDetail';
+import { UpdateApplicantParams } from '@/types/applicants';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-export const useUpdateApplicant = (clubId: string, applicantId: string) => {
+export const useUpdateApplicant = (clubId: string) => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({memo, status}: { memo: string, status: ApplicationStatus }) => 
-      updateApplicantDetail(memo, status, clubId, applicantId),
+    mutationFn: (applicant: UpdateApplicantParams[]) =>
+      updateApplicantDetail(applicant, clubId!),
     onSuccess: () => {
-        queryClient.invalidateQueries({ queryKey: ["clubApplicants"] });
+      queryClient.invalidateQueries({ queryKey: ['clubApplicants'] });
     },
     onError: (error) => {
       console.log(`Error updating applicant detail: ${error}`);
-    }
-  })
-}
+    },
+  });
+};

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPage.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPage.tsx
@@ -38,11 +38,13 @@ const ApplicantDetailPage = () => {
   const { questionId } = useParams<{ questionId: string }>();
   const navigate = useNavigate();
   const [applicantMemo, setAppMemo] = useState('');
-  const [applicantStatus, setApplicantStatus] = useState<ApplicationStatus>(ApplicationStatus.SUBMITTED);
+  const [applicantStatus, setApplicantStatus] = useState<ApplicationStatus>(
+    ApplicationStatus.SUBMITTED,
+  );
   const { applicantsData, clubId } = useAdminClubContext();
 
   const { data: formData, isLoading, isError } = useGetApplication(clubId!);
-  const { mutate: updateApplicant } = useUpdateApplicant(clubId!, questionId!);
+  const { mutate: updateApplicant } = useUpdateApplicant(clubId!);
 
   const applicantIndex =
     applicantsData?.applicants.findIndex((a) => a.id === questionId) ?? -1;
@@ -58,20 +60,23 @@ const ApplicantDetailPage = () => {
   const updateApplicantDetail = useMemo(
     () =>
       debounce((memo, status) => {
-
         function isApplicationStatus(v: unknown): v is ApplicationStatus {
-          return typeof v === 'string' && Object.values(ApplicationStatus).includes(v as ApplicationStatus);
+          return (
+            typeof v === 'string' &&
+            Object.values(ApplicationStatus).includes(v as ApplicationStatus)
+          );
         }
 
         if (typeof memo !== 'string') return;
         if (!isApplicationStatus(status)) return;
 
-        updateApplicant(
+        updateApplicant([
           {
-            memo, 
-            status
-          }
-        );
+            memo,
+            status,
+            applicantId: questionId,
+          },
+        ]);
       }, 400),
     [clubId, questionId],
   );

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsTab.styles.ts
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsTab.styles.ts
@@ -103,21 +103,52 @@ export const VerticalLine = styled.div`
   margin: 8px 4px;
 `;
 
-export const StatusSelect = styled.select`
+export const StatusSelect = styled.p<{ disabled: boolean }>`
   height: 30px;
   border: 1px solid #dcdcdc;
   background: #fff;
   border-radius: 55px;
-  padding: 0px 22px 0px 8px;
-  margin: 5px 0px 5px 0px;
-  font-weight: 700;
-  color: ${({ disabled }) => (disabled ? '#DCDCDC' : '#000')};
+  padding: 0 22px 0 8px;
+  margin: 5px 0;
 
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
+  ${({ disabled }) =>
+    disabled
+      ? 'color: #DCDCDC'
+      : 'color: #000; &:hover { background: #f5f5f5; }'};
 
-  &:not(:disabled):hover {
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: default;
+
+  display: inline-flex;
+  align-items: center;
+`;
+
+export const StatusSelectMenu = styled.div<{ open: boolean }>`
+  display: ${({ open }) => (open ? 'block' : 'none')};
+  position: absolute;
+  top: 100%;
+  height: auto;
+  background: #fff;
+  left: 0;
+  border: 1px solid #dcdcdc;
+  border-radius: 6px;
+  box-shadow: 0px 1px 8px 0px #0000001f;
+  z-index: 10;
+  padding: 8px 0;
+  color: #787878;
+`;
+
+export const StatusSelectMenuItem = styled.div`
+  font-size: 12px;
+  font-weight: 600;
+  padding: 8px 13px;
+  cursor: pointer;
+  text-align: left;
+  &:hover {
     background: #f5f5f5;
   }
 `;

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsTab.tsx
@@ -80,7 +80,7 @@ const ApplicantsTab = () => {
     setCheckedItem((prev) => {
       const newMap = new Map(prev);
 
-      const isAllChecked = Array.from(checkedItem.values()).every(Boolean);
+      const isAllChecked = Array.from(prev.values()).every(Boolean);
 
       if (mode === 'all') {
         newMap.forEach((_, key) => newMap.set(key, !isAllChecked));

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsTab.tsx
@@ -1,6 +1,6 @@
 import { useAdminClubContext } from '@/context/AdminClubContext';
 import { Applicant, ApplicationStatus } from '@/types/applicants';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import * as Styled from './ApplicantsTab.styles';
 import { useNavigate } from 'react-router-dom';
 import { useDeleteApplicants } from '@/hooks/queries/applicants/useDeleteApplicants';
@@ -9,6 +9,7 @@ import mapStatusToGroup from '@/utils/mapStatusToGroup';
 import selectIcon from '@/assets/images/icons/selectArrow.svg';
 import deleteIcon from '@/assets/images/icons/applicant_delete.svg';
 import selectAllIcon from '@/assets/images/icons/applicant_select_arrow.svg';
+import { useUpdateApplicant } from '@/hooks/queries/applicants/useUpdateApplicant';
 
 const ApplicantsTab = () => {
   const navigate = useNavigate();
@@ -19,7 +20,12 @@ const ApplicantsTab = () => {
   );
   const [selectAll, setSelectAll] = useState(false);
   const [open, setOpen] = useState(false);
+  const [statusOpen, setStatusOpen] = useState(false);
+  const [isChecked, setIsChecked] = useState(false);
   const { mutate: deleteApplicants } = useDeleteApplicants(clubId!);
+  const { mutate: updateDetailApplicants } = useUpdateApplicant(clubId!);
+  const allSelectRef = useRef<HTMLDivElement | null>(null);
+  const statusSelectRef = useRef<HTMLDivElement | null>(null);
 
   const filteredApplicants = useMemo(() => {
     if (!applicantsData?.applicants) return [];
@@ -34,6 +40,32 @@ const ApplicantsTab = () => {
   }, [applicantsData, keyword]);
 
   useEffect(() => {
+    const handleOutsideClick = (e: MouseEvent) => {
+      const target = e.target as Node;
+
+      if (
+        open &&
+        allSelectRef.current &&
+        !allSelectRef.current.contains(target)
+      ) {
+        setOpen(false);
+      }
+      if (
+        statusOpen &&
+        statusSelectRef.current &&
+        !statusSelectRef.current.contains(target)
+      ) {
+        setStatusOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleOutsideClick);
+    return () => {
+      document.removeEventListener('mousedown', handleOutsideClick);
+    };
+  }, [open, statusOpen]);
+
+  useEffect(() => {
     const newMap = new Map<string, boolean>();
     filteredApplicants.forEach((user: Applicant) => {
       newMap.set(user.id, false);
@@ -45,6 +77,7 @@ const ApplicantsTab = () => {
     const all =
       checkedItem.size > 0 && Array.from(checkedItem.values()).every(Boolean);
     setSelectAll(all);
+    setIsChecked(Array.from(checkedItem.values()).some(Boolean));
   }, [checkedItem]);
 
   if (!clubId) return null;
@@ -112,6 +145,29 @@ const ApplicantsTab = () => {
     });
   };
 
+  const updateAllApplicants = (status: ApplicationStatus) => {
+    updateDetailApplicants(
+      applicantsData!.applicants
+        .filter((applicant) => checkedItem.get(applicant.id))
+        .map(
+          (applicant) => ({
+            applicantId: applicant.id,
+            memo: applicant.memo,
+            status: status,
+          }),
+          {
+            onSuccess: () => {
+              checkoutAllApplicants();
+              setStatusOpen(false);
+            },
+            onError: () => {
+              alert('지원자 상태 변경에 실패했습니다. 다시 시도해주세요.');
+            },
+          },
+        ),
+    );
+  };
+
   return (
     <>
       <Styled.ApplicationHeader>
@@ -171,18 +227,52 @@ const ApplicantsTab = () => {
               <Styled.Arrow src={selectIcon} />
             </Styled.SelectWrapper>
             <Styled.VerticalLine />
-            <Styled.SelectWrapper>
-              <Styled.StatusSelect
-                disabled={!Array.from(checkedItem.values()).some(Boolean)}
-              >
-                <option value='상태변경'>상태변경</option>
+            <Styled.SelectWrapper
+              ref={statusSelectRef}
+              onClick={() => {
+                if (!isChecked) return;
+                setStatusOpen((prev) => !prev);
+              }}
+            >
+              <Styled.StatusSelect disabled={!isChecked}>
+                상태변경
               </Styled.StatusSelect>
               <Styled.Arrow width={8} height={8} src={selectIcon} />
+              <Styled.StatusSelectMenu open={statusOpen}>
+                <Styled.StatusSelectMenuItem
+                  onClick={() => {
+                    updateAllApplicants(ApplicationStatus.SUBMITTED);
+                  }}
+                >
+                  서류검토
+                </Styled.StatusSelectMenuItem>
+                <Styled.StatusSelectMenuItem
+                  onClick={() => {
+                    updateAllApplicants(ApplicationStatus.INTERVIEW_SCHEDULED);
+                  }}
+                >
+                  면접예정
+                </Styled.StatusSelectMenuItem>
+                <Styled.StatusSelectMenuItem
+                  onClick={() => {
+                    updateAllApplicants(ApplicationStatus.ACCEPTED);
+                  }}
+                >
+                  합격
+                </Styled.StatusSelectMenuItem>
+                <Styled.StatusSelectMenuItem
+                  onClick={() => {
+                    updateAllApplicants(ApplicationStatus.DECLINED);
+                  }}
+                >
+                  불합격
+                </Styled.StatusSelectMenuItem>
+              </Styled.StatusSelectMenu>
             </Styled.SelectWrapper>
             <Styled.DeleteButton
               src={deleteIcon}
               alt='삭제'
-              disabled={!Array.from(checkedItem.values()).some(Boolean)}
+              disabled={!isChecked}
               onClick={() => {
                 const toBeDeleted = Array.from(checkedItem.entries())
                   .filter(([_, isChecked]) => isChecked)
@@ -205,7 +295,7 @@ const ApplicantsTab = () => {
           <Styled.ApplicantTableHeaderWrapper>
             <Styled.ApplicantTableRow>
               <Styled.ApplicantTableHeader width={55}>
-                <Styled.ApplicantAllSelectWrapper>
+                <Styled.ApplicantAllSelectWrapper ref={allSelectRef}>
                   <Styled.ApplicantTableAllSelectCheckbox
                     checked={selectAll}
                     onClick={(e: React.MouseEvent<HTMLInputElement>) => {

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsTab.tsx
@@ -149,22 +149,20 @@ const ApplicantsTab = () => {
     updateDetailApplicants(
       applicantsData!.applicants
         .filter((applicant) => checkedItem.get(applicant.id))
-        .map(
-          (applicant) => ({
-            applicantId: applicant.id,
-            memo: applicant.memo,
-            status: status,
-          }),
-          {
-            onSuccess: () => {
-              checkoutAllApplicants();
-              setStatusOpen(false);
-            },
-            onError: () => {
-              alert('지원자 상태 변경에 실패했습니다. 다시 시도해주세요.');
-            },
-          },
-        ),
+        .map((applicant) => ({
+          applicantId: applicant.id,
+          memo: applicant.memo,
+          status: status,
+        })),
+      {
+        onSuccess: () => {
+          checkoutAllApplicants();
+          setStatusOpen(false);
+        },
+        onError: () => {
+          alert('지원자 상태 변경에 실패했습니다. 다시 시도해주세요.');
+        },
+      },
     );
   };
 

--- a/frontend/src/types/applicants.ts
+++ b/frontend/src/types/applicants.ts
@@ -1,4 +1,4 @@
-import { AnswerItem } from "./application";
+import { AnswerItem } from './application';
 
 export enum ApplicationStatus {
   SUBMITTED = 'SUBMITTED', // 제출 완료
@@ -11,14 +11,20 @@ export interface ApplicantsInfo {
   total: number;
   reviewRequired: number;
   scheduledInterview: number;
-  accepted: number;    
-  applicants: Applicant[]
+  accepted: number;
+  applicants: Applicant[];
 }
 
 export interface Applicant {
   id: string;
   status: ApplicationStatus;
-  answers: AnswerItem[]
+  answers: AnswerItem[];
   memo: string;
   createdAt: string;
+}
+
+export interface UpdateApplicantParams {
+  memo: string;
+  status: ApplicationStatus;
+  applicantId: string | undefined;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#701

## 📝작업 내용
- 이전값 기준으로 변경하지않아 최신성을 보장하지 못하는 오류를 수정하였습니다. c625679fa1bb17dba83728e1e2f04d812267bf30
- 이번에 변경된 api 명세를 따라 변경하였습니다 d3815ea9e0db1a09ecbe961dd44d7b9a8d4733f7
- - #702 
- css 디자인을 가이드에 따라 적용하였습니다. 55bd9552f6f1d08843d0353d7cf8e53171ffab07
- 메뉴 클릭시 정보 변경 API를 호출하게 연결하였습니다. 4fdd93c738adf74a2c6772bd054a49c2cf7ead1d

### 코드 변경점
```js
export interface UpdateApplicantParams {
  memo: string;
  status: ApplicationStatus;
  applicantId: string | undefined;
}
```
applicantId를 파라미터로 넘겨받게 하였습니다.
```js
const { mutate: updateApplicant } = useUpdateApplicant(clubId!, questionId!);
```
이전코드는 ```useUpdateApplicant``` 훅을 초기화할때 현재 context의 applicantId 기준으로 초기화가 되어 
```updateApplicant```의 함수가 호출될때 debounce 적용 시간(400ms) 이전에 페이지를 옮기게되면
훅이 바뀐 applicantId 기준으로 초기화 되어 이전 지원자를 변경하지 못하는 버그가 존재하였습니다.
따라서 applicantId를 함수 인자로 옮김에 따라 다른 페이지 변경시에도 이전 사용자를 호출하게 변경하였습니다
___
```js
  useEffect(() => {
    const handleOutsideClick = (e: MouseEvent) => {
      const target = e.target as Node;

      if (
        open &&
        allSelectRef.current &&
        !allSelectRef.current.contains(target)
      ) {
        setOpen(false);
      }
      if (
        statusOpen &&
        statusSelectRef.current &&
        !statusSelectRef.current.contains(target)
      ) {
        setStatusOpen(false);
      }
    };

    document.addEventListener('mousedown', handleOutsideClick);
    return () => {
      document.removeEventListener('mousedown', handleOutsideClick);
    };
  }, [open, statusOpen]);
```
useRef로 드롭메뉴를 펼친후 다른 부분을 클릭했을때 꺼지게 변경하였습니다.
___
```js
  const [isChecked, setIsChecked] = useState(false);

  useEffect(() => {
    ...
    setIsChecked(Array.from(checkedItem.values()).some(Boolean));
  }, [checkedItem]);
```
기존 disabled에 사용한 조건을 상태로 옮겼습니다.
disabled를 이용하는 컴포넌트가 3개로 많아짐에 따라 한개의 상태로 반복하는 코드를 줄였습니다.
___
```js
  const updateAllApplicants = (status: ApplicationStatus) => {
    updateDetailApplicants(
      applicantsData!.applicants
        .filter((applicant) => checkedItem.get(applicant.id))
        .map(
          (applicant) => ({
            applicantId: applicant.id,
            memo: applicant.memo,
            status: status,
          })
        ),
    );
  };
```
현재 체크된 applicantId를 기준으로 필터 후 map을 이용해 ```UpdateApplicantParams``` 형식에 맞게 변환후 배열로 응답해줬습니다.
___
## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
API를 호출하고 응답받는 딜레이가 존재하는데, Spinner를 추가해서 응답중임을 나타내는것이 좋을까요?

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 지원자 상태 일괄 변경: 여러 지원자를 선택해 서류검토/면접예정/합격/불합격을 한 번에 업데이트할 수 있습니다.
  - 배치 업데이트 방식 도입으로 여러 지원자에 대한 동시 수정이 가능해졌습니다.
- **Style**
  - 상태 선택 UI를 커스텀 드롭다운으로 개선하고, 외부 클릭 시 자동으로 닫히도록 처리했습니다.
  - 항목 선택 시에만 상태 변경 메뉴와 삭제 버튼이 활성화되며, 전체선택/개별선택 흐름을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->