### PR TITLE
[fix] 소개 페이지 동아리 카드의 모집 상태가 불러와지지 않는 오류를 수정한다

### DIFF
--- a/frontend/src/pages/IntroducePage/constants/mockData.ts
+++ b/frontend/src/pages/IntroducePage/constants/mockData.ts
@@ -17,7 +17,7 @@ export const floatingClubs: Club[] = [
     name: '모아보자',
     logo: '',
     tags: ['봉사', '지역사회'],
-    recruitmentStatus: 'UPCOMING',
+    recruitmentStatus: 'ALWAYS',
     division: '중동',
     category: '봉사',
     introduction: '지역 사회와 함께 봉사하며 따뜻함을 전하는 동아리',


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #897 

## 📝작업 내용

> 소개페이지의 '알수 없음' 상태로 뜨는 모집 상태를 '상시모집'으로 수정
<img width="300" height="auto" alt="image" src="https://github.com/user-attachments/assets/f0be7348-c29d-4c21-adb4-7529373e02d0" />
<img width="300" height="auto" alt="image" src="https://github.com/user-attachments/assets/e2eb3f2e-4be1-4a4e-bd96-976fc878df29" />

=> 'UPCOMING' 상태가 없는데, 잘못 불러오고 있어서, 변경함

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **변경사항**
  * 클럽 모집 상태 데이터 업데이트: 특정 클럽의 모집 상태가 '예정' 에서 '상시' 로 변경되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->