### PR TITLE
[fix] 토큰이 리프레시 되지않던 문제 수정 - fe

### DIFF
--- a/frontend/src/apis/auth/secureFetch.ts
+++ b/frontend/src/apis/auth/secureFetch.ts
@@ -17,7 +17,7 @@ export const secureFetch = async (
   });
 
   // accessToken 만료 시 → refresh 시도
-  if (response.status === 403) {
+  if (response.status === 401) {
     try {
       const newAccessToken = await refreshAccessToken();
       localStorage.setItem('accessToken', newAccessToken);


### PR DESCRIPTION
- 403이아니라 401이 Unauthorized status code임

## #️⃣연관된 이슈

- #1237 

## 📝작업 내용

서버에선 토큰 만료 응답으로 401을 내려주는데 클라이언트에선 403으로 분기처리가되어있었습니다.

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 사용자 세션이 만료된 경우 자동 토큰 갱신 및 요청 재시도 메커니즘이 개선되었습니다.
  * 인증 과정에서 필요한 헤더 정보가 올바르게 포함되어 더 안정적인 동작을 보장합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->