### PR TITLE
[fix] backdrop-filter가 적용되어 이미지가 흐릿한 문제 수정

### DIFF
--- a/frontend/src/assets/images/icons/next_button_icon.svg
+++ b/frontend/src/assets/images/icons/next_button_icon.svg
@@ -1,5 +1,5 @@
 <svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
-<foreignObject x="-5" y="-5" width="38" height="38"><div xmlns="http://www.w3.org/1999/xhtml" style="backdrop-filter:blur(2.5px);clip-path:url(#bgblur_next_clip_path);height:100%;width:100%"></div></foreignObject><circle data-figma-bg-blur-radius="5" cx="14" cy="14" r="14" transform="rotate(-180 14 14)" fill="white" fill-opacity="0.6"/>
+<foreignObject x="-5" y="-5" width="38" height="38"><div xmlns="http://www.w3.org/1999/xhtml" style="clip-path:url(#bgblur_next_clip_path);height:100%;width:100%"></div></foreignObject><circle data-figma-bg-blur-radius="5" cx="14" cy="14" r="14" transform="rotate(-180 14 14)" fill="white" fill-opacity="0.6"/>
 <path d="M11.6667 19.8335L17.5 14.0002L11.6667 8.16683" stroke="#3A3A3A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 <defs>
 <clipPath id="bgblur_next_clip_path" transform="translate(5 5)"><circle cx="14" cy="14" r="14" transform="rotate(-180 14 14)"/>

--- a/frontend/src/assets/images/icons/prev_button_icon.svg
+++ b/frontend/src/assets/images/icons/prev_button_icon.svg
@@ -1,5 +1,5 @@
 <svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
-<foreignObject x="-5" y="-5" width="38" height="38"><div xmlns="http://www.w3.org/1999/xhtml" style="backdrop-filter:blur(2.5px);clip-path:url(#bgblur_prev_clip_path);height:100%;width:100%"></div></foreignObject><circle data-figma-bg-blur-radius="5" cx="14" cy="14" r="14" transform="rotate(-180 14 14)" fill="white" fill-opacity="0.6"/>
+<foreignObject x="-5" y="-5" width="38" height="38"><div xmlns="http://www.w3.org/1999/xhtml" style="clip-path:url(#bgblur_prev_clip_path);height:100%;width:100%"></div></foreignObject><circle data-figma-bg-blur-radius="5" cx="14" cy="14" r="14" transform="rotate(-180 14 14)" fill="white" fill-opacity="0.6"/>
 <path d="M16.3333 19.8335L10.5 14.0002L16.3333 8.16683" stroke="#3A3A3A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 <defs>
 <clipPath id="bgblur_prev_clip_path" transform="translate(5 5)"><circle cx="14" cy="14" r="14" transform="rotate(-180 14 14)"/>


### PR DESCRIPTION
## #️⃣연관된 이슈


## 📝작업 내용

<img width="73" height="61" alt="스크린샷 2026-03-02 12 42 29" src="https://github.com/user-attachments/assets/553c6785-0d07-4653-8e8e-058d0018a02e" />

어느순간 backdrop-filter가 svg파일에 적용되어 흐릿하게 보이는 문제가있었습니다...
chrome에선 svg안 style이 적용안되어서 괜찮았는데 사파리는 적용돼서 흐릿하게 보이던 문제 수정하였습니다..

## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항
