### PR TITLE
[feat] 동아리 지원자 양식 복제 기능 추가

### DIFF
--- a/backend/src/main/java/moadong/club/controller/ClubApplyAdminController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubApplyAdminController.java
@@ -80,6 +80,16 @@ public class ClubApplyAdminController {
         return Response.ok("success delete application");
     }
 
+    @PostMapping("/application/{applicationFormId}/duplicate")
+    @Operation(summary = "클럽 지원서 양식 복제", description = "클럽의 지원서 양식을 복제합니다")
+    @PreAuthorize("isAuthenticated()")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> duplicateClubApplicationForm(@PathVariable String applicationFormId,
+                                                          @CurrentUser CustomUserDetails user) {
+        clubApplyAdminService.duplicateClubApplicationForm(applicationFormId, user);
+        return Response.ok("success duplicate application");
+    }
+
     @GetMapping("/apply/info/{applicationFormId}")
     @Operation(summary = "클럽 지원자 현황", description = "클럽 지원자 현황을 불러옵니다")
     @PreAuthorize("isAuthenticated()")

--- a/backend/src/main/java/moadong/club/service/ClubApplyAdminService.java
+++ b/backend/src/main/java/moadong/club/service/ClubApplyAdminService.java
@@ -4,7 +4,8 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import moadong.club.entity.*;
 import moadong.club.enums.SemesterTerm;
-import moadong.club.payload.dto.*;
+import moadong.club.payload.dto.ApplicantStatusEvent;
+import moadong.club.payload.dto.ClubApplicantsResult;
 import moadong.club.payload.request.*;
 import moadong.club.payload.response.ClubApplicationFormsResponse;
 import moadong.club.payload.response.ClubApplyInfoResponse;
@@ -126,6 +127,23 @@ public class ClubApplyAdminService {
 
         clubApplicantsRepository.deleteAllByFormId(applicationForm.getId());
         clubApplicationFormsRepository.delete(applicationForm);
+    }
+
+    @Transactional
+    public void duplicateClubApplicationForm(String applicationFormId, CustomUserDetails user) {
+        ClubApplicationForm oldApplicationForm = clubApplicationFormsRepository.findByClubIdAndId(user.getClubId(), applicationFormId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.APPLICATION_NOT_FOUND));
+
+        ClubApplicationForm newApplicationForm = ClubApplicationForm.builder()
+                .title("무제")
+                .clubId(oldApplicationForm.getClubId())
+                .description(oldApplicationForm.getDescription())
+                .formMode(oldApplicationForm.getFormMode())
+                .questions(oldApplicationForm.getQuestions())
+                .externalApplicationUrl(oldApplicationForm.getExternalApplicationUrl())
+                .build();
+
+        clubApplicationFormsRepository.save(newApplicationForm);
     }
 
     public ClubApplyInfoResponse getClubApplyInfo(String applicationFormId, CustomUserDetails user) {


### PR DESCRIPTION
## #️⃣연관된 이슈

#1019 

## 📝작업 내용

추가 엔드 포인트
``POST`` ``/application/{applicationFormId}/duplicate``
전달된 applicationFormId의 설명, 질문을 복사하여 새로운 동아리 지원서 양식을 만듭니다
이름은 ``무제``로 지어집니다

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 신규 기능

* 클럽 지원서 양식 복제 기능 추가: 기존의 클럽 지원서 양식을 복제하여 새로운 지원서 형식을 빠르게 생성할 수 있습니다. 제목, 설명, 질문 항목 등을 포함하여 동일한 구조의 지원서를 효율적으로 만들 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->