### PR TITLE
feat: 헤더에 패치 노트 추가

### DIFF
--- a/frontend/src/components/common/Header/Header.styles.ts
+++ b/frontend/src/components/common/Header/Header.styles.ts
@@ -207,8 +207,7 @@ export const DropdownContainer = styled.div`
   text-decoration: none;
 `;
 
-// 실제로 나타나는 드롭다운 메뉴 스타일입니다.
-// position: absolute; 로 부모(DropdownContainer) 기준으로 위치를 잡습니다.
+
 export const DropdownMenu = styled.div`
   display: block;
   position: absolute;
@@ -222,7 +221,6 @@ export const DropdownMenu = styled.div`
   padding: 8px 0;
 `;
 
-// 드롭다운 메뉴 안의 각 아이템 스타일입니다.
 export const DropdownItem = styled.div`
   color: black;
   padding: 4px 16px;

--- a/frontend/src/components/common/Header/Header.styles.ts
+++ b/frontend/src/components/common/Header/Header.styles.ts
@@ -65,7 +65,8 @@ export const LogoButtonStyles = styled.button`
 
 export const IntroduceButtonStyles = styled.a`
   margin-left: 45px;
-  width: 63px;
+  // width: 63px;
+  flex-shrink: 0
   height: 43px;
   font-weight: 500;
   font-size: 14px;

--- a/frontend/src/components/common/Header/Header.styles.ts
+++ b/frontend/src/components/common/Header/Header.styles.ts
@@ -192,3 +192,49 @@ export const MenubarIntroduceBox = styled.div`
   background: rgba(255, 84, 20, 0.08);
   cursor: pointer;
 `;
+
+
+export const DropdownContainer = styled.div`
+  position: relative;
+  display: inline-block;
+  margin-left: 45px;
+  cursor: pointer;
+
+  height: 43px;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 42px; /* 텍스트 수직 정렬의 핵심입니다! */
+  color: inherit;
+  text-decoration: none;
+`;
+
+// 실제로 나타나는 드롭다운 메뉴 스타일입니다.
+// position: absolute; 로 부모(DropdownContainer) 기준으로 위치를 잡습니다.
+export const DropdownMenu = styled.div`
+  display: block;
+  position: absolute;
+  top: 100%; // 부모 요소 바로 아래에 위치시킵니다.
+  left: 50%;
+  transform: translateX(-50%); // 가운데 정렬합니다.
+  background-color: white;
+  min-width: 120px; // 최소 너비
+  box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.1);
+  border-radius: 8px;
+  z-index: 3; // 다른 요소들 위에 보이도록 z-index를 높게 설정합니다.
+  padding: 8px 0;
+`;
+
+// 드롭다운 메뉴 안의 각 아이템 스타일입니다.
+export const DropdownItem = styled.div`
+  color: black;
+  padding: 12px 16px;
+  text-decoration: none;
+  display: block;
+  text-align: center;
+  font-size: 14px;
+  white-space: nowrap;
+
+  &:hover {
+    background-color: #f1f1f1;
+  }
+`;

--- a/frontend/src/components/common/Header/Header.styles.ts
+++ b/frontend/src/components/common/Header/Header.styles.ts
@@ -199,7 +199,6 @@ export const DropdownContainer = styled.div`
   display: inline-block;
   margin-left: 45px;
   cursor: pointer;
-
   height: 43px;
   font-weight: 500;
   font-size: 14px;
@@ -217,7 +216,6 @@ export const DropdownMenu = styled.div`
   left: 50%;
   transform: translateX(-50%); // 가운데 정렬합니다.
   background-color: white;
-  min-width: 120px; // 최소 너비
   box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.1);
   border-radius: 8px;
   z-index: 3; // 다른 요소들 위에 보이도록 z-index를 높게 설정합니다.
@@ -227,7 +225,7 @@ export const DropdownMenu = styled.div`
 // 드롭다운 메뉴 안의 각 아이템 스타일입니다.
 export const DropdownItem = styled.div`
   color: black;
-  padding: 12px 16px;
+  padding: 4px 16px;
   text-decoration: none;
   display: block;
   text-align: center;

--- a/frontend/src/components/common/Header/Header.tsx
+++ b/frontend/src/components/common/Header/Header.tsx
@@ -125,6 +125,11 @@ const Header = () => {
   const navLinks: NavLinkData[] = [
     { label: '모아동 소개', handler: handleIntroduceClick },
     { label: '총동아리연합회 소개', handler: handleClubUnionClick },
+    {
+      label: '패치 노트',
+      handler: () =>
+        window.open('https://honorable-cough-8f9.notion.site/1e8aad232096804f9ea9ee4f5cf0cd10?pvs=74', '_blank'),
+    },
   ];
 
   return (

--- a/frontend/src/components/common/Header/Header.tsx
+++ b/frontend/src/components/common/Header/Header.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import * as Styled from './Header.styles';
 
@@ -36,7 +36,10 @@ interface MobileMenuDrawerProps {
 }
 
 const DesktopHeader = memo(
-  ({ isAdminPage, navLinks, onHomeClick }: DesktopHeaderProps) => (
+  ({ isAdminPage, navLinks, onHomeClick }: DesktopHeaderProps) => {
+    const [isDropdownOpen, setDropdownOpen] = useState(false);
+
+    return (
     <Styled.HeaderStyles>
       <Styled.HeaderContainer>
         <Styled.TextCoverStyles>
@@ -46,6 +49,7 @@ const DesktopHeader = memo(
           >
             <img src={DesktopMainIcon} alt='모아동 로고' />
           </Styled.LogoButtonStyles>
+
           {!isAdminPage &&
             navLinks.map((link) => (
               <Styled.IntroduceButtonStyles
@@ -55,11 +59,41 @@ const DesktopHeader = memo(
                 {link.label}
               </Styled.IntroduceButtonStyles>
             ))}
+          {/*드랍 다운 페이지*/}
+          {!isAdminPage && (
+              <Styled.DropdownContainer
+                onMouseEnter={() => setDropdownOpen(true)}
+                onMouseLeave={() => setDropdownOpen(false)}
+              >
+                {/* <Styled.IntroduceButtonStyles as='div'>
+                  공지사항
+                </Styled.IntroduceButtonStyles> */}
+                <span>공지사항</span>
+                
+                {isDropdownOpen && (
+                  <Styled.DropdownMenu>
+                    <Styled.DropdownItem
+                      onClick={() =>
+                        window.open(
+                          'https://honorable-cough-8f9.notion.site/1e8aad232096804f9ea9ee4f5cf0cd10',
+                          '_blank',
+                        )
+                      }
+                    >
+                      패치 노트
+                    </Styled.DropdownItem>
+                    {/* 다른 메뉴 아이템이 필요하면 여기에 추가할 수 있습니다. */}
+                  </Styled.DropdownMenu>
+                )}
+              </Styled.DropdownContainer>
+            )}
+
         </Styled.TextCoverStyles>
         {!isAdminPage && <SearchBox />}
       </Styled.HeaderContainer>
     </Styled.HeaderStyles>
-  ),
+  );
+  },
 );
 
 const MobileMenuDrawer = memo(
@@ -125,11 +159,6 @@ const Header = () => {
   const navLinks: NavLinkData[] = [
     { label: '모아동 소개', handler: handleIntroduceClick },
     { label: '총동아리연합회 소개', handler: handleClubUnionClick },
-    {
-      label: '패치 노트',
-      handler: () =>
-        window.open('https://honorable-cough-8f9.notion.site/1e8aad232096804f9ea9ee4f5cf0cd10?pvs=74', '_blank'),
-    },
   ];
 
   return (

--- a/frontend/src/components/common/Header/Header.tsx
+++ b/frontend/src/components/common/Header/Header.tsx
@@ -156,9 +156,23 @@ const Header = () => {
     handleMenuClick,
   });
 
-  const navLinks: NavLinkData[] = [
+  const desktopNavLinks: NavLinkData[] = [
     { label: '모아동 소개', handler: handleIntroduceClick },
     { label: '총동아리연합회 소개', handler: handleClubUnionClick },
+  ];
+
+
+  const mobileNavLinks: NavLinkData[] = [
+    { label: '모아동 소개', handler: handleIntroduceClick },
+    { label: '총동아리연합회 소개', handler: handleClubUnionClick },
+    {
+      label: '패치 노트',
+      handler: () =>
+        window.open(
+          'https://honorable-cough-8f9.notion.site/1e8aad232096804f9ea9ee4f5cf0cd10',
+          '_blank',
+        ),
+    },
   ];
 
   return (
@@ -171,14 +185,14 @@ const Header = () => {
       ) : (
         <DesktopHeader
           isAdminPage={isAdminPage}
-          navLinks={navLinks}
+          navLinks={desktopNavLinks}
           onHomeClick={() => handleHomeClick('desktop')}
         />
       )}
       <MobileMenuDrawer
         isOpen={isMenuOpen}
         onClose={closeMenu}
-        navLinks={navLinks}
+        navLinks={mobileNavLinks}
         onHomeClick={() => {
           handleHomeClick('mobile');
           closeMenu();


### PR DESCRIPTION
## #️⃣연관된 이슈

#770 

## 📝작업 내용
패치 노트 링크를 헤더에 추가하였습니다.
-> 데스크탑 헤더 데이터와 모바일 헤더 데이터를 분리했습니다.

데스크탑 버전
<img width="601" height="108" alt="image" src="https://github.com/user-attachments/assets/aea5907c-6bcb-4b1a-907f-08a201767d91" />

모바일 버전
<img width="242" height="100" alt="image" src="https://github.com/user-attachments/assets/2c6a1c12-b041-4a1f-9dba-7f7cc781598d" />


