### PR TITLE
[feature]  지원서 활성화 버튼 기능 구현

### DIFF
--- a/frontend/src/apis/application/updateApplication.ts
+++ b/frontend/src/apis/application/updateApplication.ts
@@ -10,7 +10,7 @@ export const updateApplication = async (
     const response = await secureFetch(
       `${API_BASE_URL}/api/club/application/${applicationFormId}`,
       {
-        method: 'PUT',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -30,4 +30,30 @@ export const updateApplication = async (
   }
 };
 
-export default updateApplication;
+export const updateApplicationStatus = async ( 
+  applicationFormId: string,
+  currentStatus: string,
+) => {
+  const newStatus = currentStatus === 'ACTIVE' ? false : true;
+  try {
+    const response = await secureFetch(
+      `${API_BASE_URL}/api/club/application/${applicationFormId}`,
+      {
+        method: 'PATCH',
+        headers: { 
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ active: newStatus }),
+      },
+    );
+    if (!response.ok) {
+      throw new Error('지원서 상태 수정에 실패했습니다.');
+    }
+    const result = await response.json();
+    return result.data;
+  } catch (error) {
+    console.error('지원서 상태 수정 중 오류 발생:', error);
+    throw error;
+  }
+};
+

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsListTab/ApplicantsListTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsListTab/ApplicantsListTab.tsx
@@ -117,7 +117,7 @@ const ApplicationListTab = () => {
             </Styled.DateHeader>
           </Styled.ListHeader>
           {(group.forms.map((application: ApplicationFormItem) => {
-            const isActive = application.status === 'active';
+            const isActive = application.status === 'ACTIVE';
             return (
             <Styled.ApplicationRow key={application.id}>
               <Styled.ApplicationTitle $active={isActive} onClick={() => handleGoToDetailForm(application.id)}>

--- a/frontend/src/pages/AdminPage/tabs/ApplicationListTab/ApplicationListTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicationListTab/ApplicationListTab.tsx
@@ -9,9 +9,12 @@ import Spinner from '@/components/common/Spinner/Spinner';
 import { useAdminClubContext } from '@/context/AdminClubContext';
 // import { useDeleteApplication } from '@/hooks/queries/application/useDeleteApplication';
 import { ApplicationFormItem, SemesterGroup } from '@/types/application';
+import { updateApplicationStatus } from '@/apis/application/updateApplication';
+import { useQueryClient } from '@tanstack/react-query';
 
 const ApplicationListTab = () => {
   const {data: allforms, isLoading, isError, error} = useGetApplicationlist();
+  const queryClient = useQueryClient();
   const navigate = useNavigate();
   const { setApplicationFormId } = useAdminClubContext();
   // const { mutate: deleteApplication } = useDeleteApplication();
@@ -37,6 +40,20 @@ const ApplicationListTab = () => {
   //     });
   //   }
   // };
+
+  const handleToggleClick = async (applicationFormId: string, currentStatus: string) => {
+  try {
+    await updateApplicationStatus(
+      applicationFormId,
+      currentStatus
+    );
+    queryClient.invalidateQueries({ queryKey: ['applicationForm'] });
+    setOpenMenuId(null);
+  } catch (error) {
+    console.error('지원서 상태 변경 실패:', error);
+    alert("상태 변경에 실패했습니다.");
+  }
+};
 
   const [openMenuId, setOpenMenuId] = useState<string | null>(null);
 
@@ -117,7 +134,7 @@ const ApplicationListTab = () => {
             </Styled.DateHeader>
           </Styled.ListHeader>
           {(group.forms.map((application: ApplicationFormItem) => {
-            const isActive = application.status === 'active';
+            const isActive = application.status === 'ACTIVE';
             return (
             <Styled.ApplicationRow key={application.id}>
               <Styled.ApplicationTitle $active={isActive} onClick={() => handleGoToEditForm(application.id)}>
@@ -139,6 +156,7 @@ const ApplicationListTab = () => {
                     <ApplicationMenu
                       isActive={isActive}
                       // onDelete={() => handleDeleteApplication(application.id)}
+                      onToggleStatus={() => handleToggleClick(application.id, application.status)}
                     />
                   )}
                 </Styled.MoreButtonContainer>

--- a/frontend/src/pages/AdminPage/tabs/ApplicationListTab/ApplicationMenu.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicationListTab/ApplicationMenu.tsx
@@ -8,24 +8,24 @@ import check_inactive from '@/assets/images/icons/check_inactive.svg';
 interface ApplicationMenuProps {
   isActive: boolean;
   // onDelete: () => void;
+  onToggleStatus?: () => void;
 }
 
-const ApplicationMenu = ({ isActive, 
+const ApplicationMenu = ({ isActive, onToggleStatus, 
   // onDelete
  }: ApplicationMenuProps) => {
-  // 각 메뉴 아이템 클릭 시 실행될 함수 (지금은 비워둠)
-  const onSetDefault = () => console.log('기본지원서로 설정');
   const onEditTitle = () => console.log('제목 수정하기');
+  const toggleButtonText = isActive ? '기본지원서 해제' : '기본지원서로 설정';
 
   return (
     <Styled.MenuContainer>
-      <Styled.MenuItem onClick={onSetDefault} className='default'>
+      <Styled.MenuItem onClick={onToggleStatus} className='default'>
         {isActive ? (
           <Styled.MenuIcon src={checkBox} />
         ) : (
           <Styled.MenuIcon src={check_inactive} />
         )}
-        기본지원서로 설정
+        {toggleButtonText}
       </Styled.MenuItem>
       <Styled.Separator />
       <Styled.MenuItem onClick={onEditTitle}>

--- a/frontend/src/types/application.ts
+++ b/frontend/src/types/application.ts
@@ -69,7 +69,7 @@ export interface ApplicationFormItem {
   id: string;
   title: string;
   editedAt: string;
-  status: 'active' | 'published' | 'unpublished';
+  status: 'ACTIVE' | 'PUBLISHED' | 'UNPUBLISHED';
 }
 
 export interface SemesterGroup {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#848 
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지/동영상 첨부 가능)
- 기본 지원서로 설정 클릭시 지원서 활성화 
- 활성화된 지원서는 기본 지원서 해제로 버튼 문구 변경
활성화 전
<img width="1268" height="285" alt="image" src="https://github.com/user-attachments/assets/b98b45a7-938c-4fcc-967b-5d5227db79e5" />
활성화 후
<img width="1232" height="272" alt="image" src="https://github.com/user-attachments/assets/a01dd7ab-ff6e-4073-a351-058b6b4d9989" />
기본지원서가 두개 이상일 경우 정상적으로 지원 모달이 뜨는 모습도 확인
<img width="627" height="387" alt="image" src="https://github.com/user-attachments/assets/568432e0-3187-45da-8e07-21f868fb0f61" />



## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 지원 관리 인터페이스 개선: 계층적 경로 구조 및 상세 리스트 뷰 추가
  * 지원서 관리 기능 확대: 학기 정보 및 활성화 상태 관리 기능 추가
  * 지원서 상태 전환 기능 구현

* **스타일**
  * UI 컴포넌트 개선: 로고, 태그, 카드 스타일 최적화
  * 반응형 디자인 강화: 모바일 화면 대응 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->