### PR TITLE
[fix] 페이지 체류 시간 중복 집계 버그 수정

### DIFF
--- a/frontend/src/hooks/useTrackPageView.ts
+++ b/frontend/src/hooks/useTrackPageView.ts
@@ -16,6 +16,7 @@ const useTrackPageView = (pageName: string, clubName?: string) => {
     });
 
     const trackPageDuration = () => {
+      // 레이스 컨디션 방지: 체크와 설정을 원자적으로 처리
       if (isTracked.current) return;
       isTracked.current = true;
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #803

## 📝작업 내용

### 이전의 trackPageDuration함수

`trackPageDuration`은 사용자가 특정 페이지에 머무는 시간을 기록하는 함수입니다. 

```typescript
    const trackPageDuration = () => {
      if (isTracked.current) return;

      const duration = Date.now() - startTime.current;
      mixpanel.track(`${pageName} Duration`, {
        url: window.location.href,
        duration: duration,
        duration_seconds: Math.round(duration / 1000),
        clubName,
      });
     isTracked.current = true;
    };
```

`mixpanel.track()` 함수는 비동기 네트워크 요청이기에  `trackPageDuration`함수는` isTracked.current = true;`가 수행되기 전까지 기다리지 않습니다.

만약 `visibilitychange`이벤트와 useEffect의 클린업 함수가 거의 동시에 `trackPageDuration`함수를 호출하면, 현재 코드는 아래와 같이 동작합니다.

```
1. [호출 1] (visibilitychange): if (isTracked.current)가 false인지 확인 -> 통과
2. [호출 2] (useEffect Cleanup): if (isTracked.current)가 false인지 확인 -> 또 통과 (아직 [호출 1]이 true로 바꾸기 전)
3. [호출 1]: mixpanel.track() 실행 (Duration 1번째 전송)
4. [호출 2]: mixpanel.track() 실행 (Duration 2번째 중복 전송)
5. [호출 1]: isTracked.current = true;로 설정
6. [호출 2]: isTracked.current = true;로 설정 (이미 늦음)
```
이러면 `Visited`는 1번인데 `Duration`은 2번 전송됩니다. 

### 개선하기

비동기 트래킹 로직 전에 isTracked 플래그를 사용한 중복 트래킹 방지 로직을 배치함으로써 레이스 컨디션을 해결할 수 있습니다.

```typescript
const trackPageDuration = () => {
  if (isTracked.current) return;

  // 통과했으면 즉시 '잠금'을 설정
  isTracked.current = true; 

  // 그 다음에 안전하게 비동기 작업을 수행
  const duration = Date.now() - startTime.current;
  mixpanel.track(`${pageName} Duration`, {
    url: window.location.href,
    duration: duration,
    duration_seconds: Math.round(duration / 1000),
    clubName,
  });
};
```



## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 페이지 조회 추적의 안정성을 개선했습니다. 중복 실행을 방지해 한 번만 페이지 체류 시간을 기록하도록 했고, 기록 시점 조정으로 경합 상황에서의 재진입 문제를 막아 조회 정보의 정확도가 향상됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->