### PR TITLE
[fix] 소개페이지 카드 위치 조정

### DIFF
--- a/frontend/src/pages/IntroducePage/components/sections/1.IntroSection/IntroSection.tsx
+++ b/frontend/src/pages/IntroducePage/components/sections/1.IntroSection/IntroSection.tsx
@@ -19,8 +19,8 @@ import introduce_phone_mockup from '@/assets/images/introduce/introduce_phone_mo
 import ClubCard from '@/pages/MainPage/components/ClubCard/ClubCard';
 
 const cardPositions = [
-  { top: '300px', left: '-300px' },
-  { top: '300px', left: '-630px' },
+  { top: '280px', left: '-300px' },
+  { top: '330px', left: '-630px' },
   { top: '280px', right: '-220px' },
   { top: '310px', right: '-580px' },
 ];


### PR DESCRIPTION
## #️⃣연관된 이슈

> #818 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지/동영상 첨부 가능)

### 1. 메인 페이지 동아리 카드 디자인 변경으로 어색해진 UI를 살짝 다듬었습니다.


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 소개 섹션의 카드 배치 위치 조정으로 화면 레이아웃 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->