### PR TITLE
[fix] 지원서 설명은 내부지원서에서만 유효성검사

### DIFF
--- a/frontend/src/pages/AdminPage/validation/validateApplicationForm.ts
+++ b/frontend/src/pages/AdminPage/validation/validateApplicationForm.ts
@@ -28,10 +28,12 @@ export const validateApplicationForm = (
     errors.title = '지원서 제목은 최대 50자까지 입력할 수 있습니다.';
   }
 
-  if (!formData.description?.trim()) {
-    errors.description = '지원서 설명을 입력해주세요.';
-  } else if (formData.description.length > 3000) {
-    errors.description = '지원서 설명은 최대 3000자까지 입력할 수 있습니다.';
+  if (mode === ApplicationFormMode.INTERNAL) {
+    if (!formData.description?.trim()) {
+      errors.description = '지원서 설명을 입력해주세요.';
+    } else if (formData.description.length > 3000) {
+      errors.description = '지원서 설명은 최대 3000자까지 입력할 수 있습니다.';
+    }
   }
 
   if (mode === ApplicationFormMode.INTERNAL) {


### PR DESCRIPTION

## #️⃣연관된 이슈

> ex) #1264 

## 📝작업 내용

### 문제
외부/내부 지원서가 저장하기 버튼을 공유하고 있는데 이전에 추가한 벨리데이션에서 "지원서 설명"부분에 
내부지원서 조건문을 달지 않았습니다. 그래서 외부지원서 저장하기 시 지원서 설명을 추가하라는 alert가 떴습니다.

### 해결

내부 지원서 조건을 달아 해결했습니다.

## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 개선 사항
* 신청 양식의 검증 로직을 최적화했습니다. 양식 제출 방식에 따라 검증 기준이 더욱 세밀하게 적용되도록 개선되었으며, 이를 통해 시스템의 효율성이 증대되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->