### PR TITLE
[Feature] 동소한 웹 필터칩 추가

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,7 @@ import {
 } from './components/common/ErrorBoundary';
 import LegacyClubDetailPage from './pages/ClubDetailPage/LegacyClubDetailPage';
 import ErrorTestPage from './pages/ErrorTestPage/ErrorTestPage';
+import IntroductionPage from './pages/FestivalPage/IntroductionPage/IntroductionPage';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -121,6 +122,14 @@ const App = () => {
                   element={
                     <ContentErrorBoundary>
                       <ClubUnionPage />
+                    </ContentErrorBoundary>
+                  }
+                />
+                <Route
+                  path='/festival-introduction'
+                  element={
+                    <ContentErrorBoundary>
+                      <IntroductionPage />
                     </ContentErrorBoundary>
                   }
                 />

--- a/frontend/src/constants/eventName.ts
+++ b/frontend/src/constants/eventName.ts
@@ -44,6 +44,9 @@ export const USER_EVENT = {
   APPLICATION_FORM_SUBMITTED: 'Application Form Submitted',
   PATCH_NOTE_BUTTON_CLICKED: 'Patch Note Button Clicked',
   FAQ_TOGGLE_CLICKED: 'FAQ Toggle Clicked',
+
+  // 필터칩
+  FILTER_OPTION_CLICKED: 'Filter Option Clicked',
 } as const;
 
 export const ADMIN_EVENT = {
@@ -97,6 +100,7 @@ export const PAGE_VIEW = {
   MAIN_PAGE: 'MainPage',
   INTRODUCE_PAGE: 'IntroducePage',
   CLUB_UNION_PAGE: 'ClubUnionPage',
+  FESTIVAL_INTRODUCTION_PAGE: '동소한 페이지',
 
   // 관리자
   LOGIN_PAGE: '로그인페이지',

--- a/frontend/src/pages/FestivalPage/IntroductionPage/IntroductionPage.styles.ts
+++ b/frontend/src/pages/FestivalPage/IntroductionPage/IntroductionPage.styles.ts
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+import { media } from '@/styles/mediaQuery';
+
+export const Container = styled.div`
+  width: 100%;
+  max-width: 550px;
+  margin: 0 auto;
+  padding: 24px 20px 0;
+
+  ${media.mobile} {
+    padding: 0 20px;
+  }
+`;

--- a/frontend/src/pages/FestivalPage/IntroductionPage/IntroductionPage.styles.ts
+++ b/frontend/src/pages/FestivalPage/IntroductionPage/IntroductionPage.styles.ts
@@ -5,9 +5,9 @@ export const Container = styled.div`
   width: 100%;
   max-width: 550px;
   margin: 0 auto;
-  padding: 24px 20px 0;
+  padding-top: 24px;
 
   ${media.mobile} {
-    padding: 0 20px;
+    padding-top: 0;
   }
 `;

--- a/frontend/src/pages/FestivalPage/IntroductionPage/IntroductionPage.tsx
+++ b/frontend/src/pages/FestivalPage/IntroductionPage/IntroductionPage.tsx
@@ -1,0 +1,25 @@
+import Footer from '@/components/common/Footer/Footer';
+import Header from '@/components/common/Header/Header';
+import { PAGE_VIEW } from '@/constants/eventName';
+import useTrackPageView from '@/hooks/Mixpanel/useTrackPageView';
+import Filter from '@/pages/MainPage/components/Filter/Filter';
+import isInAppWebView from '@/utils/isInAppWebView';
+import * as Styled from './IntroductionPage.styles';
+
+const IntroductionPage = () => {
+  useTrackPageView(PAGE_VIEW.FESTIVAL_INTRODUCTION_PAGE);
+  return (
+    <>
+      <Header hideOn={['webview']} />
+      <Styled.Container>
+        {!isInAppWebView() && <Filter alwaysVisible />}
+        {/* 지도 | 공연시간표 탭 */}
+        {/* 동아리지도 */}
+        {/* 공연시간표 */}
+      </Styled.Container>
+      <Footer />
+    </>
+  );
+};
+
+export default IntroductionPage;

--- a/frontend/src/pages/MainPage/MainPage.tsx
+++ b/frontend/src/pages/MainPage/MainPage.tsx
@@ -50,7 +50,7 @@ const MainPage = () => {
     <>
       <Popup />
       <Header />
-      {/* <Filter /> */}
+      <Filter />
       <Banner />
       <Styled.PageContainer>
         <CategoryButtonList />

--- a/frontend/src/pages/MainPage/components/Banner/Banner.styles.ts
+++ b/frontend/src/pages/MainPage/components/Banner/Banner.styles.ts
@@ -16,7 +16,7 @@ export const BannerContainer = styled.div`
   }
 
   ${media.mobile} {
-    margin-top: 56px;
+    margin-top: 0px;
     padding: 0;
   }
 `;

--- a/frontend/src/pages/MainPage/components/Filter/Filter.styles.ts
+++ b/frontend/src/pages/MainPage/components/Filter/Filter.styles.ts
@@ -14,7 +14,6 @@ export const FilterButton = styled(Button)<{ $isActive?: boolean }>`
   border-radius: 100px;
   height: 32px;
   padding: 6px 12px;
-  border-radius: 100px;
   font-size: ${theme.typography.button.button1.size};
   font-weight: ${theme.typography.button.button1.weight};
   color: ${({ $isActive }) =>

--- a/frontend/src/pages/MainPage/components/Filter/Filter.tsx
+++ b/frontend/src/pages/MainPage/components/Filter/Filter.tsx
@@ -4,13 +4,20 @@ import * as Styled from './Filter.styles';
 
 const FILTER_OPTIONS = [
   { label: '동아리', path: '/' },
-  { label: '홍보', path: '/promotion' },
+  { label: '동소한', path: '/festival-introduction' },
 ] as const;
 
 const Filter = () => {
   const { isMobile } = useDevice();
   const navigate = useNavigate();
   const { pathname } = useLocation();
+  const trackEvent = useMixpanelTrack();
+  const handleFilterOptionClick = (path: string) => {
+    trackEvent(USER_EVENT.FILTER_OPTION_CLICKED, {
+      path: path,
+    });
+    navigate(path);
+  };
 
   return (
     <>
@@ -20,7 +27,7 @@ const Filter = () => {
             <Styled.FilterButton
               key={filter.path}
               $isActive={pathname === filter.path}
-              onClick={() => navigate(filter.path)}
+              onClick={() => handleFilterOptionClick(filter.path)}
             >
               {filter.label}
             </Styled.FilterButton>

--- a/frontend/src/pages/MainPage/components/Filter/Filter.tsx
+++ b/frontend/src/pages/MainPage/components/Filter/Filter.tsx
@@ -8,6 +8,7 @@ const FILTER_OPTIONS = [
   { label: '동소한', path: '/festival-introduction' },
   { label: '동아리', path: '/' },
 ] as const;
+const FESTIVAL_PATH = '/festival-introduction';
 
 interface FilterProps {
   alwaysVisible?: boolean;
@@ -32,13 +33,17 @@ const Filter = ({ alwaysVisible = false }: FilterProps) => {
       {shouldShow && (
         <Styled.FilterListContainer>
           {FILTER_OPTIONS.map((filter) => (
-            <Styled.FilterButton
-              key={filter.path}
-              $isActive={pathname === filter.path}
-              onClick={() => handleFilterOptionClick(filter.path)}
-            >
-              {filter.label}
-            </Styled.FilterButton>
+            <Styled.FilterButtonWrapper key={filter.path}>
+              <Styled.NotificationDot
+                $isVisible={filter.path === FESTIVAL_PATH}
+              />
+              <Styled.FilterButton
+                $isActive={pathname === filter.path}
+                onClick={() => handleFilterOptionClick(filter.path)}
+              >
+                {filter.label}
+              </Styled.FilterButton>
+            </Styled.FilterButtonWrapper>
           ))}
         </Styled.FilterListContainer>
       )}

--- a/frontend/src/pages/MainPage/components/Filter/Filter.tsx
+++ b/frontend/src/pages/MainPage/components/Filter/Filter.tsx
@@ -5,8 +5,8 @@ import useDevice from '@/hooks/useDevice';
 import * as Styled from './Filter.styles';
 
 const FILTER_OPTIONS = [
-  { label: '동아리', path: '/' },
   { label: '동소한', path: '/festival-introduction' },
+  { label: '동아리', path: '/' },
 ] as const;
 
 interface FilterProps {

--- a/frontend/src/pages/MainPage/components/Filter/Filter.tsx
+++ b/frontend/src/pages/MainPage/components/Filter/Filter.tsx
@@ -1,4 +1,6 @@
 import { useLocation, useNavigate } from 'react-router-dom';
+import { USER_EVENT } from '@/constants/eventName';
+import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import useDevice from '@/hooks/useDevice';
 import * as Styled from './Filter.styles';
 
@@ -7,11 +9,17 @@ const FILTER_OPTIONS = [
   { label: '동소한', path: '/festival-introduction' },
 ] as const;
 
-const Filter = () => {
+interface FilterProps {
+  alwaysVisible?: boolean;
+}
+
+const Filter = ({ alwaysVisible = false }: FilterProps) => {
   const { isMobile } = useDevice();
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const trackEvent = useMixpanelTrack();
+  const shouldShow = alwaysVisible || isMobile;
+
   const handleFilterOptionClick = (path: string) => {
     trackEvent(USER_EVENT.FILTER_OPTION_CLICKED, {
       path: path,
@@ -21,7 +29,7 @@ const Filter = () => {
 
   return (
     <>
-      {isMobile && (
+      {shouldShow && (
         <Styled.FilterListContainer>
           {FILTER_OPTIONS.map((filter) => (
             <Styled.FilterButton


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #1245 

## 📝작업 내용

## 작업 내용

  메인페이지에 필터칩을 추가하고, 동소한 소개 페이지(/festival-introduction)를 신규 라우트로 연결했습니다.
  또한 Filter 컴포넌트를 재사용 가능하게 개선하여, 메인페이지에서는 기존처럼 모바일에서만 보이고 동소한 페이지에서
  는 디바이스와 무관하게 표시되도록 처리했습니다.

추가로 동소한 칩 알림표시가 클릭여부와 상관없이 계속 뜨도록 했습니다.

  ## 주요 변경 사항

  - 동소한 소개 페이지 신규 추가
      - src/pages/FestivalPage/IntroductionPage/IntroductionPage.tsx
      - src/pages/FestivalPage/IntroductionPage/IntroductionPage.styles.ts
  - 라우트 추가
      - /festival-introduction
  - Mixpanel 이벤트/페이지뷰 상수 추가
      - FILTER_OPTION_CLICKED
      - FESTIVAL_INTRODUCTION_PAGE
  - 메인페이지 필터칩 활성화
      - MainPage에서 Filter 렌더링
  - Filter 컴포넌트 개선
      - alwaysVisible 옵션 추가
      - 메인페이지: 모바일에서만 표시 (기존 동작 유지)
      - 동소한 페이지: 디바이스와 무관하게 표시
      - 필터칩 클릭 이벤트 트래킹 추가

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 축제 소개 페이지 추가 및 별도 라우트로 접근 가능
  * 필터 UI에 소개 페이지로 이동하는 옵션 추가 및 필터 클릭 시 분석 이벤트 전송
  * 필터에 항상 표시 옵션 도입 및 특정 옵션에 알림점 표시

* **개선 사항**
  * 소개 페이지 레이아웃 정렬·여백 개선(최대 너비·상단 패딩, 모바일 조정)
  * 모바일 배너 상단 여백 조정으로 레이아웃 개선

* **스타일**
  * 중복 CSS 속성 제거로 스타일 정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->