### PR TITLE
[fix] 지원서 생성/수정 후 목록 갱신

### DIFF
--- a/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.tsx
@@ -6,6 +6,7 @@ import Button from '@/components/common/Button/Button';
 import CustomTextArea from '@/components/common/CustomTextArea/CustomTextArea';
 import { APPLICATION_FORM } from '@/constants/applicationForm';
 import INITIAL_FORM_DATA from '@/constants/initialFormData';
+import { queryKeys } from '@/constants/queryKeys';
 import { useAdminClubContext } from '@/context/AdminClubContext';
 import { useGetApplication } from '@/hooks/Queries/useApplication';
 import QuestionBuilder from '@/pages/AdminPage/components/QuestionBuilder/QuestionBuilder';
@@ -70,7 +71,7 @@ const ApplicationEditTab = () => {
   const { mutate: createMutate, isPending: isCreating } = useMutation({
     mutationFn: (payload: ApplicationFormData) => createApplication(payload),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['allApplicationForms'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.application.all });
       alert('지원서가 성공적으로 생성되었습니다.');
       navigate(`/admin/application-list`);
     },
@@ -87,9 +88,9 @@ const ApplicationEditTab = () => {
       applicationFormId: string;
     }) => updateApplication(data, applicationFormId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['allApplicationForms'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.application.all });
       queryClient.invalidateQueries({
-        queryKey: ['applicationForm', clubId, formId],
+        queryKey: queryKeys.application.detail(clubId ?? 'unknown', formId ?? ''),
       });
       alert('지원서가 성공적으로 수정되었습니다.');
       navigate('/admin/application-list');


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #1120

## 📝작업 내용

지원서 생성 후 지원서 리스트 페이지에 바로 갱신되지 않는 문제가 있었습니다.

  - 지원서 생성/수정 성공 시 invalidateQueries 쿼리키를 실제 리스트 키로 수정
  - queryKeys.application.all / detail 사용으로 정합성 확보

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 애플리케이션 데이터 캐싱 메커니즘을 최적화하여 캐시 무효화 로직을 표준화했습니다. 이러한 변경은 시스템 안정성과 유지보수성을 개선합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->