### PR TITLE
[fix] 개발, 배포 환경에서 SSE 연결이 되지않는 문제 수정

### DIFF
--- a/backend/src/main/java/moadong/club/controller/ClubApplyAdminController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubApplyAdminController.java
@@ -3,6 +3,7 @@ package moadong.club.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
@@ -115,13 +116,16 @@ public class ClubApplyAdminController {
         return Response.ok("success delete applicant");
     }
 
-    @GetMapping(value = "/applicant/{applicationFormId}/events",produces = "text/event-stream")
-    @Operation(summary = "지원자 상태 변경 실시간 이벤트", 
-               description = "지원자의 상태 변경을 실시간으로 받아볼 수 있는 SSE 엔드포인트입니다.")
+    @GetMapping(value = "/applicant/{applicationFormId}/events", produces = "text/event-stream")
+    @Operation(summary = "지원자 상태 변경 실시간 이벤트",
+            description = "지원자의 상태 변경을 실시간으로 받아볼 수 있는 SSE 엔드포인트입니다.")
     @PreAuthorize("isAuthenticated()")
     @SecurityRequirement(name = "BearerAuth")
-    public SseEmitter getApplicantStatusEvents(@PathVariable String applicationFormId,
+    public SseEmitter getApplicantStatusEvents(HttpServletResponse response,
+                                               @PathVariable String applicationFormId,
                                                @CurrentUser CustomUserDetails user) {
+        response.addHeader("X-Accel-Buffering", "no");
+        response.addHeader("Cache-Control", "no-cache");
         return clubApplyAdminService.createSseConnection(applicationFormId, user);
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#894

## 📝작업 내용

SSE 연결을 수립하는 응답 헤더에 `X-Accel-Buffering: no`를 추가했습니다.
Nginx를 리버스 프록시로 사용하는 환경에서 SSE 통신 시, Nginx의 기본 버퍼링 설정 때문에 클라이언트가 이벤트를 실시간으로 받지 못하는 문제가 있었습니다.
Nginx는 백엔드 서버의 응답 헤더에 `X-Accel-Buffering: no`가 포함되어 있으면, 해당 응답에 대해 프록시 버퍼링을 비활성화하고 데이터를 즉시 클라이언트로 전송합니다.

<img width="581" height="38" alt="스크린샷 2025-11-26 15 07 29" src="https://github.com/user-attachments/assets/053bd0cd-f500-41ef-b855-e36f8abef044" />

헤더가 추가된모습

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 클럽 신청 상태 실시간 업데이트 기능의 응답 처리 안정성 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->