### PR TITLE
[fix] 한글 url 말줄임이 안 되는 오류를 해결한다

### DIFF
--- a/frontend/src/pages/ClubDetailPage/components/ClubProfileCard/ClubProfileCard.styles.ts
+++ b/frontend/src/pages/ClubDetailPage/components/ClubProfileCard/ClubProfileCard.styles.ts
@@ -169,6 +169,7 @@ export const SocialUrl = styled.span`
   overflow: hidden;
   text-overflow: ellipsis;
   vertical-align: bottom;
+  white-space: nowrap;
 
   ${media.laptop} {
     max-width: 100px;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

### 문제 상황
> 보블리스 동아리와 같이 SNS url이 한글인 경우, 말줄임이 안 되는 오류 발생

### 문제 원인
- 기존 `Social URL`은 말줄임 처리가 영어 URL로 정상 동작했습니다.
- 이는 영어를 브라우저가 한 단어로 인식하기 때문에, 줄바꿈이 불가하여 `max-width` 초과 시 바로 말줄임(`...`)이 적용되었던 것입니다.

- 그런데, **한글 문자열**은 브라우저가 줄바꿈이 가능하다고 인식해서 `max-width`를 초과해도 말줄임이 적용되지 않는 문제가 있었습니다.

### 해결
따라서 한글 문자열을 위해 `SocialUrl` 스타일에 `white-space: nowrap`을 추가해주어 한글/영문 URL 모두 말줄임(`...`)이 적용되도록 했습니다.

<img width="250" height="auto" alt="image" src="https://github.com/user-attachments/assets/1ffcd723-1df9-49e2-b1db-20d1f348f78a" />


## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 클럽 프로필 카드의 소셜 URL 표시 방식을 개선했습니다. URL 텍스트가 여러 줄로 나뉘지 않고 한 줄로 유지되도록 변경하여 더 나은 시각적 표현을 제공합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->