### PR TITLE
[feature] 관리자 로그인 페이지에서 공통 헤더를 노출한다

### DIFF
--- a/frontend/src/components/common/Header/Header.tsx
+++ b/frontend/src/components/common/Header/Header.tsx
@@ -14,6 +14,7 @@ const Header = () => {
   const trackEvent = useMixpanelTrack();
   const location = useLocation();
   const isAdminPage = location.pathname.startsWith('/admin');
+  const isAdminLoginPage = location.pathname.startsWith('/admin/login');
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const isScrolled = useScrollDetection();
 
@@ -85,7 +86,8 @@ const Header = () => {
           </Styled.MenuButton>
         )}
 
-        {isAdminPage ? <AdminProfile /> : <SearchBox />}
+        {!isAdminPage && <SearchBox />}
+        {isAdminPage && !isAdminLoginPage && <AdminProfile />}
       </Styled.Container>
     </Styled.Header>
   );

--- a/frontend/src/pages/AdminPage/auth/LoginTab/LoginTab.tsx
+++ b/frontend/src/pages/AdminPage/auth/LoginTab/LoginTab.tsx
@@ -9,6 +9,7 @@ import useAuth from '@/hooks/useAuth';
 import useMixpanelTrack from '@/hooks/useMixpanelTrack';
 import useTrackPageView from '@/hooks/useTrackPageView';
 import * as Styled from './LoginTab.styles';
+import Header from '@/components/common/Header/Header';
 
 const LoginTab = () => {
   useTrackPageView(PAGE_VIEW.LOGIN_PAGE);
@@ -52,6 +53,8 @@ const LoginTab = () => {
   if (authLoading) return <div>로딩 중...</div>;
 
   return (
+    <>
+    <Header />
     <Styled.LoginContainer>
       <Styled.LoginBox>
         <Styled.Logo src={moadong_name_logo} alt='Moadong Logo' />
@@ -125,6 +128,7 @@ const LoginTab = () => {
         </Styled.ForgotLinks>
       </Styled.LoginBox>
     </Styled.LoginContainer>
+    </>
   );
 };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #1039 

## 📝작업 내용
> 관리자 로그인 페이지(/admin/login)에서도 공통 헤더가 보이도록 수정했습니다.
- 로그인 페이지에서 헤더 미노출 문제 해결
- 로그인 전 상태를 고려해 우측 관리자 프로필 및 검색 영역은 노출하지 않도록 처리

<img width="2012" height="1215" alt="image" src="https://github.com/user-attachments/assets/a00925e0-50d4-4d47-a63b-4855f1c1ccde" />


## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
- 관리자 로그인 페이지에서 불필요한 UI 요소가 제거되도록 수정했습니다.

## 개선 사항
- 관리자 로그인 페이지에 헤더가 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->