### PR TITLE
[refactor] 관리자페이지 모집정보수정에서 소개글 섹션을 제거한다

### DIFF
--- a/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.tsx
@@ -114,8 +114,8 @@ const RecruitEditTab = () => {
 
     const updatedData = {
       id: clubDetail.id,
-      recruitmentStart: startForSave?.toISOString() ?? '',
-      recruitmentEnd: endForSave?.toISOString() ?? '',
+      recruitmentStart: startForSave?.toISOString() ?? null,
+      recruitmentEnd: endForSave?.toISOString() ?? null,
       recruitmentTarget: recruitmentTarget,
     };
 

--- a/frontend/src/types/club.ts
+++ b/frontend/src/types/club.ts
@@ -20,8 +20,8 @@ export interface ClubDetail extends Club {
   presidentName: string;
   presidentPhoneNumber: string;
   recruitmentForm: string;
-  recruitmentStart: string;
-  recruitmentEnd: string;
+  recruitmentStart: string | null;
+  recruitmentEnd: string | null;
   recruitmentTarget: string;
   socialLinks: Record<SNSPlatform, string>;
   externalApplicationUrl?: string;
@@ -29,7 +29,7 @@ export interface ClubDetail extends Club {
 
 export interface ClubDescription {
   id: string;
-  recruitmentStart: string;
-  recruitmentEnd: string;
+  recruitmentStart: string | null;
+  recruitmentEnd: string | null;
   recruitmentTarget: string;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #955 

## 📝작업 내용

### 1. 모집 정보 탭(RecruitEditTab) 로직 간소화

해당 탭에서 동아리 상세 설명(description) 필드를 제거했습니다. 
이에 따라 불필요해진 MarkdownEditor 컴포넌트와 관련 상태/로직을 삭제했습니다.

### 2. 타입 정의 업데이트 (types/club.ts)

`ClubDescription` 타입을 실제 API 요청에 맞게 수정했습니다. (recruitmentStart, recruitmentEnd, recruitmentTarget 추가)

### 3. 기타 버그 수정

날짜 데이터 변환 시 undefined가 발생할 수 있는 타입 에러를 수정했습니다.

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **기능 변경**
  * 모집 정보 수정 페이지에서 소개글(Markdown) 편집 기능이 제거되었습니다.
  * 사용자 알림 문구가 "동아리 정보"에서 "모집 정보"로 변경되었습니다.
  * 외부 신청 URL 관련 입력/처리 항목이 제거되었습니다.

* **개선 사항**
  * 모집 시작/종료 일정의 기본값 처리가 null 허용으로 개선되어 일정 처리 안정성이 향상되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->