### PR TITLE
[fix] 카드 목록에 기본 이미지가 안불러 와지는 문제 수정

### DIFF
--- a/frontend/src/components/ClubLogo/ClubLogo.tsx
+++ b/frontend/src/components/ClubLogo/ClubLogo.tsx
@@ -29,7 +29,7 @@ const StyledClubLogo = styled.div<{
     background-color: #efefef;
     background-size: cover;
     background-position: center;
-    background-image: ${$imageSrc ? `url(${$imageSrc})` : 'none'};
+    background-image: ${$imageSrc ? `url("${$imageSrc}")` : 'none'};
   `}
 
   @media (max-width: 500px) {

--- a/frontend/src/pages/ClubDetailPage/components/ClubCard/ClubCard.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubCard/ClubCard.tsx
@@ -37,7 +37,7 @@ const ClubCard = ({ club }: { club: Club }) => {
     >
       <Styled.CardHeader>
         <Styled.ClubProfile>
-          <ClubLogo $imageSrc={club.logo || `"${default_profile_image}"`} />
+          <ClubLogo $imageSrc={club.logo || default_profile_image} />
           <Styled.ClubName>{club.name}</Styled.ClubName>
         </Styled.ClubProfile>
         <ClubStateBox state={club.recruitmentStatus} />

--- a/frontend/src/pages/MainPage/components/ClubCard/ClubCard.tsx
+++ b/frontend/src/pages/MainPage/components/ClubCard/ClubCard.tsx
@@ -35,7 +35,7 @@ const ClubCard = ({ club }: { club: Club }) => {
     >
       <Styled.CardHeader>
         <Styled.ClubProfile>
-          <ClubLogo $imageSrc={club.logo || `"${default_profile_image}"`} />
+          <ClubLogo $imageSrc={club.logo || default_profile_image} />
           <Styled.ClubInfo>
             <Styled.ClubName>{club.name}</Styled.ClubName>
             <Styled.Introduction>{club.introduction}</Styled.Introduction>


### PR DESCRIPTION
vite 환경으로 바꾸면서 
기존 background-image: url(base:64); 문자에 %24로 인코딩되던 작은 따옴표가 인코딩되지 않고 들어가서 invalid property로 인식됨
따라서 url 밖에 쌍따옴표를 감싸주면 해결됩니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 클럽 카드 컴포넌트의 마이너 포맷팅 개선
  * 클럽 로고 컴포넌트의 CSS 스타일 조정

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->