### PR TITLE
[feature] Banner API PlatformType 추가

### DIFF
--- a/backend/src/main/java/moadong/media/controller/BannerImagesController.java
+++ b/backend/src/main/java/moadong/media/controller/BannerImagesController.java
@@ -7,15 +7,12 @@ import lombok.RequiredArgsConstructor;
 import moadong.global.payload.Response;
 import moadong.media.dto.BannerImagesRequest;
 import moadong.media.dto.BannerImagesResponse;
+import moadong.media.enums.PlatformType;
 import moadong.media.service.BannerImagesService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/banner")
@@ -30,14 +27,14 @@ public class BannerImagesController {
     @SecurityRequirement(name = "BearerAuth")
     @Operation(summary = "배너 이미지 목록 저장", description = "배너 이미지 URL 배열 전체를 저장합니다. 배열 인덱스가 노출 순서를 의미합니다.")
     public ResponseEntity<?> putBannerImages(@RequestBody @Validated BannerImagesRequest request) {
-        bannerImagesService.putBannerImages(request.images());
+        bannerImagesService.putBannerImages(request.images(), request.type());
         return Response.ok("배너 이미지가 저장되었습니다.");
     }
 
     @GetMapping
     @Operation(summary = "배너 이미지 목록 조회", description = "저장된 배너 이미지 URL 배열을 반환합니다.")
-    public ResponseEntity<?> getBannerImages() {
-        BannerImagesResponse response = bannerImagesService.getBannerImages();
+    public ResponseEntity<?> getBannerImages(@RequestParam(value = "type", required = false, defaultValue = "WEB") PlatformType type) {
+        BannerImagesResponse response = bannerImagesService.getBannerImages(type);
         return Response.ok(response);
     }
 }

--- a/backend/src/main/java/moadong/media/dto/BannerImagesRequest.java
+++ b/backend/src/main/java/moadong/media/dto/BannerImagesRequest.java
@@ -2,11 +2,13 @@ package moadong.media.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import moadong.media.enums.PlatformType;
 
 import java.util.List;
 
 public record BannerImagesRequest(
     @NotNull(message = "배너 이미지 목록은 null일 수 없습니다.")
-    List<@NotBlank(message = "배너 이미지 URL은 비어 있을 수 없습니다.") String> images
+    List<@NotBlank(message = "배너 이미지 URL은 비어 있을 수 없습니다.") String> images,
+    @NotNull PlatformType type
 ) {
 }

--- a/backend/src/main/java/moadong/media/enums/PlatformType.java
+++ b/backend/src/main/java/moadong/media/enums/PlatformType.java
@@ -5,5 +5,7 @@ import lombok.Getter;
 @Getter
 public enum PlatformType {
     WEB,
-    APP_HOME;
+    APP_HOME,
+    WEB_MOBILE,
+    ;
 }

--- a/backend/src/main/java/moadong/media/enums/PlatformType.java
+++ b/backend/src/main/java/moadong/media/enums/PlatformType.java
@@ -4,13 +4,6 @@ import lombok.Getter;
 
 @Getter
 public enum PlatformType {
-    WEB("WEB"),
-    APP_HOME("APP_HOME");
-
-    private final String type;
-
-    PlatformType(String type) {
-        this.type = type;
-    }
-
+    WEB,
+    APP_HOME;
 }

--- a/backend/src/main/java/moadong/media/enums/PlatformType.java
+++ b/backend/src/main/java/moadong/media/enums/PlatformType.java
@@ -1,0 +1,16 @@
+package moadong.media.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum PlatformType {
+    WEB("WEB"),
+    APP_HOME("APP_HOME");
+
+    private final String type;
+
+    PlatformType(String type) {
+        this.type = type;
+    }
+
+}

--- a/backend/src/main/java/moadong/media/service/BannerImagesService.java
+++ b/backend/src/main/java/moadong/media/service/BannerImagesService.java
@@ -3,6 +3,7 @@ package moadong.media.service;
 import lombok.RequiredArgsConstructor;
 import moadong.media.dto.BannerImagesResponse;
 import moadong.media.entity.BannerImages;
+import moadong.media.enums.PlatformType;
 import moadong.media.repository.BannerImagesRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,9 +21,9 @@ public class BannerImagesService {
     private final BannerImagesRepository bannerImagesRepository;
 
     @Transactional
-    public void putBannerImages(List<String> images) {
+    public void putBannerImages(List<String> images, PlatformType platformType) {
         BannerImages bannerImages = BannerImages.builder()
-            .id(BANNER_IMAGES_ID)
+            .id(BANNER_IMAGES_ID + "_" + platformType.name())
             .images(new ArrayList<>(images))
             .updatedAt(Instant.now())
             .build();
@@ -30,8 +31,8 @@ public class BannerImagesService {
         bannerImagesRepository.save(bannerImages);
     }
 
-    public BannerImagesResponse getBannerImages() {
-        List<String> images = bannerImagesRepository.findById(BANNER_IMAGES_ID)
+    public BannerImagesResponse getBannerImages(PlatformType platformType) {
+        List<String> images = bannerImagesRepository.findById(BANNER_IMAGES_ID + "_" + platformType.name())
             .map(BannerImages::getImages)
             .orElseGet(List::of);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- #1251

## 📝작업 내용

PlatformType
```
WEB, //데스크탑웹
WEB_MOBILE, //모바일웹
APP_HOME //앱 메인화면
```
3가지 타입으로 이미지 목록을 받아올 수 있게 변경하였습니다.

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 플랫폼별 배너 이미지 관리 기능 추가 (웹, 모바일, 앱 홈)
* 배너 조회 및 저장 시 플랫폼 유형별 필터링 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->