### PR TITLE
[fix] 지원서 목록에서 지원자 목록으로 안바뀌는 문제를 수정한다

### DIFF
--- a/frontend/src/pages/AdminPage/AdminRoutes.tsx
+++ b/frontend/src/pages/AdminPage/AdminRoutes.tsx
@@ -9,6 +9,7 @@ import ApplicationListTab from '@/pages/AdminPage/tabs/ApplicationListTab/Applic
 import PhotoEditTab from '@/pages/AdminPage/tabs/PhotoEditTab/PhotoEditTab';
 import ApplicantsListTab from '@/pages/AdminPage/tabs/ApplicantsTab/ApplicantsListTab/ApplicantsListTab';
 import ApplicantDetailPage from '@/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPage';
+import ApplicantsTab from './tabs/ApplicantsTab/ApplicantsTab';
 
 export default function AdminRoutes() {
   return (
@@ -24,7 +25,7 @@ export default function AdminRoutes() {
         <Route path='applicants-list' element={<ApplicantsListTab />} />
         <Route
           path='applicants-list/:applicationFormId'
-          element={<ApplicantsListTab />}
+          element={<ApplicantsTab />}
         />
         <Route
           path='applicants-list/:applicationFormId/:questionId'


### PR DESCRIPTION
## #️⃣연관된 이슈

#891

## 📝작업 내용

예전 PR 컨플릭 수정중에 잘못변경되어서, 지원서 -> 지원자 목록으로 이동하지않았음

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선사항**
  * 관리자 페이지의 신청자 목록 표시 방식이 특정 상세 경로에서 변경되어 해당 화면이 새 뷰로 표시됩니다.
  * 이 변경으로 해당 경로에서의 신청자 목록 UI 및 동작이 업데이트되어 더 일관된 탐색 경험을 제공합니다.
  * 외부에 노출되는 기능 인터페이스에는 영향이 없습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->