### PR TITLE
[fix] 지원서 목록이 항상 비어있던 문제 수정

### DIFF
--- a/frontend/src/pages/ClubDetailPage/components/ClubApplyButton/ClubApplyButton.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubApplyButton/ClubApplyButton.tsx
@@ -19,10 +19,13 @@ const ClubApplyButton = ({
   deadlineText,
   hideShareButtonOnMobile = false,
 }: ClubApplyButtonProps) => {
-  const { clubId } = useParams<{ clubId: string }>();
+  const { clubId, clubName } = useParams<{
+    clubId: string;
+    clubName: string;
+  }>();
   const navigate = useNavigate();
   const trackEvent = useMixpanelTrack();
-  const { data: clubDetail } = useGetClubDetail(clubId!);
+  const { data: clubDetail } = useGetClubDetail((clubName ?? clubId) || '');
   const { isMobile, isTablet } = useDevice();
   const shouldShowShareButton = hideShareButtonOnMobile
     ? !isMobile && !isTablet
@@ -37,7 +40,7 @@ const ClubApplyButton = ({
 
   const navigateToApplicationForm = async (formId: string) => {
     try {
-      const formDetail = await getApplication(clubId, formId);
+      const formDetail = await getApplication(clubDetail.id, formId);
 
       // 외부 지원서인 경우
       if (formDetail?.formMode === ApplicationFormMode.EXTERNAL) {
@@ -50,7 +53,9 @@ const ClubApplyButton = ({
       }
 
       // 내부 지원서인 경우
-      navigate(`/application/${clubId}/${formId}`, { state: { formDetail } });
+      navigate(`/application/${clubDetail.id}/${formId}`, {
+        state: { formDetail },
+      });
       setIsApplicationModalOpen(false);
     } catch (error) {
       console.error('지원서 조회 중 오류가 발생했습니다', error);
@@ -74,7 +79,7 @@ const ClubApplyButton = ({
     }
 
     try {
-      const forms = await getApplicationOptions(clubId);
+      const forms = await getApplicationOptions(clubDetail.id);
 
       if (forms.length <= 0) {
         return;
@@ -118,7 +123,7 @@ const ClubApplyButton = ({
 
   return (
     <Styled.ApplyButtonContainer>
-      {shouldShowShareButton && <ShareButton clubId={clubId} />}
+      {shouldShowShareButton && <ShareButton clubId={clubDetail.id} />}
       <Styled.ApplyButton
         disabled={isRecruitmentUpcoming || isRecruitmentClosed}
         onClick={handleApplyButtonClick}

--- a/frontend/src/pages/ClubDetailPage/components/ShareButton/ShareButton.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ShareButton/ShareButton.tsx
@@ -24,7 +24,7 @@ const ShareButton = ({ clubId }: ShareButtonProps) => {
   if (!clubDetail) return;
 
   const handleShare = async () => {
-    const url = `${MOADONG_BASE_URL}${clubDetail.id}`;
+    const url = `${MOADONG_BASE_URL}@${clubDetail.name}`;
 
     if (isRNWebView) {
       const isSent = requestShare({


### PR DESCRIPTION
> 🚀 릴리즈 PR인 경우 [**릴리즈 템플릿으로 전환**](?template=release.md)해 주세요. _(Preview 탭에서 클릭)_

## #️⃣연관된 이슈

- #1305 

## 📝작업 내용

동아리 상세페이지를 id에서 이름으로 마이그레이션 후
동아리 지원서에 관한 API가 id로 유지되어야하는데 파라미터로 넘겨진 동아리 이름을 이용해 API에 조회하였음
아직 백엔드는 한글이름을 통해 API조회를 제공하지않는데 한글로 조회하니 404 응답.
따라서 지원서에는 아무런 목록이 보이지 않게됨..

## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **버그 수정**
  * 클럽 공유 링크의 URL 형식이 개선되었습니다. 클럽 ID 대신 클럽 이름을 사용하는 새로운 형식으로 변경되었습니다.
  * 클럽 신청 기능의 데이터 처리 흐름이 안정화되었습니다.
  * 클럽 상세 페이지 라우팅 및 공유 기능이 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->