### PR TITLE
[fix] 지원서 양식 생성시에 placeholder가 안보이는 문제 수정

### DIFF
--- a/frontend/src/components/application/QuestionTitle/QuestionTitle.tsx
+++ b/frontend/src/components/application/QuestionTitle/QuestionTitle.tsx
@@ -25,13 +25,12 @@ const QuestionTitle = ({
     if (textAreaRef.current) {
       const el = textAreaRef.current;
       if (mode === 'answer') {
-        el.style.width = el.value.length + "ch";
+        el.style.width = el.value.length + 'ch';
       }
       el.style.height = '0px';
       el.style.height = `${el.scrollHeight}px`;
     }
   }, [title]);
-  
   return (
     <Styled.QuestionTitleRow>
       {!isMobile && id && (
@@ -50,9 +49,8 @@ const QuestionTitle = ({
             }
           }}
           value={title}
-          data-placeholder={title ? '' : APPLICATION_FORM.QUESTION_TITLE.placeholder}
-        >
-        </Styled.QuestionTitleText>
+          placeholder={title ? '' : APPLICATION_FORM.QUESTION_TITLE.placeholder}
+        ></Styled.QuestionTitleText>
         {mode === 'answer' && required && <Styled.QuestionRequired />}
       </Styled.QuestionTitleTextContainer>
     </Styled.QuestionTitleRow>


### PR DESCRIPTION
## #️⃣연관된 이슈

#838 

## 📝작업 내용

이전 
<img width="563" height="252" alt="스크린샷 2025-11-12 16 13 42" src="https://github.com/user-attachments/assets/e17b729a-cfda-4031-bb2a-8812cd29f6ab" />

변경후
<img width="537" height="234" alt="스크린샷 2025-11-12 16 13 24" src="https://github.com/user-attachments/assets/64111037-8eba-4266-b1cd-00b0a42035cc" />

큰문제는 아니고 placeholder여야하는 속성이 data-placeholder로 들어가있었습니다.

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항