### PR TITLE
[fix] 관리자 페이지 모집 기간 캘린더 레이아웃 오류를 수정한다

### DIFF
--- a/frontend/src/pages/AdminPage/tabs/RecruitEditTab/components/Calendar/Calendar.styles.ts
+++ b/frontend/src/pages/AdminPage/tabs/RecruitEditTab/components/Calendar/Calendar.styles.ts
@@ -34,7 +34,7 @@ export const DatepickerContainer = styled.div`
     overflow: hidden;
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
     display: inline-flex;
-    align-items: stretch;
+    align-items: flex-start;
     width: auto;
   }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #1148 

## 📝작업 내용

> 모집 기간 캘린더 레이아웃 오류 수정

| 변경 전 | 변경 후 |
|---|---|
| <img width="891" height="1131" alt="image" src="https://github.com/user-attachments/assets/ff170f5c-f44d-464a-9cc0-2e434ef4de71" /> | <img width="799" height="584" alt="image" src="https://github.com/user-attachments/assets/5575a29d-16f7-4dd6-bd35-841641df49d0" /> |

### 문제 상황
관리자 페이지의 모집 기간 설정 캘린더에서 달력 하단이 계속 늘어나며 레이아웃이 깨지는 현상이 발생했습니다.

특히 `showTimeSelect`가 활성화된 상태에서
시간 리스트가 길어질수록 달력 전체 높이가 함께 확장되는 문제가 있었습니다.

동아리 관리자들의 사용성을 고려하여 빠르게 수정해야겠다고 생각했습니다.

### 원인 분석
`react-datepicker`에서 기존에 아래와 같은 구조였습니다.
```css
.react-datepicker {
  display: inline-flex;
  align-items: stretch;
}
``` 
`.react-datepicker`가 flex 컨테이너이기 때문에, `align-items: stretch` 로 인해 자식 중 가장 큰 높이인 시간 리스트에 맞춰 달력 전체 컨테이너가 함께 늘어나고 있었습니다.

### 해결 방법
flex 컨테이너의 정렬 방식을 명시적으로 수정했습니다.
```css
.react-datepicker {
  align-items: flex-start;
}
```
각 컬림이 자신의 높이만큼만 렌더링되도록 하여 시간 리스트의 높이가 커져도 달력 전체 높이에 영향이 없도록 했습니다.



## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 관리자 페이지의 달력 컴포넌트 레이아웃을 개선하여 날짜 선택기의 수직 정렬을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->