### PR TITLE
[fix] createApplicationSSE import 분리

### DIFF
--- a/frontend/src/apis/club.ts
+++ b/frontend/src/apis/club.ts
@@ -1,9 +1,4 @@
-import { EventSource } from 'eventsource';
 import API_BASE_URL from '@/constants/api';
-import {
-  ApplicantSSECallbacks,
-  ApplicantStatusEvent,
-} from '@/types/applicants';
 import { ClubDescription, ClubDetail } from '@/types/club';
 import { secureFetch } from './auth/secureFetch';
 import { handleResponse, withErrorHandling } from './utils/apiHelpers';
@@ -83,52 +78,4 @@ export const updateClubDetail = async (
     });
     await handleResponse(response, '클럽 정보 수정에 실패했습니다.');
   }, 'Failed to update club detail');
-};
-
-export const createApplicantSSE = (
-  applicationFormId: string,
-  eventHandlers: ApplicantSSECallbacks,
-): EventSource | null => {
-  let eventSource: EventSource | null = null;
-
-  const connect = (): EventSource | null => {
-    const accessToken = localStorage.getItem('accessToken');
-    if (!accessToken) return null;
-
-    const source = new EventSource(
-      `${API_BASE_URL}/api/club/applicant/${applicationFormId}/sse`,
-      {
-        fetch: (input, init) =>
-          fetch(input, {
-            ...init,
-            headers: {
-              ...init?.headers,
-              Authorization: `Bearer ${accessToken}`,
-            },
-            credentials: 'include',
-          }),
-      },
-    );
-
-    source.addEventListener('applicant-status-changed', (e) => {
-      try {
-        const eventData: ApplicantStatusEvent = JSON.parse(e.data);
-        eventHandlers.onStatusChange(eventData);
-      } catch (parseError) {
-        console.error('SSE PARSING ERROR:', parseError);
-      }
-    });
-
-    source.onerror = (error) => {
-      source.close();
-      eventHandlers.onError(
-        new Error(error?.message || 'SSE connection error'),
-      );
-    };
-
-    return source;
-  };
-
-  eventSource = connect();
-  return eventSource;
 };

--- a/frontend/src/apis/clubSSE.ts
+++ b/frontend/src/apis/clubSSE.ts
@@ -1,0 +1,54 @@
+import { EventSource } from 'eventsource';
+import API_BASE_URL from '@/constants/api';
+import {
+  ApplicantSSECallbacks,
+  ApplicantStatusEvent,
+} from '@/types/applicants';
+
+export const createApplicantSSE = (
+  applicationFormId: string,
+  eventHandlers: ApplicantSSECallbacks,
+): EventSource | null => {
+  let eventSource: EventSource | null = null;
+
+  const connect = (): EventSource | null => {
+    const accessToken = localStorage.getItem('accessToken');
+    if (!accessToken) return null;
+
+    const source = new EventSource(
+      `${API_BASE_URL}/api/club/applicant/${applicationFormId}/sse`,
+      {
+        fetch: (input, init) =>
+          fetch(input, {
+            ...init,
+            headers: {
+              ...init?.headers,
+              Authorization: `Bearer ${accessToken}`,
+            },
+            credentials: 'include',
+          }),
+      },
+    );
+
+    source.addEventListener('applicant-status-changed', (e) => {
+      try {
+        const eventData: ApplicantStatusEvent = JSON.parse(e.data);
+        eventHandlers.onStatusChange(eventData);
+      } catch (parseError) {
+        console.error('SSE PARSING ERROR:', parseError);
+      }
+    });
+
+    source.onerror = (error) => {
+      source.close();
+      eventHandlers.onError(
+        new Error(error?.message || 'SSE connection error'),
+      );
+    };
+
+    return source;
+  };
+
+  eventSource = connect();
+  return eventSource;
+};

--- a/frontend/src/context/AdminClubContext.tsx
+++ b/frontend/src/context/AdminClubContext.tsx
@@ -6,7 +6,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import { createApplicantSSE } from '@/apis/club';
+import { createApplicantSSE } from '@/apis/clubSSE';
 import {
   ApplicantsInfo,
   ApplicantStatusEvent,


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

- eventSource import를 피하기 위해 SSE 함수 다른 파일로 분리
- RN에서 eventSource 호환불가능으로 에러 가능성 

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항