### PR TITLE
[fix] 필터탭 메인에서 제거 

### DIFF
--- a/frontend/src/pages/MainPage/MainPage.tsx
+++ b/frontend/src/pages/MainPage/MainPage.tsx
@@ -54,7 +54,7 @@ const MainPage = () => {
     <>
       <Popup />
       <Header />
-      <Filter />
+      {/* <Filter /> */}
       <Banner />
       <Styled.PageContainer>
         <CategoryButtonList />

--- a/frontend/src/pages/MainPage/components/Banner/Banner.styles.ts
+++ b/frontend/src/pages/MainPage/components/Banner/Banner.styles.ts
@@ -16,7 +16,7 @@ export const BannerContainer = styled.div`
   }
 
   ${media.mobile} {
-    margin-top: 0px;
+    margin-top: 56px;
     padding: 0;
   }
 `;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

- 홍보게시판 완성 전에 필터탭이 메인에 있는게 이상해서 지웠습니다.

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **스타일**
  * 모바일 화면에서 배너의 여백이 조정되었습니다.

* **버그 수정**
  * 필터 기능이 일시적으로 비활성화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->