### PR TITLE
[feature] 액세스 토큰 및 리프레시 토큰의 만료 시간을 수정하고, 로그인, 관리자 계정 관련의 동시성 문제를 해결한다

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
-
+    testImplementation 'io.github.artsok:rerunner-jupiter:2.1.6'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testCompileOnly 'org.projectlombok:lombok'

--- a/backend/src/main/java/moadong/club/entity/Club.java
+++ b/backend/src/main/java/moadong/club/entity/Club.java
@@ -10,7 +10,7 @@ import moadong.club.payload.request.ClubRecruitmentInfoUpdateRequest;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.annotation.Transient;
+import org.springframework.data.annotation.Version;
 import org.springframework.data.domain.Persistable;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
@@ -41,7 +41,7 @@ public class Club implements Persistable<String> {
     @Field("recruitmentInformation")
     private ClubRecruitmentInformation clubRecruitmentInformation;
 
-    @org.springframework.data.annotation.Version
+    @Version
     private Long version;
 
     public Club() {
@@ -122,6 +122,6 @@ public class Club implements Persistable<String> {
 
     @Override
     public boolean isNew() {
-        return id == null;
+        return this.version == null;
     }
 }

--- a/backend/src/main/java/moadong/club/entity/Club.java
+++ b/backend/src/main/java/moadong/club/entity/Club.java
@@ -1,10 +1,5 @@
 package moadong.club.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.Id;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,6 +9,9 @@ import moadong.club.payload.request.ClubInfoRequest;
 import moadong.club.payload.request.ClubRecruitmentInfoUpdateRequest;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Transient;
+import org.springframework.data.domain.Persistable;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
@@ -23,25 +21,17 @@ import java.util.Map;
 @Document("clubs")
 @AllArgsConstructor
 @Getter
-public class Club {
+public class Club implements Persistable<String> {
 
     @Id
     private String id;
 
-    @NotNull
-    @Column(length = 20)
     private String name;
 
-    @NotNull
-    @Column(length = 20)
     private String category;
 
-    @NotNull
-    @Column(length = 20)
     private String division;
 
-    @Enumerated(EnumType.STRING)
-    @NotNull
     private ClubState state;
 
     private String userId;
@@ -50,6 +40,9 @@ public class Club {
 
     @Field("recruitmentInformation")
     private ClubRecruitmentInformation clubRecruitmentInformation;
+
+    @org.springframework.data.annotation.Version
+    private Long version;
 
     public Club() {
         this.name = "";
@@ -125,5 +118,10 @@ public class Club {
 
     public void updateRecruitmentStatus(ClubRecruitmentStatus clubRecruitmentStatus) {
         this.clubRecruitmentInformation.updateRecruitmentStatus(clubRecruitmentStatus);
+    }
+
+    @Override
+    public boolean isNew() {
+        return id == null;
     }
 }

--- a/backend/src/main/java/moadong/club/entity/ClubQuestion.java
+++ b/backend/src/main/java/moadong/club/entity/ClubQuestion.java
@@ -67,6 +67,6 @@ public class ClubQuestion  implements Persistable<String> {
 
     @Override
     public boolean isNew() {
-        return this.id == null;
+        return this.version == null;
     }
 }

--- a/backend/src/main/java/moadong/club/entity/ClubQuestion.java
+++ b/backend/src/main/java/moadong/club/entity/ClubQuestion.java
@@ -6,6 +6,9 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.data.annotation.Transient;
+import org.springframework.data.annotation.Version;
+import org.springframework.data.domain.Persistable;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.LocalDateTime;
@@ -18,7 +21,7 @@ import java.util.List;
 @AllArgsConstructor
 @Getter
 @Builder(toBuilder = true)
-public class ClubQuestion {
+public class ClubQuestion  implements Persistable<String> {
 
     @Id
     private String id;
@@ -42,6 +45,9 @@ public class ClubQuestion {
     @Builder.Default
     private LocalDateTime editedAt = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime();
 
+    @Version
+    private Long version;
+
     public void updateFormTitle(String title) {
         this.title = title;
     }
@@ -59,4 +65,8 @@ public class ClubQuestion {
        this.editedAt = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime();
     }
 
+    @Override
+    public boolean isNew() {
+        return this.id == null;
+    }
 }

--- a/backend/src/main/java/moadong/club/service/ClubApplyService.java
+++ b/backend/src/main/java/moadong/club/service/ClubApplyService.java
@@ -38,12 +38,22 @@ public class ClubApplyService {
 
         clubQuestionRepository.save(createQuestions(clubQuestion, request));
     }
-
+    @Transactional
     public void editClubApplication(String clubId, CustomUserDetails user, ClubApplicationEditRequest request) {
         ClubQuestion clubQuestion = getClubQuestion(clubId, user);
 
         clubQuestion.updateEditedAt();
         clubQuestionRepository.save(updateQuestions(clubQuestion, request));
+    }
+    @Transactional
+    public void editClubApplicationQuestion(String questionId, CustomUserDetails user, ClubApplicationEditRequest request) {
+        ClubQuestion clubQuestion = clubQuestionRepository.findById(questionId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.QUESTION_NOT_FOUND));
+
+        updateQuestions(clubQuestion, request);
+        clubQuestion.updateEditedAt();
+
+        clubQuestionRepository.save(clubQuestion);
     }
 
     public ResponseEntity<?> getClubApplication(String clubId) {

--- a/backend/src/main/java/moadong/club/service/ClubProfileService.java
+++ b/backend/src/main/java/moadong/club/service/ClubProfileService.java
@@ -15,7 +15,11 @@ import moadong.global.exception.RestApiException;
 import moadong.global.util.ObjectIdConverter;
 import moadong.user.payload.CustomUserDetails;
 import org.bson.types.ObjectId;
+import org.springframework.dao.DataAccessException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -26,10 +30,10 @@ public class ClubProfileService {
     private final ClubRepository clubRepository;
     private final ClubSearchRepository clubSearchRepository;
 
+    @Transactional
     public void updateClubInfo(ClubInfoRequest request, CustomUserDetails user) {
         Club club = clubRepository.findClubByUserId(user.getId())
-            .orElseThrow(() -> new RestApiException(ErrorCode.CLUB_NOT_FOUND));
-
+                .orElseThrow(() -> new RestApiException(ErrorCode.CLUB_NOT_FOUND));
         club.update(request);
         clubRepository.save(club);
     }

--- a/backend/src/main/java/moadong/club/service/ClubProfileService.java
+++ b/backend/src/main/java/moadong/club/service/ClubProfileService.java
@@ -15,9 +15,6 @@ import moadong.global.exception.RestApiException;
 import moadong.global.util.ObjectIdConverter;
 import moadong.user.payload.CustomUserDetails;
 import org.bson.types.ObjectId;
-import org.springframework.dao.DataAccessException;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/backend/src/main/java/moadong/club/service/RecruitmentStateChecker.java
+++ b/backend/src/main/java/moadong/club/service/RecruitmentStateChecker.java
@@ -6,6 +6,7 @@ import moadong.club.entity.ClubRecruitmentInformation;
 import moadong.club.enums.ClubRecruitmentStatus;
 import moadong.club.repository.ClubRepository;
 import moadong.club.util.RecruitmentStateCalculator;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -14,6 +15,7 @@ import java.util.List;
 
 @Component
 @RequiredArgsConstructor
+@ConditionalOnProperty(name = "scheduling.enabled", havingValue = "true", matchIfMissing = true)
 public class RecruitmentStateChecker {
 
     private final ClubRepository clubRepository;

--- a/backend/src/main/java/moadong/global/config/MongoConfig.java
+++ b/backend/src/main/java/moadong/global/config/MongoConfig.java
@@ -1,0 +1,14 @@
+package moadong.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoTransactionManager;
+
+@Configuration
+public class MongoConfig {
+    @Bean
+    public MongoTransactionManager transactionManager(MongoDatabaseFactory dbFactory) {
+        return new MongoTransactionManager(dbFactory);
+    }
+}

--- a/backend/src/main/java/moadong/global/exception/ErrorCode.java
+++ b/backend/src/main/java/moadong/global/exception/ErrorCode.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ErrorCode {
+    CONCURRENCY_CONFLICT(HttpStatus.CONFLICT, "100-1","다른 사용자가 먼저 수정했습니다. 페이지를 새로고침 후 다시 이용해주세요"),
     CLUB_NOT_FOUND(HttpStatus.NOT_FOUND, "600-1", "동아리가 존재하지 않습니다."),
     CLUB_INFORMATION_NOT_FOUND(HttpStatus.NOT_FOUND, "600-2", "동아리 상세 정보가 존재하지 않습니다."),
     CLUB_FEED_IMAGES_NOT_FOUND(HttpStatus.NOT_FOUND, "600-3", "동아리 피드가 존재하지 않습니다."),

--- a/backend/src/test/java/moadong/club/service/ClubApplyServiceTest.java
+++ b/backend/src/test/java/moadong/club/service/ClubApplyServiceTest.java
@@ -1,0 +1,96 @@
+package moadong.club.service;
+
+import moadong.club.entity.Club;
+import moadong.club.entity.ClubQuestion;
+import moadong.club.payload.request.ClubApplicationEditRequest;
+import moadong.club.repository.ClubQuestionRepository;
+import moadong.club.repository.ClubRepository;
+import moadong.fixture.ClubApplicationEditFixture;
+import moadong.fixture.UserFixture;
+import moadong.user.entity.User;
+import moadong.user.payload.CustomUserDetails;
+import moadong.user.repository.UserRepository;
+import moadong.util.annotations.IntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.OptimisticLockingFailureException;
+
+import java.util.NoSuchElementException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@IntegrationTest
+public class ClubApplyServiceTest {
+    @Autowired
+    private ClubApplyService clubApplyService;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private ClubRepository clubRepository;
+    @Autowired
+    private ClubQuestionRepository clubQuestionRepository;
+
+    private CustomUserDetails userDetails;
+    private ClubQuestion clubQuestion;
+
+    @BeforeEach
+    void setUp() {
+        // 1. 기본 유저 정보 설정
+        User user = userRepository.findUserByUserId(UserFixture.collectUserId).get();
+        userDetails = new CustomUserDetails(user);
+        Club club = clubRepository.findClubByUserId(user.getId()).get();
+
+        this.clubQuestion = clubQuestionRepository.findByClubId(club.getId())
+                .orElseThrow(() -> new NoSuchElementException("테스트를 위한 ClubQuestion 문서가 DB에 존재하지 않습니다. 먼저 문서를 생성해주세요."));
+    }
+
+    @Test
+    @DisplayName("DB에 이미 존재하는 문서에 대해 동시 수정 시, 한 스레드만 성공하고 나머지는 실패해야 한다")
+    void concurrentUpdateOnExistingDocumentTest() throws InterruptedException {
+        // GIVEN: @BeforeEach에서 DB에 존재하는 문서를 성공적으로 조회한 상태
+        int numberOfThreads = 1;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger conflictCount = new AtomicInteger(0);
+
+        // WHEN: 여러 스레드가 조회된 문서의 ID를 가지고 수정을 시도
+        for (int i = 0; i < numberOfThreads; i++) {
+            executorService.submit(() -> {
+                try {
+                    ClubApplicationEditRequest request = ClubApplicationEditFixture.createClubApplicationEditRequest();
+
+                    // 3. 조회해 둔 clubQuestion의 ID를 명확히 전달
+                    clubApplyService.editClubApplicationQuestion(this.clubQuestion.getId(), userDetails, request);
+                    successCount.incrementAndGet();
+                } catch (OptimisticLockingFailureException e) {
+                    conflictCount.incrementAndGet();
+                } catch (DataAccessException e) {
+                    if (e.getMessage() != null && e.getMessage().contains("WriteConflict")) {
+                        conflictCount.incrementAndGet();
+                    } else {
+                        e.printStackTrace();
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+        executorService.shutdown();
+
+        // THEN: 정확히 하나의 스레드만 성공하고, 나머지는 모두 충돌 예외를 받아야 함
+        assertEquals(1, successCount.get());
+        assertEquals(numberOfThreads - 1, conflictCount.get());
+    }
+}

--- a/backend/src/test/java/moadong/club/service/ClubProfileServiceTest.java
+++ b/backend/src/test/java/moadong/club/service/ClubProfileServiceTest.java
@@ -1,5 +1,6 @@
 package moadong.club.service;
 
+import io.github.artsok.RepeatedIfExceptionsTest;
 import moadong.club.payload.request.ClubInfoRequest;
 import moadong.fixture.ClubRequestFixture;
 import moadong.fixture.UserFixture;
@@ -9,7 +10,6 @@ import moadong.user.repository.UserRepository;
 import moadong.util.annotations.IntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.OptimisticLockingFailureException;
@@ -33,8 +33,8 @@ public class ClubProfileServiceTest {
         userDetails = new CustomUserDetails(user);
     }
 
-    @Test
     @DisplayName("여러 스레드에서 동시에 수정 요청 시, 한 번만 성공하고 나머지는 실패해야 한다")
+    @RepeatedIfExceptionsTest(repeats = 3, exceptions = org.opentest4j.AssertionFailedError.class)
     void optimistic_lock_multi_thread_test() throws InterruptedException {
         // GIVEN
         int numberOfThreads = 4;

--- a/backend/src/test/java/moadong/club/service/ClubProfileServiceTest.java
+++ b/backend/src/test/java/moadong/club/service/ClubProfileServiceTest.java
@@ -1,0 +1,82 @@
+package moadong.club.service;
+
+import moadong.club.payload.request.ClubInfoRequest;
+import moadong.club.repository.ClubRepository;
+import moadong.fixture.ClubRequestFixture;
+import moadong.fixture.UserFixture;
+import moadong.user.entity.User;
+import moadong.user.payload.CustomUserDetails;
+import moadong.user.repository.UserRepository;
+import moadong.util.annotations.IntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@IntegrationTest
+public class ClubProfileServiceTest {
+    @Autowired
+    private ClubProfileService clubProfileService;
+    @Autowired
+    private UserRepository userRepository;
+    private CustomUserDetails userDetails;
+
+    @BeforeEach
+    void setUp() {
+        User user = userRepository.findUserByUserId(UserFixture.collectUserId).get();
+        userDetails = new CustomUserDetails(user);
+    }
+
+    @Test
+    @DisplayName("여러 스레드에서 동시에 수정 요청 시, 한 번만 성공하고 나머지는 실패해야 한다")
+    void optimistic_lock_multi_thread_test() throws InterruptedException {
+        // GIVEN: @BeforeEach에서 이미 데이터 준비가 완료됨
+        int numberOfThreads = 2;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger conflictCount = new AtomicInteger(0);
+
+        // WHEN: 여러 스레드에서 동시에 업데이트 시도
+        for (int i = 0; i < numberOfThreads; i++) {
+            executorService.submit(() -> {
+                try {
+                    ClubInfoRequest request = ClubRequestFixture.createValidClubInfoRequest();
+                    clubProfileService.updateClubInfo(request, userDetails);
+                    successCount.incrementAndGet();
+                } catch (OptimisticLockingFailureException e) {
+                    conflictCount.incrementAndGet();
+                } catch (DataAccessException e) {
+                    // WriteConflict 후 재시도 끝에 OptimisticLock으로 변환되지 못한 경우
+                    // 이 경우도 충돌로 간주할 수 있음
+                    if (e.getMessage().contains("WriteConflict")) {
+                        conflictCount.incrementAndGet();
+                    } else {
+                        e.printStackTrace();
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+        executorService.shutdown();
+
+        // THEN: 정확히 하나의 스레드만 성공하고, 나머지는 모두 충돌 예외를 받아야 함
+        assertEquals(1, successCount.get());
+        assertEquals(numberOfThreads - 1, conflictCount.get());
+    }
+}

--- a/backend/src/test/java/moadong/fixture/ClubApplicationEditFixture.java
+++ b/backend/src/test/java/moadong/fixture/ClubApplicationEditFixture.java
@@ -1,0 +1,26 @@
+package moadong.fixture;
+
+import moadong.club.entity.ClubQuestionOption;
+import moadong.club.enums.ClubApplicationQuestionType;
+import moadong.club.payload.request.ClubApplicationEditRequest;
+import moadong.club.payload.request.ClubApplyQuestion;
+
+import java.util.ArrayList;
+
+public class ClubApplicationEditFixture {
+    public static ClubApplicationEditRequest createClubApplicationEditRequest(){
+//        ClubApplyQuestion clubApplyQuestion = new ClubApplyQuestion(
+//                1,
+//                "타이틀",
+//                "설명",
+//                ClubApplicationQuestionType.CHOICE,
+//                new ClubApplyQuestion.Options(false),
+//                new ArrayList<>()
+//        );
+        return new ClubApplicationEditRequest(
+                "테스트123",
+                "테스트 지원서입니다",
+                new ArrayList<>()
+        );
+    }
+}

--- a/backend/src/test/java/moadong/fixture/UserFixture.java
+++ b/backend/src/test/java/moadong/fixture/UserFixture.java
@@ -7,13 +7,17 @@ import moadong.user.payload.request.UserRegisterRequest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 public class UserFixture {
-    public static final String collectUserId = "test12345";
+    public static final String collectUserId = "test123458";
     public static final String collectPassword = "test12345@";
     public static final String collectName = "테스터";
     public static final String collectPhoneNumber = "010-1234-5678";
 
     public static User createUser(PasswordEncoder passwordEncoder, String userId, String password, String name, String phoneNumber) {
         return new UserRegisterRequest(userId, password, name, phoneNumber).toUserEntity(passwordEncoder);
+    }
+
+    public static User createUser(PasswordEncoder passwordEncoder){
+        return new UserRegisterRequest(collectUserId,collectPassword,collectName,collectPhoneNumber).toUserEntity(passwordEncoder);
     }
 
     public static CustomUserDetails createUserDetails(String userId) {


### PR DESCRIPTION
## #️⃣연관된 이슈

#708 

## 📝작업 내용

- 메인 서버 액세스 토큰 및 리프레시 토큰 만료 시간 수정
- 로그인, 관리자 계정 관련의 동시성 문제 해결을 위한 Version 추가

**중요**
개발 서버에서 테스트를 거치고 메인에 머지가 되어야 함
그리고 메인 서버 컬렉션에 미리 동아리 정보, 동아리 지원서 version 필드를 추가시켜야 함

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 동아리 지원서 문항 단건 수정 API 추가
  * 모집 상태 스케줄러를 설정(scheduling.enabled)으로 온/오프 가능
  * 동시 수정 충돌 시 409 응답과 안내 메시지 제공

* **Refactor**
  * MongoDB 기반 저장소 전환 및 버전 기반 낙관적 락 도입
  * 주요 수정/저장 로직에 트랜잭션 적용

* **Tests**
  * 동시성 시나리오 검증 통합 테스트 및 테스트 픽스처(사용자 ID 등) 업데이트
  * 테스트용 의존성 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->