### PR TITLE
[fix] 프로덕션 호스트 판별 방식 개선

### DIFF
--- a/frontend/src/utils/initSDK.ts
+++ b/frontend/src/utils/initSDK.ts
@@ -2,7 +2,7 @@ import mixpanel from 'mixpanel-browser';
 import * as ChannelService from '@channel.io/channel-web-sdk-loader';
 import * as Sentry from '@sentry/react';
 
-const PRODUCTION_URL = 'https://moadong.com';
+const PRODUCTION_HOSTNAMES = ['moadong.com', 'www.moadong.com'];
 
 export function initializeMixpanel() {
   if (import.meta.env.VITE_MIXPANEL_TOKEN) {
@@ -12,7 +12,7 @@ export function initializeMixpanel() {
     });
   }
 
-  const isProductionHost = window.location.hostname === 'moadong.com';
+  const isProductionHost = PRODUCTION_HOSTNAMES.includes(window.location.hostname);
   if (!isProductionHost) {
     mixpanel.disable();
   }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

- window.location.href.startsWith(...) 대신 window.location.hostname === 'moadong.com'으로 변경해 프로토콜·경로 차이 때문에 Mixpanel 로그가 차단되는 문제를 해결했습니다.
- PRODUCTION_HOSTNAMES 배열을 도입해 moadong.com뿐 아니라 www.moadong.com에서도 Mixpanel 로깅이 가능하도록 수정했습니다.


## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항