### PR TITLE
[refactor] 검색 범위를 동아리명, 분과태그, 지원정보태그로 변경한다

### DIFF
--- a/backend/src/main/java/moadong/club/repository/ClubSearchRepository.java
+++ b/backend/src/main/java/moadong/club/repository/ClubSearchRepository.java
@@ -43,8 +43,7 @@ public class ClubSearchRepository {
         if (keyword != null && !keyword.trim().isEmpty()) {
             operations.add(Aggregation.match(new Criteria().orOperator(
                 Criteria.where("name").regex(keyword, "i"),
-                Criteria.where("recruitmentInformation.introduction").regex(keyword, "i"),
-                Criteria.where("recruitmentInformation.description").regex(keyword, "i"),
+                Criteria.where("category").regex(keyword, "i"),
                 Criteria.where("recruitmentInformation.tags").regex(keyword, "i")
             )));
         }


### PR DESCRIPTION
## #️⃣연관된 이슈

#929 

## 📝작업 내용

### 작업 배경
소개글과 상세설명에 실제 동아리와 무관한 키워드가 포함될 경우,
검색 결과에 관련 없는 동아리까지 무분별하게 노출되는 문제가 있었습니다.

이로 인해 검색 범위를 아래와 같이 개선하게 되었습니다.

### 기존 검색범위
- 동아리명
- 소개글(introduction)
- 상세설명(description)
- 지원정보의 태그(recruitmentInformation.tags)

### 변경된 검색범위
- 동아리명
- 분과 태그(category)
- 지원정보의 태그(recruitmentInformation.tags)

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
> 검색 범위 조정으로 인해 검색 정확도가 중요해졌습니다.
예를 들어 O.S.T 동아리는 기존에는 ost로 검색 시 상세 설명에 포함된 문자열로 인해 조회가 가능했지만,
현재는 상세 설명이 검색 대상에서 제외되어 동아리명과 동일한 o.s.t로 입력해야 검색됩니다.
## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선사항**
  * 클럽 키워드 검색이 강화되어 카테고리 정보도 검색 대상에 포함됩니다.
  * 기존에 검색에 포함되던 모집 정보의 소개(introduction) 및 설명(description) 필드는 검색 대상에서 제외되어 결과가 보다 관련성 있게 조정됩니다.
  * 모집 정보의 태그(tag) 검색 동작은 변경되지 않았습니다.
  * 공개 API 시그니처 등 외부 인터페이스에는 변경이 없습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->