### PR TITLE
[feature] 사이드바가 스크롤을 따라온다

### DIFF
--- a/frontend/src/pages/AdminPage/components/SideBar/SideBar.styles.ts
+++ b/frontend/src/pages/AdminPage/components/SideBar/SideBar.styles.ts
@@ -8,6 +8,9 @@ export const SidebarWrapper = styled.aside`
   overflow-wrap: break-word;
   white-space: normal;
   width: 168px;
+  position: sticky;
+  top: 98px;
+  height: fit-content;
 `;
 
 export const SidebarHeader = styled.p`


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #718 

## 📝작업 내용

> 스크롤 시, 사이드바 고정

https://github.com/user-attachments/assets/fb9f8e94-13e6-4457-8c81-c7a81562e553

애니메이션을 넣으니 이상해서, 고정하는 것으로 진행했습니다.

## 중점적으로 리뷰받고 싶은 부분(선택)
>


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항
현재 글이 박스 안에 들어가 있어 스크롤 시 상단이 잘려 보이는 어색함이 있습니다. 
이를 개선하기 위해 글 영역의 박스를 제거하고, 사이드바와 본문 사이에 구분선을 추가하며, 상단 모아동 로고 영역과 (사이드바, 본문 영역) 사이에도 구분선을 넣는 방식을 고려하고 있습니다. 이렇게 하면 레이아웃 전환이 보다 자연스럽고 시각적으로도 덜 어색해질 것 같은데, 디자인이 없어서 일단 해보겠습니다...