### PR TITLE
[refactor] 하드코딩된 드롭다운 메뉴 변경

### DIFF
--- a/frontend/src/constants/status.ts
+++ b/frontend/src/constants/status.ts
@@ -1,0 +1,8 @@
+import { ApplicationStatus } from '@/types/applicants';
+
+export const AVAILABLE_STATUSES = [
+  ApplicationStatus.SUBMITTED, // 서류검토 (SUBMITTED 포함)
+  ApplicationStatus.INTERVIEW_SCHEDULED, // 면접예정
+  ApplicationStatus.ACCEPTED, // 합격
+  ApplicationStatus.DECLINED, // 불합격
+] as const;

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPage.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPage.tsx
@@ -14,13 +14,7 @@ import { Question } from '@/types/application';
 import PrevApplicantButton from '@/assets/images/icons/prev_applicant.svg';
 import NextApplicantButton from '@/assets/images/icons/next_applicant.svg';
 import { useUpdateApplicant } from '@/hooks/queries/applicants/useUpdateApplicant';
-
-const AVAILABLE_STATUSES = [
-  ApplicationStatus.SUBMITTED, // 서류검토 (SUBMITTED 포함)
-  ApplicationStatus.INTERVIEW_SCHEDULED, // 면접예정
-  ApplicationStatus.ACCEPTED, // 합격
-  ApplicationStatus.DECLINED, // 불합격
-] as const;
+import { AVAILABLE_STATUSES } from '@/constants/status';
 
 const getStatusColor = (status: ApplicationStatus | undefined): string => {
   switch (status) {

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsTab.tsx
@@ -10,6 +10,7 @@ import selectIcon from '@/assets/images/icons/selectArrow.svg';
 import deleteIcon from '@/assets/images/icons/applicant_delete.svg';
 import selectAllIcon from '@/assets/images/icons/applicant_select_arrow.svg';
 import { useUpdateApplicant } from '@/hooks/queries/applicants/useUpdateApplicant';
+import { AVAILABLE_STATUSES } from '@/constants/status';
 
 const ApplicantsTab = () => {
   const navigate = useNavigate();
@@ -237,34 +238,15 @@ const ApplicantsTab = () => {
               </Styled.StatusSelect>
               <Styled.Arrow width={8} height={8} src={selectIcon} />
               <Styled.StatusSelectMenu open={statusOpen}>
-                <Styled.StatusSelectMenuItem
-                  onClick={() => {
-                    updateAllApplicants(ApplicationStatus.SUBMITTED);
-                  }}
-                >
-                  서류검토
-                </Styled.StatusSelectMenuItem>
-                <Styled.StatusSelectMenuItem
-                  onClick={() => {
-                    updateAllApplicants(ApplicationStatus.INTERVIEW_SCHEDULED);
-                  }}
-                >
-                  면접예정
-                </Styled.StatusSelectMenuItem>
-                <Styled.StatusSelectMenuItem
-                  onClick={() => {
-                    updateAllApplicants(ApplicationStatus.ACCEPTED);
-                  }}
-                >
-                  합격
-                </Styled.StatusSelectMenuItem>
-                <Styled.StatusSelectMenuItem
-                  onClick={() => {
-                    updateAllApplicants(ApplicationStatus.DECLINED);
-                  }}
-                >
-                  불합격
-                </Styled.StatusSelectMenuItem>
+                {AVAILABLE_STATUSES.map((status) => (
+                  <Styled.StatusSelectMenuItem
+                    onClick={() => {
+                      updateAllApplicants(status);
+                    }}
+                  >
+                    {mapStatusToGroup(status).label}
+                  </Styled.StatusSelectMenuItem>
+                ))}
               </Styled.StatusSelectMenu>
             </Styled.SelectWrapper>
             <Styled.DeleteButton


### PR DESCRIPTION
## #️⃣연관된 이슈

#715 

## 📝작업 내용

반복되는 태그 구조를 사용가능한 상태를 변수로 받아 반복을 하게 변경되었습니다.
```ts
<Styled.StatusSelect
  id='statusSelect'
  value={applicantStatus}
  onChange={handleStatusChange}
  $backgroundColor={getStatusColor(applicantStatus)}
>
  {AVAILABLE_STATUSES.map((status) => (
    <option key={status} value={status}>
      {mapStatusToGroup(status).label}
    </option>
  ))}
</Styled.StatusSelect>
```

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 관리자 페이지의 지원자 상태 선택 메뉴(목록/상세)가 단일한 상태 소스에 기반해 동일하게 동작하도록 통합했습니다.
  - 상태 옵션을 데이터 기반으로 생성하여 화면 전반의 일관성을 높이고, 향후 상태 추가 시 자동 반영되도록 개선했습니다.

- Chores
  - 상태 옵션을 중앙집중화해 중복 정의를 제거하고 관리 용이성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->