### PR TITLE
[feature] BannerAPI 응답 타입 변경

### DIFF
--- a/backend/src/main/java/moadong/media/controller/BannerImagesController.java
+++ b/backend/src/main/java/moadong/media/controller/BannerImagesController.java
@@ -25,14 +25,14 @@ public class BannerImagesController {
     @PutMapping
     @PreAuthorize("hasRole('DEVELOPER')")
     @SecurityRequirement(name = "BearerAuth")
-    @Operation(summary = "배너 이미지 목록 저장", description = "배너 이미지 URL 배열 전체를 저장합니다. 배열 인덱스가 노출 순서를 의미합니다.")
+    @Operation(summary = "배너 목록 저장", description = "배너 객체 배열 전체를 저장합니다. 배열 인덱스가 노출 순서를 의미합니다.")
     public ResponseEntity<?> putBannerImages(@RequestBody @Validated BannerImagesRequest request) {
         bannerImagesService.putBannerImages(request.images(), request.type());
         return Response.ok("배너 이미지가 저장되었습니다.");
     }
 
     @GetMapping
-    @Operation(summary = "배너 이미지 목록 조회", description = "저장된 배너 이미지 URL 배열을 반환합니다.")
+    @Operation(summary = "배너 목록 조회", description = "저장된 배너 객체 배열을 반환합니다.")
     public ResponseEntity<?> getBannerImages(@RequestParam(value = "type", required = false, defaultValue = "WEB") PlatformType type) {
         BannerImagesResponse response = bannerImagesService.getBannerImages(type);
         return Response.ok(response);

--- a/backend/src/main/java/moadong/media/dto/BannerImagesRequest.java
+++ b/backend/src/main/java/moadong/media/dto/BannerImagesRequest.java
@@ -1,6 +1,6 @@
 package moadong.media.dto;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import moadong.media.enums.PlatformType;
 
@@ -8,7 +8,7 @@ import java.util.List;
 
 public record BannerImagesRequest(
     @NotNull(message = "배너 이미지 목록은 null일 수 없습니다.")
-    List<@NotBlank(message = "배너 이미지 URL은 비어 있을 수 없습니다.") String> images,
+    List<@Valid BannerItemRequest> images,
     @NotNull PlatformType type
 ) {
 }

--- a/backend/src/main/java/moadong/media/dto/BannerImagesResponse.java
+++ b/backend/src/main/java/moadong/media/dto/BannerImagesResponse.java
@@ -3,6 +3,6 @@ package moadong.media.dto;
 import java.util.List;
 
 public record BannerImagesResponse(
-    List<String> images
+    List<BannerItemResponse> images
 ) {
 }

--- a/backend/src/main/java/moadong/media/dto/BannerItemRequest.java
+++ b/backend/src/main/java/moadong/media/dto/BannerItemRequest.java
@@ -1,0 +1,16 @@
+package moadong.media.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record BannerItemRequest(
+    @NotBlank(message = "배너 ID는 비어 있을 수 없습니다.")
+    String id,
+    @NotBlank(message = "배너 이미지 URL은 비어 있을 수 없습니다.")
+    String imageUrl,
+    @Schema(nullable = true, description = "배너 클릭 시 이동 링크. 없으면 null")
+    String linkTo,
+    @NotBlank(message = "배너 대체 텍스트는 비어 있을 수 없습니다.")
+    String alt
+) {
+}

--- a/backend/src/main/java/moadong/media/dto/BannerItemResponse.java
+++ b/backend/src/main/java/moadong/media/dto/BannerItemResponse.java
@@ -1,0 +1,12 @@
+package moadong.media.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record BannerItemResponse(
+    String id,
+    String imageUrl,
+    @Schema(nullable = true, description = "배너 클릭 시 이동 링크. 없으면 null")
+    String linkTo,
+    String alt
+) {
+}

--- a/backend/src/main/java/moadong/media/entity/BannerImages.java
+++ b/backend/src/main/java/moadong/media/entity/BannerImages.java
@@ -20,7 +20,7 @@ public class BannerImages {
     @Id
     private String id;
 
-    private List<String> images;
+    private List<BannerItem> images;
 
     @Builder.Default
     private Instant updatedAt = Instant.now();

--- a/backend/src/main/java/moadong/media/entity/BannerItem.java
+++ b/backend/src/main/java/moadong/media/entity/BannerItem.java
@@ -1,0 +1,21 @@
+package moadong.media.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class BannerItem {
+
+    private String id;
+
+    private String imageUrl;
+
+    private String linkTo;
+
+    private String alt;
+}

--- a/backend/src/main/java/moadong/media/service/BannerImagesService.java
+++ b/backend/src/main/java/moadong/media/service/BannerImagesService.java
@@ -1,7 +1,10 @@
 package moadong.media.service;
 
 import lombok.RequiredArgsConstructor;
+import moadong.media.dto.BannerItemRequest;
+import moadong.media.dto.BannerItemResponse;
 import moadong.media.dto.BannerImagesResponse;
+import moadong.media.entity.BannerItem;
 import moadong.media.entity.BannerImages;
 import moadong.media.enums.PlatformType;
 import moadong.media.repository.BannerImagesRepository;
@@ -9,7 +12,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -21,10 +23,12 @@ public class BannerImagesService {
     private final BannerImagesRepository bannerImagesRepository;
 
     @Transactional
-    public void putBannerImages(List<String> images, PlatformType platformType) {
+    public void putBannerImages(List<BannerItemRequest> images, PlatformType platformType) {
         BannerImages bannerImages = BannerImages.builder()
             .id(BANNER_IMAGES_ID + "_" + platformType.name())
-            .images(new ArrayList<>(images))
+            .images(images.stream()
+                .map(this::toEntity)
+                .toList())
             .updatedAt(Instant.now())
             .build();
 
@@ -32,10 +36,31 @@ public class BannerImagesService {
     }
 
     public BannerImagesResponse getBannerImages(PlatformType platformType) {
-        List<String> images = bannerImagesRepository.findById(BANNER_IMAGES_ID + "_" + platformType.name())
+        List<BannerItemResponse> images = bannerImagesRepository.findById(BANNER_IMAGES_ID + "_" + platformType.name())
             .map(BannerImages::getImages)
-            .orElseGet(List::of);
+            .orElseGet(List::of)
+            .stream()
+            .map(this::toResponse)
+            .toList();
 
         return new BannerImagesResponse(images);
+    }
+
+    private BannerItem toEntity(BannerItemRequest item) {
+        return BannerItem.builder()
+            .id(item.id())
+            .imageUrl(item.imageUrl())
+            .linkTo(item.linkTo())
+            .alt(item.alt())
+            .build();
+    }
+
+    private BannerItemResponse toResponse(BannerItem item) {
+        return new BannerItemResponse(
+            item.getId(),
+            item.getImageUrl(),
+            item.getLinkTo(),
+            item.getAlt()
+        );
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #1254 

## 📝작업 내용

응답 규격
``linkTo``는 nullable이라 프론트에서 대응을 따로 해야할꺼 같습니다.

```json
{
  "statuscode": "200",
  "message": "ok",
  "data": {
    "images": [
      {
        "id": "2026-club-fair",
        "imageUrl": "https://banner.moadong.com/web/banner-desktop-2.png",
        "linkTo": null,
        "alt": "2026 동아리 소개 한마당 홍보"
      },
      {
        "id": "app-release-december-2025",
        "imageUrl": "https://banner.moadong.com/web/banner-desktop-3.png",
        "linkTo": "APP_STORE_LINK",
        "alt": "앱 다운로드 배너"
      },
      {
        "id": "all-clubs-in-one-place",
        "imageUrl": "https://banner.moadong.com/web/banner-desktop-1.png",
        "linkTo": "/introduce",
        "alt": "모든 동아리 한곳에 모으다 - 모아동"
      },
      {
        "id": "start-with-moadong",
        "imageUrl": "https://banner.moadong.com/web/banner-desktop-4.png",
        "linkTo": "/introduce",
        "alt": "지금 바로 모아동에서 시작하세요"
      }
    ]
  }
}
```

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
>논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 배너 관리 기능 확장: 기존 URL 기반에서 ID, 이미지 URL, 링크, ALT 텍스트를 포함한 배너 객체 기반으로 업그레이드되었습니다.

* **Documentation**
  * API 문서 업데이트: 배너 관련 엔드포인트의 설명이 개선되어 객체 배열 처리 방식을 명확히 합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->