### PR TITLE
[fix] 관리자 탭 클릭 시 데이터 리패칭

### DIFF
--- a/frontend/src/pages/AdminPage/components/SideBar/SideBar.tsx
+++ b/frontend/src/pages/AdminPage/components/SideBar/SideBar.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
 import { logout } from '@/apis/auth';
 import { ADMIN_EVENT } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
@@ -42,6 +43,7 @@ const tabs: TabCategory[] = [
 ];
 
 const SideBar = () => {
+  const queryClient = useQueryClient();
   const trackEvent = useMixpanelTrack();
   const location = useLocation();
   const navigate = useNavigate();
@@ -56,6 +58,7 @@ const SideBar = () => {
     trackEvent(ADMIN_EVENT.TAB_CLICKED, {
       tabName: item.label,
     });
+    queryClient.invalidateQueries();
     navigate(item.path);
   };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #1095 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지/동영상 첨부 가능)


브라우저 캐시에 서버 상태가 저장되고 있어 (혹시나 그럴일은 없겠지만) 중요한 정보들이 캐시될 위험을 방지하기 위해

관리자탭 클릭마다 데이터를 새로 가져오도록 변경했습니다.

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  - 관리자 페이지 탭 전환 시 데이터 갱신 메커니즘 최적화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->