### PR TITLE
[fix] 모바일 헤더 검색바 레이아웃 순서 버그 수정

### DIFF
--- a/frontend/src/components/common/Header/Header.styles.ts
+++ b/frontend/src/components/common/Header/Header.styles.ts
@@ -150,6 +150,7 @@ export const MenuButton = styled.button<{ isOpen: boolean }>`
     display: flex;
     flex-direction: column;
     justify-content: space-between;
+    order: 2;
   }
 
   ${media.mobile} {


### PR DESCRIPTION
## #️⃣연관된 이슈

#870

## 📝작업 내용

모바일/태블릿 헤더에서 검색바가 중앙에 위치하지 않는 문제를 해결했습니다.

<img width="481"  alt="image" src="https://github.com/user-attachments/assets/3f952270-da5f-42b8-8409-ec1baca03ca3" />


<br />


### 변경사항
- `MenuButton`에 `order: 2`를 적용하여 flex 순서 조정
- 모바일 레이아웃: 로고(왼쪽) - 검색바(가운데) - 메뉴버튼(오른쪽)



<img width="481" height="334" alt="image" src="https://github.com/user-attachments/assets/3503a2ad-b1f4-4108-bdf5-cf728d9fd609" />


<br />


### 해결 방법
- Flexbox의 기본 order 값(0)을 활용
- 추가적인 wrapper 컴포넌트 없이 CSS만으로 간단하게 해결

<br />

## 중점적으로 리뷰받고 싶은 부분(선택)

헤더가 관리자/사용자에서 의도대로 동작하는지 확인 부탁드립니다.



## 논의하고 싶은 부분(선택)

-

## 🫡 참고사항

-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
- 태블릿 화면에서 헤더 메뉴 버튼의 레이아웃 위치가 조정되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->