### PR TITLE
[fix] 이미지 미로드 시 early return

### DIFF
--- a/frontend/src/pages/MainPage/components/Popup/Popup.tsx
+++ b/frontend/src/pages/MainPage/components/Popup/Popup.tsx
@@ -35,6 +35,8 @@ const Popup = () => {
   }, []);
 
   useEffect(() => {
+    if (!imageLoaded) return;
+
     const isHidden = isPopupHidden();
 
     if (isMobile && !isHidden && imageLoaded) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

- 이미지 미로드 시에도 `MAIN_POPUP_NOT_SHOWN` 이벤트가 찍힘. 
- 미로드 시 얼리리턴하도록 변경

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* **팝업 성능 개선** - 이미지 로드 전 불필요한 처리를 건너뛰도록 최적화하여 초기 렌더링 시 팝업 창의 반응성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->