### PR TITLE
[feature] 동아리 한글 표시 이름 추가 -BE

### DIFF
--- a/backend/src/main/java/moadong/club/controller/ClubProfileController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubProfileController.java
@@ -31,6 +31,14 @@ public class ClubProfileController {
         return Response.ok(clubDetailedPageResponse);
     }
 
+    @GetMapping("/{clubName:@[^/]+}")
+    @Operation(summary = "클럽 상세 정보 조회", description = "클럽 이름을 이용해 상세 정보를 조회합니다.")
+    public ResponseEntity<?> getClubDetailByClubName(@PathVariable String clubName) {
+        ClubDetailedResponse clubDetailedResponse = clubProfileService.getClubDetailByClubName(clubName);
+        return Response.ok(clubDetailedResponse);
+    }
+
+
     @PutMapping("/info")
     @Operation(summary = "클럽 약력 수정", description = "클럽 약력을 수정합니다.<br>"
         + "tags는 최대 2개, 5글자 이내로 입력해야 합니다.<br>"

--- a/backend/src/main/java/moadong/club/controller/ClubProfileController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubProfileController.java
@@ -31,7 +31,7 @@ public class ClubProfileController {
         return Response.ok(clubDetailedPageResponse);
     }
 
-    @GetMapping("/{clubName:@[^/]+}")
+    @GetMapping("/@{clubName}")
     @Operation(summary = "클럽 상세 정보 조회", description = "클럽 이름을 이용해 상세 정보를 조회합니다.")
     public ResponseEntity<?> getClubDetailByClubName(@PathVariable String clubName) {
         ClubDetailedResponse clubDetailedResponse = clubProfileService.getClubDetailByClubName(clubName);

--- a/backend/src/main/java/moadong/club/entity/Club.java
+++ b/backend/src/main/java/moadong/club/entity/Club.java
@@ -29,7 +29,7 @@ public class Club implements Persistable<String> {
     private String id;
 
     @Indexed(name = "uk_club_name_not_blank", unique = true,
-            partialFilter = "{ \"name\": { \"$exists\": true, \"$nin\": [null, \"\"] } }")
+            partialFilter = "{ \"name\": { \"$type\": \"string\", \"$gt\": \"\" } }")
     private String name;
 
     private String category;

--- a/backend/src/main/java/moadong/club/entity/Club.java
+++ b/backend/src/main/java/moadong/club/entity/Club.java
@@ -13,6 +13,7 @@ import org.javers.core.metamodel.annotation.DiffIgnore;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Version;
 import org.springframework.data.domain.Persistable;
+import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
@@ -27,6 +28,8 @@ public class Club implements Persistable<String> {
     @Id
     private String id;
 
+    @Indexed(name = "uk_club_name_not_blank", unique = true,
+            partialFilter = "{ \"name\": { \"$exists\": true, \"$nin\": [null, \"\"] } }")
     private String name;
 
     private String category;

--- a/backend/src/main/java/moadong/club/repository/ClubRepository.java
+++ b/backend/src/main/java/moadong/club/repository/ClubRepository.java
@@ -20,4 +20,7 @@ public interface ClubRepository extends MongoRepository<Club, String> {
     Long countByIdIn(List<String> id);
 
     List<Club> findAllByClubRecruitmentInformation_ClubRecruitmentStatus(ClubRecruitmentStatus status);
+
+    Optional<Club> findClubByName(String name);
+
 }

--- a/backend/src/main/java/moadong/club/repository/ClubRepository.java
+++ b/backend/src/main/java/moadong/club/repository/ClubRepository.java
@@ -23,4 +23,6 @@ public interface ClubRepository extends MongoRepository<Club, String> {
 
     Optional<Club> findClubByName(String name);
 
+    boolean existsByNameAndIdNot(String name, String id);
+
 }

--- a/backend/src/main/java/moadong/club/service/ClubProfileService.java
+++ b/backend/src/main/java/moadong/club/service/ClubProfileService.java
@@ -94,6 +94,16 @@ public class ClubProfileService {
         return new ClubDetailedResponse(clubDetailedResult);
     }
 
+    public ClubDetailedResponse getClubDetailByClubName(String clubName) {
+        Club club = clubRepository.findClubByName(clubName)
+                .orElseThrow(() -> new RestApiException(ErrorCode.CLUB_NOT_FOUND));
+
+        ClubDetailedResult clubDetailedResult = ClubDetailedResult.of(
+                club
+        );
+        return new ClubDetailedResponse(clubDetailedResult);
+    }
+
     @Transactional
     public void updateClubInfoByClubId(String clubId, ClubInfoRequest request, CustomUserDetails user) {
         ObjectId objectId = ObjectIdConverter.convertString(clubId);

--- a/backend/src/main/java/moadong/global/exception/ErrorCode.java
+++ b/backend/src/main/java/moadong/global/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     TOO_MANY_TAGS(HttpStatus.BAD_REQUEST, "600-8", "태그는 최대 3개까지 입력할 수 있습니다."),
     TOO_LONG_TAG(HttpStatus.BAD_REQUEST, "600-9", "태그는 최대 5글자까지 입력할 수 있습니다."),
     TOO_LONG_INTRODUCTION(HttpStatus.BAD_REQUEST, "600-10", "소개는 최대 24글자까지 입력할 수 있습니다."),
+    CLUB_NAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "600-11", "이미 사용 중인 동아리 이름입니다."),
 
     // 601xx: 파일/미디어 관련 오류
     IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "601-1", "이미지 업로드에 실패하였습니다."),


### PR DESCRIPTION
## #️⃣연관된 이슈

- #1205

## 📝작업 내용

기존 동아리 상세 조회 엔드포인트에서 @이로 시작하는 요청일시 이름기반으로 검색합니다.
그에따라 동아리 이름의 유니크 보장이 필요해졌고 동아리 이름 중복 방지 로직이 추가되었습니다.

하다가 알게된사실은 몽고디비의 유니크 제약은
https://www.mongodb.com/ko-kr/docs/manual/core/index-unique/
인덱스로만 걸수있다~

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 동아리 이름으로 동아리 상세 정보를 조회할 수 있는 기능 추가

* **개선사항**
  * 동아리 이름 중복 검증 로직 강화
  * 동아리 정보 업데이트 시 이름 중복 감지 및 처리 개선
  * 데이터베이스에 이름 고유성 제약 조건 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->