### PR TITLE
[refactor] FCM token 저장 로직 변경

### DIFF
--- a/backend/src/main/java/moadong/fcm/controller/FcmV2Controller.java
+++ b/backend/src/main/java/moadong/fcm/controller/FcmV2Controller.java
@@ -1,0 +1,39 @@
+package moadong.fcm.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import moadong.fcm.payload.request.ClubSubscribeV2Request;
+import moadong.fcm.service.StudentFcmTokenService;
+import moadong.global.payload.Response;
+import moadong.user.service.StudentJwtService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v2/fcm")
+@RequiredArgsConstructor
+@Tag(name = "FCM V2", description = "JWT 기반 FCM 구독 API")
+public class FcmV2Controller {
+
+    private final StudentJwtService studentJwtService;
+    private final StudentFcmTokenService studentFcmTokenService;
+
+    @PutMapping("/subscribe")
+    @Operation(summary = "동아리 모집정보 알림 구독(v2)", description = "Authorization의 학생 토큰 sub(UUID) 기준으로 구독 동아리 목록을 갱신합니다.")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> subscribeRecruitment(
+            @RequestHeader("Authorization") String authorization,
+            @RequestBody @Validated ClubSubscribeV2Request request
+    ) {
+        String studentId = studentJwtService.extractStudentId(authorization);
+        studentFcmTokenService.subscribeClubs(studentId, request.clubIds());
+        return Response.ok("success subscribe club");
+    }
+}

--- a/backend/src/main/java/moadong/fcm/controller/StudentFcmController.java
+++ b/backend/src/main/java/moadong/fcm/controller/StudentFcmController.java
@@ -5,12 +5,14 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import moadong.fcm.payload.request.StudentFcmTokenRotateRequest;
+import moadong.fcm.payload.response.ClubSubscribeListResponse;
 import moadong.fcm.payload.response.StudentFcmTokenRotateResponse;
 import moadong.fcm.service.StudentFcmTokenService;
 import moadong.global.payload.Response;
 import moadong.user.service.StudentJwtService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -35,6 +37,17 @@ public class StudentFcmController {
     ) {
         String studentId = studentJwtService.extractStudentId(authorization);
         StudentFcmTokenRotateResponse response = studentFcmTokenService.rotateFcmToken(studentId, request.fcmToken());
+        return Response.ok(response);
+    }
+
+    @GetMapping("/subscriptions")
+    @Operation(summary = "학생 구독 동아리 목록 조회", description = "Authorization의 학생 토큰 sub(UUID) 기준으로 구독 중인 동아리 목록을 조회합니다.")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> getSubscribedClubs(
+            @RequestHeader("Authorization") String authorization
+    ) {
+        String studentId = studentJwtService.extractStudentId(authorization);
+        ClubSubscribeListResponse response = studentFcmTokenService.getSubscribedClubs(studentId);
         return Response.ok(response);
     }
 }

--- a/backend/src/main/java/moadong/fcm/controller/StudentFcmController.java
+++ b/backend/src/main/java/moadong/fcm/controller/StudentFcmController.java
@@ -1,0 +1,40 @@
+package moadong.fcm.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import moadong.fcm.payload.request.StudentFcmTokenRotateRequest;
+import moadong.fcm.payload.response.StudentFcmTokenRotateResponse;
+import moadong.fcm.service.StudentFcmTokenService;
+import moadong.global.payload.Response;
+import moadong.user.service.StudentJwtService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/student")
+@RequiredArgsConstructor
+@Tag(name = "Student FCM", description = "학생 FCM 토큰 관리 API")
+public class StudentFcmController {
+
+    private final StudentJwtService studentJwtService;
+    private final StudentFcmTokenService studentFcmTokenService;
+
+    @PutMapping("/fcm-token")
+    @Operation(summary = "학생 FCM 토큰 교체", description = "Authorization의 학생 토큰 sub(UUID) 기준으로 FCM 토큰을 교체합니다.")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> rotateFcmToken(
+            @RequestHeader("Authorization") String authorization,
+            @RequestBody @Validated StudentFcmTokenRotateRequest request
+    ) {
+        String studentId = studentJwtService.extractStudentId(authorization);
+        StudentFcmTokenRotateResponse response = studentFcmTokenService.rotateFcmToken(studentId, request.fcmToken());
+        return Response.ok(response);
+    }
+}

--- a/backend/src/main/java/moadong/fcm/entity/StudentFcmToken.java
+++ b/backend/src/main/java/moadong/fcm/entity/StudentFcmToken.java
@@ -1,0 +1,54 @@
+package moadong.fcm.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Document("student_fcm_token")
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class StudentFcmToken {
+
+    @Id
+    private String id;
+
+    @Indexed(unique = true, sparse = true)
+    private String studentId;
+
+    @Indexed(unique = true)
+    private String token;
+
+    @Builder.Default
+    private List<String> clubIds = new ArrayList<>();
+
+    @Builder.Default
+    private LocalDateTime timestamp = LocalDateTime.now();
+
+    public void updateStudentId(String studentId) {
+        this.studentId = studentId;
+    }
+
+    public void replaceToken(String token) {
+        this.token = token;
+        this.timestamp = LocalDateTime.now();
+    }
+
+    public void updateClubIds(List<String> clubIds) {
+        this.clubIds.clear();
+        this.clubIds.addAll(clubIds);
+    }
+
+    public void updateTimestamp() {
+        this.timestamp = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/moadong/fcm/payload/request/ClubSubscribeV2Request.java
+++ b/backend/src/main/java/moadong/fcm/payload/request/ClubSubscribeV2Request.java
@@ -1,0 +1,11 @@
+package moadong.fcm.payload.request;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.ArrayList;
+
+public record ClubSubscribeV2Request(
+        @NotNull
+        ArrayList<String> clubIds
+) {
+}

--- a/backend/src/main/java/moadong/fcm/payload/request/StudentFcmTokenRotateRequest.java
+++ b/backend/src/main/java/moadong/fcm/payload/request/StudentFcmTokenRotateRequest.java
@@ -1,0 +1,9 @@
+package moadong.fcm.payload.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record StudentFcmTokenRotateRequest(
+        @NotBlank
+        String fcmToken
+) {
+}

--- a/backend/src/main/java/moadong/fcm/payload/response/StudentFcmTokenRotateResponse.java
+++ b/backend/src/main/java/moadong/fcm/payload/response/StudentFcmTokenRotateResponse.java
@@ -1,0 +1,10 @@
+package moadong.fcm.payload.response;
+
+import java.time.LocalDateTime;
+
+public record StudentFcmTokenRotateResponse(
+        String fcmToken,
+        boolean replaced,
+        LocalDateTime timestamp
+) {
+}

--- a/backend/src/main/java/moadong/fcm/repository/StudentFcmTokenRepository.java
+++ b/backend/src/main/java/moadong/fcm/repository/StudentFcmTokenRepository.java
@@ -1,0 +1,12 @@
+package moadong.fcm.repository;
+
+import moadong.fcm.entity.StudentFcmToken;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.Optional;
+
+public interface StudentFcmTokenRepository extends MongoRepository<StudentFcmToken, String> {
+    Optional<StudentFcmToken> findByToken(String token);
+
+    Optional<StudentFcmToken> findByStudentId(String studentId);
+}

--- a/backend/src/main/java/moadong/fcm/service/FcmTxService.java
+++ b/backend/src/main/java/moadong/fcm/service/FcmTxService.java
@@ -4,7 +4,9 @@ import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import moadong.fcm.entity.FcmToken;
+import moadong.fcm.entity.StudentFcmToken;
 import moadong.fcm.repository.FcmTokenRepository;
+import moadong.fcm.repository.StudentFcmTokenRepository;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
 import org.springframework.dao.DataAccessException;
@@ -25,6 +27,7 @@ import java.util.Set;
 public class FcmTxService {
 
     private final FcmTokenRepository fcmTokenRepository;
+    private final StudentFcmTokenRepository studentFcmTokenRepository;
 
     @Transactional
     public void deleteUnregisteredFcmToken(String token) {
@@ -40,5 +43,22 @@ public class FcmTxService {
         fcmToken.updateClubIds(newClubIds.stream().toList());
 
         fcmTokenRepository.save(fcmToken);
+    }
+
+    @Transactional
+    public void deleteUnregisteredStudentFcmToken(String token) {
+        studentFcmTokenRepository.findByToken(token).ifPresent(t -> {
+            studentFcmTokenRepository.delete(t);
+            log.info("Deleted unregistered student FCM token {}", token);
+        });
+    }
+
+    @Transactional
+    public void updateStudentFcmToken(String token, Set<String> newClubIds) {
+        StudentFcmToken studentFcmToken = studentFcmTokenRepository.findByToken(token)
+                .orElseThrow(() -> new RestApiException(ErrorCode.FCMTOKEN_NOT_FOUND));
+        studentFcmToken.updateClubIds(newClubIds.stream().toList());
+
+        studentFcmTokenRepository.save(studentFcmToken);
     }
 }

--- a/backend/src/main/java/moadong/fcm/service/StudentFcmSubscriptionService.java
+++ b/backend/src/main/java/moadong/fcm/service/StudentFcmSubscriptionService.java
@@ -1,0 +1,72 @@
+package moadong.fcm.service;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.TopicManagementResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import moadong.fcm.util.FcmTopicResolver;
+import moadong.global.exception.ErrorCode;
+import moadong.global.exception.RestApiException;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StudentFcmSubscriptionService {
+
+    private final FirebaseMessaging firebaseMessaging;
+    private final FcmTopicResolver fcmTopicResolver;
+
+    public void transferSubscriptions(String studentId, String oldFcmToken, String newFcmToken, List<String> finalClubIds) {
+        for (String clubId : finalClubIds) {
+            subscribeToClub(studentId, newFcmToken, clubId);
+        }
+
+        for (String clubId : finalClubIds) {
+            unsubscribeFromClub(studentId, oldFcmToken, clubId);
+        }
+    }
+
+    private void subscribeToClub(String studentId, String token, String clubId) {
+        String topic = fcmTopicResolver.resolveTopic(clubId);
+        try {
+            TopicManagementResponse response = firebaseMessaging.subscribeToTopic(Collections.singletonList(token), topic);
+            if (response.getFailureCount() > 0) {
+                log.error("Student FCM subscribe failed. studentId={}, token={}, clubId={}, topic={}, errors={}",
+                        studentId, mask(token), clubId, topic, response.getErrors());
+                throw new RestApiException(ErrorCode.FCMTOKEN_SUBSCRIBE_ERROR);
+            }
+        } catch (FirebaseMessagingException e) {
+            log.error("Student FCM subscribe exception. studentId={}, token={}, clubId={}, topic={}, message={}",
+                    studentId, mask(token), clubId, topic, e.getMessage());
+            throw new RestApiException(ErrorCode.FCMTOKEN_SUBSCRIBE_ERROR);
+        }
+    }
+
+    private void unsubscribeFromClub(String studentId, String token, String clubId) {
+        String topic = fcmTopicResolver.resolveTopic(clubId);
+        try {
+            TopicManagementResponse response = firebaseMessaging.unsubscribeFromTopic(Collections.singletonList(token), topic);
+            if (response.getFailureCount() > 0) {
+                log.error("Student FCM unsubscribe failed. studentId={}, token={}, clubId={}, topic={}, errors={}",
+                        studentId, mask(token), clubId, topic, response.getErrors());
+                throw new RestApiException(ErrorCode.FCMTOKEN_SUBSCRIBE_ERROR);
+            }
+        } catch (FirebaseMessagingException e) {
+            log.error("Student FCM unsubscribe exception. studentId={}, token={}, clubId={}, topic={}, message={}",
+                    studentId, mask(token), clubId, topic, e.getMessage());
+            throw new RestApiException(ErrorCode.FCMTOKEN_SUBSCRIBE_ERROR);
+        }
+    }
+
+    private String mask(String token) {
+        if (token == null || token.length() < 10) {
+            return "***";
+        }
+        return token.substring(0, 6) + "..." + token.substring(token.length() - 4);
+    }
+}

--- a/backend/src/main/java/moadong/fcm/service/StudentFcmTokenService.java
+++ b/backend/src/main/java/moadong/fcm/service/StudentFcmTokenService.java
@@ -3,6 +3,7 @@ package moadong.fcm.service;
 import lombok.RequiredArgsConstructor;
 import moadong.fcm.entity.FcmToken;
 import moadong.fcm.entity.StudentFcmToken;
+import moadong.fcm.payload.response.ClubSubscribeListResponse;
 import moadong.fcm.payload.response.StudentFcmTokenRotateResponse;
 import moadong.fcm.repository.FcmTokenRepository;
 import moadong.fcm.repository.StudentFcmTokenRepository;
@@ -50,6 +51,17 @@ public class StudentFcmTokenService {
         studentUserRepository.save(studentUser);
 
         return new StudentFcmTokenRotateResponse(saved.getToken(), replaced, saved.getTimestamp());
+    }
+
+    @Transactional(readOnly = true)
+    public ClubSubscribeListResponse getSubscribedClubs(String studentId) {
+        if (studentId == null || studentId.isBlank()) {
+            throw new RestApiException(ErrorCode.TOKEN_INVALID);
+        }
+
+        StudentFcmToken token = studentFcmTokenRepository.findByStudentId(studentId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.FCMTOKEN_NOT_FOUND));
+        return new ClubSubscribeListResponse(token.getClubIds());
     }
 
     private StudentUser upsertStudentUser(String studentId) {

--- a/backend/src/main/java/moadong/fcm/service/StudentFcmTokenService.java
+++ b/backend/src/main/java/moadong/fcm/service/StudentFcmTokenService.java
@@ -1,0 +1,109 @@
+package moadong.fcm.service;
+
+import lombok.RequiredArgsConstructor;
+import moadong.fcm.entity.FcmToken;
+import moadong.fcm.entity.StudentFcmToken;
+import moadong.fcm.payload.response.StudentFcmTokenRotateResponse;
+import moadong.fcm.repository.FcmTokenRepository;
+import moadong.fcm.repository.StudentFcmTokenRepository;
+import moadong.global.exception.ErrorCode;
+import moadong.global.exception.RestApiException;
+import moadong.user.entity.StudentUser;
+import moadong.user.repository.StudentUserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class StudentFcmTokenService {
+
+    private final StudentFcmTokenRepository studentFcmTokenRepository;
+    private final StudentUserRepository studentUserRepository;
+    private final FcmTokenRepository fcmTokenRepository;
+
+    @Transactional
+    public StudentFcmTokenRotateResponse rotateFcmToken(String studentId, String newFcmToken) {
+        if (studentId == null || studentId.isBlank()) {
+            throw new RestApiException(ErrorCode.TOKEN_INVALID);
+        }
+
+        StudentUser studentUser = upsertStudentUser(studentId);
+
+        StudentFcmToken byStudent = studentFcmTokenRepository.findByStudentId(studentId).orElse(null);
+        boolean replaced = false;
+        StudentFcmToken saved;
+
+        if (byStudent == null) {
+            saved = createOrClaimToken(studentId, newFcmToken);
+        } else if (newFcmToken.equals(byStudent.getToken())) {
+            byStudent.updateTimestamp();
+            saved = studentFcmTokenRepository.save(byStudent);
+        } else {
+            replaced = true;
+            saved = replaceStudentToken(byStudent, newFcmToken);
+        }
+
+        studentUser.updateCurrentFcmToken(saved.getToken());
+        studentUserRepository.save(studentUser);
+
+        return new StudentFcmTokenRotateResponse(saved.getToken(), replaced, saved.getTimestamp());
+    }
+
+    private StudentUser upsertStudentUser(String studentId) {
+        Optional<StudentUser> existing = studentUserRepository.findByStudentId(studentId);
+        if (existing.isPresent()) {
+            StudentUser studentUser = existing.get();
+            studentUser.updateLastSeen();
+            return studentUserRepository.save(studentUser);
+        }
+
+        return studentUserRepository.save(StudentUser.builder()
+                .studentId(studentId)
+                .build());
+    }
+
+    private StudentFcmToken createOrClaimToken(String studentId, String newFcmToken) {
+        Optional<StudentFcmToken> byToken = studentFcmTokenRepository.findByToken(newFcmToken);
+        if (byToken.isPresent()) {
+            StudentFcmToken studentFcmToken = byToken.get();
+            studentFcmToken.updateStudentId(studentId);
+            studentFcmToken.updateTimestamp();
+            return studentFcmTokenRepository.save(studentFcmToken);
+        }
+
+        Optional<FcmToken> legacyToken = fcmTokenRepository.findFcmTokenByToken(newFcmToken);
+        if (legacyToken.isPresent()) {
+            FcmToken legacy = legacyToken.get();
+            return studentFcmTokenRepository.save(StudentFcmToken.builder()
+                    .studentId(studentId)
+                    .token(newFcmToken)
+                    .clubIds(new ArrayList<>(legacy.getClubIds()))
+                    .timestamp(legacy.getTimestamp())
+                    .build());
+        }
+
+        return studentFcmTokenRepository.save(StudentFcmToken.builder()
+                .studentId(studentId)
+                .token(newFcmToken)
+                .build());
+    }
+
+    private StudentFcmToken replaceStudentToken(StudentFcmToken byStudent, String newFcmToken) {
+        Optional<StudentFcmToken> byToken = studentFcmTokenRepository.findByToken(newFcmToken);
+        if (byToken.isPresent() && !byToken.get().getId().equals(byStudent.getId())) {
+            studentFcmTokenRepository.delete(byToken.get());
+        }
+
+        byStudent.replaceToken(newFcmToken);
+
+        if (byStudent.getClubIds().isEmpty()) {
+            fcmTokenRepository.findFcmTokenByToken(newFcmToken)
+                    .ifPresent(legacy -> byStudent.updateClubIds(new ArrayList<>(legacy.getClubIds())));
+        }
+
+        return studentFcmTokenRepository.save(byStudent);
+    }
+}

--- a/backend/src/main/java/moadong/global/util/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/moadong/global/util/JwtAuthenticationFilter.java
@@ -28,6 +28,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String requestUri = request.getRequestURI();
+        return requestUri.startsWith("/api/student") || requestUri.startsWith("/auth/student");
+    }
+
+    @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
         FilterChain filterChain) throws ServletException, IOException {
         final String authorizationHeader = request.getHeader("Authorization");

--- a/backend/src/main/java/moadong/global/util/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/moadong/global/util/JwtAuthenticationFilter.java
@@ -30,7 +30,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String requestUri = request.getRequestURI();
-        return requestUri.startsWith("/api/student") || requestUri.startsWith("/auth/student");
+        return requestUri.startsWith("/api/student") || requestUri.startsWith("/auth/student") || requestUri.startsWith("/api/v2/fcm");
     }
 
     @Override

--- a/backend/src/main/java/moadong/global/util/JwtProvider.java
+++ b/backend/src/main/java/moadong/global/util/JwtProvider.java
@@ -32,6 +32,14 @@ public class JwtProvider {
                 .compact();
     }
 
+    public String generateAccessTokenWithoutExpiration(String subject) {
+        return Jwts.builder()
+                .setSubject(subject)
+                .setIssuedAt(new Date())
+                .signWith(SignatureAlgorithm.HS256, SECRET_KEY)
+                .compact();
+    }
+
     public RefreshToken generateRefreshToken(String username) {
         Date expiresAt = new Date(System.currentTimeMillis() + (long) REFRESH_EXPIRATION_HOUR * 1000 * 60 * 60);
         String refreshToken = Jwts.builder()

--- a/backend/src/main/java/moadong/user/controller/StudentAuthController.java
+++ b/backend/src/main/java/moadong/user/controller/StudentAuthController.java
@@ -1,0 +1,28 @@
+package moadong.user.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AllArgsConstructor;
+import moadong.global.payload.Response;
+import moadong.user.payload.response.StudentIssueResponse;
+import moadong.user.service.UserCommandService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth/student")
+@AllArgsConstructor
+@Tag(name = "Student Auth", description = "학생 임시 토큰 발급 API")
+public class StudentAuthController {
+
+    private final UserCommandService userCommandService;
+
+    @PostMapping
+    @Operation(summary = "학생 임시 JWT 발급", description = "랜덤 UUID를 sub로 사용하는 만료 없는 JWT를 발급합니다.")
+    public ResponseEntity<?> issueStudentToken() {
+        StudentIssueResponse response = userCommandService.issueStudentAccessToken();
+        return Response.ok(response);
+    }
+}

--- a/backend/src/main/java/moadong/user/entity/StudentUser.java
+++ b/backend/src/main/java/moadong/user/entity/StudentUser.java
@@ -1,0 +1,46 @@
+package moadong.user.entity;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.Date;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Document("student_users")
+public class StudentUser {
+
+    @Id
+    private String id;
+
+    @Indexed(unique = true)
+    @NotNull
+    private String studentId;
+
+    @Builder.Default
+    @NotNull
+    private Date createdAt = new Date();
+
+    @Builder.Default
+    @NotNull
+    private Date lastSeenAt = new Date();
+
+    private String currentFcmToken;
+
+    public void updateLastSeen() {
+        this.lastSeenAt = new Date();
+    }
+
+    public void updateCurrentFcmToken(String currentFcmToken) {
+        this.currentFcmToken = currentFcmToken;
+        this.lastSeenAt = new Date();
+    }
+}

--- a/backend/src/main/java/moadong/user/payload/response/StudentIssueResponse.java
+++ b/backend/src/main/java/moadong/user/payload/response/StudentIssueResponse.java
@@ -1,0 +1,4 @@
+package moadong.user.payload.response;
+
+public record StudentIssueResponse(String accessToken) {
+}

--- a/backend/src/main/java/moadong/user/repository/StudentUserRepository.java
+++ b/backend/src/main/java/moadong/user/repository/StudentUserRepository.java
@@ -1,0 +1,10 @@
+package moadong.user.repository;
+
+import moadong.user.entity.StudentUser;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.Optional;
+
+public interface StudentUserRepository extends MongoRepository<StudentUser, String> {
+    Optional<StudentUser> findByStudentId(String studentId);
+}

--- a/backend/src/main/java/moadong/user/service/StudentJwtService.java
+++ b/backend/src/main/java/moadong/user/service/StudentJwtService.java
@@ -1,0 +1,38 @@
+package moadong.user.service;
+
+import lombok.RequiredArgsConstructor;
+import moadong.global.exception.ErrorCode;
+import moadong.global.exception.RestApiException;
+import moadong.global.util.JwtProvider;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class StudentJwtService {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtProvider jwtProvider;
+
+    public String extractStudentId(String authorizationHeader) {
+        if (authorizationHeader == null || !authorizationHeader.startsWith(BEARER_PREFIX)) {
+            throw new RestApiException(ErrorCode.TOKEN_INVALID);
+        }
+
+        String token = authorizationHeader.substring(BEARER_PREFIX.length());
+        String studentId = jwtProvider.extractUsername(token);
+        if (studentId == null || studentId.isBlank()) {
+            throw new RestApiException(ErrorCode.TOKEN_INVALID);
+        }
+
+        try {
+            UUID.fromString(studentId);
+        } catch (RuntimeException e) {
+            throw new RestApiException(ErrorCode.TOKEN_INVALID);
+        }
+
+        return studentId;
+    }
+}

--- a/backend/src/main/java/moadong/user/service/UserCommandService.java
+++ b/backend/src/main/java/moadong/user/service/UserCommandService.java
@@ -3,6 +3,7 @@ package moadong.user.service;
 import com.mongodb.MongoWriteException;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Date;
+import java.util.UUID;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,7 @@ import moadong.user.payload.request.UserRegisterRequest;
 import moadong.user.payload.request.UserUpdateRequest;
 import moadong.user.payload.response.LoginResponse;
 import moadong.user.payload.response.RefreshResponse;
+import moadong.user.payload.response.StudentIssueResponse;
 import moadong.user.payload.response.TempPasswordResponse;
 import moadong.user.repository.UserRepository;
 import moadong.user.util.CookieMaker;
@@ -111,6 +113,12 @@ public class UserCommandService {
         } catch (MongoWriteException e) {
             throw new RestApiException(ErrorCode.USER_ALREADY_EXIST);
         }
+    }
+
+    public StudentIssueResponse issueStudentAccessToken() {
+        String studentId = UUID.randomUUID().toString();
+        String accessToken = jwtProvider.generateAccessTokenWithoutExpiration(studentId);
+        return new StudentIssueResponse(accessToken);
     }
 
     public void logoutUser(String refreshToken) {


### PR DESCRIPTION
## #️⃣연관된 이슈

- #1244

간단 기록: https://www.notion.so/FCM-313aad2320968010bda1cb2338941a40?source=copy_link

## 📝작업 내용

### 1) 변경 요약
- 학생(비로그인 사용자) 대상의 JWT 기반 FCM 토큰 관리 플로우를 추가했습니다.
- 학생 전용 저장소를 분리해 `student_users`, `student_fcm_token` 중심으로 동작하도록 구성했습니다.
- 토큰 교체 시 구독 이전(transfer)을 **동기 처리**로 수행하도록 반영했습니다.
- 레거시 `fcm_tokens`는 즉시 백필하지 않고, 필요 시점 copy 방식으로 점진 이관 가능하게 설계했습니다.

### 2) API 명세
1. `POST /auth/student`
- 설명: 학생 임시 JWT 발급 (`sub=uuid`, 만료 없음)
- Request Body: 없음
- Response
```json
{
  "statuscode": "200",
  "message": "ok",
  "data": {
    "accessToken": "<JWT>"
  }
}
```

2. `PUT /api/student/fcm-token`
- 설명: Authorization JWT의 `sub(studentId)` 기준으로 학생 FCM 토큰 저장/교체
- Header: `Authorization: Bearer <accessToken>`
- Request Body
```json
{
  "fcmToken": "<fcmToken>"
}
```
- Response
```json
{
  "statuscode": "200",
  "message": "ok",
  "data": {
    "fcmToken": "<fcmToken>",
    "replaced": true,
    "timestamp": "2026-02-26T12:34:56"
  }
}
```

3. `GET /api/student/subscriptions`
- 설명: Authorization JWT 기준 학생의 구독 동아리 목록 조회
- Header: `Authorization: Bearer <accessToken>`
- Response
```json
{
  "statuscode": "200",
  "message": "ok",
  "data": {
    "clubIds": ["clubId1", "clubId2"]
  }
}
```

### 3) JWT 토큰 도입 이유
- 기존 FCM Token 관리 방식에는 사용하던 FCM Token이 새로 갱신될 경우 추적 및 transfer 작업이 부족해, 대응이 불가하였음
  - 즉, 알림이 누락될 가능성이 존재했음.
- 이렇듯 FCM Token이 일관성을 보장하지 못하였고, 아래의 이유 때문에 JWT 토큰을 도입하게되었음.
  - 조작 불가
  - 추후 로그인과 확장 용이
  - 한번 저장된 token의 일관성
- JWT 기준점으로 임시 사용자를 추가하여 토큰을 보다 추적하기 쉽게 만들었습니다.
- `/api/student/**`는 기존 사용자 JWT 필터와 충돌하지 않도록 별도 student JWT 검증 경로를 사용합니다.

### 4) 토큰 교체(transfer) 동기 처리 이유
- transfer 작업은 횟수가 많지않고 응답 보장이 중요하다 생각해 동기방식을 사용하였습니다.
- 교체 성공 응답의 의미를 “실제 FCM 구독 이전 완료”로 보장하기 위해 동기 처리했습니다.
- 처리 순서는 알림 공백 최소화를 위해 `new token subscribe -> old token unsubscribe`로 고정했습니다.
- 실패 시 재시도 없이 즉시 실패 처리하고 로그를 남깁니다.
- 실패 시 DB 교체를 진행하지 않아 저장 상태와 전송 상태 불일치를 줄입니다.

### 5) 의사결정 정리
- `student_users` 저장은 발급 시점이 아니라 `fcm-token` 저장/교체 요청 시점에 upsert합니다.
- `finalClubIds`는 최종 반영 대상 clubIds를 의미합니다.
  - 우선순위: `student_fcm_token.clubIds` -> 비어있으면 legacy `fcm_tokens`에서 fallback copy
- 컬렉션 역할:
  - `student_fcm_token`: 학생 구독 상태 최종 데이터
  - `fcm_tokens`: 레거시 유지, 신규 student 플로우에서는 fallback copy 용도

### 6) 레거시 전환 계획
- 당장은 레거시 API(`/api/fcm/**`)를 유지합니다.
- 학생 플로우는 `student_fcm_token` 중심으로 운영합니다.
- 백필(batch) 없이, 실제 요청 시 필요한 토큰만 copy/claim하는 점진 이관 전략을 사용합니다.
- 레거시 사용률 감소 후 `/api/fcm/**` 단계적 정리 예정입니다.

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * 학생 사용자를 위한 FCM 토큰 로테이션 및 갱신 기능을 추가했습니다
  * 동아리별 푸시 알림 구독 및 해지를 개별적으로 관리할 수 있습니다
  * 학생 임시 접근 토큰 발급으로 향상된 인증 기능을 제공합니다
  * 학생이 구독 중인 모든 동아리 목록을 조회할 수 있는 기능이 추가되었습니다
  * 학생 사용자 활동 추적으로 더 나은 사용자 관리 경험을 제공합니다

<!-- end of auto-generated comment: release notes by coderabbit.ai -->