### PR TITLE
[feat] 홍보게시판 API 구현

### DIFF
--- a/backend/src/main/java/moadong/club/controller/PromotionArticleController.java
+++ b/backend/src/main/java/moadong/club/controller/PromotionArticleController.java
@@ -1,0 +1,44 @@
+package moadong.club.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import moadong.club.payload.request.PromotionArticleCreateRequest;
+import moadong.club.payload.response.PromotionArticleResponse;
+import moadong.club.service.PromotionArticleService;
+import moadong.global.payload.Response;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/promotion")
+@RequiredArgsConstructor
+@Tag(name = "Promotion", description = "홍보게시판 API")
+public class PromotionArticleController {
+
+    private final PromotionArticleService promotionArticleService;
+
+    @GetMapping
+    @Operation(summary = "홍보 게시글 목록 조회", description = "전체 홍보 게시글 목록을 조회합니다.")
+    public ResponseEntity<?> getPromotionArticles() {
+        PromotionArticleResponse response = promotionArticleService.getPromotionArticles();
+        return Response.ok(response);
+    }
+
+    @PostMapping
+    @Operation(summary = "홍보 게시글 생성", description = "새로운 홍보 게시글을 생성합니다.")
+    @PreAuthorize("isAuthenticated()")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> createPromotionArticle(
+        @RequestBody @Validated PromotionArticleCreateRequest request) {
+        promotionArticleService.createPromotionArticle(request);
+        return Response.ok("홍보 게시글이 생성되었습니다.");
+    }
+}

--- a/backend/src/main/java/moadong/club/entity/PromotionArticle.java
+++ b/backend/src/main/java/moadong/club/entity/PromotionArticle.java
@@ -1,0 +1,41 @@
+package moadong.club.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+import java.util.List;
+
+@Document("promotion_articles")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PromotionArticle {
+
+    @Id
+    private String id;
+
+    private String clubId;
+
+    private String clubName;
+
+    private String title;
+
+    private String location;
+
+    private Instant eventStartDate;
+
+    private Instant eventEndDate;
+
+    private String description;
+
+    private List<String> images;
+
+    @Builder.Default
+    private Instant createdAt = Instant.now();
+}

--- a/backend/src/main/java/moadong/club/payload/dto/PromotionArticleDto.java
+++ b/backend/src/main/java/moadong/club/payload/dto/PromotionArticleDto.java
@@ -1,0 +1,16 @@
+package moadong.club.payload.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+public record PromotionArticleDto(
+    String clubName,
+    String clubId,
+    String title,
+    String location,
+    Instant eventStartDate,
+    Instant eventEndDate,
+    String description,
+    List<String> images
+) {
+}

--- a/backend/src/main/java/moadong/club/payload/request/PromotionArticleCreateRequest.java
+++ b/backend/src/main/java/moadong/club/payload/request/PromotionArticleCreateRequest.java
@@ -1,0 +1,19 @@
+package moadong.club.payload.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.Instant;
+import java.util.List;
+
+public record PromotionArticleCreateRequest(
+    @NotBlank String clubId,
+    @NotBlank String title,
+    String location,
+    @NotNull Instant eventStartDate,
+    @NotNull Instant eventEndDate,
+    @NotBlank String description,
+    @NotEmpty List<String> images
+) {
+}

--- a/backend/src/main/java/moadong/club/payload/response/PromotionArticleResponse.java
+++ b/backend/src/main/java/moadong/club/payload/response/PromotionArticleResponse.java
@@ -1,0 +1,10 @@
+package moadong.club.payload.response;
+
+import moadong.club.payload.dto.PromotionArticleDto;
+
+import java.util.List;
+
+public record PromotionArticleResponse(
+    List<PromotionArticleDto> articles
+) {
+}

--- a/backend/src/main/java/moadong/club/repository/PromotionArticleRepository.java
+++ b/backend/src/main/java/moadong/club/repository/PromotionArticleRepository.java
@@ -1,0 +1,18 @@
+package moadong.club.repository;
+
+import moadong.club.entity.PromotionArticle;
+import moadong.club.payload.dto.PromotionArticleDto;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PromotionArticleRepository extends MongoRepository<PromotionArticle, String> {
+
+    @Query(value = "{}", sort = "{ 'createdAt': -1 }")
+    List<PromotionArticleDto> findAllProjectedBy();
+
+    List<PromotionArticle> findByClubIdOrderByCreatedAtDesc(String clubId);
+}

--- a/backend/src/main/java/moadong/club/service/PromotionArticleService.java
+++ b/backend/src/main/java/moadong/club/service/PromotionArticleService.java
@@ -1,0 +1,51 @@
+package moadong.club.service;
+
+import lombok.RequiredArgsConstructor;
+import moadong.club.entity.Club;
+import moadong.club.entity.PromotionArticle;
+import moadong.club.payload.dto.PromotionArticleDto;
+import moadong.club.payload.request.PromotionArticleCreateRequest;
+import moadong.club.payload.response.PromotionArticleResponse;
+import moadong.club.repository.ClubRepository;
+import moadong.club.repository.PromotionArticleRepository;
+import moadong.global.exception.ErrorCode;
+import moadong.global.exception.RestApiException;
+import moadong.global.util.ObjectIdConverter;
+import org.bson.types.ObjectId;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PromotionArticleService {
+
+    private final PromotionArticleRepository promotionArticleRepository;
+    private final ClubRepository clubRepository;
+
+    public PromotionArticleResponse getPromotionArticles() {
+        List<PromotionArticleDto> articles = promotionArticleRepository.findAllProjectedBy();
+        return new PromotionArticleResponse(articles);
+    }
+
+    @Transactional
+    public void createPromotionArticle(PromotionArticleCreateRequest request) {
+        ObjectId clubObjectId = ObjectIdConverter.convertString(request.clubId());
+        Club club = clubRepository.findClubById(clubObjectId)
+            .orElseThrow(() -> new RestApiException(ErrorCode.CLUB_NOT_FOUND));
+
+        PromotionArticle article = PromotionArticle.builder()
+            .clubId(request.clubId())
+            .clubName(club.getName())
+            .title(request.title())
+            .location(request.location())
+            .eventStartDate(request.eventStartDate())
+            .eventEndDate(request.eventEndDate())
+            .description(request.description())
+            .images(request.images())
+            .build();
+
+        promotionArticleRepository.save(article);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#1122

## 📝작업 내용

홍보게시판 API 엔드포인트 구현

### 추가된 엔드포인트

| Method | Endpoint | Auth | Description |
|--------|----------|------|-------------|
| GET | `/api/promotion` | ✗ | 홍보 게시글 목록 조회 |
| POST | `/api/promotion` | ✓ | 홍보 게시글 생성 |

### 구조

- **Entity**: [PromotionArticle] (MongoDB `promotion_articles` 컬렉션)
- **날짜 타입**: `Instant` 사용 (`eventStartDate`, `eventEndDate`)
- **조회 최적화**: MongoDB Projection으로 DTO 직접 조회

### Request/Response 예시

**GET Response:**
```json
{
  "articles": [
    {
      "clubName": "WAP",
      "clubId": "1230badsf",
      "title": "WAP 최종전시..",
      "location": "향파관",
      "eventStartDate": "2025-12-01T00:00:00Z",
      "eventEndDate": "2025-12-02T00:00:00Z",
      "description": "홍보 설명",
      "images": ["https://cdn.moadong.com","https://cdn.moadong.com~~~"]
    }
  ]
}
```
**POST Request:**
```json
{
  "clubId": "1230badsf",
  "title": "WAP 최종전시..",
  "location": "향파관",
  "eventStartDate": "2025-12-01T00:00:00Z",
  "eventEndDate": "2025-12-02T00:00:00Z",
  "description": "홍보 설명",
  "images": ["https://cdn.moadong.com","https://cdn.moadong.com~~~"]
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 프로모션 아티클 조회 기능 추가 - 모든 프로모션 아티클 목록을 조회할 수 있습니다.
  * 프로모션 아티클 생성 기능 추가 - 인증된 사용자가 새로운 프로모션 아티클을 생성할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->