### PR TITLE
[Fix] 관리자 지원서 상세 메모옆 막대기 제거

### DIFF
--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPage.styles.ts
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPage.styles.ts
@@ -112,17 +112,6 @@ export const MemoLabel = styled.label`
   font-size: 16px;
   font-style: normal;
   font-weight: 600;
-
-  &::after {
-    content: '';
-    position: absolute;
-    right: -20px;
-    top: 30%;
-    height: 40%;
-    width: 4px;
-    height: 14px;
-    background: #d9d9d9;
-  }
 `;
 
 export const MemoTextarea = styled.textarea`


### PR DESCRIPTION

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용
<img width="306" height="138" alt="스크린샷 2026-02-28 오후 11 58 22" src="https://github.com/user-attachments/assets/6d7ff83b-d801-43a6-b419-2e1ecde83184" />

드디어 막대기를 제거했습니다.

## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 신청자 상세 페이지의 메모 레이블에서 우측 정렬된 수직 장식선이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->