### PR TITLE
[refactor] 클럽 지원 양식 불러오기 구버전 api를 제거한다

### DIFF
--- a/backend/src/main/java/moadong/club/controller/ClubApplyControllerV1.java
+++ b/backend/src/main/java/moadong/club/controller/ClubApplyControllerV1.java
@@ -38,15 +38,6 @@ public class ClubApplyControllerV1 {
     private final ClubApplyServiceV1 clubApplyServiceV1;
     private final ClubApplicationFormsRepository clubApplicationFormsRepository;
 
-    @GetMapping("/apply") //
-    @Operation(summary = "클럽 지원서 양식 불러오기",
-            description = "clubId를 기반으로 활성화된 최신 지원서를 반환합니다. <br>"
-                    + "<br>v2 api : /api/club/{clubId}/apply/{applicationFormId}")
-    public ResponseEntity<?> getClubApplication(@PathVariable String clubId) {
-
-        return clubApplyServiceV1.getClubApplicationForm(clubId, convertClubIdToFormId(clubId));
-    }
-
     @PostMapping("/apply")
     @Operation(summary = "클럽 지원", description = "clubId를 기반으로 활성화된 최신 지원서에 지원합니다. <br>"
                     + "<br>v2 api : /api/club/{clubId}/apply/{applicationFormId}")

--- a/backend/src/main/java/moadong/club/controller/ClubApplyPublicController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubApplyPublicController.java
@@ -34,11 +34,11 @@ public class ClubApplyPublicController {
         return Response.ok("success apply");
     }
 
-     /*@GetMapping("/apply")
+     @GetMapping("/apply")
     @Operation(summary = "클럽의 활성화된 지원서 목록 불러오기", description = "클럽의 활성화된 모든 지원서 목록을 불러옵니다")
     public ResponseEntity<?> getActiveApplicationForms(@PathVariable String clubId) {
-        return Response.ok(clubApplyService.getActiveApplicationForms(clubId));
-    }*/
+        return Response.ok(clubApplyPublicService.getActiveApplicationForms(clubId));
+    }
 
 
 

--- a/backend/src/main/java/moadong/club/payload/dto/ClubActiveFormResult.java
+++ b/backend/src/main/java/moadong/club/payload/dto/ClubActiveFormResult.java
@@ -5,7 +5,6 @@ import lombok.Builder;
 @Builder
 public record ClubActiveFormResult(
         String id,
-        String title,
-        String description
+        String title
 ) {
 }

--- a/backend/src/main/java/moadong/club/payload/dto/ClubActiveFormSlim.java
+++ b/backend/src/main/java/moadong/club/payload/dto/ClubActiveFormSlim.java
@@ -3,5 +3,4 @@ package moadong.club.payload.dto;
 public interface ClubActiveFormSlim {
     String getId();
     String getTitle();
-    String getDescription();
 }

--- a/backend/src/main/java/moadong/club/repository/ClubApplicationFormsRepository.java
+++ b/backend/src/main/java/moadong/club/repository/ClubApplicationFormsRepository.java
@@ -27,7 +27,7 @@ public interface ClubApplicationFormsRepository extends MongoRepository<ClubAppl
 
     @Query(
             value = "{'clubId':  ?0, 'status': 'ACTIVE'}",
-            fields = "{'_id': 1, 'title':  1, 'description': 1}"
+            fields = "{'_id': 1, 'title':  1}"
     )
     List<ClubActiveFormSlim> findClubActiveFormsByClubId(String clubId);
 

--- a/backend/src/main/java/moadong/club/service/ClubApplyAdminService.java
+++ b/backend/src/main/java/moadong/club/service/ClubApplyAdminService.java
@@ -176,30 +176,6 @@ public class ClubApplyAdminService {
     private record SemesterKey(Integer year, SemesterTerm term) {
     }
 
-
-    public ClubActiveFormsResponse getActiveApplicationForms(String clubId) {
-        List<ClubActiveFormSlim> forms = clubApplicationFormsRepository.findClubActiveFormsByClubId(clubId);
-
-        if (forms == null || forms.isEmpty())
-            throw new RestApiException(ErrorCode.ACTIVE_APPLICATION_NOT_FOUND);
-
-        List<ClubActiveFormResult> results = new ArrayList<>();
-        for (ClubActiveFormSlim form : forms) {
-            ClubActiveFormResult result = ClubActiveFormResult.builder()
-                    .id(form.getId())
-                    .title(form.getTitle())
-                    .description(form.getDescription())
-                    .build();
-            results.add(result);
-        }
-
-        return ClubActiveFormsResponse.builder()
-                .forms(results)
-                .build();
-
-    }
-
-    //V1
     public ClubApplyInfoResponse getClubApplyInfo(String applicationFormId, CustomUserDetails user) {
         ClubApplicationForm applicationForm = clubApplicationFormsRepository.findByClubIdAndId(user.getClubId(), applicationFormId)
                 .orElseThrow(() -> new RestApiException(ErrorCode.APPLICATION_NOT_FOUND));

--- a/backend/src/main/java/moadong/club/service/ClubApplyPublicService.java
+++ b/backend/src/main/java/moadong/club/service/ClubApplyPublicService.java
@@ -7,11 +7,13 @@ import moadong.club.entity.ClubApplicationForm;
 import moadong.club.entity.ClubApplicationFormQuestion;
 import moadong.club.entity.ClubQuestionAnswer;
 import moadong.club.enums.ClubApplicationQuestionType;
+import moadong.club.payload.dto.ClubActiveFormResult;
+import moadong.club.payload.dto.ClubActiveFormSlim;
 import moadong.club.payload.request.ClubApplyRequest;
+import moadong.club.payload.response.ClubActiveFormsResponse;
 import moadong.club.payload.response.ClubApplicationFormResponse;
 import moadong.club.repository.ClubApplicantsRepository;
 import moadong.club.repository.ClubApplicationFormsRepository;
-import moadong.club.repository.ClubApplicationFormsRepositoryCustom;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
 import moadong.global.payload.Response;
@@ -30,8 +32,28 @@ public class ClubApplyPublicService {
     private final ClubApplicationFormsRepository clubApplicationFormsRepository;
     private final ClubApplicantsRepository clubApplicantsRepository;
     private final AESCipher cipher;
-    private final ClubApplicationFormsRepositoryCustom clubApplicationFormsRepositoryCustom;
 
+
+    public ClubActiveFormsResponse getActiveApplicationForms(String clubId) {
+        List<ClubActiveFormSlim> forms = clubApplicationFormsRepository.findClubActiveFormsByClubId(clubId);
+
+        if (forms == null || forms.isEmpty())
+            throw new RestApiException(ErrorCode.ACTIVE_APPLICATION_NOT_FOUND);
+
+        List<ClubActiveFormResult> results = new ArrayList<>();
+        for (ClubActiveFormSlim form : forms) {
+            ClubActiveFormResult result = ClubActiveFormResult.builder()
+                    .id(form.getId())
+                    .title(form.getTitle())
+                    .build();
+            results.add(result);
+        }
+
+        return ClubActiveFormsResponse.builder()
+                .forms(results)
+                .build();
+
+    }
 
     public ResponseEntity<?> getClubApplicationForm(String clubId, String applicationFormId) {
         ClubApplicationForm clubApplicationForm = clubApplicationFormsRepository.findByClubIdAndId(clubId, applicationFormId)

--- a/backend/src/main/java/moadong/club/service/ClubApplyServiceV1.java
+++ b/backend/src/main/java/moadong/club/service/ClubApplyServiceV1.java
@@ -37,23 +37,6 @@ public class ClubApplyServiceV1 {
     private final ClubApplicantsRepository clubApplicantsRepository;
     private final AESCipher cipher;
 
-    public ResponseEntity<?> getClubApplicationForm(String clubId, String applicationFormId) {
-        ClubApplicationForm clubApplicationForm = clubApplicationFormsRepository.findByClubIdAndId(clubId, applicationFormId)
-                .orElseThrow(() -> new RestApiException(ErrorCode.APPLICATION_NOT_FOUND));
-
-
-        ClubApplicationFormResponse clubApplicationFormResponse = ClubApplicationFormResponse.builder()
-                .title(clubApplicationForm.getTitle())
-                .description(Optional.ofNullable(clubApplicationForm.getDescription()).orElse(""))
-                .questions(clubApplicationForm.getQuestions())
-                .semesterYear(clubApplicationForm.getSemesterYear())
-                .semesterTerm(clubApplicationForm.getSemesterTerm())
-                .status(clubApplicationForm.getStatus())
-                .build();
-
-        return Response.ok(clubApplicationFormResponse);
-    }
-
     public void applyToClub(String clubId, String applicationFormId, ClubApplyRequest request) {
         ClubApplicationForm clubApplicationForm = clubApplicationFormsRepository.findByClubIdAndId(clubId, applicationFormId)
                 .orElseThrow(() -> new RestApiException(ErrorCode.APPLICATION_NOT_FOUND));


### PR DESCRIPTION
## #️⃣연관된 이슈

#790 

## 📝작업 내용

> 구버전 api 중에 "클럽 지원서 양식 불러오기"를 제거하고,
> 지난 pr에 주석처리 되어 있던 "클럽의 활성화된 지원서 목록 불러오기" api의 주석을 제거했습니다.
> -> 이제 **/api/club/{clubId}/apply** 로 다중 지원서 모달에 사용될 활성화된 지원서 리스트 반환합니다.
<img width="748" height="298" alt="스크린샷 2025-10-12 16 32 03" src="https://github.com/user-attachments/assets/0444c78a-427e-406c-a87d-b4cb59d246d9" />


## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 공개 API로 클럽의 활성 지원서 목록 조회 엔드포인트를 제공합니다. 목록 항목은 id와 title을 포함합니다.

* 리팩터링
  * 기존의 클럽별 최신 지원서 단건 조회 GET 엔드포인트가 제거되었습니다. 제출용 POST 엔드포인트는 그대로입니다.
  * 활성 지원서 목록 응답에서 description 필드가 제거되어 응답 스키마가 간소화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->