### PR TITLE
[fix] 지원자 수정 디바운스 제거

### DIFF
--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPage.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPage.tsx
@@ -112,9 +112,11 @@ const ApplicantDetailPage = () => {
   };
 
   const handleMemoChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const newMemo = e.target.value;
-    setAppMemo(newMemo);
-    updateApplicantDetail(newMemo, applicantStatus);
+    setAppMemo(e.target.value);
+  };
+
+  const handleMemoBlur = () => {
+    updateApplicantDetail(applicantMemo, applicantStatus);
   };
 
   const handleStatusChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -186,7 +188,8 @@ const ApplicantDetailPage = () => {
         <Styled.MemoContainer>
           <Styled.MemoLabel>메모</Styled.MemoLabel>
           <Styled.MemoTextarea
-            onInput={handleMemoChange}
+            onChange={handleMemoChange}
+            onBlur={handleMemoBlur}
             placeholder='메모를 입력해주세요'
             value={applicantMemo}
           ></Styled.MemoTextarea>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #1222

## 변경 배경
  `updateApplicantDetail`의 검증 로직이 truthy 기반(`!memo || !status`)으로
  빈 문자열 메모(`''`)가 유효한 입력임에도 업데이트가 차단되는 회귀 가능성

  - `memo` 검증을 truthy 체크에서 타입 체크로 변경
  - `status` 검증을 enum 타입가드로 명시화
    - `isApplicationStatus(value): value is ApplicationStatus` 추가
  - 디바운스, useMemo 제거
    - `updateApplicantDetail`의 불필요한 의존성 `clubId` 제거

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 지원자 상세정보 업데이트가 즉시 처리되도록 변경되어 반응성이 향상되었습니다.
  * 메모 및 상태 변경 시 더 일관되게 업데이트가 실행됩니다.
  * 입력값(상태, 메모)에 대한 검증이 강화되어 잘못된 입력을 방지합니다.
  * 오류 발생 시 기존과 동일한 안내(에러 알림)를 유지합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->