### PR TITLE
[refactor] 헤더 구조 리펙토링 / 탭 활성 상태 추가 / 각종 UI 버그 수정

### DIFF
--- a/frontend/src/components/common/Header/Header.styles.ts
+++ b/frontend/src/components/common/Header/Header.styles.ts
@@ -1,193 +1,171 @@
 import styled from 'styled-components';
+import { media } from '@/styles/mediaQuery';
 
-export const HeaderStyles = styled.header`
+export const Header = styled.header`
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
+  width: 100%;
   height: 62px;
   padding: 10px 40px;
-  max-width: 1180px;
-  margin: 0 auto;
-  z-index: 2;
   background-color: white;
+  z-index: 2;
 
-  @media (max-width: 500px) {
-    display: none;
+  ${media.tablet} {
+    height: 56px;
+    padding: 10px 40px;
+  }
+
+  ${media.mobile}{
+    padding: 5px 20px;
+  }
+
+  ${media.mobile}{
+    padding: 5px 10px;
   }
 `;
 
-export const HeaderContainer = styled.div`
+export const Container = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  gap: 80px;
+  max-width: 1100px;
+  margin: 0 auto;
+  gap: 50px;
 
-  @media (max-width: 698px) {
-    gap: 50px;
+  ${media.tablet} {
+    gap: 35px;
+  }
+  ${media.mobile} {
+    gap: 30px;
+  }
+  ${media.mini_mobile} {
+    gap: 15px;
   }
 `;
 
-export const TextCoverStyles = styled.div`
-  display: flex;
-  width: 365px;
-  white-space: nowrap;
-
-  @media (max-width: 698px) {
-    width: 220px;
-  }
-`;
-
-export const LogoButtonStyles = styled.button`
-  width: 152px;
-  height: 43px;
-  background-color: transparent;
+export const LogoButton = styled.button`
+  background: none;
   border: none;
-  color: #000000;
   cursor: pointer;
+  padding: 0;
 
-  img {
+  .desktop-logo {
+    display: block;
     width: 152px;
     height: auto;
-    object-fit: cover;
   }
 
-  @media (max-width: 698px) {
-    width: 117px;
-    height: 41px;
+  .mobile-logo {
+    display: none;
+  }
 
-    img {
-      width: 117px;
+  @media (max-width: 870px) {
+    .desktop-logo {
+      display: none;
+    }
+    .mobile-logo {
+      display: block;
+      width: 32px;
+      height: auto;
     }
   }
 `;
 
-export const IntroduceButtonStyles = styled.a`
-  margin-left: 45px;
-  width: 63px;
-  height: 43px;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 42px;
-  cursor: pointer;
-  color: inherit;
-  text-decoration: none;
+export const Nav = styled.nav<{ isOpen: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 45px;
 
-  &:visited {
-    color: inherit;
-    text-decoration: none;
-  }
-
-  @media (max-width: 698px) {
-    width: 63px;
-    height: 43px;
-  }
-`;
-
-export const MobileHeaderContainer = styled.header`
-  display: none;
-
-  @media (max-width: 500px) {
+  ${media.tablet} {
     position: fixed;
-    display: flex;
-    top: 0;
+    top: 56px;
     left: 0;
     right: 0;
-    height: 56px;
-    padding: 0px 20px;
-    margin: 0 auto;
-    z-index: 2;
-    background-color: white;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0;
+    background: #fff;
+    margin-bottom: 16px;
+    border-radius: 0 0 20px 20px;
+    box-shadow: 0px 20px 30px rgba(0, 0, 0, 0.16);
+    transform: translateY(${({ isOpen }) => (isOpen ? '0' : '-200%')});
+    transition: opacity 0.3s ease-in-out;
+    z-index: 1;
   }
 `;
 
-export const MobileHeaderWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-`;
-
-export const MobileMainIcon = styled.button`
-  width: 32.562px;
-  height: 26px;
-  background-color: transparent;
+export const NavLink = styled.button<{ isActive?: boolean }>`
   border: none;
+  font-weight: 500;
+  font-size: 14px;
   cursor: pointer;
+  white-space: nowrap;
+  color: ${({ isActive }) => (isActive ? '#FF5414' : '#3A3A3A')};
+  background: transparent;
+  transition: all 0.2s ease-in-out;
 
-  img {
-    width: 32.562px;
-    height: auto;
-    object-fit: cover;
+  &:hover {
+    opacity: 0.7;
+  }
+
+  ${media.tablet} {
+    display: inline-flex;
+    padding: 12px 24px;
+    background: ${({ isActive }) => (isActive ? 'rgba(255, 84, 20, 0.08)' : 'none')};
+    
+    &:last-child {
+      margin-bottom: 16px;
+    }
   }
 `;
 
-export const MobileMenu = styled.button`
-  width: 20px;
-  height: 16px;
-  background-color: transparent;
+export const MenuButton = styled.button<{ isOpen: boolean }>`
+  display: none;
+  background: none;
   border: none;
   cursor: pointer;
+  padding: 0;
+  width: 24px;
+  height: 18px;
+  position: relative;
+  z-index: 3;
 
-  img {
+  ${media.tablet} {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+  }
+
+  ${media.mobile} {
     width: 20px;
-    height: auto;
-    object-fit: cover;
   }
-`;
 
-export const DrawerContainer = styled.div<{ isOpen: boolean }>`
-  position: fixed;
-  top: ${({ isOpen }) => (isOpen ? '0' : '-175px')};
-  height: 175px;
-  left: 0;
-  right: 0;
-  border-radius: 0px 0px 20px 20px;
-  background: #fff;
-  box-shadow: 0px 20px 30px 0px rgba(0, 0, 0, 0.25);
-  transition: top 0.2s ease-in-out;
-  z-index: 2;
-  padding: 20px;
+  span {
+    display: block;
+    width: 100%;
+    height: 2px;
+    background-color: #4B4B4B;
+    border-radius: 2px;
+    transition: all 0.3s ease-in-out;
+    transform-origin: center;
+  }
 
-  visibility: ${({ isOpen }) => (isOpen ? 'visible' : 'hidden')};
-`;
-
-export const DrawerWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  gap: 34.75px;
-`;
-
-export const DrawerHeader = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  gap: 150px;
-`;
-
-export const DrawerMainIcon = styled.img`
-  width: 158px;
-  height: 32.25px;
-  flex-shrink: 0;
-  cursor: pointer;
-`;
-
-export const DrawerDeleteIcon = styled.img`
-  width: 17px;
-  height: 17px;
-  flex-shrink: 0;
-`;
-
-export const MenubarIntroduceBox = styled.div`
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  padding: 6px 36px;
-  border-radius: 52px;
-  background: rgba(255, 84, 20, 0.08);
-  cursor: pointer;
+  ${({ isOpen }) =>
+    isOpen &&
+    `
+    span:nth-child(1) {
+      transform: translateY(8.25px) rotate(45deg);
+    }
+    
+    span:nth-child(2) {
+      opacity: 0;
+    }
+    
+    span:nth-child(3) {
+      transform: translateY(-8.25px) rotate(-45deg);
+    }
+  `}
 `;

--- a/frontend/src/components/common/Header/Header.tsx
+++ b/frontend/src/components/common/Header/Header.tsx
@@ -1,155 +1,73 @@
-import { memo } from 'react';
+import { useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import * as Styled from './Header.styles';
 
 import SearchBox from '@/pages/MainPage/components/SearchBox/SearchBox';
-import useIsMobile from '@/hooks/useIsMobile';
-import useMobileMenu from '@/services/header/useMobileMenu';
 import useHeaderService from '@/services/header/useHeaderService';
 
 import DesktopMainIcon from '@/assets/images/moadong_name_logo.svg';
 import MobileMainIcon from '@/assets/images/logos/moadong_mobile_logo.svg';
-import MenuBarIcon from '@/assets/images/icons/menu_button_icon.svg';
-import DeleteIcon from '@/assets/images/introduce/delete.png';
-
-interface NavLinkData {
-  label: string;
-  handler: () => void;
-}
-
-interface DesktopHeaderProps {
-  isAdminPage: boolean;
-  navLinks: NavLinkData[];
-  onHomeClick: () => void;
-}
-
-interface MobileHeaderProps {
-  onHomeClick: () => void;
-  onMenuClick: () => void;
-}
-
-interface MobileMenuDrawerProps {
-  isOpen: boolean;
-  onClose: () => void;
-  navLinks: NavLinkData[];
-  onHomeClick: () => void;
-}
-
-const DesktopHeader = memo(
-  ({ isAdminPage, navLinks, onHomeClick }: DesktopHeaderProps) => (
-    <Styled.HeaderStyles>
-      <Styled.HeaderContainer>
-        <Styled.TextCoverStyles>
-          <Styled.LogoButtonStyles
-            onClick={onHomeClick}
-            aria-label='홈으로 이동'
-          >
-            <img src={DesktopMainIcon} alt='모아동 로고' />
-          </Styled.LogoButtonStyles>
-          {!isAdminPage &&
-            navLinks.map((link) => (
-              <Styled.IntroduceButtonStyles
-                key={link.label}
-                onClick={link.handler}
-              >
-                {link.label}
-              </Styled.IntroduceButtonStyles>
-            ))}
-        </Styled.TextCoverStyles>
-        {!isAdminPage && <SearchBox />}
-      </Styled.HeaderContainer>
-    </Styled.HeaderStyles>
-  ),
-);
-
-const MobileMenuDrawer = memo(
-  ({ isOpen, onClose, navLinks, onHomeClick }: MobileMenuDrawerProps) => (
-    <Styled.DrawerContainer isOpen={isOpen}>
-      <Styled.DrawerHeader>
-        <Styled.DrawerMainIcon
-          src={DesktopMainIcon}
-          alt='모아동 로고'
-          onClick={onHomeClick}
-        />
-        <Styled.DrawerDeleteIcon
-          src={DeleteIcon}
-          alt='메뉴 닫기'
-          onClick={onClose}
-        />
-      </Styled.DrawerHeader>
-      {navLinks.map((link) => (
-        <Styled.MenubarIntroduceBox
-          key={link.label}
-          onClick={() => {
-            link.handler();
-            onClose();
-          }}
-        >
-          {link.label}
-        </Styled.MenubarIntroduceBox>
-      ))}
-    </Styled.DrawerContainer>
-  ),
-);
-
-const MobileHeader = memo(({ onHomeClick, onMenuClick }: MobileHeaderProps) => (
-  <Styled.MobileHeaderContainer>
-    <Styled.MobileHeaderWrapper>
-      <Styled.MobileMainIcon onClick={onHomeClick} aria-label='홈으로 이동'>
-        <img src={MobileMainIcon} alt='모아동 로고' />
-      </Styled.MobileMainIcon>
-      <SearchBox />
-      <Styled.MobileMenu onClick={onMenuClick} aria-label='메뉴 열기'>
-        <img src={MenuBarIcon} alt='' />
-      </Styled.MobileMenu>
-    </Styled.MobileHeaderWrapper>
-  </Styled.MobileHeaderContainer>
-));
 
 const Header = () => {
-  const isMobile = useIsMobile();
   const location = useLocation();
   const isAdminPage = location.pathname.startsWith('/admin');
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   const {
     handleHomeClick,
     handleIntroduceClick,
     handleClubUnionClick,
-    handleMenuClick,
   } = useHeaderService();
 
-  const { isMenuOpen, openMenu, closeMenu } = useMobileMenu({
-    handleMenuClick,
-  });
-
-  const navLinks: NavLinkData[] = [
-    { label: '모아동 소개', handler: handleIntroduceClick },
-    { label: '총동아리연합회 소개', handler: handleClubUnionClick },
+  const navLinks = [
+    { label: '모아동 소개', handler: handleIntroduceClick, path: '/introduce' },
+    { label: '총동아리연합회 소개', handler: handleClubUnionClick, path: '/club-union' },
+    { label: '패치노트', handler: () => {}, path: '/patch-note' },
   ];
+
+  const closeMenu = () => setIsMenuOpen(false);
+  const toggleMenu = () => setIsMenuOpen((prev) => !prev);
 
   return (
     <>
-      {isMobile ? (
-        <MobileHeader
-          onHomeClick={() => handleHomeClick('mobile')}
-          onMenuClick={openMenu}
-        />
-      ) : (
-        <DesktopHeader
-          isAdminPage={isAdminPage}
-          navLinks={navLinks}
-          onHomeClick={() => handleHomeClick('desktop')}
-        />
-      )}
-      <MobileMenuDrawer
-        isOpen={isMenuOpen}
-        onClose={closeMenu}
-        navLinks={navLinks}
-        onHomeClick={() => {
-          handleHomeClick('mobile');
-          closeMenu();
-        }}
-      />
+      <Styled.Header>
+        <Styled.Container>
+          <Styled.LogoButton onClick={handleHomeClick} aria-label="홈으로 이동">
+            <img className="desktop-logo" src={DesktopMainIcon} alt="모아동 로고" />
+            <img className="mobile-logo" src={MobileMainIcon} alt="모아동 로고" />
+          </Styled.LogoButton>
+
+          {!isAdminPage && (
+            <Styled.Nav isOpen={isMenuOpen}>
+              {navLinks.map((link) => (
+                <Styled.NavLink
+                  key={link.label}
+                  isActive={location.pathname === link.path}
+                  onClick={() => {
+                    link.handler();
+                    closeMenu();
+                  }}
+                >
+                  {link.label}
+                </Styled.NavLink>
+              ))}
+            </Styled.Nav>
+          )}
+
+          {/* TODO 동아리 관리자 프로필 추가 */}
+          {!isAdminPage && <SearchBox />}
+
+          <Styled.MenuButton 
+            onClick={toggleMenu} 
+            isOpen={isMenuOpen}
+            aria-label={isMenuOpen ? '메뉴 닫기' : '메뉴 열기'}
+          >
+            <span />
+            <span />
+            <span />
+          </Styled.MenuButton>
+        </Styled.Container>
+      </Styled.Header>
     </>
   );
 };

--- a/frontend/src/components/common/SearchField/SearchField.styles.ts
+++ b/frontend/src/components/common/SearchField/SearchField.styles.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { media } from '@/styles/mediaQuery';
 
 export const SearchBoxContainer = styled.form<{ $isFocused: boolean }>`
   display: flex;
@@ -7,18 +8,18 @@ export const SearchBoxContainer = styled.form<{ $isFocused: boolean }>`
   width: 345px;
   height: 36px;
   padding: 3px 20px;
-  border: transparent;
+  border: 1px solid transparent;
   border-radius: 41px;
-  background-color: #eeeeee;
+  background-color: ${({ $isFocused }) =>
+    $isFocused ? '#ffffff' : '#eeeeee'};
+  transition: all 0.2s ease-in-out;
 
-  @media (max-width: 500px) {
+  border-color: ${({ $isFocused }) =>
+    $isFocused ? 'rgba(255, 84, 20, 0.8)' : 'transparent'};
+  ${media.mobile} {
     width: 255px;
     height: 36px;
     padding: 6px 16px;
-
-    border: 1px solid
-      ${({ $isFocused }) =>
-        $isFocused ? 'rgba(255, 84, 20, 0.8)' : 'transparent'};
   }
 `;
 
@@ -39,12 +40,12 @@ export const SearchInputStyles = styled.input`
     opacity: 0;
   }
 
-  @media (max-width: 550px) {
-    font-size: 10px;
+  ${media.mobile} {
+    font-size: 12px;
   }
 
-  @media (max-width: 500px) {
-    font-size: 14px;
+  ${media.mini_mobile} {
+    font-size: 11px;
   }
 `;
 
@@ -54,6 +55,7 @@ export const SearchButton = styled.button<{ $isFocused: boolean }>`
   background-color: transparent;
   font-size: 16px;
   cursor: pointer;
+  transition: all 0.2s ease-in-out;
 
   width: 16px;
   height: 16px;
@@ -61,15 +63,16 @@ export const SearchButton = styled.button<{ $isFocused: boolean }>`
   img {
     width: 100%;
     height: 100%;
+    transition: filter 0.2s ease-in-out;
   }
 
-  @media (max-width: 500px) {
+  filter: ${({ $isFocused }) =>
+    $isFocused
+      ? 'invert(36%) sepia(83%) saturate(746%) hue-rotate(359deg) brightness(95%) contrast(92%)'
+      : 'none'};
+
+  ${media.mobile} {
     width: 14px;
     height: 14px;
-
-    filter: ${({ $isFocused }) =>
-      $isFocused
-        ? 'invert(36%) sepia(83%) saturate(746%) hue-rotate(359deg) brightness(95%) contrast(92%)'
-        : 'none'};
   }
 `;

--- a/frontend/src/services/header/useHeaderService.ts
+++ b/frontend/src/services/header/useHeaderService.ts
@@ -4,24 +4,18 @@ import { useSearchStore } from '@/store/useSearchStore';
 import useMixpanelTrack from '@/hooks/useMixpanelTrack';
 import { EVENT_NAME } from '@/constants/eventName';
 
-const trackEventNames = {
-  desktop: EVENT_NAME.HOME_BUTTON_CLICKED,
-  mobile: EVENT_NAME.MOBILE_HOME_BUTTON_CLICKED,
-} as const;
-
 const useHeaderService = () => {
   const navigate = useNavigate();
   const trackEvent = useMixpanelTrack();
 
-  const navigateToHome = useCallback(
-    (device: keyof typeof trackEventNames) => {
-      navigate('/');
-      const { resetSearch } = useSearchStore.getState();
-      resetSearch();
-      trackEvent(trackEventNames[device]);
-    },
-    [navigate, trackEvent],
-  );
+  const handleHomeClick = useCallback(() => {
+    navigate('/');
+    useSearchStore.getState().resetSearch();
+    // 속성으로 관리
+    trackEvent(EVENT_NAME.HOME_BUTTON_CLICKED, {
+      device_type: window.innerWidth <= 700 ? 'mobile' : 'desktop'
+    });
+  }, [navigate, trackEvent]);
 
   const handleIntroduceClick = useCallback(() => {
     navigate('/introduce');
@@ -33,15 +27,10 @@ const useHeaderService = () => {
     trackEvent(EVENT_NAME.CLUB_UNION_BUTTON_CLICKED);
   }, [navigate, trackEvent]);
 
-  const handleMenuClick = useCallback(() => {
-    trackEvent(EVENT_NAME.MOBILE_MENU_BUTTON_CLICKED);
-  }, [trackEvent]);
-
   return {
-    handleHomeClick: navigateToHome,
+    handleHomeClick,
     handleIntroduceClick,
     handleClubUnionClick,
-    handleMenuClick,
   };
 };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지/동영상 첨부 가능)


헤더 컴포넌트 구조를 개선하고 반응형 처리를 CSS로 전환

## 주요 변경사항
### 1. 컴포넌트 구조 단순화
- DesktopHeader, MobileHeader, MobileDrawer 통합 → 단일 Nav 컴포넌트
- 조건부 렌더링 제거, CSS 미디어 쿼리로 반응형 처리
- 코드량 약 60% 감소

### 2. 레이아웃 버그 수정
- Header width 100% 적용
- Container max-width로 콘텐츠 제한
- 1280px 이상에서 헤더 잘림 현상 해결
<img width="1904" height="206" alt="image" src="https://github.com/user-attachments/assets/a694646c-2ae3-4370-b29c-2ecb08dd7567" />


<img width="462" height="187" alt="image" src="https://github.com/user-attachments/assets/886cdf66-fb9e-4c98-a43d-2a4d726262ed" />



### 3. 기능 개선
- 활성 NavLink 표시 추가 (현재 경로 하이라이트)
- 햄버거 → X 애니메이션 개선


<br />

## 기술적 개선
- useIsMobile 훅 제거
- useMobileMenu 제거
- 불필요한 device 파라미터 제거











## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항