### PR TITLE
[feature] 민감한 Endpoint 접근 권한 상승

### DIFF
--- a/backend/src/main/java/moadong/club/controller/PromotionArticleController.java
+++ b/backend/src/main/java/moadong/club/controller/PromotionArticleController.java
@@ -34,7 +34,7 @@ public class PromotionArticleController {
 
     @PostMapping
     @Operation(summary = "홍보 게시글 생성", description = "새로운 홍보 게시글을 생성합니다.")
-    @PreAuthorize("isAuthenticated()")
+    @PreAuthorize("hasRole('DEVELOPER')")
     @SecurityRequirement(name = "BearerAuth")
     public ResponseEntity<?> createPromotionArticle(
         @RequestBody @Validated PromotionArticleCreateRequest request) {

--- a/backend/src/main/java/moadong/user/controller/UserController.java
+++ b/backend/src/main/java/moadong/user/controller/UserController.java
@@ -44,6 +44,8 @@ public class UserController {
             summary = UserSwaggerView.ADMIN_REGISTER_SUMMARY,
             description = UserSwaggerView.ADMIN_PWD_ROLE_DESCRIPTION
     )
+    @PreAuthorize("hasRole('DEVELOPER')")
+    @SecurityRequirement(name = "BearerAuth")
     public ResponseEntity<?> registerUser(@RequestBody @Validated UserRegisterRequest request) {
         userCommandService.registerUser(request);
         return Response.ok("success register");
@@ -102,6 +104,8 @@ public class UserController {
 
     @PostMapping("/reset")
     @Operation(summary = "사용자 비밀번호 초기화", description = "사용자 비밀번호를 초기화합니다.")
+    @PreAuthorize("hasRole('DEVELOPER')")
+    @SecurityRequirement(name = "BearerAuth")
     public ResponseEntity<?> reset(@RequestBody @Validated UserResetRequest userResetRequest) {
         TempPasswordResponse tempPwdResponse = userCommandService.reset(userResetRequest.userId());
         return Response.ok(tempPwdResponse);


### PR DESCRIPTION
## #️⃣연관된 이슈
- #1198
- MOA-651

## 📝작업 내용
- `POST /api/promotion` 접근 권한을 `isAuthenticated()`에서 `hasRole('DEVELOPER')`로 강화했습니다.
- `POST /auth/user/register`에 `@PreAuthorize("hasRole('DEVELOPER')")`를 추가했습니다.
- `POST /auth/user/reset`에 `@PreAuthorize("hasRole('DEVELOPER')")`를 추가했습니다.
- 위 2개 유저 API에 `@SecurityRequirement(name = "BearerAuth")`를 추가해 인증 요구사항을 명시했습니다.
- 권한 제어 위치를 엔드포인트별 어노테이션 기준으로 정리했습니다.

## 중점적으로 리뷰받고 싶은 부분(선택)


## 논의하고 싶은 부분(선택)


## 🫡 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **보안**
  * 프로모션 게시물 작성 엔드포인트의 접근 권한이 변경되었습니다.
  * 사용자 등록 및 초기화 엔드포인트의 접근 권한이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->