### PR TITLE
[feature] 관리자 페이지 모집기간 선택에 상시모집 처리 버튼을 추가한다

### DIFF
--- a/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.styles.ts
+++ b/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.styles.ts
@@ -25,6 +25,30 @@ export const InfoGroup = styled.div`
   margin-bottom: 140px;
 `;
 
+export const RecruitmentPeriodContainer = styled.div`
+  display: flex; 
+  gap: 16px; 
+  max-width: 706px;
+`;
+
+export const AlwaysRecruitButton = styled.button<{ $active: boolean }>`
+  border-radius: 6px;
+  height: 45px;
+  padding: 0px 16px ;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+
+  color: ${({ $active }) => ($active ? '#fff' : '#797979')};
+  background: ${({ $active }) => ($active ? '#FF7543' : 'rgba(0,0,0,0.05)')};
+  border: ${({ $active }) => ($active ? 'none' : '1px solid #C5C5C5')};
+  transition: background-color 0.12s ease, transform 0.06s ease;
+
+  &:active {
+    transform: translateY(1px); 
+  }
+`;
+
 export const Label = styled.p`
   font-size: 1.125rem;
   margin-bottom: 12px;

--- a/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.tsx
@@ -128,6 +128,7 @@ const RecruitEditTab = () => {
               recruitmentEnd={recruitmentEnd}
               onChangeStart={setRecruitmentStart}
               onChangeEnd={setRecruitmentEnd}
+              disabled={always}
             />
             <Styled.AlwaysRecruitButton
               type="button"

--- a/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.tsx
@@ -19,6 +19,8 @@ const RecruitEditTab = () => {
   const [recruitmentEnd, setRecruitmentEnd] = useState<Date | null>(null);
   const [recruitmentTarget, setRecruitmentTarget] = useState('');
   const [description, setDescription] = useState('');
+  const [always, setAlways] = useState(false);
+  const toggleAlways = () => setAlways((prev) => !prev);
 
   const queryClient = useQueryClient();
   useEffect(() => {
@@ -80,12 +82,22 @@ const RecruitEditTab = () => {
       <Styled.InfoGroup>
         <div>
           <Styled.Label>모집 기간 설정</Styled.Label>
-          <Calendar
-            recruitmentStart={recruitmentStart}
-            recruitmentEnd={recruitmentEnd}
-            onChangeStart={setRecruitmentStart}
-            onChangeEnd={setRecruitmentEnd}
-          />
+          <Styled.RecruitmentPeriodContainer>
+            <Calendar
+              recruitmentStart={recruitmentStart}
+              recruitmentEnd={recruitmentEnd}
+              onChangeStart={setRecruitmentStart}
+              onChangeEnd={setRecruitmentEnd}
+            />
+            <Styled.AlwaysRecruitButton
+              type="button"
+              $active={always}
+              onClick={toggleAlways}
+              aria-pressed={always}
+            >
+              상시모집
+            </Styled.AlwaysRecruitButton>
+          </Styled.RecruitmentPeriodContainer>
         </div>
         <InputField
           label='모집 대상'

--- a/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.tsx
@@ -69,10 +69,19 @@ const RecruitEditTab = () => {
   const handleUpdateClub = async () => {
     if (!clubDetail) return;
 
+    let startForSave: Date | null = recruitmentStart;
+    let endForSave: Date | null = recruitmentEnd;
+
+    if (always) {
+      const now = new Date();
+      startForSave = now;
+      endForSave = setYear(now, FAR_FUTURE_YEAR);
+    }
+
     const updatedData = {
       id: clubDetail.id,
-      recruitmentStart: correctRequestKoreanDate(recruitmentStart)?.toISOString(),
-      recruitmentEnd: correctRequestKoreanDate(recruitmentEnd)?.toISOString(),
+      recruitmentStart: correctRequestKoreanDate(startForSave)?.toISOString(),
+      recruitmentEnd: correctRequestKoreanDate(endForSave)?.toISOString(),
       recruitmentTarget: recruitmentTarget,
       description: description,
       externalApplicationUrl: clubDetail.externalApplicationUrl ?? '',

--- a/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.tsx
@@ -32,9 +32,21 @@ const RecruitEditTab = () => {
       parseRecruitmentPeriod(clubDetail.recruitmentPeriod ?? '');
 
     const now = new Date();
+    const start = correctResponseKoreanDate(initialStart);
+    const end = correctResponseKoreanDate(initialEnd);
 
-    setRecruitmentStart((prev) => prev ?? correctResponseKoreanDate(initialStart) ?? now);
-    setRecruitmentEnd((prev) => prev ?? correctResponseKoreanDate(initialEnd) ?? now);
+    const isAlways = !!end && end.getFullYear() === FAR_FUTURE_YEAR;
+    
+    if (isAlways) {
+      setAlways(true);
+      setBackupRange({ start, end });
+      setRecruitmentStart(start ?? now);
+      setRecruitmentEnd(end ?? setYear(now, FAR_FUTURE_YEAR));
+    } else {
+      setRecruitmentStart((prev) => prev ?? start ?? now);
+      setRecruitmentEnd((prev) => prev ?? end ?? now);
+    }
+    
     setRecruitmentTarget((prev) => prev || clubDetail.recruitmentTarget || '');
     setDescription((prev) => prev || clubDetail.description || '');
   }, [clubDetail]);

--- a/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.tsx
@@ -9,6 +9,7 @@ import { parseRecruitmentPeriod } from '@/utils/recruitmentPeriodParser';
 import { ClubDetail } from '@/types/club';
 import { useQueryClient } from '@tanstack/react-query';
 import MarkdownEditor from '@/pages/AdminPage/tabs/RecruitEditTab/components/MarkdownEditor/MarkdownEditor';
+import { setYear } from 'date-fns';
 
 const RecruitEditTab = () => {
   const clubDetail = useOutletContext<ClubDetail>();
@@ -19,8 +20,9 @@ const RecruitEditTab = () => {
   const [recruitmentEnd, setRecruitmentEnd] = useState<Date | null>(null);
   const [recruitmentTarget, setRecruitmentTarget] = useState('');
   const [description, setDescription] = useState('');
+  const FAR_FUTURE_YEAR = 2999;
   const [always, setAlways] = useState(false);
-  const toggleAlways = () => setAlways((prev) => !prev);
+  const [backupRange, setBackupRange] = useState<{ start: Date | null; end: Date | null }>({ start: null, end: null });
 
   const queryClient = useQueryClient();
   useEffect(() => {
@@ -46,6 +48,23 @@ const RecruitEditTab = () => {
     if (!date) return null;
     return new Date(date?.getTime() - 9 * 60 * 60 * 1000);
   }
+
+  const toggleAlways = () => {
+    setAlways((prev) => {
+      if (!prev) {
+        // 상시모집 활성화
+        setBackupRange({ start: recruitmentStart, end: recruitmentEnd });
+        const now = new Date();
+        setRecruitmentStart(now);
+        setRecruitmentEnd(setYear(now, FAR_FUTURE_YEAR));
+      } else {
+        // 상시모집 비활성화
+        setRecruitmentStart(backupRange.start) ?? new Date;
+        setRecruitmentEnd(backupRange.end) ?? new Date;
+      }
+      return !prev;
+    });
+  };
 
   const handleUpdateClub = async () => {
     if (!clubDetail) return;

--- a/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.tsx
@@ -21,6 +21,7 @@ const RecruitEditTab = () => {
   const [recruitmentTarget, setRecruitmentTarget] = useState('');
   const [description, setDescription] = useState('');
   const FAR_FUTURE_YEAR = 2999;
+  const isFarFuture = (date: Date | null) => !!date && date.getFullYear() === FAR_FUTURE_YEAR;
   const [always, setAlways] = useState(false);
   const [backupRange, setBackupRange] = useState<{ start: Date | null; end: Date | null }>({ start: null, end: null });
 
@@ -63,16 +64,25 @@ const RecruitEditTab = () => {
 
   const toggleAlways = () => {
     setAlways((prev) => {
+      const now = new Date();
+
       if (!prev) {
         // 상시모집 활성화
         setBackupRange({ start: recruitmentStart, end: recruitmentEnd });
-        const now = new Date();
         setRecruitmentStart(now);
         setRecruitmentEnd(setYear(now, FAR_FUTURE_YEAR));
       } else {
         // 상시모집 비활성화
-        setRecruitmentStart(backupRange.start) ?? new Date;
-        setRecruitmentEnd(backupRange.end) ?? new Date;
+        const backupWasAlways = isFarFuture(backupRange.end);
+        if (backupWasAlways) {
+          // 백업이 상시모집인 경우
+          setRecruitmentStart(now);
+          setRecruitmentEnd(now);
+        } else {
+          // 백업이 상시모집이 아닌 경우
+          setRecruitmentStart(backupRange.start ?? new Date());
+          setRecruitmentEnd(backupRange.end ?? new Date());
+        }
       }
       return !prev;
     });

--- a/frontend/src/pages/AdminPage/tabs/RecruitEditTab/components/Calendar/Calendar.styles.ts
+++ b/frontend/src/pages/AdminPage/tabs/RecruitEditTab/components/Calendar/Calendar.styles.ts
@@ -5,7 +5,9 @@ const primary = 'rgba(255, 84, 20, 0.8)';
 const primaryHover = 'rgba(255, 84, 20, 0.95)';
 const white = '#fff';
 const gray = 'rgba(0,0,0,0.5)';
+const disabledGray = 'rgba(0,0,0,0.2)';
 const inputBg = 'rgba(0,0,0,0.05)';
+const inputDisabledBg = '#DFDFDF';
 
 /* 재사용 블록 */
 const selected = css`
@@ -137,6 +139,13 @@ export const DatepickerContainer = styled.div`
       outline: none;
       ${selected};
     }
+  }
+
+  /* 비활성화 입력 필드 */
+  .react-datepicker__input-container input:disabled {
+    background: ${inputDisabledBg};
+    color: ${disabledGray};
+    cursor: not-allowed;
   }
 
   /*  날짜 셀 스타일  */

--- a/frontend/src/pages/AdminPage/tabs/RecruitEditTab/components/Calendar/Calendar.styles.ts
+++ b/frontend/src/pages/AdminPage/tabs/RecruitEditTab/components/Calendar/Calendar.styles.ts
@@ -145,7 +145,6 @@ export const DatepickerContainer = styled.div`
   .react-datepicker__input-container input:disabled {
     background: ${inputDisabledBg};
     color: ${disabledGray};
-    cursor: not-allowed;
   }
 
   /*  날짜 셀 스타일  */

--- a/frontend/src/pages/AdminPage/tabs/RecruitEditTab/components/Calendar/Calendar.tsx
+++ b/frontend/src/pages/AdminPage/tabs/RecruitEditTab/components/Calendar/Calendar.tsx
@@ -51,7 +51,7 @@ const Calendar = ({
 }: CalendarProps) => {
   const handleStartChange = useCallback(
     (date: Date | null) => {
-      if (!disabled) return;
+      if (disabled) return;
       onChangeStart(date);
       if (recruitmentEnd && date && date > recruitmentEnd) {
         onChangeEnd(date);
@@ -62,7 +62,7 @@ const Calendar = ({
 
   const handleEndChange = useCallback(
     (date: Date | null) => {
-      if (!disabled) return;
+      if (disabled) return;
       onChangeEnd(date);
       if (recruitmentStart && date && date < recruitmentStart) {
         onChangeStart(date);

--- a/frontend/src/pages/AdminPage/tabs/RecruitEditTab/components/Calendar/Calendar.tsx
+++ b/frontend/src/pages/AdminPage/tabs/RecruitEditTab/components/Calendar/Calendar.tsx
@@ -9,6 +9,7 @@ interface CalendarProps {
   recruitmentEnd: Date | null;
   onChangeStart: (date: Date | null) => void;
   onChangeEnd: (date: Date | null) => void;
+  disabled?: boolean;
 }
 
 const CustomHeader = ({
@@ -46,30 +47,34 @@ const Calendar = ({
   recruitmentEnd,
   onChangeStart,
   onChangeEnd,
+  disabled = false,
 }: CalendarProps) => {
   const handleStartChange = useCallback(
     (date: Date | null) => {
+      if (!disabled) return;
       onChangeStart(date);
       if (recruitmentEnd && date && date > recruitmentEnd) {
         onChangeEnd(date);
       }
     },
-    [onChangeStart, onChangeEnd, recruitmentEnd],
+    [disabled, onChangeStart, onChangeEnd, recruitmentEnd],
   );
 
   const handleEndChange = useCallback(
     (date: Date | null) => {
+      if (!disabled) return;
       onChangeEnd(date);
       if (recruitmentStart && date && date < recruitmentStart) {
         onChangeStart(date);
       }
     },
-    [onChangeStart, onChangeEnd, recruitmentStart],
+    [disabled, onChangeStart, onChangeEnd, recruitmentStart],
   );
 
   return (
-    <Styled.DatepickerContainer>
+    <Styled.DatepickerContainer data-disabled={disabled ? true : false}>
       <DatePicker
+        disabled={disabled}
         locale={ko}
         selected={recruitmentStart}
         onChange={handleStartChange}
@@ -84,6 +89,7 @@ const Calendar = ({
       />
       <Styled.Tidle>~</Styled.Tidle>
       <DatePicker
+        disabled={disabled}
         locale={ko}
         selected={recruitmentEnd}
         onChange={handleEndChange}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #767 

## 📝작업 내용

> 상시모집 버튼 추가
<img width="1682" height="934" alt="image" src="https://github.com/user-attachments/assets/5bdae0fd-d240-4c5b-9fe5-14c783e69e5a" />

> 상시모집 버튼 활성화 시, 캘린더 비활성화
<img width="1696" height="910" alt="image" src="https://github.com/user-attachments/assets/5d515368-96f1-4577-8cf4-6ab5c6f4a1c5" />
-> 모집 기간은 자동으로 현재 날짜 ~ 현재 날짜 + 2999
-> 수정 후, 상시모집 상태인 동아리는 최초 로딩 시에도 상시모집 버튼 활성화 상태로 유지

> 상시모집 버튼 비활성화 시, 캘린더 활성화
<img width="1683" height="876" alt="image" src="https://github.com/user-attachments/assets/f568dce6-d0be-4889-bfb6-13f1d50cd25a" />
-> 날짜 수정하기 쉽도록, 현재 날짜 ~ 현재 날짜로 초기화



## 중점적으로 리뷰받고 싶은 부분(선택)


## 논의하고 싶은 부분(선택)
> 일단 현재 상시모집 버튼을 클릭하면, 사용자에게도 2999년으로 날짜가 보이도록 해뒀는데, 보여주면 안 될 것 같아서 고민입니다.

> 그리고, 현재 상시모집 판별을 2999년으로 하고 있는데, 3000년으로 할 경우 상시모집이 아닌 것도 조금 이상한 것 같습니다...

## 🫡 참고사항