### PR TITLE
[feature] 비밀번호 변경 시 아이디/이전 비밀번호 동일 여부 검증 추가하고 초기화 api 비인증 사용자에게 제공한다

### DIFF
--- a/backend/src/main/java/moadong/global/exception/ErrorCode.java
+++ b/backend/src/main/java/moadong/global/exception/ErrorCode.java
@@ -1,5 +1,6 @@
 package moadong.global.exception;
 
+import com.google.api.Http;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
@@ -33,6 +34,9 @@ public enum ErrorCode {
 
     TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "701-1", "유효하지 않은 토큰입니다."),
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "701-2", "토큰이 만료되었습니다."),
+
+    PASSWORD_SAME_AS_USERID(HttpStatus.BAD_REQUEST, "702-1", "아이디와 동일한 비밀번호는 설정할 수 없습니다."),
+    PASSWORD_SAME_AS_OLD(HttpStatus.BAD_REQUEST,"702-2","이전 비밀번호와 동일한 비밀번호는 설정할 수 없습니다."),
 
     APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "800-1", "지원서가 존재하지 않습니다."),
     SHORT_EXCEED_LENGTH(HttpStatus.BAD_REQUEST, "800-2", "단답형 최대 글자를 초과하였습니다."),

--- a/backend/src/main/java/moadong/user/controller/UserController.java
+++ b/backend/src/main/java/moadong/user/controller/UserController.java
@@ -10,6 +10,7 @@ import moadong.user.annotation.CurrentUser;
 import moadong.user.payload.CustomUserDetails;
 import moadong.user.payload.request.UserLoginRequest;
 import moadong.user.payload.request.UserRegisterRequest;
+import moadong.user.payload.request.UserResetRequest;
 import moadong.user.payload.request.UserUpdateRequest;
 import moadong.user.payload.response.FindUserClubResponse;
 import moadong.user.payload.response.LoginResponse;
@@ -95,20 +96,8 @@ public class UserController {
 
     @PostMapping("/reset")
     @Operation(summary = "사용자 비밀번호 초기화", description = "사용자 비밀번호를 초기화합니다.")
-    @PreAuthorize("isAuthenticated()")
-    @SecurityRequirement(name = "BearerAuth")
-    public ResponseEntity<?> reset(@CurrentUser CustomUserDetails user,
-                                   HttpServletResponse response) {
-        TempPasswordResponse tempPwdResponse = userCommandService.reset(user.getUserId());
-
-        ResponseCookie cookie = ResponseCookie.from("refresh_token", "")
-                .path("/")
-                .maxAge(0)
-                .httpOnly(true)
-                .sameSite("None")
-                .secure(true)
-                .build();
-        response.addHeader("Set-Cookie", cookie.toString());
+    public ResponseEntity<?> reset(@RequestBody @Validated UserResetRequest userResetRequest) {
+        TempPasswordResponse tempPwdResponse = userCommandService.reset(userResetRequest.userId());
         return Response.ok(tempPwdResponse);
     }
 

--- a/backend/src/main/java/moadong/user/payload/request/UserResetRequest.java
+++ b/backend/src/main/java/moadong/user/payload/request/UserResetRequest.java
@@ -1,0 +1,11 @@
+package moadong.user.payload.request;
+
+import jakarta.validation.constraints.NotNull;
+import moadong.global.annotation.UserId;
+
+public record UserResetRequest (
+        @NotNull
+        @UserId
+        String userId
+) {
+}

--- a/backend/src/main/java/moadong/user/payload/response/TempPasswordResponse.java
+++ b/backend/src/main/java/moadong/user/payload/response/TempPasswordResponse.java
@@ -5,6 +5,5 @@ import moadong.global.annotation.Password;
 
 public record TempPasswordResponse(
         @NotNull
-        @Password
         String tempPassword
 ){ }

--- a/backend/src/main/java/moadong/user/service/UserCommandService.java
+++ b/backend/src/main/java/moadong/user/service/UserCommandService.java
@@ -114,6 +114,16 @@ public class UserCommandService {
         HttpServletResponse response) {
         User user = userRepository.findUserByUserId(userId)
             .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_EXIST));
+
+        //아이디와 동일한지
+        if (userId.equals(userUpdateRequest.password())) {
+            throw new RestApiException(ErrorCode.PASSWORD_SAME_AS_USERID);
+        }
+        //기존 비밀번호와 동일한지
+        if (passwordEncoder.matches(userUpdateRequest.password(), user.getPassword())) {
+            throw new RestApiException(ErrorCode.PASSWORD_SAME_AS_OLD);
+        }
+
         user.updateUserProfile(userUpdateRequest.encryptPassword(passwordEncoder));
 
         userRepository.save(user);


### PR DESCRIPTION
## #️⃣연관된 이슈

> #727 

## 📝작업 내용

> 비밀번호 변경 시 검증 로직(아이디/이전 비밀번호 동일 여부)을 추가하고 초기화를 비로그인 상태에서 가능하도록 개선
<img width="575" height="134" alt="스크린샷 2025-09-06 19 43 55" src="https://github.com/user-attachments/assets/965ea8f6-8f53-476a-b746-15529841fe47" />
<img width="581" height="148" alt="스크린샷 2025-09-06 19 42 53" src="https://github.com/user-attachments/assets/2ffd7703-6131-4c7a-a0cd-6d17f5b3b9fa" />




## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 비밀번호 정책 강화: 아이디와 동일한 비밀번호 및 이전 비밀번호 재사용을 금지하며, 위반 시 명확한 오류 메시지를 제공합니다.
- 변경 사항
  - 비밀번호 재설정 방식 개선: 사용자 ID 입력으로 비로그인 상태에서도 재설정을 요청할 수 있도록 변경되었습니다.
  - 임시비밀번호 응답의 유효성 처리 일부 조정이 적용되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->