### PR TITLE
[fix] 외부지원서 리다이렉트 방식 window.location.href로 변경

### DIFF
--- a/frontend/src/pages/ClubDetailPage/components/ClubApplyButton/ClubApplyButton.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubApplyButton/ClubApplyButton.tsx
@@ -27,26 +27,33 @@ const ClubApplyButton = ({ deadlineText }: ClubApplyButtonProps) => {
   if (!clubId || !clubDetail) return null;
 
   const navigateToApplicationForm = async (formId: string) => {
+    const externalWindow = window.open('', '_blank', 'noopener,noreferrer');
+
     try {
       const formDetail = await getApplication(clubId, formId);
       if (formDetail?.formMode === ApplicationFormMode.EXTERNAL) {
         const externalApplicationUrl =
           formDetail.externalApplicationUrl?.trim();
         if (externalApplicationUrl) {
-          // 동적 a 태그로 새 탭에서 열기 (히스토리 유지)
-          const link = document.createElement('a');
-          link.href = externalApplicationUrl;
-          link.target = '_blank';
-          link.rel = 'noopener noreferrer';
-          document.body.appendChild(link);
-          link.click();
-          document.body.removeChild(link);
+          if (externalWindow) {
+            externalWindow.location.href = externalApplicationUrl;
+          } else {
+            window.location.href = externalApplicationUrl;
+          }
           return;
         }
       }
+
+      if (externalWindow && !externalWindow.closed) {
+        externalWindow.close();
+      }
+
       navigate(`/application/${clubId}/${formId}`, { state: { formDetail } });
       setIsApplicationModalOpen(false);
     } catch (error) {
+      if (externalWindow && !externalWindow.closed) {
+        externalWindow.close();
+      }
       console.error('지원서 조회 중 오류가 발생했습니다', error);
       alert(
         '지원서 정보를 불러오는 중 오류가 발생했습니다. 다시 시도해주세요.',


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #1064 

## 📝작업 내용

### 문제
iOS Safari에서 "지원하기" 버튼 클릭 시 외부 지원서 링크로 리다이렉트되지 않는 문제


### 원인

- `window.open()`을 비동기 함수(async/await) 내에서 호출
- `await getApplication()` 이후 `window.open()` 호출 시점에는 사용자 제스처 컨텍스트가 끊어짐
- iOS Safari의 팝업 차단 정책으로 인해 window.open() 호출이 차단됨

### 해결
window.open() 대신 window.location.href를 사용하여 현재 탭에서 외부 링크로 이동


### 
## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 외부 클럽 지원 양식으로 이동할 때 보안 및 팝업 차단 대응을 개선하여 내비게이션 안정성을 높였습니다.
  * 팝업이 차단되면 현재 탭으로 안전하게 이동하도록 동작을 보완했습니다.
  * 오류 발생 시 미리 열린 창을 닫아 불필요한 탭/창을 줄이고, iOS Safari 등에서 더 일관된 동작을 제공합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->