### PR TITLE
[feat] 외부지원서 허용목록에 에브리타임 주소 추가

### DIFF
--- a/backend/src/main/java/moadong/club/entity/ClubApplicationForm.java
+++ b/backend/src/main/java/moadong/club/entity/ClubApplicationForm.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 @Getter
 @Builder(toBuilder = true)
 public class ClubApplicationForm implements Persistable<String> {
-    private static final String[] externalApplicationUrlAllowed = {"https://forms.gle", "https://docs.google.com/forms", "https://form.naver.com", "https://naver.me"};
+    private static final String[] externalApplicationUrlAllowed = {"https://forms.gle", "https://docs.google.com/forms", "https://form.naver.com", "https://naver.me", "https://everytime.kr"};
 
     @Id
     private String id;


### PR DESCRIPTION
## #️⃣연관된 이슈

#1043 

## 📝작업 내용

외부 지원서 주소로 ``https://everytime.kr``로 시작하는 주소를 기입가능하게 허용하였습니다

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 클럽 신청 폼에서 Everytime 링크를 외부 신청 URL로 사용할 수 있도록 지원을 확대했습니다. 기존 Google Forms, Naver Form, Naver URL 단축 외에 Everytime 플랫폼이 추가되어 더 다양한 신청 방식을 제공할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->