### PR TITLE
[Hotfix] 백엔드 totalCount 미응답 시 clubs.length 기준으로 카드리스트 표시 처리 

### DIFF
--- a/frontend/src/pages/MainPage/MainPage.tsx
+++ b/frontend/src/pages/MainPage/MainPage.tsx
@@ -24,18 +24,23 @@ const MainPage = () => {
   const division = 'all';
   const searchCategory = isSearching ? 'all' : selectedCategory;
   const tabs = ['중앙동아리'] as const;
-  const [active, setActive] = useState<typeof tabs[number]>('중앙동아리');
+  const [active, setActive] = useState<(typeof tabs)[number]>('중앙동아리');
   // TODO: 추후 확정되면 DivisionKey(중동/가동/과동) 같은 타입을
   // types/club.ts에 정의해서 tabs 관리하도록 리팩터링하기
-  
-  const { data, error, isLoading } = 
-    useGetCardList({ keyword, recruitmentStatus, category: searchCategory, division });
-  
-  const clubs = data?.clubs || [];
-  const totalCount = data?.totalCount || 0;
 
-  const isEmpty = !isLoading && totalCount === 0;
-  const hasData = totalCount > 0;
+  const { data, error, isLoading } = useGetCardList({
+    keyword,
+    recruitmentStatus,
+    category: searchCategory,
+    division,
+  });
+
+  const clubs = data?.clubs || [];
+  // const totalCount = data?.totalCount || 0; // ⚠️ 백엔드 업데이트 전까지 임시 주석
+  const totalCount = data?.totalCount ?? clubs.length;
+
+  const isEmpty = !isLoading && clubs.length === 0;
+  const hasData = clubs.length > 0;
 
   const clubList = useMemo(() => {
     if (!hasData) return null;
@@ -58,18 +63,21 @@ const MainPage = () => {
 
         <Styled.SectionBar>
           <Styled.SectionTabs>
-          {tabs
-            .map((tab) =>(
-            <Styled.Tab key={tab} $active={active===tab} onClick={() => setActive(tab)}>
-              {tab}
-            </Styled.Tab>
-          ))}
-        </Styled.SectionTabs>
-        <Styled.TotalCountResult role="status">
-          {`전체 ${isLoading ? 0 : totalCount}개의 동아리`}
-        </Styled.TotalCountResult>
+            {tabs.map((tab) => (
+              <Styled.Tab
+                key={tab}
+                $active={active === tab}
+                onClick={() => setActive(tab)}
+              >
+                {tab}
+              </Styled.Tab>
+            ))}
+          </Styled.SectionTabs>
+          <Styled.TotalCountResult role='status'>
+            {`전체 ${isLoading ? 0 : totalCount}개의 동아리`}
+          </Styled.TotalCountResult>
         </Styled.SectionBar>
-      
+
         <Styled.ContentWrapper>
           {isLoading ? (
             <Spinner />


### PR DESCRIPTION
## #️⃣연관된 이슈

> #825

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지/동영상 첨부 가능)

백엔드 totalCount 응답 누락 시, clubs.length를 기준으로 카드리스트 표시하도록 임시 처리했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리즈 노트

* **리팩터링**
  * 코드 안정성 및 타입 안전성 강화를 위한 내부 개선사항 적용

이번 업데이트는 주로 코드 품질 개선에 중점을 두었으며, 사용자에게 영향을 주는 기능 변경사항은 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->