### PR TITLE
[feature] 관리자 계정의 비밀번호 변경 및 초기화한다

### DIFF
--- a/backend/src/main/java/moadong/global/util/SecurePasswordGenerator.java
+++ b/backend/src/main/java/moadong/global/util/SecurePasswordGenerator.java
@@ -1,0 +1,24 @@
+package moadong.global.util;
+
+import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+
+@Component
+public class SecurePasswordGenerator {
+
+    // 알파벳 대소문자와 특수문자 배열
+    private static final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#";
+
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    public String generate(int length) {
+        StringBuilder password = new StringBuilder(length);
+
+        for (int i = 0; i < length; i++) {
+            int index = secureRandom.nextInt(CHARACTERS.length());
+            password.append(CHARACTERS.charAt(index));
+        }
+        return password.toString();
+    }
+}

--- a/backend/src/main/java/moadong/global/util/SecurePasswordGenerator.java
+++ b/backend/src/main/java/moadong/global/util/SecurePasswordGenerator.java
@@ -10,7 +10,7 @@ public class SecurePasswordGenerator {
     // 알파벳 대소문자와 특수문자 배열
     private static final String ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
     private static final String NUMBERS = "0123456789";
-    private static final String SPECIAL = "!@#$%^&*?/";
+    private static final String SPECIAL = "!@#$%^";
 
     private static final String ALL = ALPHABET + NUMBERS + SPECIAL;
 

--- a/backend/src/main/java/moadong/global/util/SecurePasswordGenerator.java
+++ b/backend/src/main/java/moadong/global/util/SecurePasswordGenerator.java
@@ -8,17 +8,39 @@ import java.security.SecureRandom;
 public class SecurePasswordGenerator {
 
     // 알파벳 대소문자와 특수문자 배열
-    private static final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#";
+    private static final String ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    private static final String NUMBERS = "0123456789";
+    private static final String SPECIAL = "!@#$%^&*?/";
+
+    private static final String ALL = ALPHABET + NUMBERS + SPECIAL;
 
     private final SecureRandom secureRandom = new SecureRandom();
 
+    //영어, 숫자, 특수문자 각각 최소 1개씩
     public String generate(int length) {
         StringBuilder password = new StringBuilder(length);
 
+        password.append(ALPHABET.charAt(secureRandom.nextInt(ALPHABET.length())));
+        password.append(NUMBERS.charAt(secureRandom.nextInt(NUMBERS.length())));
+        password.append(SPECIAL.charAt(secureRandom.nextInt(SPECIAL.length())));
+
         for (int i = 0; i < length; i++) {
-            int index = secureRandom.nextInt(CHARACTERS.length());
-            password.append(CHARACTERS.charAt(index));
+            int index = secureRandom.nextInt(ALL.length());
+            password.append(ALL.charAt(index));
         }
-        return password.toString();
+
+        //뒤섞기
+        return shuffleString(password.toString(), secureRandom);
+    }
+
+    private static String shuffleString(String password, SecureRandom secureRandom) {
+        char[] characters = password.toCharArray();
+        for (int i = characters.length - 1; i > 0; i--) {
+            int j = secureRandom.nextInt(i + 1);
+            char tmp = characters[i];
+            characters[i] = characters[j];
+            characters[j] = tmp;
+        }
+        return new String(characters);
     }
 }

--- a/backend/src/main/java/moadong/global/util/SecurePasswordGenerator.java
+++ b/backend/src/main/java/moadong/global/util/SecurePasswordGenerator.java
@@ -18,13 +18,16 @@ public class SecurePasswordGenerator {
 
     //영어, 숫자, 특수문자 각각 최소 1개씩
     public String generate(int length) {
+        if (length < 8) {
+            throw new IllegalArgumentException("Length must be at least 8");}
+        
         StringBuilder password = new StringBuilder(length);
 
         password.append(ALPHABET.charAt(secureRandom.nextInt(ALPHABET.length())));
         password.append(NUMBERS.charAt(secureRandom.nextInt(NUMBERS.length())));
         password.append(SPECIAL.charAt(secureRandom.nextInt(SPECIAL.length())));
 
-        for (int i = 0; i < length; i++) {
+        for (int i = 3; i < length; i++) {
             int index = secureRandom.nextInt(ALL.length());
             password.append(ALL.charAt(index));
         }

--- a/backend/src/main/java/moadong/user/controller/UserController.java
+++ b/backend/src/main/java/moadong/user/controller/UserController.java
@@ -6,7 +6,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
 import moadong.global.payload.Response;
-import moadong.global.util.JwtProvider;
 import moadong.user.annotation.CurrentUser;
 import moadong.user.payload.CustomUserDetails;
 import moadong.user.payload.request.UserLoginRequest;
@@ -15,6 +14,7 @@ import moadong.user.payload.request.UserUpdateRequest;
 import moadong.user.payload.response.FindUserClubResponse;
 import moadong.user.payload.response.LoginResponse;
 import moadong.user.payload.response.RefreshResponse;
+import moadong.user.payload.response.TempPasswordResponse;
 import moadong.user.service.UserCommandService;
 import moadong.user.view.UserSwaggerView;
 import org.springframework.http.ResponseCookie;
@@ -91,6 +91,15 @@ public class UserController {
                                     HttpServletResponse response) {
         userCommandService.update(user.getUserId(), userUpdateRequest, response);
         return Response.ok("success update");
+    }
+
+    @PostMapping("/reset")
+    @Operation(summary = "사용자 비밀번호 초기화", description = "사용자 비밀번호를 초기화합니다.")
+    @PreAuthorize("isAuthenticated()")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> reset(@CurrentUser CustomUserDetails user) {
+        TempPasswordResponse tempPwdResponse = userCommandService.reset(user.getUserId());
+        return Response.ok(tempPwdResponse);
     }
 
     @PostMapping("/find/club")

--- a/backend/src/main/java/moadong/user/controller/UserController.java
+++ b/backend/src/main/java/moadong/user/controller/UserController.java
@@ -97,8 +97,18 @@ public class UserController {
     @Operation(summary = "사용자 비밀번호 초기화", description = "사용자 비밀번호를 초기화합니다.")
     @PreAuthorize("isAuthenticated()")
     @SecurityRequirement(name = "BearerAuth")
-    public ResponseEntity<?> reset(@CurrentUser CustomUserDetails user) {
+    public ResponseEntity<?> reset(@CurrentUser CustomUserDetails user,
+                                   HttpServletResponse response) {
         TempPasswordResponse tempPwdResponse = userCommandService.reset(user.getUserId());
+
+        ResponseCookie cookie = ResponseCookie.from("refresh_token", "")
+                .path("/")
+                .maxAge(0)
+                .httpOnly(true)
+                .sameSite("None")
+                .secure(true)
+                .build();
+        response.addHeader("Set-Cookie", cookie.toString());
         return Response.ok(tempPwdResponse);
     }
 

--- a/backend/src/main/java/moadong/user/entity/User.java
+++ b/backend/src/main/java/moadong/user/entity/User.java
@@ -74,7 +74,6 @@ public class User implements UserDetails {
     }
 
     public void updateUserProfile(UserUpdateRequest userUpdateRequest) {
-        this.userId = userUpdateRequest.userId();
         this.password = userUpdateRequest.password();
     }
     public void updateRefreshToken(RefreshToken refreshToken) {

--- a/backend/src/main/java/moadong/user/entity/User.java
+++ b/backend/src/main/java/moadong/user/entity/User.java
@@ -76,6 +76,10 @@ public class User implements UserDetails {
     public void updateUserProfile(UserUpdateRequest userUpdateRequest) {
         this.password = userUpdateRequest.password();
     }
+
+    public void resetPassword(String encodedPassword) { //초기화된 비밀번호 업데이트
+        this.password = encodedPassword;
+    }
     public void updateRefreshToken(RefreshToken refreshToken) {
         this.refreshToken = refreshToken;
     }

--- a/backend/src/main/java/moadong/user/payload/request/UserUpdateRequest.java
+++ b/backend/src/main/java/moadong/user/payload/request/UserUpdateRequest.java
@@ -7,14 +7,11 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 public record UserUpdateRequest(
     @NotNull
-    @UserId
-    String userId,
-    @NotNull
     @Password
     String password
 ) {
     public UserUpdateRequest encryptPassword(PasswordEncoder passwordEncoder){
-        return new UserUpdateRequest(userId, passwordEncoder.encode(this.password));
+        return new UserUpdateRequest(passwordEncoder.encode(this.password));
     }
 
 }

--- a/backend/src/main/java/moadong/user/payload/response/TempPasswordResponse.java
+++ b/backend/src/main/java/moadong/user/payload/response/TempPasswordResponse.java
@@ -1,0 +1,10 @@
+package moadong.user.payload.response;
+
+import jakarta.validation.constraints.NotNull;
+import moadong.global.annotation.Password;
+
+public record TempPasswordResponse(
+        @NotNull
+        @Password
+        String tempPassword
+){ }

--- a/backend/src/main/java/moadong/user/service/UserCommandService.java
+++ b/backend/src/main/java/moadong/user/service/UserCommandService.java
@@ -9,6 +9,7 @@ import moadong.club.repository.ClubRepository;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
 import moadong.global.util.JwtProvider;
+import moadong.global.util.SecurePasswordGenerator;
 import moadong.user.entity.RefreshToken;
 import moadong.user.entity.User;
 import moadong.user.payload.CustomUserDetails;
@@ -17,6 +18,7 @@ import moadong.user.payload.request.UserRegisterRequest;
 import moadong.user.payload.request.UserUpdateRequest;
 import moadong.user.payload.response.LoginResponse;
 import moadong.user.payload.response.RefreshResponse;
+import moadong.user.payload.response.TempPasswordResponse;
 import moadong.user.repository.UserRepository;
 import moadong.user.util.CookieMaker;
 import org.springframework.http.ResponseCookie;
@@ -36,6 +38,7 @@ public class UserCommandService {
     private final PasswordEncoder passwordEncoder;
     private final ClubRepository clubRepository;
     private final CookieMaker cookieMaker;
+    private final SecurePasswordGenerator securePasswordGenerator;
 
     public User registerUser(UserRegisterRequest userRegisterRequest) {
         try {
@@ -120,6 +123,23 @@ public class UserCommandService {
         response.addHeader("Set-Cookie", cookie.toString());
     }
 
+    public TempPasswordResponse reset(String userId) {
+        User user = userRepository.findUserByUserId(userId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_EXIST));
+
+        //랜덤 임시 비밀번호 생성
+        TempPasswordResponse tempPwdResponse = new TempPasswordResponse(
+                securePasswordGenerator.generate(8));
+
+        //암호화
+        user.resetPassword(passwordEncoder.encode(tempPwdResponse.tempPassword()));
+
+        user.updateRefreshToken(null);
+        userRepository.save(user);
+
+        return tempPwdResponse;
+    }
+
     public String findClubIdByUserId(String userID) {
         Club club = clubRepository.findClubByUserId(userID)
             .orElseThrow(() -> new RestApiException(ErrorCode.CLUB_NOT_FOUND));
@@ -130,4 +150,5 @@ public class UserCommandService {
         Club club = new Club(userId);
         clubRepository.save(club);
     }
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #719 

## 📝작업 내용

- 관리자 계정에서 변경할 필요 없는 userId 필드 제거
- 비밀번호 초기화 api 
- 랜덤 임시 비밀번호 발급 -> 응답으로 전달 -> 암호화해서 db 저장

## 중점적으로 리뷰받고 싶은 부분(선택)
> 임시 비밀번호 발급을 위해 SecurePasswordGenerator를 추가했는데, length는 현재 임의로 설정해둔 상태입니다

## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항
- 현재는 응답으로 임시 비밀번호를 직접 전달하지만, 추후에는 메일 또는 문자로 전송 방식으로 리팩토링할 계획입니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신기능**
  - 인증된 사용자가 비밀번호를 초기화하면 임시 비밀번호가 발급되고 응답으로 제공됩니다.
  - 초기화 시 자동로그인/세션용 쿠키가 삭제되어 보안이 강화됩니다.

- **변경**
  - 프로필 수정 요청에서 사용자 ID는 더 이상 전송/수정 대상이 아니며, 비밀번호만 업데이트됩니다.
  - 비밀번호 초기화 흐름에 임시 비밀번호 반환용 응답 형식이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->