### PR TITLE
[fix] 지원서 PATCH API 외부지원서 저장안되는 버그 수정

### DIFF
--- a/backend/src/main/java/moadong/club/payload/request/ClubApplicationFormEditRequest.java
+++ b/backend/src/main/java/moadong/club/payload/request/ClubApplicationFormEditRequest.java
@@ -4,12 +4,10 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
 import moadong.club.enums.ApplicationFormMode;
 import moadong.club.enums.SemesterTerm;
-import org.springframework.util.StringUtils;
 
 import java.util.List;
 
 public record ClubApplicationFormEditRequest(
-        @NotBlank
         @Size(max = 50)
         String title,
 
@@ -31,25 +29,4 @@ public record ClubApplicationFormEditRequest(
 
         SemesterTerm semesterTerm
 ) {
-
-    @AssertTrue(message = "지원서 양식에 필요한 필드가 누락되었습니다.")
-    private boolean isInternalFormValid() {
-        if (formMode != ApplicationFormMode.INTERNAL) {
-            return true;
-        }
-
-        boolean hasDescription = StringUtils.hasText(description);
-        boolean hasQuestions = questions != null && !questions.isEmpty();
-
-        return hasDescription && hasQuestions;
-    }
-
-    @AssertTrue(message = "외부 링크가 누락되었습니다.")
-    private boolean isExternalFormValid() {
-        if (formMode != ApplicationFormMode.EXTERNAL) {
-            return true;
-        }
-
-        return StringUtils.hasText(externalApplicationUrl);
-    }
 }

--- a/backend/src/main/java/moadong/global/exception/ErrorCode.java
+++ b/backend/src/main/java/moadong/global/exception/ErrorCode.java
@@ -58,6 +58,8 @@ public enum ErrorCode {
     APPLICATION_SEMESTER_INVALID(HttpStatus.BAD_REQUEST, "800-7", "올바르지 않은 학기입니다."),
     NOT_ALLOWED_EXTERNAL_URL(HttpStatus.BAD_REQUEST, "800-8", "형식에 맞지않은 외부지원서 URL 입니다."),
     DUPLICATE_QUESTIONS_ITEMS(HttpStatus.BAD_REQUEST, "800-9", "중복된 질문 선택지가 존재합니다."),
+    APPLICATION_REQUIRED_FIELDS_MISSING(HttpStatus.BAD_REQUEST, "800-10", "지원서 양식에 필요한 필드가 누락되었습니다."),
+    EXTERNAL_APPLICATION_URL_MISSING(HttpStatus.BAD_REQUEST, "800-11", "외부 링크가 누락되었습니다."),
 
     // 900xx: 기타 시스템 오류
     AES_CIPHER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "900-1", "암호화 중 오류가 발생했습니다."),


### PR DESCRIPTION
> 🚀 릴리즈 PR인 경우 [**릴리즈 템플릿으로 전환**](?template=release.md)해 주세요. _(Preview 탭에서 클릭)_

## #️⃣연관된 이슈

- #1270 

## 📝작업 내용

PATCH는 부분 수정 요청인데, DTO 교차 필드 검증(@AssertTrue)이 요청 본문만 기준으로 동작해 필드 미포함 시 검증 실패가 발생할 수 있었습니다.
요청 데이터가 아니라 기존 엔티티 + 요청값을 머지한 최종 상태 기준으로 검증하도록 구조를 변경했습니다.

**주요 변경 사항**
1. DTO 교차 필드 검증 제거  
- [`ClubApplicationFormEditRequest.java`](/Users/lockpick/Desktop/moadong-be/moadong/backend/src/main/java/moadong/club/payload/request/ClubApplicationFormEditRequest.java)  
- `@AssertTrue` 기반 `INTERNAL/EXTERNAL` 검증 로직 제거  
- 필드 단위 검증(`@Size`, `@Min/@Max`, `@Valid`)만 유지

2. 서비스 최종 상태 검증 추가  
- [`ClubApplyAdminService.java`](/Users/lockpick/Desktop/moadong-be/moadong/backend/src/main/java/moadong/club/service/ClubApplyAdminService.java)  
- `validateFinalApplicationFormState(...)` 추가  
- 검증 기준:
  - 최종 `formMode == INTERNAL`이면 최종 `description` 텍스트 존재 + 최종 `questions` 비어있지 않음
  - 최종 `formMode == EXTERNAL`이면 최종 `externalApplicationUrl` 텍스트 존재
- `updateApplicationForm(...)` 시작 시 위 검증 수행


## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 동아리 지원서 양식 검증을 강화했습니다.
  * 필수 항목 누락 시 더 구체적인 오류 메시지를 표시하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->