### PR TITLE
[fix] 앱의 지원하기 모달 색상이 파란색으로 표시되는 버그를 수정한다

### DIFF
--- a/frontend/src/components/application/modals/ApplicationSelectModal.styles.ts
+++ b/frontend/src/components/application/modals/ApplicationSelectModal.styles.ts
@@ -22,6 +22,7 @@ export const OptionButton = styled.button`
   font-weight: 600;
   font-size: 16px;
   cursor: pointer;
+  color: black;
   transition:
     background-color 0.15s ease,
     color 0.15s ease,


### PR DESCRIPTION
## #️⃣연관된 이슈

#1085 

## 📝작업 내용

<img width="590" height="554" alt="image" src="https://github.com/user-attachments/assets/0a9676c2-dead-4f20-ab2a-8707b4ebca96" />

앱에서 지원하기 모달 선택 텍스트 색상이 파란색으로 보이는 문제를 수정하였습니다.

원인:
``OptionButton``의 color css 가 설정이 되어있지않아, 기본 웹 스타일인 ``color: buttontext``로 설정되어있어 색상이 다르게 보여졌습니다.

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 선택 모달의 버튼 텍스트 색상을 검은색으로 업데이트하여 기본 텍스트 표시를 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->