### PR TITLE
[chore] 배포 이미지가 latest로 통일되던 문제 수정 및 전체 배포 로직 개선

### DIFF
--- a/.github/workflows/oracle_server_cd_develop.yml
+++ b/.github/workflows/oracle_server_cd_develop.yml
@@ -85,20 +85,33 @@ jobs:
     needs: build
 
     steps:
-      # oracle ssh 접속 후 배포
-      - name: Update Container on VM
+      - name: Deploy to Oracle VM
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.ORACLE_INSTANCE_DEV_IP }}
           username: ${{ secrets.ORACLE_INSTANCE_USER }}
           key: ${{ secrets.ORACLE_INSTANCE_DEV_PRIVATE_KEY }}
           port: ${{ secrets.ORACLE_INSTANCE_DEV_PORT }}
+          # 타임아웃 설정 (이미지 pull 시간이 길어질 경우 대비)
+          timeout: 120s
           script: |
-            docker pull ${{ secrets.DOCKER_IMAGE_DEV }}:latest
+            # 1. 사용할 이미지 태그를 변수로 지정 (latest가 아닌 github.sha 사용)
+            # github.sha는 빌드 잡에서 생성한 태그와 동일한 값입니다.
+            TARGET_IMAGE="${{ secrets.DOCKER_IMAGE_DEV }}:${{ github.sha }}"
 
+            echo "Deploying target image: $TARGET_IMAGE"
+
+            # 2. 명시된 버전의 이미지를 Pull (latest가 아니므로 캐시 문제 없음)
+            docker pull $TARGET_IMAGE
+
+            # 3. 환경 변수 설정
             export USERNAME=${{ secrets.ORACLE_INSTANCE_USER }}
-            export DOCKER_APP_IMAGE=${{ secrets.DOCKER_IMAGE_DEV }}:latest
+            export DOCKER_APP_IMAGE=$TARGET_IMAGE
+
+            # 4. 배포 스크립트 실행
+            # 주의: deploy.sh 내부에서 'docker run ... $DOCKER_APP_IMAGE'를 사용하도록 작성되어 있어야 합니다.
             sudo chmod +x /home/${{ secrets.ORACLE_INSTANCE_USER }}/deploy.sh
             sudo -E /home/${{ secrets.ORACLE_INSTANCE_USER }}/deploy.sh
 
-            docker image prune -af
+            # 5. 불필요한 이미지 정리 (공간 확보)
+            docker image prune -f


### PR DESCRIPTION
## #️⃣연관된 이슈

#1212 

## 📝작업 내용

어느날 개발서버에 최신 형상이 반영되지 않던 문제 발견.

배포이미지 태그가 latest로 고정되어있던 문제 수정.
배포 이미지 관리를 쉽게 하도록 커밋 해시값을 이용하도록 변경.
가끔 네트워크 이슈나 빌드 중에 이슈로 latest가 겹쳐서 최신 이미지가 옛날 버전 갈 수가 있는데 unique한 이름을 부여해서 원천 차단.

추가로 프로덕션 서버랑 개발섭 deploy.sh 도커컴포즈 헬스체크 타임아웃을 개발섭 60초, 배포섭 20초 -> 120초로 증가.
```
BEFORE_HEALTH_CHECK_DELAY=120 # 실행 후 대기시간(앱 초기화 시간)
```



## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 배포 워크플로우 개선으로 더욱 안정적인 배포 환경 구성
  * 배포 프로세스에 타임아웃 설정 추가로 배포 신뢰성 향상
  * 배포 로깅 강화로 배포 추적 및 모니터링 개선
  * 특정 버전의 컨테이너 이미지를 사용하여 배포 일관성 보증

<!-- end of auto-generated comment: release notes by coderabbit.ai -->