### PR TITLE
[fix] Vercel 기본 도메인(vercel.app) 접속 시 커스텀 도메인으로 리다이렉트

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,3 +1,11 @@
 {
+  "redirects": [
+    {
+      "source": "/:path(.*)",
+      "has": [{ "type": "host", "value": "moadong.vercel.app" }],
+      "destination": "https://www.moadong.com/:path",
+      "permanent": true
+    }
+  ],
   "rewrites": [{ "source": "/(.*)", "destination": "/" }]
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #1153

## 📝작업 내용

 `moadong.vercel.app`으로 접근 시 커스텀 도메인 `www.moadong.com`으로 301 리다이렉트되도록 `vercel.json`에 redirect 규칙을 추가했습니다.

 - 하위 경로(예: `/club/123`)도 그대로 유지됩니다.
 - 커스텀 도메인으로 직접 접근한 경우에는 리다이렉트되지 않습니다.

## 🫡 참고사항

 - `has` 필드의 `"type": "host"` 조건으로 호스트명을 매칭하여, 커스텀 도메인 사용자에게는 영향이 없습니다.
 - `"permanent": true` → 301 영구 리다이렉트 (SEO 유리)
 - `/:path(.*)`로 하위 경로를 캡처하여 `destination`에 그대로 전달합니다.

 **참고한 공식 문서**
 - [Configuration Redirects](https://vercel.com/docs/redirects/configuration-redirects)
 - [Redirects Overview](https://vercel.com/docs/redirects)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 배포 설정에 도메인 리다이렉트 구성을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->