### PR TITLE
[feature] 앱 다운로드 배너 트래킹에 A/B 테스트 그룹 정보 추가

### DIFF
--- a/frontend/src/pages/MainPage/components/Banner/Banner.tsx
+++ b/frontend/src/pages/MainPage/components/Banner/Banner.tsx
@@ -9,6 +9,7 @@ import useDevice from '@/hooks/useDevice';
 import useMixpanelTrack from '@/hooks/useMixpanelTrack';
 import useNavigator from '@/hooks/useNavigator';
 import { detectPlatform, getAppStoreLink } from '@/utils/appStoreLink';
+import { getABTestGroup } from '@/pages/MainPage/components/Popup/Popup';
 import * as Styled from './Banner.styles';
 import BANNERS from './bannerData';
 
@@ -36,10 +37,12 @@ const Banner = () => {
 
     if (url === 'APP_STORE_LINK') {
       const storeLink = getAppStoreLink();
+      const abGroup = getABTestGroup();
       trackEvent(USER_EVENT.APP_DOWNLOAD_BANNER_CLICKED, {
         bannerId,
         bannerName,
         platform: detectPlatform(),
+        abTestGroup: abGroup,
       });
       handleLink(storeLink);
       return;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #1055 

## 📝작업 내용

메인 페이지 앱 다운로드 배너 클릭 이벤트에 abTestGroup property를 추가하여 팝업 A/B 테스트의 정확한 효과 측정이 가능하도록 개선했습니다.

### 배경

현재 메인 페이지에서 앱 다운로드를 유도하는 두 가지 경로가 있습니다
- 팝업 (모바일, 50% 사용자에게 노출)
- 배너 (전체 사용자에게 노출)

팝업은 A/B 테스트 중이며, 사용자의 50%에게만 노출되고 있습니다:
- show_popup 그룹: 팝업 + 배너 모두 볼 수 있음
- no_popup 그룹: 배너만 볼 수 있음

### Problem

현재 배너 클릭 이벤트(`APP_DOWNLOAD_BANNER_CLICKED`)에는 A/B 테스트 그룹 정보가 없어, 다음과 같은 핵심 질문에 답할 수 없었습니다.

1. 총 전환율 비교
- show_popup 그룹: (팝업 클릭 + 배너 클릭) / 방문자 = ?
- no_popup 그룹: 배너 클릭 / 방문자 = ?
- 팝업이 실제로 총 앱 다운로드를 증가시키는가?

2. 캐니벌라이제이션 확인

> 카니발리제이션: 신제품(팝업)이 기존제품(배너)를 깎아먹는 현상

- show_popup 그룹의 배너 클릭률 = ?
- no_popup 그룹의 배너 클릭률 = ?
- 팝업이 배너 클릭을 감소시키는가? (사용자가 팝업만 보고 배너를 무시)


4. 순수 증가 효과
- 팝업 전환 - 배너 전환 감소분 = ?
- 팝업이 추가한 순수한 전환은 얼마인가?



## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * App Store 링크 클릭 시 트래킹 이벤트 데이터 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->