### PR TITLE
[fix] MOA-218 동아리 정보나 지원서 수정 시에 동시성 문제를 해결한다

### DIFF
--- a/backend/src/main/java/moadong/club/service/ClubApplyService.java
+++ b/backend/src/main/java/moadong/club/service/ClubApplyService.java
@@ -38,6 +38,7 @@ public class ClubApplyService {
 
         clubQuestionRepository.save(createQuestions(clubQuestion, request));
     }
+
     @Transactional
     public void editClubApplication(String clubId, CustomUserDetails user, ClubApplicationEditRequest request) {
         ClubQuestion clubQuestion = getClubQuestion(clubId, user);
@@ -45,6 +46,7 @@ public class ClubApplyService {
         clubQuestion.updateEditedAt();
         clubQuestionRepository.save(updateQuestions(clubQuestion, request));
     }
+
     @Transactional
     public void editClubApplicationQuestion(String questionId, CustomUserDetails user, ClubApplicationEditRequest request) {
         ClubQuestion clubQuestion = clubQuestionRepository.findById(questionId)

--- a/backend/src/main/java/moadong/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/moadong/global/exception/GlobalExceptionHandler.java
@@ -1,12 +1,16 @@
 package moadong.global.exception;
 
+import lombok.extern.slf4j.Slf4j;
 import moadong.global.payload.Response;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.data.mongodb.UncategorizedMongoDbException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -19,6 +23,14 @@ public class GlobalExceptionHandler {
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
             .body(new Response("BAD_REQUEST", finalErrorMessage, null));
+    }
+
+    @ExceptionHandler({OptimisticLockingFailureException.class, UncategorizedMongoDbException.class})
+    public ResponseEntity<Response> handleConcurrencyConflict(Exception ex) {
+        log.warn("데이터베이스 충돌 발생: {}", ex.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(new Response(ErrorCode.CONCURRENCY_CONFLICT.getCode(), ErrorCode.CONCURRENCY_CONFLICT.getMessage(), null));
     }
 
     @ExceptionHandler(RestApiException.class)

--- a/backend/src/test/java/moadong/club/service/ClubApplyServiceTest.java
+++ b/backend/src/test/java/moadong/club/service/ClubApplyServiceTest.java
@@ -1,6 +1,7 @@
 package moadong.club.service;
 
 import moadong.club.entity.Club;
+import moadong.club.entity.ClubApplicationQuestion;
 import moadong.club.entity.ClubQuestion;
 import moadong.club.payload.request.ClubApplicationEditRequest;
 import moadong.club.repository.ClubQuestionRepository;
@@ -11,6 +12,7 @@ import moadong.user.entity.User;
 import moadong.user.payload.CustomUserDetails;
 import moadong.user.repository.UserRepository;
 import moadong.util.annotations.IntegrationTest;
+import org.bson.types.ObjectId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,9 +21,7 @@ import org.springframework.dao.DataAccessException;
 import org.springframework.dao.OptimisticLockingFailureException;
 
 import java.util.NoSuchElementException;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -38,47 +38,58 @@ public class ClubApplyServiceTest {
     private ClubQuestionRepository clubQuestionRepository;
 
     private CustomUserDetails userDetails;
-    private ClubQuestion clubQuestion;
+    private String clubQuestionId; // --- 변경: 객체 대신 ID만 저장 ---
 
     @BeforeEach
     void setUp() {
-        // 1. 기본 유저 정보 설정
         User user = userRepository.findUserByUserId(UserFixture.collectUserId).get();
         userDetails = new CustomUserDetails(user);
         Club club = clubRepository.findClubByUserId(user.getId()).get();
 
-        this.clubQuestion = clubQuestionRepository.findByClubId(club.getId())
+        // 테스트 전에 문서를 한 번만 조회하여 ID를 확보
+        ClubQuestion clubQuestion = clubQuestionRepository.findByClubId(club.getId())
                 .orElseThrow(() -> new NoSuchElementException("테스트를 위한 ClubQuestion 문서가 DB에 존재하지 않습니다. 먼저 문서를 생성해주세요."));
+        this.clubQuestionId = clubQuestion.getId();
     }
 
     @Test
     @DisplayName("DB에 이미 존재하는 문서에 대해 동시 수정 시, 한 스레드만 성공하고 나머지는 실패해야 한다")
     void concurrentUpdateOnExistingDocumentTest() throws InterruptedException {
-        // GIVEN: @BeforeEach에서 DB에 존재하는 문서를 성공적으로 조회한 상태
-        int numberOfThreads = 1;
+        // GIVEN
+        int numberOfThreads = 3;
         ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
         CountDownLatch latch = new CountDownLatch(numberOfThreads);
+        // --- 핵심 추가: CyclicBarrier ---
+        CyclicBarrier barrier = new CyclicBarrier(numberOfThreads);
 
         AtomicInteger successCount = new AtomicInteger(0);
         AtomicInteger conflictCount = new AtomicInteger(0);
 
-        // WHEN: 여러 스레드가 조회된 문서의 ID를 가지고 수정을 시도
+        // WHEN: 여러 스레드가 각자 데이터를 조회한 후, 동시에 수정을 시도
         for (int i = 0; i < numberOfThreads; i++) {
+            final int threadNum = i;
             executorService.submit(() -> {
                 try {
-                    ClubApplicationEditRequest request = ClubApplicationEditFixture.createClubApplicationEditRequest();
+                    // 1. 각 스레드가 DB에서 데이터를 직접 조회 (모두 같은 버전을 읽음)
+                    ClubQuestion questionToUpdate = clubQuestionRepository.findById(this.clubQuestionId).get();
 
-                    // 3. 조회해 둔 clubQuestion의 ID를 명확히 전달
-                    clubApplyService.editClubApplicationQuestion(this.clubQuestion.getId(), userDetails, request);
+                    // 2. 모든 스레드가 조회를 마칠 때까지 대기
+                    barrier.await();
+
+                    // 3. 동시에 업데이트 로직 호출
+                    // 서비스 메서드를 직접 호출하는 대신, 테스트에서 로직을 제어
+                    ClubApplicationEditRequest clubApplicationEditRequest = ClubApplicationEditFixture.createClubApplicationEditRequest();
+                    questionToUpdate.updateFormTitle(clubApplicationEditRequest.title()); // 엔티티 수정
+                    clubQuestionRepository.save(questionToUpdate); // 저장 (충돌 발생 지점)
+
                     successCount.incrementAndGet();
-                } catch (OptimisticLockingFailureException e) {
-                    conflictCount.incrementAndGet();
+
                 } catch (DataAccessException e) {
-                    if (e.getMessage() != null && e.getMessage().contains("WriteConflict")) {
-                        conflictCount.incrementAndGet();
-                    } else {
-                        e.printStackTrace();
-                    }
+                    // DataAccessException은 WriteConflict 등을 포함
+                    conflictCount.incrementAndGet();
+                } catch (InterruptedException | BrokenBarrierException e) {
+                    Thread.currentThread().interrupt();
+                    e.printStackTrace();
                 } catch (Exception e) {
                     e.printStackTrace();
                 } finally {
@@ -90,7 +101,7 @@ public class ClubApplyServiceTest {
         executorService.shutdown();
 
         // THEN: 정확히 하나의 스레드만 성공하고, 나머지는 모두 충돌 예외를 받아야 함
-        assertEquals(1, successCount.get());
-        assertEquals(numberOfThreads - 1, conflictCount.get());
+        assertEquals(1, successCount.get(), "성공한 요청은 1개여야 합니다.");
+        assertEquals(numberOfThreads - 1, conflictCount.get(), "실패(충돌)한 요청은 " + (numberOfThreads - 1) + "개여야 합니다.");
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#723 

## 📝작업 내용

동시성 문제 발생 시에 에러 핸들링 추가
-> 커스텀 에러 반환
<img width="1380" height="212" alt="image" src="https://github.com/user-attachments/assets/06548460-b4f2-4446-b16b-d4567ca0fdb5" />

동아리 지원서 동시성 문제 테스트 코드 추가
<img width="1122" height="607" alt="image" src="https://github.com/user-attachments/assets/79c471ce-9d92-416a-8f1e-b52bbd1838b5" />


## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항