### PR TITLE
[feature] 지원서 상태에 따라 분류하고 이름, 제출 순으로 정렬 할 수 있다.

### DIFF
--- a/frontend/src/components/common/CustomDropDown/CustomDropDown.styles.ts
+++ b/frontend/src/components/common/CustomDropDown/CustomDropDown.styles.ts
@@ -32,7 +32,7 @@ export const OptionItem = styled.li<{ isSelected: boolean }>`
   padding: 10px;
   font-weight: 600;
   color: #787878;
-  background-color: ${({ isSelected }) => (isSelected ? '#DCDCDC' : '#fff')};
+  background-color: ${({ isSelected }) => (isSelected ? '#f5f5f5' : '#fff')};
   cursor: pointer;
   padding: 8px 13px;
 

--- a/frontend/src/components/common/CustomDropDown/CustomDropDown.styles.ts
+++ b/frontend/src/components/common/CustomDropDown/CustomDropDown.styles.ts
@@ -17,25 +17,27 @@ export const OptionList = styled.ul<OptionListProps>`
   left: ${({ right }) => (right ? 'auto' : '0')};
   width: ${({ width }) => width || '100%'};
   right: ${({ right }) => right || 'auto'};
-  background: #fff;
   border-radius: 6px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
+  border: 1px solid #dcdcdc;
+  background: #fff;
+  box-shadow: 0 1px 8px 0 rgba(0, 0, 0, 0.12);
+  padding: 6px 0;
   z-index: 10;
+  height: auto;
   list-style: none;
 `;
 
 export const OptionItem = styled.li<{ isSelected: boolean }>`
   text-align: center;
   padding: 10px;
-  margin: 4px;
   font-weight: 600;
-  border-radius: 6px;
   color: #787878;
   background-color: ${({ isSelected }) => (isSelected ? '#DCDCDC' : '#fff')};
   cursor: pointer;
+  padding: 8px 13px;
 
   &:hover {
-    background-color: #dcdcdc;
+    background-color: #f5f5f5;
   }
 
   transition: background-color 0.2s ease;

--- a/frontend/src/components/common/CustomDropDown/CustomDropDown.styles.ts
+++ b/frontend/src/components/common/CustomDropDown/CustomDropDown.styles.ts
@@ -13,7 +13,7 @@ interface OptionListProps {
 
 export const OptionList = styled.ul<OptionListProps>`
   position: absolute;
-  top: ${({ top }) => top || '100%'};
+  top: ${({ top }) => top || '110%'};
   left: ${({ right }) => (right ? 'auto' : '0')};
   width: ${({ width }) => width || '100%'};
   right: ${({ right }) => right || 'auto'};

--- a/frontend/src/components/common/CustomDropDown/CustomDropDown.styles.ts
+++ b/frontend/src/components/common/CustomDropDown/CustomDropDown.styles.ts
@@ -5,27 +5,18 @@ export const DropDownWrapper = styled.div`
   width: 100%;
 `;
 
-export const Selected = styled.div<{ open: boolean }>`
-  padding: 12px 16px;
-  border-radius: 0.375rem;
-  background: ${({ open }) => (open ? '#fff' : '#f5f5f5')};
-  color: #787878;
-  font-size: 0.875rem;
-  font-weight: 600;
-  cursor: pointer;
-  border: 1px solid ${({ open }) => (open ? '#c5c5c5' : 'transparent')};
-  transition:
-    border-color 0.2s ease,
-    background-color 0.2s ease;
+interface OptionListProps {
+  top?: string;
+  width?: string;
+  right?: string;
+}
 
-  user-select: none;
-`;
-
-export const OptionList = styled.ul`
+export const OptionList = styled.ul<OptionListProps>`
   position: absolute;
-  top: 100%;
-  left: 0;
-  width: 100%;
+  top: ${({ top }) => top || '100%'};
+  left: ${({ right }) => (right ? 'auto' : '0')};
+  width: ${({ width }) => width || '100%'};
+  right: ${({ right }) => right || 'auto'};
   background: #fff;
   border-radius: 6px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
@@ -49,12 +40,4 @@ export const OptionItem = styled.li<{ isSelected: boolean }>`
 
   transition: background-color 0.2s ease;
   user-select: none;
-`;
-
-export const Icon = styled.img`
-  position: absolute;
-  top: 50%;
-  right: 19px;
-  transform: translateY(-50%);
-  pointer-events: none;
 `;

--- a/frontend/src/components/common/CustomDropDown/CustomDropDown.tsx
+++ b/frontend/src/components/common/CustomDropDown/CustomDropDown.tsx
@@ -1,10 +1,4 @@
-import React, {
-  createContext,
-  useContext,
-  useMemo,
-  ReactNode,
-  useEffect,
-} from 'react';
+import React, { createContext, useContext, useMemo, ReactNode } from 'react';
 import * as Styled from './CustomDropDown.styles';
 
 interface DropdownOption<TValue> {

--- a/frontend/src/pages/AdminPage/components/QuestionBuilder/QuestionBuilder.styles.ts
+++ b/frontend/src/pages/AdminPage/components/QuestionBuilder/QuestionBuilder.styles.ts
@@ -75,6 +75,30 @@ export const SelectionToggleButton = styled.button<{ active: boolean }>`
     color 0.2s ease;
 `;
 
+export const Selected = styled.div<{ open: boolean }>`
+  padding: 12px 16px;
+  border-radius: 0.375rem;
+  background: ${({ open }) => (open ? '#fff' : '#f5f5f5')};
+  color: #787878;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid ${({ open }) => (open ? '#c5c5c5' : 'transparent')};
+  transition:
+    border-color 0.2s ease,
+    background-color 0.2s ease;
+
+  user-select: none;
+`;
+
+export const Icon = styled.img`
+  position: absolute;
+  top: 50%;
+  right: 19px;
+  transform: translateY(-50%);
+  pointer-events: none;
+`;
+
 export const DeleteButton = styled.button`
   display: flex;
   align-items: center;

--- a/frontend/src/pages/AdminPage/components/QuestionBuilder/QuestionBuilder.tsx
+++ b/frontend/src/pages/AdminPage/components/QuestionBuilder/QuestionBuilder.tsx
@@ -7,8 +7,9 @@ import { QuestionBuilderProps } from '@/types/application';
 import { QUESTION_LABEL_MAP } from '@/constants/APPLICATION_FORM';
 import { DROPDOWN_OPTIONS } from '@/constants/APPLICATION_FORM';
 import * as Styled from './QuestionBuilder.styles';
-import CustomDropdown from '@/components/common/CustomDropDown/CustomDropDown';
 import DeleteIcon from '@/assets/images/icons/delete_question.svg';
+import { CustomDropDown } from '@/components/common/CustomDropDown/CustomDropDown';
+import dropdown_icon from '@/assets/images/icons/drop_button_icon.svg';
 
 const QuestionBuilder = ({
   id,
@@ -32,6 +33,8 @@ const QuestionBuilder = ({
   const [selectionType, setSelectionType] = useState<'single' | 'multi'>(
     type === 'MULTI_CHOICE' ? 'multi' : 'single',
   );
+
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
   useEffect(() => {
     if (type === 'MULTI_CHOICE') {
@@ -118,6 +121,11 @@ const QuestionBuilder = ({
     );
   };
 
+  const selectedType = type === 'MULTI_CHOICE' ? 'CHOICE' : type;
+  const selectedLabel = DROPDOWN_OPTIONS.find(
+    (option) => option.value === selectedType,
+  )?.label;
+
   return (
     <Styled.QuestionWrapper readOnly={readOnly}>
       <Styled.QuestionMenu>
@@ -127,13 +135,32 @@ const QuestionBuilder = ({
           답변 필수
           <Styled.RequiredToggleCircle active={options?.required} />
         </Styled.RequiredToggleButton>
-        <CustomDropdown
-          selected={type === 'MULTI_CHOICE' ? 'CHOICE' : type}
+        <CustomDropDown
+          selected={selectedType}
           options={DROPDOWN_OPTIONS}
           onSelect={(value) => {
             onTypeChange?.(value as QuestionType);
           }}
-        />
+          open={isDropdownOpen}
+          onToggle={() => setIsDropdownOpen((prev) => !prev)}
+        >
+          <CustomDropDown.Trigger>
+            <Styled.Selected
+              open={isDropdownOpen}
+              onClick={() => setIsDropdownOpen((prev) => !prev)}
+            >
+              <span>{selectedLabel}</span>
+              <Styled.Icon src={dropdown_icon} alt='드롭다운 버튼' />
+            </Styled.Selected>
+          </CustomDropDown.Trigger>
+          <CustomDropDown.Menu>
+            {DROPDOWN_OPTIONS.map(({ label, value }) => (
+              <CustomDropDown.Item key={value} value={value}>
+                {label}
+              </CustomDropDown.Item>
+            ))}
+          </CustomDropDown.Menu>
+        </CustomDropDown>
         {renderSelectionToggle()}
         {!readOnly && (
           <Styled.DeleteButton type='button' onClick={() => onRemoveQuestion()}>

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsTab.styles.ts
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsTab.styles.ts
@@ -282,7 +282,8 @@ export const ApplicantAllSelectWrapper = styled.div`
 
 export const ApplicantAllSelectArrow = styled.img`
   position: absolute;
-  right: -1px;
+  right: -18px;
+  top: -7px;
   width: 16px;
   height: 16px;
   object-fit: none;

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsTab.styles.ts
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsTab.styles.ts
@@ -160,6 +160,7 @@ export const ApplicantFilterSelect = styled.select`
   border: none;
   background: var(--f5, #f5f5f5);
   font-size: 16px;
+  color: #000;
 
   -webkit-appearance: none;
   -moz-appearance: none;

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsTab.styles.ts
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsTab.styles.ts
@@ -153,7 +153,9 @@ export const StatusSelectMenuItem = styled.div`
   }
 `;
 
-export const ApplicantFilterSelect = styled.select`
+export const ApplicantFilterSelect = styled.div`
+  display: flex;
+  align-items: center;
   height: 35px;
   padding: 4px 32px 4px 14px;
   border-radius: 8px;

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsTab.tsx
@@ -262,7 +262,6 @@ const ApplicantsTab = () => {
               >
                 <CustomDropDown.Trigger>
                   <Styled.ApplicantFilterSelect
-                    as='div'
                     onClick={() => setIsFilterOpen((prev) => !prev)}
                   >
                     {
@@ -271,14 +270,15 @@ const ApplicantsTab = () => {
                       )?.label
                     }
                   </Styled.ApplicantFilterSelect>
-                  <Styled.Arrow
-                    src={selectIcon}
-                    onClick={() => setIsFilterOpen((prev) => !prev)}
-                  />
+                  <Styled.Arrow src={selectIcon} />
                 </CustomDropDown.Trigger>
                 <CustomDropDown.Menu>
                   {filterOptions.map(({ value, label }) => (
-                    <CustomDropDown.Item key={value} value={value}>
+                    <CustomDropDown.Item
+                      key={value}
+                      value={value}
+                      style={{ fontSize: '12px' }}
+                    >
                       {label}
                     </CustomDropDown.Item>
                   ))}
@@ -306,19 +306,19 @@ const ApplicantsTab = () => {
               >
                 <CustomDropDown.Trigger>
                   <Styled.ApplicantFilterSelect
-                    as='div'
                     onClick={() => setIsSortOpen((prev) => !prev)}
                   >
                     {selectedSort.label}
                   </Styled.ApplicantFilterSelect>
-                  <Styled.Arrow
-                    src={selectIcon}
-                    onClick={() => setIsSortOpen((prev) => !prev)}
-                  />
+                  <Styled.Arrow src={selectIcon} />
                 </CustomDropDown.Trigger>
                 <CustomDropDown.Menu>
                   {sortOptions.map(({ value, label }) => (
-                    <CustomDropDown.Item key={value} value={value}>
+                    <CustomDropDown.Item
+                      key={value}
+                      value={value}
+                      style={{ fontSize: '12px' }}
+                    >
                       {label}
                     </CustomDropDown.Item>
                   ))}

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsTab.tsx
@@ -215,13 +215,13 @@ const ApplicantsTab = () => {
         <Styled.ApplicantListHeader>
           <Styled.FilterContainer>
             <Styled.SelectWrapper>
-              <Styled.ApplicantFilterSelect>
+              <Styled.ApplicantFilterSelect disabled={true}>
                 <option>전체</option>
               </Styled.ApplicantFilterSelect>
               <Styled.Arrow src={selectIcon} />
             </Styled.SelectWrapper>
             <Styled.SelectWrapper>
-              <Styled.ApplicantFilterSelect>
+              <Styled.ApplicantFilterSelect disabled={true}>
                 <option>제출순</option>
               </Styled.ApplicantFilterSelect>
               <Styled.Arrow src={selectIcon} />

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsTab.tsx
@@ -26,7 +26,7 @@ const ApplicantsTab = () => {
   const [isChecked, setIsChecked] = useState(false);
   const { mutate: deleteApplicants } = useDeleteApplicants(clubId!);
   const { mutate: updateDetailApplicants } = useUpdateApplicant(clubId!);
-  const allSelectRef = useRef<HTMLDivElement | null>(null);
+  const dropdwonRef = useRef<Array<HTMLDivElement | null>>([]);
 
   const filteredApplicants = useMemo(() => {
     if (!applicantsData?.applicants) return [];
@@ -43,13 +43,12 @@ const ApplicantsTab = () => {
   useEffect(() => {
     const handleOutsideClick = (e: MouseEvent) => {
       const target = e.target as Node;
-
       if (
-        open &&
-        allSelectRef.current &&
-        !allSelectRef.current.contains(target)
+        dropdwonRef.current &&
+        !dropdwonRef.current.some((ref) => ref && ref.contains(target))
       ) {
-        setOpen(false);
+        if (open) setOpen(false);
+        if (isStatusDropdownOpen) setIsStatusDropdownOpen(false);
       }
     };
 
@@ -228,7 +227,11 @@ const ApplicantsTab = () => {
               <Styled.Arrow src={selectIcon} />
             </Styled.SelectWrapper>
             <Styled.VerticalLine />
-            <Styled.SelectWrapper>
+            <Styled.SelectWrapper
+              ref={(el) => {
+                dropdwonRef.current[0] = el;
+              }}
+            >
               <CustomDropDown
                 options={statusOptions}
                 onSelect={(status) =>
@@ -291,7 +294,11 @@ const ApplicantsTab = () => {
           <Styled.ApplicantTableHeaderWrapper>
             <Styled.ApplicantTableRow>
               <Styled.ApplicantTableHeader width={55}>
-                <Styled.ApplicantAllSelectWrapper ref={allSelectRef}>
+                <Styled.ApplicantAllSelectWrapper
+                  ref={(el) => {
+                    dropdwonRef.current[1] = el;
+                  }}
+                >
                   <Styled.ApplicantTableAllSelectCheckbox
                     checked={selectAll}
                     onClick={(e: React.MouseEvent<HTMLInputElement>) => {

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsTab.tsx
@@ -272,7 +272,7 @@ const ApplicantsTab = () => {
                   </Styled.ApplicantFilterSelect>
                   <Styled.Arrow src={selectIcon} />
                 </CustomDropDown.Trigger>
-                <CustomDropDown.Menu>
+                <CustomDropDown.Menu top='115%'>
                   {filterOptions.map(({ value, label }) => (
                     <CustomDropDown.Item
                       key={value}
@@ -312,7 +312,7 @@ const ApplicantsTab = () => {
                   </Styled.ApplicantFilterSelect>
                   <Styled.Arrow src={selectIcon} />
                 </CustomDropDown.Trigger>
-                <CustomDropDown.Menu>
+                <CustomDropDown.Menu top='115%'>
                   {sortOptions.map(({ value, label }) => (
                     <CustomDropDown.Item
                       key={value}

--- a/frontend/src/utils/mapStatusToGroup.ts
+++ b/frontend/src/utils/mapStatusToGroup.ts
@@ -1,18 +1,23 @@
-import { ApplicationStatus } from "@/types/applicants";
+import { ApplicationStatus } from '@/types/applicants';
 
-const mapStatusToGroup = (status: ApplicationStatus): { status: ApplicationStatus, label: string } => {
+const mapStatusToGroup = (
+  status: ApplicationStatus,
+): { status: ApplicationStatus; label: string } => {
   switch (status) {
     case ApplicationStatus.SUBMITTED:
       return { status: ApplicationStatus.SUBMITTED, label: '서류검토' };
     case ApplicationStatus.INTERVIEW_SCHEDULED:
-      return { status: ApplicationStatus.INTERVIEW_SCHEDULED, label: '면접예정' };
+      return {
+        status: ApplicationStatus.INTERVIEW_SCHEDULED,
+        label: '면접예정',
+      };
     case ApplicationStatus.ACCEPTED:
       return { status: ApplicationStatus.ACCEPTED, label: '합격' };
     case ApplicationStatus.DECLINED:
       return { status: ApplicationStatus.DECLINED, label: '불합' };
     default:
-      return { status: ApplicationStatus.SUBMITTED, label: '서류검토'};
+      return { status: ApplicationStatus.SUBMITTED, label: '전체' };
   }
-}
+};
 
 export default mapStatusToGroup;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #721 

## 📝작업 내용
<img width="187" height="281" alt="스크린샷 2025-09-21 20 16 39" src="https://github.com/user-attachments/assets/ecc1f67c-ee87-44e6-bd17-c1e21073d1cf" />

지원자 목록에 볼수 있는 옵션 리스트 (전체, 서류검토, 면접예정, 합격, 불합)
정렬 옵션 기능 추가(제출순, 이름순)

기존 드롭다운 컴포넌트를 CustomDropdown 컴포넌트로 분리하여 재사용했습니다.
또한 CustomDropdown 컴포넌트를 Compound 패턴으로 작성하여 재사용성을 증가시켰습니다.
Trigger, Menu, Item을 변경하여 사용할 수 있습니다.
패턴을통해 유연성과 가독성을 챙겼습니다.

기존 드롭다운 메뉴들도 디자인을 통일 시켰습니다
(QuestionBuilder)

<이전>
<img width="210" height="584" alt="image" src="https://github.com/user-attachments/assets/0cac9eb0-0219-4955-a212-263f0896f1f6" />

<이후>
<img width="156" height="247" alt="스크린샷 2025-09-21 20 34 17" src="https://github.com/user-attachments/assets/b125f56d-173c-4cc3-b244-71385cca243f" />


## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항