### PR TITLE
[fix] 공연 카드 UX 개선 및 웹뷰 환경 대응

### DIFF
--- a/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
@@ -12,6 +12,7 @@ import useDevice from '@/hooks/useDevice';
 import ClubFeed from '@/pages/ClubDetailPage/components/ClubFeed/ClubFeed';
 import ClubIntroContent from '@/pages/ClubDetailPage/components/ClubIntroContent/ClubIntroContent';
 import ClubProfileCard from '@/pages/ClubDetailPage/components/ClubProfileCard/ClubProfileCard';
+import isInAppWebView from '@/utils/isInAppWebView';
 import * as Styled from './ClubDetailPage.styles';
 import ClubDetailFooter from './components/ClubDetailFooter/ClubDetailFooter';
 import ClubDetailTopBar from './components/ClubDetailTopBar/ClubDetailTopBar';
@@ -137,7 +138,7 @@ const ClubDetailPage = () => {
           </Styled.RightSection>
         </Styled.ContentWrapper>
       </Styled.Container>
-      <Footer />
+      {!isInAppWebView() && <Footer />}
       <ClubDetailFooter
         recruitmentStart={clubDetail.recruitmentStart}
         recruitmentEnd={clubDetail.recruitmentEnd}

--- a/frontend/src/pages/FestivalPage/components/PerformanceCard/PerformanceCard.styles.ts
+++ b/frontend/src/pages/FestivalPage/components/PerformanceCard/PerformanceCard.styles.ts
@@ -33,8 +33,6 @@ export const SongArea = styled.div<{ $active: boolean }>`
   background-color: ${({ $active }) => ($active ? '#ffece5' : '#ebebeb')};
 `;
 
-export const SongContent = styled.div``;
-
 export const SongList = styled.ul`
   display: flex;
   flex-direction: column;

--- a/frontend/src/pages/FestivalPage/components/PerformanceCard/PerformanceCard.styles.ts
+++ b/frontend/src/pages/FestivalPage/components/PerformanceCard/PerformanceCard.styles.ts
@@ -7,7 +7,8 @@ export const Card = styled.div<{ $active: boolean }>`
   gap: 6px;
   padding: 12px;
   border-radius: 14px;
-  background-color: ${({ $active }) => ($active ? '#ffffff' : '#f5f5f5')};
+  background-color: ${({ $active, theme }) =>
+    $active ? theme.colors.base.white : theme.colors.gray[100]};
   border: 1px solid ${({ $active }) => ($active ? '#ffded2' : 'transparent')};
   cursor: pointer;
 `;
@@ -17,19 +18,22 @@ export const ClubName = styled.p<{ $active: boolean }>`
   font-size: 16px;
   font-weight: 700;
   line-height: 140%;
-  color: ${({ $active }) => ($active ? '#111111' : '#787878')};
+  color: ${({ $active, theme }) =>
+    $active ? theme.colors.gray[800] : theme.colors.gray[700]};
 `;
 
-export const SongArea = styled.div<{ $active: boolean; $expanded: boolean }>`
+export const SongArea = styled.div<{ $active: boolean }>`
   display: flex;
   flex-direction: row;
   align-items: flex-start;
   justify-content: space-between;
   gap: 8px;
   padding: ${({ $active }) => ($active ? '8px 12px' : '6px 12px')};
-  border-radius: ${({ $expanded }) => ($expanded ? '8px' : '20px')};
+  border-radius: 8px;
   background-color: ${({ $active }) => ($active ? '#ffece5' : '#ebebeb')};
 `;
+
+export const SongContent = styled.div``;
 
 export const SongList = styled.ul`
   display: flex;
@@ -37,20 +41,16 @@ export const SongList = styled.ul`
   gap: 4px;
   list-style: none;
   flex: 1;
+  margin-top: 4px;
 `;
 
-export const SongItem = styled.li`
+export const SongItem = styled.li<{ $collapsed?: boolean }>`
   font-size: 12px;
   font-weight: 400;
   line-height: 140%;
-  color: #4b4b4b;
-`;
-
-export const CollapsedSong = styled.span`
-  font-size: 12px;
-  font-weight: 400;
-  line-height: 140%;
-  color: #989898;
+  color: ${({ $collapsed, theme }) =>
+    $collapsed ? theme.colors.gray[600] : theme.colors.gray[800]};
+  transition: color 0.2s ease;
 `;
 
 export const ChevronWrapper = styled.div`
@@ -67,5 +67,6 @@ export const ChevronIcon = styled.svg<{ $expanded: boolean; $active: boolean }>`
   transition: transform 0.2s ease;
   transform: ${({ $expanded }) =>
     $expanded ? 'rotate(180deg)' : 'rotate(0deg)'};
-  stroke: ${({ $active }) => ($active ? '#ff9f7c' : '#c5c5c5')};
+  stroke: ${({ $active, theme }) =>
+    $active ? '#ff9f7c' : theme.colors.gray[500]};
 `;

--- a/frontend/src/pages/FestivalPage/components/PerformanceCard/PerformanceCard.tsx
+++ b/frontend/src/pages/FestivalPage/components/PerformanceCard/PerformanceCard.tsx
@@ -33,7 +33,7 @@ const PerformanceCard = ({ performance, active }: PerformanceCardProps) => {
       <Styled.ClubName $active={active}>{performance.clubName}</Styled.ClubName>
 
       <Styled.SongArea $active={active}>
-        <Styled.SongContent style={{ flex: 1, overflow: 'hidden' }}>
+        <div style={{ flex: 1, overflow: 'hidden' }}>
           <Styled.SongItem $collapsed={!expanded}>{performance.songs[0]}</Styled.SongItem>
           {performance.songs.length > 1 && (
             <motion.div
@@ -49,7 +49,7 @@ const PerformanceCard = ({ performance, active }: PerformanceCardProps) => {
               </Styled.SongList>
             </motion.div>
           )}
-        </Styled.SongContent>
+        </div>
 
         <Styled.ChevronWrapper>
           <Styled.ChevronIcon

--- a/frontend/src/pages/FestivalPage/components/PerformanceCard/PerformanceCard.tsx
+++ b/frontend/src/pages/FestivalPage/components/PerformanceCard/PerformanceCard.tsx
@@ -34,7 +34,9 @@ const PerformanceCard = ({ performance, active }: PerformanceCardProps) => {
 
       <Styled.SongArea $active={active}>
         <div style={{ flex: 1, overflow: 'hidden' }}>
-          <Styled.SongItem $collapsed={!expanded}>{performance.songs[0]}</Styled.SongItem>
+          <Styled.SongItem $collapsed={!expanded}>
+            {performance.songs[0]}
+          </Styled.SongItem>
           {performance.songs.length > 1 && (
             <motion.div
               initial={false}

--- a/frontend/src/pages/FestivalPage/components/PerformanceCard/PerformanceCard.tsx
+++ b/frontend/src/pages/FestivalPage/components/PerformanceCard/PerformanceCard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { AnimatePresence, motion } from 'framer-motion';
+import { motion } from 'framer-motion';
 import { USER_EVENT } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import { Performance } from '../../data/performances';
@@ -32,38 +32,24 @@ const PerformanceCard = ({ performance, active }: PerformanceCardProps) => {
     <Styled.Card $active={active} onClick={toggleExpanded}>
       <Styled.ClubName $active={active}>{performance.clubName}</Styled.ClubName>
 
-      <Styled.SongArea $active={active} $expanded={expanded}>
-        <AnimatePresence initial={false} mode='wait'>
-          {expanded ? (
+      <Styled.SongArea $active={active}>
+        <Styled.SongContent style={{ flex: 1, overflow: 'hidden' }}>
+          <Styled.SongItem $collapsed={!expanded}>{performance.songs[0]}</Styled.SongItem>
+          {performance.songs.length > 1 && (
             <motion.div
-              key='expanded'
-              initial={{ opacity: 0, height: 0 }}
-              animate={{ opacity: 1, height: 'auto' }}
-              exit={{ opacity: 0, height: 0 }}
+              initial={false}
+              animate={{ height: expanded ? 'auto' : 0 }}
               transition={{ duration: 0.2, ease: 'easeInOut' }}
-              style={{ overflow: 'hidden', flex: 1 }}
+              style={{ overflow: 'hidden' }}
             >
               <Styled.SongList>
-                {performance.songs.map((song) => (
+                {performance.songs.slice(1).map((song) => (
                   <Styled.SongItem key={song}>{song}</Styled.SongItem>
                 ))}
               </Styled.SongList>
             </motion.div>
-          ) : (
-            <motion.div
-              key='collapsed'
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.15 }}
-              style={{ flex: 1 }}
-            >
-              <Styled.CollapsedSong>
-                {performance.songs[0]}
-              </Styled.CollapsedSong>
-            </motion.div>
           )}
-        </AnimatePresence>
+        </Styled.SongContent>
 
         <Styled.ChevronWrapper>
           <Styled.ChevronIcon

--- a/frontend/src/styles/Global.styles.ts
+++ b/frontend/src/styles/Global.styles.ts
@@ -5,6 +5,7 @@ const GlobalStyles = createGlobalStyle`
     margin: 0;
     padding: 0;
     box-sizing: border-box;
+    -webkit-tap-highlight-color: transparent;
   }
   html {
     overscroll-behavior-y: none;


### PR DESCRIPTION
## #️⃣연관된 이슈

#1297

<br />

## 📝작업 내용

- 모바일 터치 시 파란 하이라이트 전역 제거 (`-webkit-tap-highlight-color: transparent`)


<img width="300" alt="image" src="https://github.com/user-attachments/assets/d838906d-f288-42eb-bd8e-a4792208c086" />


- 웹뷰 환경에서 ClubDetailPage Footer 미노출

<img width="300" alt="image" src="https://github.com/user-attachments/assets/4bc24fe0-05b0-4f81-b359-65ee48cb48e4" />



- PerformanceCard 펼침/접힘 애니메이션 개선 (찌부 현상, 재렌더 느낌, 간격 문제 수정)
- SongItem 색상 전환 (접힌 상태 gray[600] → 펼쳐지면 gray[800])

<br />

## 🫡 참고사항

- framer-motion `motion.div` height 애니메이션 사용 (0 ↔ auto)
- songs[0]은 항상 DOM에 유지하고 나머지만 motion.div로 감싸는 구조로 재렌더 느낌 제거



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 앱 내 웹뷰에서 푸터 표시 개선
  * 터치 탭 하이라이트 제거로 터치 경험 개선

* **스타일**
  * 테마 기반 색상으로 비주얼 일관성 향상
  * 공연 카드의 색상 및 스타일링 개선

* **개선사항**
  * 곡 목록 애니메이션 간소화 및 성능 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->