### PR TITLE
[feature] 동아리 커버 이미지 업로드 및 삭제 hook 추가

### DIFF
--- a/frontend/src/hooks/queries/club/cover/useCoverMutation.ts
+++ b/frontend/src/hooks/queries/club/cover/useCoverMutation.ts
@@ -1,0 +1,55 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { coverApi } from '@/apis/image/cover';
+import { uploadToStorage } from '@/apis/image/uploadToStorage';
+
+interface CoverUploadParams {
+  clubId: string;
+  file: File;
+}
+
+export const useUploadCover = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ clubId, file }: CoverUploadParams) => {
+      const { presignedUrl, finalUrl } = await coverApi.getUploadUrl(
+        clubId,
+        file.name,
+        file.type,
+      );
+
+      await uploadToStorage(presignedUrl, file);
+
+      await coverApi.completeUpload(clubId, finalUrl);
+
+      return { clubId };
+    },
+
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['clubDetail', data.clubId] });
+    },
+
+    onError: () => {
+      alert('커버 이미지 업로드에 실패했어요. 다시 시도해주세요!');
+    },
+  });
+};
+
+export const useDeleteCover = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (clubId: string) => {
+      await coverApi.delete(clubId);
+      return { clubId };
+    },
+
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['clubDetail', data.clubId] });
+    },
+
+    onError: () => {
+      alert('커버 이미지 삭제에 실패했어요. 다시 시도해주세요!');
+    },
+  });
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #944

## 📝작업 내용

- `useUploadCover`: Presigned URL 발급, 스토리지 업로드, 완료 처리 로직 구현
- `useDeleteCover`: 커버 이미지 삭제 로직 구현
- 공통: 성공 시 clubDetail 쿼리 무효화 및 에러 핸들링 추가

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **클럽 커버 이미지 업로드**: 사용자가 클럽의 커버 이미지를 간편하게 업로드할 수 있습니다. 이미지는 안전한 저장소에 보관되며, 업로드 완료 후 클럽 정보가 자동으로 즉시 갱신되어 모든 사용자에게 실시간으로 반영됩니다.

* **클럽 커버 이미지 삭제**: 더 이상 필요하지 않은 커버 이미지를 언제든지 쉽게 삭제할 수 있으며, 삭제 후에도 클럽 정보가 자동으로 업데이트됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->