### PR TITLE
[feature] 2026 동아리 소개 한마당 - 동소한 부스지도 제작

### DIFF
--- a/frontend/src/pages/FestivalPage/IntroductionPage/IntroductionPage.stories.tsx
+++ b/frontend/src/pages/FestivalPage/IntroductionPage/IntroductionPage.stories.tsx
@@ -1,0 +1,51 @@
+import { MemoryRouter } from 'react-router-dom';
+import type { Meta, StoryObj } from '@storybook/react';
+import 'swiper/css';
+import IntroductionPage from './IntroductionPage';
+
+const setViewportWidth = (width: number) => {
+  window.innerWidth = width;
+  window.dispatchEvent(new Event('resize'));
+};
+
+const meta = {
+  title: 'Pages/FestivalPage/IntroductionPage',
+  component: IntroductionPage,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: '동소한 부스지도를 슬라이드로 확인하는 소개 페이지입니다.',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <MemoryRouter initialEntries={['/festival-introduction']}>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof IntroductionPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Mobile: Story = {
+  decorators: [
+    (Story) => {
+      setViewportWidth(375);
+      return <Story />;
+    },
+  ],
+};
+
+export const Desktop: Story = {
+  decorators: [
+    (Story) => {
+      setViewportWidth(1024);
+      return <Story />;
+    },
+  ],
+};

--- a/frontend/src/pages/FestivalPage/IntroductionPage/IntroductionPage.styles.ts
+++ b/frontend/src/pages/FestivalPage/IntroductionPage/IntroductionPage.styles.ts
@@ -11,3 +11,118 @@ export const Container = styled.div`
     padding-top: 0;
   }
 `;
+
+export const SectionTitle = styled.h2`
+  margin: 16px 20px 12px;
+  font-size: 16px;
+  font-weight: 700;
+  color: #3a3a3a;
+`;
+
+export const SliderWrapper = styled.div`
+  padding: 0;
+  width: 100%;
+  .swiper {
+    width: 100%;
+  }
+`;
+
+export const MapFrame = styled.article<{ $backgroundColor: string }>`
+  position: relative;
+  width: 100%;
+  max-width: 500px;
+  aspect-ratio: 500 / 522;
+  margin: 0 auto;
+  overflow: hidden;
+  border-radius: 0 0 20px 20px;
+  background: ${({ $backgroundColor }) => $backgroundColor};
+`;
+
+export const SideBar = styled.div<{
+  $side: 'left' | 'right';
+  $top: string;
+  $height: string;
+  $color: string;
+}>`
+  position: absolute;
+  ${({ $side }) =>
+    $side === 'left' ? 'left: 0; width: 7.733%;' : 'right: 0; width: 7.467%;'}
+  top: ${({ $top }) => $top};
+  height: ${({ $height }) => $height};
+  background: ${({ $color }) => $color};
+  border-radius: ${({ $side }) =>
+    $side === 'left' ? '0 10px 10px 0' : '10px 0 0 10px'};
+`;
+
+export const SideLabel = styled.span<{
+  $x: string;
+  $y: string;
+  $rotation: number;
+}>`
+  position: absolute;
+  left: ${({ $x }) => $x};
+  top: ${({ $y }) => $y};
+  color: #787878;
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 17.667px;
+  text-align: center;
+  transform: ${({ $rotation }) =>
+    `translate(-50%, -50%) rotate(${$rotation}deg)`};
+  transform-origin: center;
+  font-family: 'Paperlogy', 'Pretendard', sans-serif;
+  white-space: nowrap;
+`;
+
+export const Booth = styled.div`
+  position: absolute;
+  border-radius: 10px;
+  background: #ffffff;
+  color: #4b4b4b;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.4;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 0 6px;
+`;
+
+export const DotPagination = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 20px;
+  margin-top: 20px;
+`;
+
+export const Dot = styled.button<{ $active: boolean }>`
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  background: ${({ $active }) => ($active ? '#ff5414' : '#dcdcdc')};
+
+  &:focus-visible {
+    outline: 2px solid #ff5414;
+    outline-offset: 2px;
+  }
+`;
+
+export const SlideCounter = styled.div`
+  width: fit-content;
+  min-width: 76px;
+  width: 62.7px;
+  padding: 10px;
+  margin: 20px auto 0;
+  border-radius: 999px;
+  background: #e5e5e5;
+  color: #454545;
+  font-size: 14px;
+  font-weight: 700;
+  text-align: center;
+  margin-bottom: 30px;
+`;

--- a/frontend/src/pages/FestivalPage/IntroductionPage/IntroductionPage.styles.ts
+++ b/frontend/src/pages/FestivalPage/IntroductionPage/IntroductionPage.styles.ts
@@ -115,7 +115,6 @@ export const Dot = styled.button<{ $active: boolean }>`
 export const SlideCounter = styled.div`
   width: fit-content;
   min-width: 76px;
-  width: 62.7px;
   padding: 10px;
   margin: 20px auto 0;
   border-radius: 999px;

--- a/frontend/src/pages/FestivalPage/IntroductionPage/IntroductionPage.styles.ts
+++ b/frontend/src/pages/FestivalPage/IntroductionPage/IntroductionPage.styles.ts
@@ -31,7 +31,7 @@ export const MapFrame = styled.article<{ $backgroundColor: string }>`
   position: relative;
   width: 100%;
   max-width: 500px;
-  aspect-ratio: 500 / 522;
+  aspect-ratio: 375 / 522;
   margin: 0 auto;
   overflow: hidden;
   border-radius: 0 0 20px 20px;

--- a/frontend/src/pages/FestivalPage/IntroductionPage/IntroductionPage.tsx
+++ b/frontend/src/pages/FestivalPage/IntroductionPage/IntroductionPage.tsx
@@ -1,3 +1,6 @@
+import { useState } from 'react';
+import type { Swiper as SwiperType } from 'swiper';
+import { Swiper, SwiperSlide } from 'swiper/react';
 import Footer from '@/components/common/Footer/Footer';
 import Header from '@/components/common/Header/Header';
 import { PAGE_VIEW } from '@/constants/eventName';
@@ -6,15 +9,307 @@ import Filter from '@/pages/MainPage/components/Filter/Filter';
 import isInAppWebView from '@/utils/isInAppWebView';
 import * as Styled from './IntroductionPage.styles';
 
+const MAP_FRAME_WIDTH = 375;
+const MAP_FRAME_HEIGHT = 522;
+
+type Booth = {
+  name: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+type MapSlide = {
+  nodeId: string;
+  backgroundColor: string;
+  sideColor: string;
+  leftBar: { top: number; height: number };
+  rightBar: { top: number; height: number };
+  leftLabel: {
+    text: string;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    rotation: number;
+  };
+  rightLabel: {
+    text: string;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    rotation: number;
+  };
+  booths: Booth[];
+};
+
+const CLUB_MAP_SLIDES: MapSlide[] = [
+  {
+    nodeId: '8851:6378',
+    backgroundColor: '#f2f8ff',
+    sideColor: '#b9defd',
+    leftBar: { top: 120, height: 277 },
+    rightBar: { top: 198, height: 277 },
+    leftLabel: {
+      text: '가온관',
+      x: 2.999998207829776,
+      y: 237.99999921319522,
+      width: 18.000001792170224,
+      height: 41.000000786804776,
+      rotation: 90,
+    },
+    rightLabel: {
+      text: '대학본부 A11동',
+      x: 355,
+      y: 285,
+      width: 18.000001228261681,
+      height: 103.00000021464803,
+      rotation: -90,
+    },
+    booths: [
+      { name: '리얼겟', x: 41, y: 70, width: 143, height: 40.75 },
+      { name: '포시즌', x: 192, y: 70, width: 143, height: 40.75 },
+      { name: '울림', x: 41, y: 116.75, width: 143, height: 40.75 },
+      { name: '그린드림', x: 192, y: 116.75, width: 143, height: 40.75 },
+      { name: '어택', x: 41, y: 163.5, width: 143, height: 40.75 },
+      { name: '거터', x: 192, y: 163.5, width: 143, height: 40.75 },
+      { name: 'TIME', x: 41, y: 210.25, width: 143, height: 40.75 },
+      { name: '청심회', x: 192, y: 210.25, width: 143, height: 40.75 },
+      { name: '아카데미', x: 41, y: 257, width: 143, height: 40.75 },
+      { name: 'SFC', x: 192, y: 257, width: 143, height: 40.75 },
+      { name: '한판', x: 41, y: 303.75, width: 143, height: 40.75 },
+      { name: '테크니칼', x: 192, y: 303.75, width: 143, height: 40.75 },
+      { name: 'UCDC', x: 41, y: 350.5, width: 143, height: 40.75 },
+      { name: '스타피쉬 (농구)', x: 192, y: 350.5, width: 143, height: 40.75 },
+      { name: '동반', x: 41, y: 397.25, width: 143, height: 40.75 },
+      { name: '백경유스호스텔', x: 192, y: 397.25, width: 143, height: 40.75 },
+    ],
+  },
+  {
+    nodeId: '8847:8495',
+    backgroundColor: '#fff0f4',
+    sideColor: '#ffd3d4',
+    leftBar: { top: 120, height: 277 },
+    rightBar: { top: 198, height: 277 },
+    leftLabel: {
+      text: '청운관',
+      x: 2.999998207829776,
+      y: 237.99999921319522,
+      width: 18.000001792170224,
+      height: 41.000000786804776,
+      rotation: 90,
+    },
+    rightLabel: {
+      text: '웅비관 A12동',
+      x: 355,
+      y: 292,
+      width: 18.000001061314833,
+      height: 89.00000021464803,
+      rotation: -90,
+    },
+    booths: [
+      { name: '한누리', x: 41, y: 70, width: 143, height: 40.75 },
+      { name: '절영회', x: 192, y: 70, width: 143, height: 40.75 },
+      { name: 'Cert-is', x: 41, y: 116.75, width: 143, height: 40.75 },
+      { name: '플레이 아데스', x: 192, y: 116.75, width: 143, height: 40.75 },
+      { name: 'PAS', x: 41, y: 163.5, width: 143, height: 40.75 },
+      { name: '프라우드', x: 192, y: 163.5, width: 143, height: 40.75 },
+      { name: '조나단', x: 41, y: 210.25, width: 143, height: 40.75 },
+      { name: '소리빛깔', x: 192, y: 210.25, width: 143, height: 40.75 },
+      { name: '보블리스', x: 41, y: 257, width: 143, height: 40.75 },
+      { name: 'JDM', x: 192, y: 257, width: 143, height: 40.75 },
+      { name: '부경 다이버', x: 41, y: 303.75, width: 143, height: 40.75 },
+      { name: '씨사운드', x: 192, y: 303.75, width: 143, height: 40.75 },
+      { name: '쇳물결', x: 41, y: 350.5, width: 143, height: 40.75 },
+      { name: '민심사랑', x: 192, y: 350.5, width: 143, height: 40.75 },
+      { name: '입자', x: 41, y: 397.25, width: 143, height: 40.75 },
+      { name: '모아동', x: 192, y: 397.25, width: 143, height: 40.75 },
+    ],
+  },
+  {
+    nodeId: '8847:8577',
+    backgroundColor: '#ffebe4',
+    sideColor: '#ffc9b4',
+    leftBar: { top: 90, height: 277 },
+    rightBar: { top: 90, height: 277 },
+    leftLabel: {
+      text: '충무관 B13동',
+      x: 2.9999960659770295,
+      y: 182.99999921319522,
+      width: 18.00000393402297,
+      height: 90.00000078680478,
+      rotation: 90,
+    },
+    rightLabel: {
+      text: '누리관 A13동',
+      x: 355,
+      y: 184,
+      width: 18.000001061314833,
+      height: 89.00000021464803,
+      rotation: -90,
+    },
+    booths: [
+      { name: '총동아리 연합회', x: 41, y: 70, width: 143, height: 40.75 },
+      { name: '공연자 대기장소', x: 41, y: 116.75, width: 143, height: 40.75 },
+      { name: '버스킹존', x: 41, y: 163.5, width: 143, height: 87 },
+      { name: '모비딕', x: 41, y: 256.5, width: 143, height: 40.75 },
+      { name: '백경극 예술연구회', x: 192, y: 257, width: 143, height: 40.75 },
+      { name: 'RCY', x: 41, y: 303.25, width: 143, height: 40.75 },
+      { name: '돼지', x: 192, y: 303.75, width: 143, height: 40.75 },
+      { name: '송웨이브', x: 41, y: 350, width: 143, height: 40.75 },
+      { name: '바구니', x: 192, y: 350.5, width: 143, height: 40.75 },
+      { name: '디그', x: 41, y: 396.75, width: 143, height: 40.75 },
+      { name: '남천 로타랙트', x: 192, y: 397.25, width: 143, height: 40.75 },
+    ],
+  },
+  {
+    nodeId: '8852:8659',
+    backgroundColor: '#f8efff',
+    sideColor: '#e9ccff',
+    leftBar: { top: 120, height: 277 },
+    rightBar: { top: 225, height: 213 },
+    leftLabel: {
+      text: '카페 파라다이스',
+      x: 2.9999957162872306,
+      y: 208.99999921319522,
+      width: 18.00000428371277,
+      height: 98.00000078680478,
+      rotation: 90,
+    },
+    rightLabel: {
+      text: '향파관 A15동',
+      x: 355,
+      y: 287,
+      width: 18.000001061314833,
+      height: 89.00000021464803,
+      rotation: -90,
+    },
+    booths: [
+      { name: '산악부', x: 41, y: 70, width: 143, height: 40.75 },
+      { name: '웨일즈', x: 192, y: 70, width: 143, height: 40.75 },
+      { name: '미담 장학회', x: 41, y: 116.75, width: 143, height: 40.75 },
+      { name: '모비딕스', x: 192, y: 116.75, width: 143, height: 40.75 },
+      {
+        name: '백경클래식기타연구회',
+        x: 41,
+        y: 163.5,
+        width: 143,
+        height: 40.75,
+      },
+      { name: 'IVF', x: 192, y: 163.5, width: 143, height: 40.75 },
+      { name: '수석회', x: 41, y: 210.25, width: 143, height: 40.75 },
+      { name: '홍백', x: 192, y: 210.25, width: 143, height: 40.75 },
+      { name: '스타피쉬 (축구)', x: 41, y: 257, width: 143, height: 40.75 },
+      { name: '피어드림', x: 192, y: 257, width: 143, height: 40.75 },
+      { name: '매니아', x: 41, y: 303.75, width: 143, height: 40.75 },
+      { name: '터', x: 192, y: 303.75, width: 143, height: 40.75 },
+      { name: '300', x: 41, y: 350.5, width: 143, height: 40.75 },
+      { name: '짚신', x: 192, y: 350.5, width: 143, height: 40.75 },
+      { name: '후라', x: 41, y: 397.25, width: 143, height: 40.75 },
+      { name: '집현전', x: 192, y: 397.25, width: 143, height: 40.75 },
+    ],
+  },
+];
+
+const toPercent = (value: number, base: number) => `${(value / base) * 100}%`;
+const toCenterPercent = (start: number, size: number, base: number) =>
+  `${((start + size / 2) / base) * 100}%`;
+
 const IntroductionPage = () => {
   useTrackPageView(PAGE_VIEW.FESTIVAL_INTRODUCTION_PAGE);
+  const [currentMapIndex, setCurrentMapIndex] = useState(0);
+  const [mapSwiper, setMapSwiper] = useState<SwiperType | null>(null);
+
   return (
     <>
       <Header hideOn={['webview']} />
       <Styled.Container>
         {!isInAppWebView() && <Filter alwaysVisible />}
-        {/* 지도 | 공연시간표 탭 */}
-        {/* 동아리지도 */}
+        <Styled.SliderWrapper>
+          <Swiper
+            onSwiper={setMapSwiper}
+            onSlideChange={(swiper) => setCurrentMapIndex(swiper.realIndex)}
+            loop
+            slidesPerView={1}
+            spaceBetween={12}
+          >
+            {CLUB_MAP_SLIDES.map((slide) => (
+              <SwiperSlide key={slide.nodeId}>
+                <Styled.MapFrame $backgroundColor={slide.backgroundColor}>
+                  <Styled.SideBar
+                    $side='left'
+                    $top={toPercent(slide.leftBar.top, MAP_FRAME_HEIGHT)}
+                    $height={toPercent(slide.leftBar.height, MAP_FRAME_HEIGHT)}
+                    $color={slide.sideColor}
+                  />
+                  <Styled.SideBar
+                    $side='right'
+                    $top={toPercent(slide.rightBar.top, MAP_FRAME_HEIGHT)}
+                    $height={toPercent(slide.rightBar.height, MAP_FRAME_HEIGHT)}
+                    $color={slide.sideColor}
+                  />
+                  <Styled.SideLabel
+                    $x={toCenterPercent(
+                      slide.leftLabel.x,
+                      slide.leftLabel.width,
+                      MAP_FRAME_WIDTH,
+                    )}
+                    $y={toCenterPercent(
+                      slide.leftLabel.y,
+                      slide.leftLabel.height,
+                      MAP_FRAME_HEIGHT,
+                    )}
+                    $rotation={slide.leftLabel.rotation}
+                  >
+                    {slide.leftLabel.text}
+                  </Styled.SideLabel>
+                  <Styled.SideLabel
+                    $x={toCenterPercent(
+                      slide.rightLabel.x,
+                      slide.rightLabel.width,
+                      MAP_FRAME_WIDTH,
+                    )}
+                    $y={toCenterPercent(
+                      slide.rightLabel.y,
+                      slide.rightLabel.height,
+                      MAP_FRAME_HEIGHT,
+                    )}
+                    $rotation={slide.rightLabel.rotation}
+                  >
+                    {slide.rightLabel.text}
+                  </Styled.SideLabel>
+                  {slide.booths.map((booth, index) => (
+                    <Styled.Booth
+                      key={`${slide.nodeId}-${booth.name}-${index}`}
+                      style={{
+                        left: toPercent(booth.x, MAP_FRAME_WIDTH),
+                        top: toPercent(booth.y, MAP_FRAME_HEIGHT),
+                        width: toPercent(booth.width, MAP_FRAME_WIDTH),
+                        height: toPercent(booth.height, MAP_FRAME_HEIGHT),
+                      }}
+                    >
+                      {booth.name}
+                    </Styled.Booth>
+                  ))}
+                </Styled.MapFrame>
+              </SwiperSlide>
+            ))}
+          </Swiper>
+        </Styled.SliderWrapper>
+        <Styled.DotPagination>
+          {CLUB_MAP_SLIDES.map((_, index) => (
+            <Styled.Dot
+              key={index}
+              type='button'
+              aria-label={`${index + 1}번 지도 보기`}
+              $active={currentMapIndex === index}
+              onClick={() => mapSwiper?.slideToLoop(index)}
+            />
+          ))}
+        </Styled.DotPagination>
+        <Styled.SlideCounter>{`${currentMapIndex + 1}/${CLUB_MAP_SLIDES.length}`}</Styled.SlideCounter>
         {/* 공연시간표 */}
       </Styled.Container>
       <Footer />


### PR DESCRIPTION

## #️⃣연관된 이슈

> ex) #1279 

## 📝작업 내용

https://github.com/user-attachments/assets/9bb9c8f9-a816-4dfb-8cee-a8ecc1a8ad2f


[Festival] IntroductionPage 동소한 부스지도 4개 노드 기반 재구현 + 슬라이드 인디케이터 개선

  ## 배경

Figma 노드 기준(8851:6378, 8847:8495, 8847:8577, 8852:8659)으로 동소한 부스지도를 구현했습니다.
 추가로 요청사항에 맞춰 하단 1/4 ~ 4/4 카운터와 점(dot) 클릭 슬라이드 이동 기능을 반영했습니다.


### codex 활용

[Figma MCP로 빠르게 개발하기 (feat. codex)](https://velog.io/@seongwon__105/Figma-MCP%EB%A1%9C-%EB%B9%A0%EB%A5%B4%EA%B2%8C-%EA%B0%9C%EB%B0%9C%ED%95%98%EA%B8%B0-feat-codex)

```
codex mcp 연결 -> 터미널에 figma 액세스 토큰 주입 -> codex 실행 -> figma node id로 프롬프트에 요청
```

  ## 변경 사항

  - IntroductionPage를 이미지 카드 방식에서 좌표 기반 맵 렌더 방식으로 변경
  - 노드별 배경색, 좌/우 세로 라벨, 부스 박스 위치/크기 데이터 반영
  - Swiper 슬라이드에 dot pagination 유지
  - dot을 button으로 변경하고 클릭 시 해당 슬라이드로 이동 (slideToLoop)
  - 하단 현재 슬라이드 카운터 추가 (1/4, 2/4, 3/4, 4/4)
  - 포커스 스타일 추가로 접근성 개선

## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 페스티벌 인트로 페이지에 인터랙티브한 맵 캐러셀 추가 — 슬라이드 전환, 클릭 가능한 페이지네이션 닷, 슬라이드 카운터 지원

* **Style**
  * 페이지 레이아웃 및 UI용 다수의 스타일 컴포넌트(섹션 타이틀, 맵 프레임, 사이드바, 부스, 페이징 등) 추가로 디자인 확장

* **Documentation**
  * 데스크탑/모바일 뷰를 시뮬레이션하는 스토리북 예제 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->