### PR TITLE
[fix] 모바일 카테고리 버튼 양쪽에 생기는 여백을 제거한다

### DIFF
--- a/frontend/src/pages/MainPage/components/CategoryButtonList/CategoryButtonList.styles.ts
+++ b/frontend/src/pages/MainPage/components/CategoryButtonList/CategoryButtonList.styles.ts
@@ -8,21 +8,18 @@ export const CategoryButtonContainer = styled.div`
   margin-top: 32px;
 
   ${media.mobile} {
-    margin: 16px 0 12px 0; 
     background-color: white;
     position: sticky;
     top: 56px;
     z-index: 1;
 
-    margin-left: -20px;
-    margin-right: -20px;
-    padding: 0 20px;
+    margin: 0px -20px;
+    padding: 6px 20px 12px;
   }
 
   ${media.mini_mobile} {
-    margin-left: -10px;
-    margin-right: -10px;
-    padding: 0 10px;
+    margin: -10px -10px;
+    padding: 16px 10px 12px;
   }
 `;
 
@@ -35,6 +32,10 @@ export const CategoryButton = styled.button`
   cursor: pointer;
   padding: 10px 0px;
   transition: transform 0.1s ease;
+
+  ${media.mobile} {
+    padding: 0px;
+  }
 
   &:active {
     transform: scale(0.95);


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #890 

## 📝작업 내용

### 핵심 변경사항
> 모바일 카테고리 버튼 양쪽에 생기는 여백 제거

**변경 목적**
<img width="500" height="auto" alt="image" src="https://github.com/user-attachments/assets/6de9f509-102e-4f3d-8ad5-f60a5ce3c67b" />

모바일 화면에서 스크롤 시 카테고리 버튼 영역이 `sticky`로 상단에 고정될 때, 양쪽에 불필요한 좌우 여백(20px)이 생기는 문제가 있었습니다.

**문제 원인**
`PageContainer`는 페이지 내 모든 콘텐츠를 일정 패딩 안에 배치하기 위한 레이아웃 컨테이너
모바일에서도 이 패딩이 유지되기 때문에, 내부에 위치한 카테고리 버튼 영역도 패딩이 적용된 것입니다.
=> `sticky`가 적용될 때는 일반 콘텐츠처럼 안쪽으로 들어가지 않아야 자연스럽습니다.

**해결**
부모 컨테이너를 수정하거나, 카테고리 버튼만 예외를 두는 방식 중 고민했습니다.

1. 부모 컨테이너(`PageContainer`)의 패딩을 건드리지 않기
`PageContainer`는 공통 레이아웃이기 때문에 패딩을 제거하면 다른 컴포넌트(탭 버튼, 카드리스트 등)에 영향을 줍니다. 따라서 내부 컴포넌트들 각각에 패딩을 줘야하여 번거롭고 부모 패딩을 유지하는 것이 더 안전하다고 판단하였습니다.

2. 카테고리 버튼 영역만 예외적으로 처리하기
모바일에서만 `PageContainer의` 패딩을 제거하기 위해 자식 컴포넌트(`CategoryButtonContainer`)에서 가로 방향 음수 마진을 적용했습니다. 음수 마진을 지양하고 싶었지만, 모바일에서만 `sticky` 속성을 적용해야하는 특이한 경우였기 때문에, 음수 마진으로 제거 후, 패딩을 주는 것이 더 이해하기 편하다고 생각했습니다.

<img width="1504" height="330" alt="image" src="https://github.com/user-attachments/assets/7e0af179-c868-4a87-98ad-3066ec39d697" />
=> 부모 레이아웃에도 변동이 없기 때문에 다른 컴포넌트에 영향을 주지 않고, 카테고리 버튼 영역만 독립적으로 처리해주면 되기 때문에 2번 방식으로 진행했습니다.

### 그 외 수정사항
> 버튼 크기, 텍스트, 여백 조정
> media 유틸 기반 리팩터링
<img width="1501" height="903" alt="image" src="https://github.com/user-attachments/assets/6c51fb0d-91d8-481e-b5dc-086b7fc8d4d3" />


## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**새로운 기능**
- 모바일 및 태블릿을 포함한 다양한 기기에 최적화된 반응형 디자인이 적용되어 향상된 사용자 경험을 제공합니다.

**기타**
- 프로덕션 환경 감지 메커니즘이 개선되었습니다.
- 내부 테스트 표준화 작업이 진행되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->