### PR TITLE
[feature] 회원 탈퇴 기능을 제거한다

### DIFF
--- a/frontend/src/pages/AdminPage/components/SideBar/SideBar.tsx
+++ b/frontend/src/pages/AdminPage/components/SideBar/SideBar.tsx
@@ -44,7 +44,6 @@ const tabs: TabCategory[] = [
     category: '계정 관리',
     items: [
       { label: '비밀번호 수정', path: '/admin/account-edit' },
-      { label: '회원탈퇴', path: '/admin/user-delete' },
     ],
   },
 ];
@@ -64,14 +63,6 @@ const SideBar = ({ clubLogo, clubName }: SideBarProps) => {
     trackEvent(ADMIN_EVENT.TAB_CLICKED, {
       tabName: item.label,
     });
-    // if (item.label === '아이디/비밀번호 수정') {
-    //   alert('아이디/비밀번호 수정 기능은 아직 준비 중이에요. ☺️');
-    //   return;
-    // }
-    if (item.label === '회원탈퇴') {
-      alert('회원탈퇴 기능은 아직 준비 중이에요. ☺️');
-      return;
-    }
     navigate(item.path);
   };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #923 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지/동영상 첨부 가능)

- 사이드바에 있던 회원 탈퇴 버튼 UI를 제거했습니다.
- 사이드바 클릭 핸들러에서 회원탈퇴 alert 부분을 제거했습니다.

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **사용자 인터페이스 변경**
  * 관리자 페이지 계정 관리 섹션에서 "회원탈퇴" 탭이 제거되었습니다.
  * 탭 네비게이션 중 발생하던 차단 및 경고 알림이 삭제되어, 사용자가 선택한 탭으로 보다 빠르게 이동할 수 있게 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->