### PR TITLE
[feature] 모집 상태 보기 기능을 제거하고 중앙동아리 태그를 이동한다

### DIFF
--- a/frontend/src/pages/MainPage/MainPage.styles.ts
+++ b/frontend/src/pages/MainPage/MainPage.styles.ts
@@ -47,6 +47,7 @@ export const Tab = styled.button<{$active?: boolean}>`
     width: 100%;
     height: 1.5px;
     background: #787878;
+    border-radius: 1.5px;
     transform: ${({$active}) => $active ? 'scaleX(1)' : 'scaleX(0)'};
     transform-origin: center;
     transition: transform 0.2s ease;

--- a/frontend/src/pages/MainPage/MainPage.styles.ts
+++ b/frontend/src/pages/MainPage/MainPage.styles.ts
@@ -18,12 +18,50 @@ export const ContentWrapper = styled.div`
   width: 100%;
 `;
 
+export const SectionTabs = styled.nav`
+  display: flex;
+  gap: 18px;
+  margin: 60px 8px 24px;
+
+  @media (max-width: 500px) {
+  gap: 16px;
+  margin: 32px 4px 16px;
+  }
+`;
+
+export const Tab = styled.button<{$active?: boolean}>`
+  display: flex;
+  position: relative;
+  font-size: 24px;
+  font-weight: bold;
+  color: ${({$active}) => $active ? '#787878' : '#DCDCDC'};
+  border: none;
+  background: none;
+  cursor: pointer;
+
+  &::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: -4px;
+    width: 100%;
+    height: 1.5px;
+    background: #787878;
+    transform: ${({$active}) => $active ? 'scaleX(1)' : 'scaleX(0)'};
+    transform-origin: center;
+    transition: transform 0.2s ease;
+  }
+
+  @media (max-width: 500px) {
+    font-size: 14px
+  }
+`;
+
 export const CardList = styled.div`
   display: grid;
   width: 100%;
   max-width: 100%;
   gap: 35px;
-  margin-top: 50px;
   transition:
     gap 0.5s ease,
     grid-template-columns 0.5s ease;
@@ -37,16 +75,11 @@ export const CardList = styled.div`
   @media (max-width: 750px) {
     grid-template-columns: repeat(1, 1fr);
   }
+
   @media (max-width: 500px) {
     gap: 16px;
     margin-top: 16px;
   }
-`;
-
-export const FilterWrapper = styled.div`
-  display: flex;
-  justify-content: right;
-  margin: 20px 0;
 `;
 
 export const EmptyResult = styled.div`

--- a/frontend/src/pages/MainPage/MainPage.tsx
+++ b/frontend/src/pages/MainPage/MainPage.tsx
@@ -27,7 +27,7 @@ const MainPage = () => {
   const division = 'all';
   const searchCategory = isSearching ? 'all' : selectedCategory;
 
-  const tabs = ['중앙동아리', '가동아리', '과동아리'] as const;
+  const tabs = ['중앙동아리'] as const;
   const [active, setActive] = useState<typeof tabs[number]>('중앙동아리');
   
   const {

--- a/frontend/src/pages/MainPage/MainPage.tsx
+++ b/frontend/src/pages/MainPage/MainPage.tsx
@@ -27,6 +27,9 @@ const MainPage = () => {
   const division = 'all';
   const searchCategory = isSearching ? 'all' : selectedCategory;
 
+  const tabs = ['중앙동아리', '가동아리', '과동아리'] as const;
+  const [active, setActive] = useState<typeof tabs[number]>('중앙동아리');
+  
   const {
     data: clubs,
     error,
@@ -53,9 +56,14 @@ const MainPage = () => {
       />
       <Styled.PageContainer>
         <CategoryButtonList />
-        <Styled.FilterWrapper>
-          <StatusRadioButton onChange={setIsFilterActive} />
-        </Styled.FilterWrapper>
+        <Styled.SectionTabs>
+          {tabs
+            .map((tab) =>(
+            <Styled.Tab key={tab} $active={active===tab} onClick={() => setActive(tab)}>
+              {tab}
+            </Styled.Tab>
+          ))}
+        </Styled.SectionTabs>
         <Styled.ContentWrapper>
           {isLoading ? (
             <Spinner />

--- a/frontend/src/pages/MainPage/MainPage.tsx
+++ b/frontend/src/pages/MainPage/MainPage.tsx
@@ -5,7 +5,6 @@ import useTrackPageView from '@/hooks/useTrackPageView';
 import { useGetCardList } from '@/hooks/queries/club/useGetCardList';
 import CategoryButtonList from '@/pages/MainPage/components/CategoryButtonList/CategoryButtonList';
 import ClubCard from '@/pages/MainPage/components/ClubCard/ClubCard';
-import StatusRadioButton from '@/pages/MainPage/components/StatusRadioButton/StatusRadioButton';
 import Footer from '@/components/common/Footer/Footer';
 import Header from '@/components/common/Header/Header';
 import Banner from '@/pages/MainPage/components/Banner/Banner';
@@ -18,15 +17,13 @@ import * as Styled from './MainPage.styles';
 const MainPage = () => {
   useTrackPageView('MainPage');
 
-  const [isFilterActive, setIsFilterActive] = useState(false);
   const { selectedCategory } = useSelectedCategory();
 
   const { keyword } = useSearchKeyword();
   const { isSearching } = useSearchIsSearching();
-  const recruitmentStatus = isFilterActive ? 'OPEN' : 'all';
+  const recruitmentStatus = 'all';
   const division = 'all';
   const searchCategory = isSearching ? 'all' : selectedCategory;
-
   const tabs = ['중앙동아리'] as const;
   const [active, setActive] = useState<typeof tabs[number]>('중앙동아리');
   


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #756 

## 📝작업 내용

> 모집 상태 보기 필터 제거
> 동아리 구분 탭 상단 추가
<img width="1894" height="958" alt="스크린샷 2025-09-22 211030" src="https://github.com/user-attachments/assets/ed16c127-fc71-4a63-b879-15330bca42c0" />

> 탭 클릭 가능하도록 구현
<img width="500"  alt="스크린샷 2025-09-22 211041" src="https://github.com/user-attachments/assets/3effa0b0-2fee-4054-b0a3-0790614e7c0a" />

> 현재는 중앙동아리 태그만 보임
<img width="1835" height="1034" alt="image" src="https://github.com/user-attachments/assets/1e1da856-c16b-40cb-9a1d-f6ca806e1877" />
=> 이후 탭 목록이 추가될 것을 고려하여 tabs 배열로 구성하였습니다.


## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항