### PR TITLE
[fix] 레이아웃이 깨지는 버그 수정

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,51 +36,57 @@ const AdminRoutes = lazy(() => import('@/pages/AdminPage/AdminRoutes'));
 const App = () => {
   return (
     <>
-    <GlobalStyles />
-    <GlobalBoundary>
-      <QueryClientProvider client={queryClient}>
-        <ThemeProvider theme={theme}>
-          <BrowserRouter>
-            <ScrollToTop />
-            <ScrollToTopButton />
-            <Routes>
-              <Route path='/' element={<MainPage />} />
-              {/*기존 웹 & 안드로이드 url (android: v1.1.0)*/}
-              <Route path='/club/:clubId' element={<LegacyClubDetailPage />} />
-              {/*웹 유저에게 신규 상세페이지 보유주기 위한 임시 url*/}
-              <Route path='/clubDetail/:clubId' element={<ClubDetailPage />} />
-              {/*새로 빌드해서 배포할 앱 주소 url*/}
-              <Route
-                path='/webview/club/:clubId'
-                element={<ClubDetailPage />}
-              />
-              <Route path='/introduce' element={<IntroducePage />} />
-              <Route path='/admin/login' element={<LoginTab />} />
-              <Route
-                path='/admin/*'
-                element={
-                  <AdminClubProvider>
-                    <PrivateRoute>
-                      <AdminRoutes />
-                    </PrivateRoute>
-                  </AdminClubProvider>
-                }
-              />
-              <Route
-                path='/application/:clubId/:applicationFormId'
-                element={<ApplicationFormPage />}
-              />
-              <Route path='/club-union' element={<ClubUnionPage />} />
-              {/* 개발 환경에서만 사용 가능한 에러 테스트 페이지 */}
-              {import.meta.env.DEV && (
-                <Route path='/error-test' element={<ErrorTestPage />} />
-              )}
-              <Route path='*' element={<Navigate to='/' replace />} />
-            </Routes>
-          </BrowserRouter>
-        </ThemeProvider>
-      </QueryClientProvider>
-    </GlobalBoundary>
+      <GlobalStyles />
+      <GlobalBoundary>
+        <QueryClientProvider client={queryClient}>
+          <ThemeProvider theme={theme}>
+            <BrowserRouter>
+              <ScrollToTop />
+              <ScrollToTopButton />
+              <Routes>
+                <Route path='/' element={<MainPage />} />
+                {/*기존 웹 & 안드로이드 url (android: v1.1.0)*/}
+                <Route
+                  path='/club/:clubId'
+                  element={<LegacyClubDetailPage />}
+                />
+                {/*웹 유저에게 신규 상세페이지 보유주기 위한 임시 url*/}
+                <Route
+                  path='/clubDetail/:clubId'
+                  element={<ClubDetailPage />}
+                />
+                {/*새로 빌드해서 배포할 앱 주소 url*/}
+                <Route
+                  path='/webview/club/:clubId'
+                  element={<ClubDetailPage />}
+                />
+                <Route path='/introduce' element={<IntroducePage />} />
+                <Route path='/admin/login' element={<LoginTab />} />
+                <Route
+                  path='/admin/*'
+                  element={
+                    <AdminClubProvider>
+                      <PrivateRoute>
+                        <AdminRoutes />
+                      </PrivateRoute>
+                    </AdminClubProvider>
+                  }
+                />
+                <Route
+                  path='/application/:clubId/:applicationFormId'
+                  element={<ApplicationFormPage />}
+                />
+                <Route path='/club-union' element={<ClubUnionPage />} />
+                {/* 개발 환경에서만 사용 가능한 에러 테스트 페이지 */}
+                {import.meta.env.DEV && (
+                  <Route path='/error-test' element={<ErrorTestPage />} />
+                )}
+                <Route path='*' element={<Navigate to='/' replace />} />
+              </Routes>
+            </BrowserRouter>
+          </ThemeProvider>
+        </QueryClientProvider>
+      </GlobalBoundary>
     </>
   );
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

- #1207 

## 📝작업 내용

기존
```jsx
<Suspense fallback={...}>
    <GlobalStyles />
</Suspense>
```

에러 바운더리를 도입하면서 GlobalStyles를 Suspense안에 두어 잠깐의 fallback동안 스타일이 제거되어 레이아웃이 깨지는 문제가 발생하였습니다.

해당문제를 수정하기 위해 GlobalStyles를 Suspense 태그 밖 최상위에 위치시켰습니다

아마 createGlobalStyle은 한번만 실행되는듯~ 마운트 될때마다 주입되는게아니듯합니다
신기하네요

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 전역 스타일의 적용 위치를 조정하여 페이지 전반의 스타일 일관성과 렌더링 순서를 개선했습니다. 사용자 인터페이스의 시각적 안정성과 초기 스타일 로드가 향상됩니다. 기능 동작에는 영향이 없습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->