### PR TITLE
[feat] 라우트 히스토리 제거를 위해 replace옵션추가

### DIFF
--- a/frontend/src/pages/MainPage/components/Banner/Banner.tsx
+++ b/frontend/src/pages/MainPage/components/Banner/Banner.tsx
@@ -9,7 +9,6 @@ import useDevice from '@/hooks/useDevice';
 import useMixpanelTrack from '@/hooks/useMixpanelTrack';
 import useNavigator from '@/hooks/useNavigator';
 import { detectPlatform, getAppStoreLink } from '@/utils/appStoreLink';
-import { getABTestGroup } from '@/pages/MainPage/components/Popup/Popup';
 import * as Styled from './Banner.styles';
 import BANNERS from './bannerData';
 
@@ -37,12 +36,10 @@ const Banner = () => {
 
     if (url === 'APP_STORE_LINK') {
       const storeLink = getAppStoreLink();
-      const abGroup = getABTestGroup();
       trackEvent(USER_EVENT.APP_DOWNLOAD_BANNER_CLICKED, {
         bannerId,
         bannerName,
         platform: detectPlatform(),
-        abTestGroup: abGroup,
       });
       handleLink(storeLink);
       return;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #1052

## 📝작업 내용

상세페이지 소개내용 | 활동사진 탭 클릭 시 라우트가 쌓여서 메인으로 돌아가려면 여러번 뒤로가기를 해야 헀습니다.

`{ replace: true }`를 추가해서 라우트 히스토리가 쌓이지 않도록 했습니다.

```ts
const handleIntroTabClick = useCallback(() => {
    setSearchParams({ tab: TAB_TYPE.INTRO }, { replace: true });
}
```


## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 탭 네비게이션 중 브라우저 뒤로 가기 버튼의 동작이 개선되었습니다. 탭을 전환할 때 이제 새로운 기록을 추가하지 않고 현재 기록을 대체합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->