### PR TITLE
지원하기 버튼 테스트 수정

### DIFF
--- a/frontend/src/utils/getDeadLineText.test.ts
+++ b/frontend/src/utils/getDeadLineText.test.ts
@@ -71,11 +71,15 @@ describe('getDeadlineText 함수 테스트', () => {
   });
 
   it(`모집 종료일이 null이면 모집 마감을 반환해야 한다`, () => {
-    expect(getDeadlineText(new Date('2025-01-01'), null, 'OPEN')).toBe('모집 마감');
+    expect(getDeadlineText(new Date('2025-01-01'), null, 'OPEN')).toBe(
+      '모집 마감',
+    );
   });
 
   it('UPCOMING 상태인데 모집 시작일이 null이면 모집 마감을 반환해야 한다', () => {
-    expect(getDeadlineText(null, new Date('2025-04-10'), 'UPCOMING')).toBe('모집 마감');
+    expect(getDeadlineText(null, new Date('2025-04-10'), 'UPCOMING')).toBe(
+      '모집 마감',
+    );
   });
 
   it('모집 중 상태인데 모집 종료일까지 1년 이상 남으면 상시 모집을 반환해야 한다', () => {
@@ -91,9 +95,9 @@ describe('getDeadlineText 함수 테스트', () => {
 });
 
 it('CLOSED 상태이고 종료일이 있으면 지난 모집 날짜를 표시한다', () => {
-  expect(
-    getDeadlineText(null, new Date('2024-12-31'), 'CLOSED'),
-  ).toBe('지난 모집・2024 12/31');
+  expect(getDeadlineText(null, new Date('2024-12-31'), 'CLOSED')).toBe(
+    '지난 모집・2024 12/31',
+  );
 });
 
 it('UPCOMING 상태이고 시작일이 있으면 모집 시작일을 표시한다', () => {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #1180 

## 📝작업 내용

> 지원하기 버튼 텍스트 수정으로 인한 오류를 수정하고 새로운 테스트를 추가했습니다.

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * 모집 마감 문구 관련 테스트를 확장 및 수정: 종료된 모집이 과거 종료일을 가질 때 "지난 모집・YYYY M/D" 형식으로 표시되도록 기대치를 변경하고, 시작일/종료일이 null인 경우(OPEN, UPCOMING 등)와 각 상태별 날짜 표시 동작에 대한 추가 경계 케이스를 검증하도록 시나리오를 보강했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->