### PR TITLE
[feature] 사이드바 내용을 계층 구조로 변경한다

### DIFF
--- a/frontend/src/pages/AdminPage/components/SideBar/SideBar.styles.ts
+++ b/frontend/src/pages/AdminPage/components/SideBar/SideBar.styles.ts
@@ -15,7 +15,7 @@ export const SidebarHeader = styled.p`
   font-weight: bold;
   letter-spacing: 0;
   margin-left: 11px;
-  margin-bottom: 24px;
+  margin-bottom: 19px;
 `;
 
 export const ClubLogo = styled.img`
@@ -36,15 +36,25 @@ export const ClubTitle = styled.p`
 
 export const divider = styled.hr`
   width: 100%;
-  color: black;
-  margin: 14px 0px 29px 0px;
+  border: 1px solid;
+  color: #C5C5C5;
+  height: 0;
+  margin: 16px 0px 16px 0px;
 `;
 
 export const SidebarButtonContainer = styled.ul`
   display: flex;
   flex-direction: column;
-  gap: 8.5px;
+  gap: 16px;
   list-style: none;
+`;
+
+export const SidebarCategoryTitle = styled.p`
+  align-items: center;
+  padding: 6px 0px 6px 10px;
+  font-size: 0.75rem;
+  font-weight: medium;
+  color: #989898;
 `;
 
 export const SidebarButton = styled.li`
@@ -54,12 +64,14 @@ export const SidebarButton = styled.li`
   border-radius: 10px;
   display: flex;
   align-items: center;
-  padding: 9px 11px;
+  padding-left: 10px;
   transition: background-color 0.1s ease;
+  font-size: 1rem;
+  font-weight: medium;
 
   &.active {
-    background-color: rgba(255, 84, 20, 0.8);
+    background-color: rgba(255, 117, 67, 1);
     color: white;
-    font-weight: bold;
+    font-weight: medium;
   }
 `;

--- a/frontend/src/pages/AdminPage/components/SideBar/SideBar.styles.ts
+++ b/frontend/src/pages/AdminPage/components/SideBar/SideBar.styles.ts
@@ -34,7 +34,7 @@ export const ClubTitle = styled.p`
   max-width: 163px;
 `;
 
-export const divider = styled.hr`
+export const Divider = styled.hr`
   width: 100%;
   border: 1px solid;
   color: #C5C5C5;
@@ -57,17 +57,23 @@ export const SidebarCategoryTitle = styled.p`
   color: #989898;
 `;
 
-export const SidebarButton = styled.li`
+export const SidebarButton = styled.button`
+  all: unset;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
   cursor: pointer;
+
   width: 100%;
   height: 37px;
   border-radius: 10px;
-  display: flex;
-  align-items: center;
+
   padding-left: 10px;
-  transition: background-color 0.1s ease;
+
   font-size: 1rem;
   font-weight: medium;
+
+  transition: background-color 0.1s ease;
 
   &.active {
     background-color: rgba(255, 117, 67, 1);
@@ -75,3 +81,4 @@ export const SidebarButton = styled.li`
     font-weight: medium;
   }
 `;
+

--- a/frontend/src/pages/AdminPage/components/SideBar/SideBar.tsx
+++ b/frontend/src/pages/AdminPage/components/SideBar/SideBar.tsx
@@ -27,14 +27,12 @@ const tabs = [
     items: [
       { label: '지원서 관리', path: '/admin/application-edit' },
       { label: '지원자 현황', path: '/admin/applicants' },
-      { label: '휴지통', path: '/admin/recycle-bean'},
     ],
   },
     {
     category: '계정 관리',
     items: [
-      // { label: '계정 관리', path: '/admin/account-edit' },
-      { label: '아이디/비밀번호 수정', path: '/admin/account-update'},
+      { label: '아이디/비밀번호 수정', path: '/admin/account-edit'},
       { label: '회원탈퇴', path: '/admin/user-delete'},
     ],
   },
@@ -51,10 +49,6 @@ const SideBar = ({ clubLogo, clubName }: SideBarProps) => {
   }, [location.pathname]);
 
   const handleTabClick = (item: (typeof tabs)[number]['items'][number]) => {
-    if (item.label === '휴지통') {
-      alert('휴지통 기능은 아직 준비 중이에요. ☺️');
-      return;
-    }
     if (item.label === '아이디/비밀번호 수정') {
       alert('아이디/비밀번호 수정 기능은 아직 준비 중이에요. ☺️');
       return;

--- a/frontend/src/pages/AdminPage/components/SideBar/SideBar.tsx
+++ b/frontend/src/pages/AdminPage/components/SideBar/SideBar.tsx
@@ -44,6 +44,10 @@ const SideBar = ({ clubLogo, clubName }: SideBarProps) => {
   const location = useLocation();
   const navigate = useNavigate();
 
+  const allItems = useMemo(() => {
+    return tabs.flatMap((tab) => tab.items);
+  }, []);
+
   const activeTab = useMemo(
     () => tabs.findIndex((tab) => location.pathname.startsWith(tab.path)),
     [location.pathname],

--- a/frontend/src/pages/AdminPage/components/SideBar/SideBar.tsx
+++ b/frontend/src/pages/AdminPage/components/SideBar/SideBar.tsx
@@ -16,7 +16,10 @@ const tabs = [
   { label: '활동 사진 수정', path: '/admin/photo-edit' },
   { label: '지원서 관리', path: '/admin/application-edit' },
   { label: '지원자 현황', path: '/admin/applicants' },
-  { label: '계정 관리', path: '/admin/account-edit' },
+  { label: '휴지통', path: '/admin/recycle-bean'},
+  // { label: '계정 관리', path: '/admin/account-edit' },
+  { label: '아이디/비밀번호 수정', path: '/admin/account-update'},
+  { label: '회원탈퇴', path: '/admin/user-delete'},
 ];
 
 const SideBar = ({ clubLogo, clubName }: SideBarProps) => {

--- a/frontend/src/pages/AdminPage/components/SideBar/SideBar.tsx
+++ b/frontend/src/pages/AdminPage/components/SideBar/SideBar.tsx
@@ -49,16 +49,24 @@ const SideBar = ({ clubLogo, clubName }: SideBarProps) => {
   }, []);
 
   const activeTab = useMemo(
-    () => tabs.findIndex((tab) => location.pathname.startsWith(tab.path)),
+    () => allItems.findIndex((item) => location.pathname.startsWith(item.path)),
     [location.pathname],
   );
 
-  const handleTabClick = (tab: (typeof tabs)[number]) => {
-    if (tab.label === '계정 관리') {
-      alert('계정 관리 기능은 아직 준비 중이에요. ☺️');
+  const handleTabClick = (item: (typeof allItems)[number]) => {
+    if (item.label === '휴지통') {
+      alert('휴지통 기능은 아직 준비 중이에요. ☺️');
       return;
     }
-    navigate(tab.path);
+    if (item.label === '아이디/비밀번호 수정') {
+      alert('아이디/비밀번호 수정 기능은 아직 준비 중이에요. ☺️');
+      return;
+    }
+    if (item.label === '회원탈퇴') {
+      alert('회원탈퇴 기능은 아직 준비 중이에요. ☺️');
+      return;
+    }
+    navigate(item.path);
   };
 
   const handleLogout = async () => {
@@ -90,14 +98,19 @@ const SideBar = ({ clubLogo, clubName }: SideBarProps) => {
       <Styled.divider />
 
       <Styled.SidebarButtonContainer>
-        {tabs.map((tab, index) => (
-          <Styled.SidebarButton
-            key={tab.label}
-            className={activeTab === index ? 'active' : ''}
-            onClick={() => handleTabClick(tab)}
-          >
-            {tab.label}
-          </Styled.SidebarButton>
+        {tabs.map((tab, tabIndex) => (
+          <div key={tab.category}>
+            <Styled.SidebarCategoryTitle>{tab.category}</Styled.SidebarCategoryTitle>
+            {tab.items.map((item, itemIndex) => (
+              <Styled.SidebarButton
+                key={item.label}
+                className={activeTab === itemIndex ? 'active' : ''}
+                onClick={() => handleTabClick(item)}
+              >
+                {item.label}
+              </Styled.SidebarButton>
+            ))}
+          </div>
         ))}
       </Styled.SidebarButtonContainer>
       <Styled.divider />

--- a/frontend/src/pages/AdminPage/components/SideBar/SideBar.tsx
+++ b/frontend/src/pages/AdminPage/components/SideBar/SideBar.tsx
@@ -44,16 +44,13 @@ const SideBar = ({ clubLogo, clubName }: SideBarProps) => {
   const location = useLocation();
   const navigate = useNavigate();
 
-  const allItems = useMemo(() => {
-    return tabs.flatMap((tab) => tab.items);
-  }, []);
+  const activeTab = useMemo(() => { 
+    return tabs.map((tab) =>
+      tab.items.findIndex((item) => location.pathname.startsWith(item.path)),
+    );
+  }, [location.pathname]);
 
-  const activeTab = useMemo(
-    () => allItems.findIndex((item) => location.pathname.startsWith(item.path)),
-    [location.pathname],
-  );
-
-  const handleTabClick = (item: (typeof allItems)[number]) => {
+  const handleTabClick = (item: (typeof tabs)[number]['items'][number]) => {
     if (item.label === '휴지통') {
       alert('휴지통 기능은 아직 준비 중이에요. ☺️');
       return;
@@ -104,7 +101,7 @@ const SideBar = ({ clubLogo, clubName }: SideBarProps) => {
             {tab.items.map((item, itemIndex) => (
               <Styled.SidebarButton
                 key={item.label}
-                className={activeTab === itemIndex ? 'active' : ''}
+                className={activeTab[tabIndex] === itemIndex ? 'active' : ''}
                 onClick={() => handleTabClick(item)}
               >
                 {item.label}

--- a/frontend/src/pages/AdminPage/components/SideBar/SideBar.tsx
+++ b/frontend/src/pages/AdminPage/components/SideBar/SideBar.tsx
@@ -10,7 +10,17 @@ interface SideBarProps {
   clubLogo: string;
 }
 
-const tabs = [
+interface TabItem {
+  label: string;
+  path: string;
+}
+
+interface TabCategory {
+  category: string;
+  items: TabItem[];
+}
+
+const tabs: TabCategory[] = [
   {
     category: '기본 정보',
     items: [{ label: '기본 정보 수정', path: '/admin/club-info' }],
@@ -48,7 +58,7 @@ const SideBar = ({ clubLogo, clubName }: SideBarProps) => {
     );
   }, [location.pathname]);
 
-  const handleTabClick = (item: (typeof tabs)[number]['items'][number]) => {
+  const handleTabClick = (item: TabItem) => {
     if (item.label === '아이디/비밀번호 수정') {
       alert('아이디/비밀번호 수정 기능은 아직 준비 중이에요. ☺️');
       return;
@@ -86,11 +96,11 @@ const SideBar = ({ clubLogo, clubName }: SideBarProps) => {
       <ClubLogoEditor clubLogo={clubLogo} />
 
       <Styled.ClubTitle>{clubName}</Styled.ClubTitle>
-      <Styled.divider />
+      <Styled.Divider />
 
       <Styled.SidebarButtonContainer>
         {tabs.map((tab, tabIndex) => (
-          <div key={tab.category}>
+          <li key={tab.category}>
             <Styled.SidebarCategoryTitle>{tab.category}</Styled.SidebarCategoryTitle>
             {tab.items.map((item, itemIndex) => (
               <Styled.SidebarButton
@@ -101,10 +111,10 @@ const SideBar = ({ clubLogo, clubName }: SideBarProps) => {
                 {item.label}
               </Styled.SidebarButton>
             ))}
-          </div>
+          </li>
         ))}
       </Styled.SidebarButtonContainer>
-      <Styled.divider />
+      <Styled.Divider />
       <Styled.SidebarButton onClick={handleLogout}>
         로그아웃
       </Styled.SidebarButton>

--- a/frontend/src/pages/AdminPage/components/SideBar/SideBar.tsx
+++ b/frontend/src/pages/AdminPage/components/SideBar/SideBar.tsx
@@ -11,15 +11,33 @@ interface SideBarProps {
 }
 
 const tabs = [
-  { label: '기본 정보 수정', path: '/admin/club-info' },
-  { label: '모집 정보 수정', path: '/admin/recruit-edit' },
-  { label: '활동 사진 수정', path: '/admin/photo-edit' },
-  { label: '지원서 관리', path: '/admin/application-edit' },
-  { label: '지원자 현황', path: '/admin/applicants' },
-  { label: '휴지통', path: '/admin/recycle-bean'},
-  // { label: '계정 관리', path: '/admin/account-edit' },
-  { label: '아이디/비밀번호 수정', path: '/admin/account-update'},
-  { label: '회원탈퇴', path: '/admin/user-delete'},
+  {
+    category: '기본 정보',
+    items: [{ label: '기본 정보 수정', path: '/admin/club-info' }],
+  },
+  {
+    category: '모집 정보',
+    items: [
+      { label: '모집 정보 수정', path: '/admin/recruit-edit' },
+      { label: '활동 사진 수정', path: '/admin/photo-edit' },
+    ],
+  },
+    {
+    category: '지원 관리',
+    items: [
+      { label: '지원서 관리', path: '/admin/application-edit' },
+      { label: '지원자 현황', path: '/admin/applicants' },
+      { label: '휴지통', path: '/admin/recycle-bean'},
+    ],
+  },
+    {
+    category: '계정 관리',
+    items: [
+      // { label: '계정 관리', path: '/admin/account-edit' },
+      { label: '아이디/비밀번호 수정', path: '/admin/account-update'},
+      { label: '회원탈퇴', path: '/admin/user-delete'},
+    ],
+  },
 ];
 
 const SideBar = ({ clubLogo, clubName }: SideBarProps) => {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #205 

## 📝작업 내용

> 사이드바 버튼 추가, 구조 변경, 색상 변경
<img width="267" height="1149" alt="image" src="https://github.com/user-attachments/assets/6f5e2ec7-cc81-43ea-83cf-25b9826609a8" />


## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 사이드바를 카테고리별로 그룹화하고 카테고리 제목을 표시합니다.
  - 항목별 활성 상태가 카테고리 단위로 적용됩니다.
  - 일부 항목(아이디/비밀번호 수정, 회원탈퇴)은 준비 중 알림을 표시하고, 다른 항목은 해당 경로로 이동합니다.
  - 로그아웃 시 확인, 토큰 정리 및 로그인 페이지로 이동하는 완전한 로그아웃 흐름을 추가했습니다.

- Style
  - 헤더·구분선·버튼 간격과 여백을 조정했습니다.
  - 구분선 색상·두께 및 버튼 글자 크기·패딩·활성 배경색을 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->