### PR TITLE
[feature] 개발자 페이지 알림 전송 기능 추가

### DIFF
--- a/backend/src/main/java/moadong/fcm/adapter/FirebasePushNotificationAdapter.java
+++ b/backend/src/main/java/moadong/fcm/adapter/FirebasePushNotificationAdapter.java
@@ -1,40 +1,174 @@
 package moadong.fcm.adapter;
 
+import com.google.firebase.messaging.BatchResponse;
 import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.MulticastMessage;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
+import com.google.firebase.messaging.SendResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import moadong.fcm.model.MulticastPushPayload;
+import moadong.fcm.model.MulticastPushResult;
 import moadong.fcm.model.PushPayload;
+import moadong.fcm.model.TokenPushPayload;
+import moadong.fcm.model.TokenPushResult;
 import moadong.fcm.port.PushNotificationPort;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class FirebasePushNotificationAdapter implements PushNotificationPort {
 
+    private static final int MULTICAST_LIMIT = 500;
+
     private final FirebaseMessaging firebaseMessaging;
 
     @Override
-    public boolean send(PushPayload payload) {
+    public TokenPushResult send(PushPayload payload) {
         log.info("PushPayload: {}", payload);
-        Message message = Message.builder()
+        Message.Builder builder = Message.builder()
                 .setNotification(Notification.builder()
                         .setTitle(payload.title())
                         .setBody(payload.body())
                         .build())
-                .putAllData(payload.data())
-                .setTopic(payload.topic())
-                .build();
+                .setTopic(payload.topic());
+
+        Map<String, String> data = sanitizeData(payload.data());
+        if (!data.isEmpty()) {
+            builder.putAllData(data);
+        }
 
         try {
-            String messageId = firebaseMessaging.send(message);
+            String messageId = firebaseMessaging.send(builder.build());
             log.info("FCM send success - topic: {}, messageId: {}", payload.topic(), messageId);
-            return true;
+            return new TokenPushResult(true, messageId);
         } catch (Exception e) {
             log.error("FCM send failed - topic: {}, error: {}", payload.topic(), e.getMessage());
-            return false;
+            return new TokenPushResult(false, null);
         }
+    }
+
+    @Override
+    public TokenPushResult sendToToken(TokenPushPayload payload) {
+        if (!StringUtils.hasText(payload.token())) {
+            log.warn("FCM send skipped - blank token");
+            return new TokenPushResult(false, null);
+        }
+
+        Message.Builder builder = Message.builder()
+                .setToken(payload.token())
+                .setNotification(Notification.builder()
+                        .setTitle(payload.title())
+                        .setBody(payload.body())
+                        .build());
+
+        Map<String, String> data = sanitizeData(payload.data());
+        if (!data.isEmpty()) {
+            builder.putAllData(data);
+        }
+
+        try {
+            String messageId = firebaseMessaging.send(builder.build());
+            return new TokenPushResult(true, messageId);
+        } catch (Exception e) {
+            log.error("FCM send failed - token: {}, error: {}", mask(payload.token()), e.getMessage(), e);
+            return new TokenPushResult(false, null);
+        }
+    }
+
+    @Override
+    public MulticastPushResult sendToTokens(MulticastPushPayload payload) {
+        List<String> tokens = payload.tokens() == null ? List.of() : payload.tokens().stream()
+                .filter(StringUtils::hasText)
+                .collect(Collectors.collectingAndThen(
+                        Collectors.toCollection(LinkedHashSet::new),
+                        List::copyOf
+                ));
+
+        if (tokens.isEmpty()) {
+            return new MulticastPushResult(0, 0, 0, List.of());
+        }
+
+        int batchCount = 0;
+        int successCount = 0;
+        int failureCount = 0;
+        List<String> failedTokens = new ArrayList<>();
+        Map<String, String> data = sanitizeData(payload.data());
+
+        for (int start = 0; start < tokens.size(); start += MULTICAST_LIMIT) {
+            int end = Math.min(start + MULTICAST_LIMIT, tokens.size());
+            List<String> batchTokens = tokens.subList(start, end);
+            batchCount++;
+
+            MulticastMessage.Builder builder = MulticastMessage.builder()
+                    .addAllTokens(batchTokens)
+                    .setNotification(Notification.builder()
+                            .setTitle(payload.title())
+                            .setBody(payload.body())
+                            .build());
+
+            if (!data.isEmpty()) {
+                builder.putAllData(data);
+            }
+
+            try {
+                BatchResponse response = firebaseMessaging.sendEachForMulticast(builder.build());
+                successCount += response.getSuccessCount();
+                failureCount += response.getFailureCount();
+                collectFailedTokens(batchTokens, response.getResponses(), failedTokens);
+            } catch (Exception e) {
+                log.error("FCM batch send failed - batch: {}, error: {}", batchCount, e.getMessage(), e);
+                failureCount += batchTokens.size();
+                failedTokens.addAll(batchTokens);
+            }
+        }
+
+        return new MulticastPushResult(
+                batchCount,
+                successCount,
+                failureCount,
+                List.copyOf(failedTokens)
+        );
+    }
+
+    private void collectFailedTokens(List<String> batchTokens, List<SendResponse> responses, List<String> failedTokens) {
+        IntStream.range(0, responses.size())
+                .filter(index -> !responses.get(index).isSuccessful())
+                .mapToObj(batchTokens::get)
+                .forEach(failedTokens::add);
+    }
+
+    public Map<String, String> sanitizeData(Map<String, String> data) {
+        if (data == null || data.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        return data.entrySet().stream()
+                .filter(entry -> StringUtils.hasText(entry.getKey()) && entry.getValue() != null)
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        Map.Entry::getValue,
+                        (left, right) -> right,
+                        LinkedHashMap::new
+                ));
+    }
+
+    private String mask(String token) {
+        if (!StringUtils.hasText(token) || token.length() < 10) {
+            return "***";
+        }
+        return token.substring(0, 6) + "..." + token.substring(token.length() - 4);
     }
 }

--- a/backend/src/main/java/moadong/fcm/controller/FcmAdminController.java
+++ b/backend/src/main/java/moadong/fcm/controller/FcmAdminController.java
@@ -1,0 +1,47 @@
+package moadong.fcm.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import moadong.fcm.payload.request.FcmAdminBatchSendRequest;
+import moadong.fcm.payload.request.FcmAdminSingleSendRequest;
+import moadong.fcm.service.FcmAdminService;
+import moadong.global.payload.Response;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin")
+@AllArgsConstructor
+@Tag(name = "Fcm_Notification_Admin", description = "FCM 알림관리자 페이지 기능")
+public class FcmAdminController {
+
+    private final FcmAdminService fcmAdminService;
+
+    @GetMapping("/tokens")
+    @Operation(summary = "전체 FCM 토큰 조회", description = "학생/비학생 토큰을 모두 합쳐 중복 제거된 토큰 목록을 조회합니다.")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> getAllAvailableToken() {
+        return Response.ok(fcmAdminService.getAllAvailableToken());
+    }
+
+    @PostMapping("/fcm/send")
+    @Operation(summary = "FCM 단건 발송", description = "특정 토큰으로 개별 FCM 메시지를 발송합니다.")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> sendToToken(@RequestBody @Valid FcmAdminSingleSendRequest request) {
+        return Response.ok("FCM 단건 발송 완료", fcmAdminService.sendToToken(request));
+    }
+
+    @PostMapping("/fcm/send-all")
+    @Operation(summary = "FCM 전체 배치 발송", description = "저장된 전체 토큰을 대상으로 FCM 메시지를 발송합니다.")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> sendToAll(@RequestBody @Valid FcmAdminBatchSendRequest request) {
+        return Response.ok("FCM 전체 배치 발송 완료", fcmAdminService.sendToAll(request));
+    }
+}

--- a/backend/src/main/java/moadong/fcm/model/MulticastPushPayload.java
+++ b/backend/src/main/java/moadong/fcm/model/MulticastPushPayload.java
@@ -1,0 +1,12 @@
+package moadong.fcm.model;
+
+import java.util.List;
+import java.util.Map;
+
+public record MulticastPushPayload(
+        List<String> tokens,
+        String title,
+        String body,
+        Map<String, String> data
+) {
+}

--- a/backend/src/main/java/moadong/fcm/model/MulticastPushResult.java
+++ b/backend/src/main/java/moadong/fcm/model/MulticastPushResult.java
@@ -1,0 +1,11 @@
+package moadong.fcm.model;
+
+import java.util.List;
+
+public record MulticastPushResult(
+        int batchCount,
+        int successCount,
+        int failureCount,
+        List<String> failedTokens
+) {
+}

--- a/backend/src/main/java/moadong/fcm/model/TokenPushPayload.java
+++ b/backend/src/main/java/moadong/fcm/model/TokenPushPayload.java
@@ -1,0 +1,11 @@
+package moadong.fcm.model;
+
+import java.util.Map;
+
+public record TokenPushPayload(
+        String token,
+        String title,
+        String body,
+        Map<String, String> data
+) {
+}

--- a/backend/src/main/java/moadong/fcm/model/TokenPushResult.java
+++ b/backend/src/main/java/moadong/fcm/model/TokenPushResult.java
@@ -1,0 +1,7 @@
+package moadong.fcm.model;
+
+public record TokenPushResult(
+        boolean success,
+        String messageId
+) {
+}

--- a/backend/src/main/java/moadong/fcm/payload/request/FcmAdminBatchSendRequest.java
+++ b/backend/src/main/java/moadong/fcm/payload/request/FcmAdminBatchSendRequest.java
@@ -1,0 +1,14 @@
+package moadong.fcm.payload.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.Map;
+
+public record FcmAdminBatchSendRequest(
+        @NotBlank
+        String title,
+        @NotBlank
+        String body,
+        Map<String, String> data
+) {
+}

--- a/backend/src/main/java/moadong/fcm/payload/request/FcmAdminSingleSendRequest.java
+++ b/backend/src/main/java/moadong/fcm/payload/request/FcmAdminSingleSendRequest.java
@@ -1,0 +1,16 @@
+package moadong.fcm.payload.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.Map;
+
+public record FcmAdminSingleSendRequest(
+        @NotBlank
+        String token,
+        @NotBlank
+        String title,
+        @NotBlank
+        String body,
+        Map<String, String> data
+) {
+}

--- a/backend/src/main/java/moadong/fcm/payload/response/FcmAdminBatchSendResponse.java
+++ b/backend/src/main/java/moadong/fcm/payload/response/FcmAdminBatchSendResponse.java
@@ -1,0 +1,12 @@
+package moadong.fcm.payload.response;
+
+import java.util.List;
+
+public record FcmAdminBatchSendResponse(
+        int totalTokenCount,
+        int batchCount,
+        int successCount,
+        int failureCount,
+        List<String> failedTokens
+) {
+}

--- a/backend/src/main/java/moadong/fcm/payload/response/FcmAdminSingleSendResponse.java
+++ b/backend/src/main/java/moadong/fcm/payload/response/FcmAdminSingleSendResponse.java
@@ -1,0 +1,7 @@
+package moadong.fcm.payload.response;
+
+public record FcmAdminSingleSendResponse(
+        String token,
+        String messageId
+) {
+}

--- a/backend/src/main/java/moadong/fcm/payload/response/TokenListResponse.java
+++ b/backend/src/main/java/moadong/fcm/payload/response/TokenListResponse.java
@@ -1,0 +1,8 @@
+package moadong.fcm.payload.response;
+
+import java.util.List;
+
+public record TokenListResponse(
+        List<String> tokens
+) {
+}

--- a/backend/src/main/java/moadong/fcm/port/PushNotificationPort.java
+++ b/backend/src/main/java/moadong/fcm/port/PushNotificationPort.java
@@ -1,7 +1,15 @@
 package moadong.fcm.port;
 
+import moadong.fcm.model.MulticastPushPayload;
+import moadong.fcm.model.MulticastPushResult;
 import moadong.fcm.model.PushPayload;
+import moadong.fcm.model.TokenPushPayload;
+import moadong.fcm.model.TokenPushResult;
 
 public interface PushNotificationPort {
-    boolean send(PushPayload payload);
+    TokenPushResult send(PushPayload payload);
+
+    TokenPushResult sendToToken(TokenPushPayload payload);
+
+    MulticastPushResult sendToTokens(MulticastPushPayload payload);
 }

--- a/backend/src/main/java/moadong/fcm/service/FcmAdminService.java
+++ b/backend/src/main/java/moadong/fcm/service/FcmAdminService.java
@@ -1,0 +1,93 @@
+package moadong.fcm.service;
+
+import lombok.extern.slf4j.Slf4j;
+import lombok.RequiredArgsConstructor;
+import moadong.fcm.entity.FcmToken;
+import moadong.fcm.entity.StudentFcmToken;
+import moadong.fcm.model.MulticastPushPayload;
+import moadong.fcm.model.MulticastPushResult;
+import moadong.fcm.model.TokenPushPayload;
+import moadong.fcm.model.TokenPushResult;
+import moadong.fcm.payload.request.FcmAdminBatchSendRequest;
+import moadong.fcm.payload.request.FcmAdminSingleSendRequest;
+import moadong.fcm.payload.response.FcmAdminBatchSendResponse;
+import moadong.fcm.payload.response.FcmAdminSingleSendResponse;
+import moadong.fcm.payload.response.TokenListResponse;
+import moadong.fcm.port.PushNotificationPort;
+import moadong.fcm.repository.FcmTokenRepository;
+import moadong.fcm.repository.StudentFcmTokenRepository;
+import moadong.global.exception.ErrorCode;
+import moadong.global.exception.RestApiException;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FcmAdminService {
+
+    private final StudentFcmTokenRepository studentFcmTokenRepository;
+    private final FcmTokenRepository fcmTokenRepository;
+    private final PushNotificationPort pushNotificationPort;
+
+    public TokenListResponse getAllAvailableToken() {
+        List<String> tokens = Stream.concat(
+                        studentFcmTokenRepository.findAll().stream().map(StudentFcmToken::getToken),
+                        fcmTokenRepository.findAll().stream().map(FcmToken::getToken)
+                )
+                .filter(StringUtils::hasText)
+                .collect(Collectors.collectingAndThen(
+                        Collectors.toCollection(LinkedHashSet::new),
+                        List::copyOf
+                ));
+
+        return new TokenListResponse(tokens);
+    }
+
+    public FcmAdminSingleSendResponse sendToToken(FcmAdminSingleSendRequest request) {
+        TokenPushResult result = pushNotificationPort.sendToToken(
+                new TokenPushPayload(request.token(), request.title(), request.body(), request.data())
+        );
+
+        if (!result.success()) {
+            log.error("Admin FCM send failed. token={}", mask(request.token()));
+            throw new RestApiException(ErrorCode.FCMMESSAGE_SEND_ERROR);
+        }
+
+        return new FcmAdminSingleSendResponse(request.token(), result.messageId());
+    }
+
+    public FcmAdminBatchSendResponse sendToAll(FcmAdminBatchSendRequest request) {
+        List<String> tokens = getAllAvailableToken().tokens();
+        if (tokens.isEmpty()) {
+            return new FcmAdminBatchSendResponse(0, 0, 0, 0, List.of());
+        }
+
+        MulticastPushResult result = pushNotificationPort.sendToTokens(
+                new MulticastPushPayload(tokens, request.title(), request.body(), request.data())
+        );
+
+        return new FcmAdminBatchSendResponse(
+                tokens.size(),
+                result.batchCount(),
+                result.successCount(),
+                result.failureCount(),
+                result.failedTokens()
+        );
+    }
+
+    private String mask(String token) {
+        if (!StringUtils.hasText(token) || token.length() < 10) {
+            return "***";
+        }
+        return token.substring(0, 6) + "..." + token.substring(token.length() - 4);
+    }
+}

--- a/backend/src/main/java/moadong/global/exception/ErrorCode.java
+++ b/backend/src/main/java/moadong/global/exception/ErrorCode.java
@@ -67,7 +67,8 @@ public enum ErrorCode {
     
     // 901xx: FCM 관련 오류
     FCMTOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "901-1", "존재하지 않는 토큰입니다."),
-    FCMTOKEN_SUBSCRIBE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "901-2", "동아리 구독중에 오류가 발생 하였습니다.");
+    FCMTOKEN_SUBSCRIBE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "901-2", "동아리 구독중에 오류가 발생 하였습니다."),
+    FCMMESSAGE_SEND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "901-3", "FCM 메시지 전송 중 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/backend/src/main/resources/static/DEV_PAGE_CONVENTION_GUIDE.md
+++ b/backend/src/main/resources/static/DEV_PAGE_CONVENTION_GUIDE.md
@@ -1,0 +1,119 @@
+# 개발자 페이지 컨벤션 & 디자인 가이드
+
+## 1) 목적
+- `src/main/resources/static/dev` 하위 정적 페이지에 기능을 추가할 때, 기존 UI/UX 톤과 구현 방식을 일관되게 유지하기 위한 기준 문서.
+
+## 2) 분석 대상
+- `src/main/resources/static/dev/index.html`
+- `src/main/resources/static/dev/edit.html`
+- `src/main/resources/static/dev/dict-edit.html`
+
+## 3) 공통 디자인 토큰
+
+### 타이포그래피
+- 기본 폰트: `system-ui, sans-serif`
+- 기본 줄간격: `line-height: 1.5`
+- 제목 크기:
+  - 메인 타이틀: `1.25rem` 내외
+  - 섹션 타이틀: `1.1rem` 내외
+  - 서브 타이틀: `1rem` 내외
+
+### 색상
+- Primary(링크/포커스/강조): `#2563eb`
+- Neutral Border: `#e5e7eb`, `#d1d5db`
+- Neutral Background: `#f9fafb`, `#f3f4f6`
+- Success:
+  - 텍스트: `#16a34a` 또는 `#166534`
+  - 배경/보더: `#f0fdf4`, `#bbf7d0`
+- Error:
+  - 텍스트: `#dc2626`
+  - 배경/보더: `#fef2f2`, `#fecaca`
+- Warning:
+  - 텍스트: `#92400e`
+  - 배경/보더: `#fffbeb`, `#fde68a`
+
+### 간격/라운드
+- 주 사용 간격 단위: `4, 8, 12, 16, 24px`
+- 주 사용 반경: `6px`, `8px`
+
+### 폭/레이아웃
+- 메인 포털: `max-width: 900px`
+- 팝업(동아리 수정): `max-width: 560px`
+- 팝업(단어사전 수정): `max-width: 480px`
+
+## 4) 공통 레이아웃 규칙
+- 모든 페이지 최상단에 `* { box-sizing: border-box; }` 유지.
+- 메인 페이지는 `header + main + section` 구조를 유지.
+- 기능 단위는 `section`으로 분리하고, 섹션 기본 스타일은 아래를 유지:
+  - `padding: 16px`
+  - `border: 1px solid #e5e7eb`
+  - `border-radius: 8px`
+  - 섹션 간 간격 `margin-bottom: 24px`
+- 메인 탐색 링크는 섹션 `id` 앵커(`#...`)와 1:1로 맞춘다.
+
+## 5) 컴포넌트 컨벤션
+
+### 폼
+- 입력 컨트롤(`input`, `select`, `textarea`)은 기본적으로 `width: 100%`.
+- 레이블은 `.form-row > label` 패턴으로 필드 위에 배치.
+- 여러 필드 배치는 `.form-grid` 사용(반응형 `auto-fill + minmax` 유지).
+
+### 버튼
+- 기본 버튼 톤:
+  - 배경 `#f9fafb`
+  - 보더 `1px solid #d1d5db`
+  - `border-radius: 6px`
+- 상태:
+  - hover 시 배경 `#f3f4f6`
+  - disabled 시 `opacity: 0.7`, `cursor: not-allowed`
+- 비동기 처리 시 버튼 `disabled` + 텍스트 `"처리 중..."` 패턴 사용.
+
+### 메시지/피드백
+- 인라인 결과: `.message-box.success | .message-box.error`
+- 섹션 배너: `.banner.warn | .banner.error`
+- 전역 알림: `.toast.success | .toast.error` (3초 후 사라짐)
+- 화면 제어용 유틸:
+  - `.hidden { display: none !important; }`
+  - `.loading`(로딩 시 시각 피드백)
+
+### 테이블
+- 기본: `border-collapse: collapse; width: 100%`
+- 셀 보더/패딩: `1px solid #e5e7eb`, `8px`
+- 행 hover 배경: `#f9fafb`
+- 긴 ID는 `.id-cell` 패턴(ellipsis + title tooltip + 클릭 복사) 재사용.
+
+## 6) 상호작용/구현 컨벤션
+
+### 상태/인증
+- 토큰/유저 저장 키는 기존 키 유지:
+  - `devPortalToken`
+  - `devPortalUserId`
+- 로그인 여부에 따라 섹션 노출을 `classList.toggle('hidden', ...)`로 제어.
+
+### API 호출 패턴
+- 공통 `headers()` 함수에서 Authorization 헤더를 조립.
+- `fetch` 후:
+  - `res.ok` 분기
+  - `res.status === 403` 명시 처리(개발자 로그인 안내)
+  - `try/catch/finally`로 로딩/버튼 복구 보장
+
+### 네이밍
+- 버튼 id: `btn + 동사/기능` (`btnLoadDict`, `btnSave`)
+- 입력 id: `edit...`, `dict...`, `login...`처럼 도메인 접두어 사용.
+- 렌더 함수: `render...`
+- 로드 함수: `load...`
+
+## 7) 접근성/사용성 최소 기준
+- 모든 인터랙션 요소에 `:focus-visible` 아웃라인 유지 (`2px solid #2563eb`).
+- `label for`와 입력 `id`를 항상 연결.
+- 버튼은 항상 `type="button"` 또는 `type="submit"` 명시.
+- 새 창 링크는 `target="_blank"` 시 `rel="noopener"` 포함.
+
+## 8) 기능 추가 체크리스트
+- [ ] 새 기능을 기존 섹션 안에 넣을지, 새 `section`으로 분리할지 결정했다.
+- [ ] 새 `section`이면 헤더 내 앵커 링크를 추가하고 `id`를 일치시켰다.
+- [ ] 폼은 `.form-row`/`.form-grid` 패턴으로 구성했다.
+- [ ] 버튼/배너/메시지 박스는 기존 클래스(`.banner`, `.message-box`, `.toast`)를 재사용했다.
+- [ ] 비동기 액션마다 로딩/실패/성공 UI와 버튼 복구 처리를 넣었다.
+- [ ] 403/네트워크 오류를 사용자 메시지로 분리 처리했다.
+- [ ] 모바일 폭에서 레이아웃 깨짐 없이 동작하는지 확인했다.

--- a/backend/src/main/resources/static/dev/index.html
+++ b/backend/src/main/resources/static/dev/index.html
@@ -47,8 +47,11 @@
     #clubList tbody tr { cursor: pointer; }
     #clubList tbody tr:hover { background: #f9fafb; }
     #dictList tbody tr:hover { background: #f9fafb; }
+    #fcmTokenList tbody tr:hover { background: #f9fafb; }
     #dictList .btn-cell { white-space: nowrap; }
     #dictList .btn-cell button { margin: 0 4px; padding: 4px 10px; font-size: 0.85rem; }
+    #fcmTokenList .btn-cell { white-space: nowrap; }
+    #fcmTokenList .btn-cell button { margin: 0 4px; padding: 4px 10px; font-size: 0.85rem; }
     .hidden { display: none !important; }
     .loading { opacity: 0.7; pointer-events: none; }
     .banner { padding: 12px 16px; border-radius: 6px; margin-bottom: 12px; font-size: 0.9rem; }
@@ -76,6 +79,15 @@
     .section-head-actions { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
     .pagination { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; font-size: 0.9rem; }
     .pagination button { margin: 0; padding: 6px 12px; }
+    .token-cell {
+      font-family: monospace;
+      font-size: 0.82rem;
+      max-width: 420px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .token-cell[title] { cursor: pointer; }
     .toast { position: fixed; bottom: 24px; right: 24px; padding: 12px 20px; border-radius: 8px; font-size: 0.9rem; z-index: 20; box-shadow: 0 4px 12px rgba(0,0,0,0.15); animation: fadeOut 3s ease-in-out forwards; }
     .toast.success { background: #166534; color: #fff; }
     .toast.error { background: #dc2626; color: #fff; }
@@ -91,6 +103,7 @@
         <a href="#api-docs">API 문서</a>
         <a href="#club">동아리</a>
         <a href="#dict">단어사전</a>
+        <a href="#fcm">FCM 알림</a>
         <a href="#conversion-batch">이미지 변환 배치</a>
       </nav>
     </div>
@@ -214,6 +227,84 @@
       </div>
     </section>
 
+    <section id="fcm" class="hidden">
+      <div class="section-head">
+        <h2>FCM 알림 관리</h2>
+        <div class="section-head-actions">
+          <button type="button" id="btnLoadFcmTokens">토큰 조회</button>
+          <button type="button" id="btnClearFcmSelection">선택 초기화</button>
+        </div>
+      </div>
+      <div id="fcmBanner" class="banner hidden"></div>
+      <p class="sub" style="margin-bottom:8px;">1) 토큰을 조회해 선택한 뒤 개별 메시지를 보낼 수 있습니다. 2) 전체 토큰 대상으로 일괄 발송할 수 있습니다.</p>
+
+      <h3 style="font-size:1rem; margin-top:0; margin-bottom:8px;">토큰 조회</h3>
+      <div id="fcmTokenLoading" class="hidden">토큰 불러오는 중...</div>
+      <p id="fcmTokenSummary" class="sub" style="margin-top:0; margin-bottom:8px;">토큰 조회를 실행하세요.</p>
+      <div class="form-grid" style="margin-bottom:8px;">
+        <div class="form-row">
+          <label for="fcmTokenSearch">토큰 검색</label>
+          <input type="search" id="fcmTokenSearch" placeholder="토큰 일부를 입력하세요.">
+        </div>
+      </div>
+      <div id="fcmTokenPagination" class="pagination hidden" style="margin-bottom:8px;"></div>
+      <div class="table-wrap">
+        <table id="fcmTokenList">
+          <thead><tr><th>#</th><th>토큰</th><th>액션</th></tr></thead>
+          <tbody>
+            <tr><td colspan="3">토큰 조회를 실행하세요.</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h3 style="font-size:1rem; margin-top:24px; margin-bottom:8px;">개별 토큰 메시지 전송</h3>
+      <div class="form-row">
+        <label for="fcmSingleToken">대상 토큰</label>
+        <textarea id="fcmSingleToken" rows="3" placeholder="토큰 목록에서 선택하거나 직접 입력하세요." style="max-width:100%; font-family:monospace; font-size:0.85rem;"></textarea>
+      </div>
+      <div class="form-grid">
+        <div class="form-row">
+          <label for="fcmSingleTitle">제목</label>
+          <input type="text" id="fcmSingleTitle" placeholder="알림 제목">
+        </div>
+        <div class="form-row">
+          <label for="fcmSingleBody">본문</label>
+          <input type="text" id="fcmSingleBody" placeholder="알림 내용">
+        </div>
+      </div>
+      <div class="form-row">
+        <label for="fcmSingleData">data (JSON 객체, 선택)</label>
+        <textarea id="fcmSingleData" rows="4" placeholder='{"screen":"club","clubId":"123"}' style="max-width:100%; font-family:monospace; font-size:0.9rem;"></textarea>
+      </div>
+      <button type="button" id="btnFcmSendSingle">개별 메시지 전송</button>
+      <div id="fcmSingleResult" class="message-box hidden"></div>
+
+      <h3 style="font-size:1rem; margin-top:24px; margin-bottom:8px;">전체 메시지 전송</h3>
+      <div class="form-grid">
+        <div class="form-row">
+          <label for="fcmBatchTitle">제목</label>
+          <input type="text" id="fcmBatchTitle" placeholder="알림 제목">
+        </div>
+        <div class="form-row">
+          <label for="fcmBatchBody">본문</label>
+          <input type="text" id="fcmBatchBody" placeholder="알림 내용">
+        </div>
+      </div>
+      <div class="form-row">
+        <label for="fcmBatchData">data (JSON 객체, 선택)</label>
+        <textarea id="fcmBatchData" rows="4" placeholder='{"type":"admin","scope":"all"}' style="max-width:100%; font-family:monospace; font-size:0.9rem;"></textarea>
+      </div>
+      <button type="button" id="btnFcmSendAll">전체 메시지 전송</button>
+      <div id="fcmBatchResult" class="message-box hidden"></div>
+
+      <div class="card-grid" style="margin-top:16px;">
+        <a href="/swagger-ui.html#/Fcm_Notification_Admin" target="_blank" rel="noopener" class="card">
+          <strong>FCM Notification Admin API</strong>
+          <span>토큰 조회, 단건 전송, 전체 배치 전송</span>
+        </a>
+      </div>
+    </section>
+
     <section id="conversion-batch" class="hidden">
       <h2>이미지 변환 배치 (전체 동아리)</h2>
       <p class="sub">source → destination 이미지 URL을 모든 동아리의 로고/커버/피드 이미지에서 일괄 갱신합니다. event=batch.completed, images 배열 필수.</p>
@@ -236,6 +327,10 @@
   <script>
     const API_BASE = '';
     const PAGE_SIZE = 50;
+    const FCM_PAGE_SIZE = 20;
+    let fcmTokens = [];
+    let fcmFilteredTokens = [];
+    let fcmCurrentPage = 1;
 
     function getToken() { return sessionStorage.getItem('devPortalToken') || ''; }
     function setToken(t) { sessionStorage.setItem('devPortalToken', t); }
@@ -264,6 +359,7 @@
       document.getElementById('tokenArea').classList.toggle('hidden', !show);
       document.getElementById('club').classList.toggle('hidden', !show);
       document.getElementById('dict').classList.toggle('hidden', !show);
+      document.getElementById('fcm').classList.toggle('hidden', !show);
       document.getElementById('conversion-batch').classList.toggle('hidden', !show);
       const headerStatus = document.getElementById('headerStatus');
       const headerUserId = document.getElementById('headerUserId');
@@ -306,6 +402,7 @@
           showLogin(true);
           loadClubsIfVisible();
           loadDictIfVisible();
+          loadFcmTokensIfVisible();
         } else {
           errEl.textContent = '토큰 없음';
           errEl.classList.remove('hidden');
@@ -338,6 +435,7 @@
       document.getElementById('clubBanner').classList.add('hidden');
       document.getElementById('dictList').querySelector('tbody').innerHTML = '';
       document.getElementById('dictBanner').classList.add('hidden');
+      clearFcmState();
     }
 
     function openEditWindow(clubId) {
@@ -351,6 +449,7 @@
       showLogin(true);
       loadClubsIfVisible();
       loadDictIfVisible();
+      loadFcmTokensIfVisible();
     }
 
     let allClubs = [];
@@ -657,6 +756,347 @@
         showToast(e.message || '요청 실패', 'error');
       }
     }
+
+    async function readJsonOrEmpty(res) {
+      try {
+        return await res.json();
+      } catch (_) {
+        return {};
+      }
+    }
+
+    function setMessageBox(elId, ok, message) {
+      const el = document.getElementById(elId);
+      el.textContent = message;
+      el.className = 'message-box ' + (ok ? 'success' : 'error');
+      el.classList.remove('hidden');
+    }
+
+    function truncateMiddle(value, left, right) {
+      if (!value) return '';
+      if (value.length <= (left + right + 1)) return value;
+      return value.slice(0, left) + '…' + value.slice(value.length - right);
+    }
+
+    function parseFcmDataMap(raw, fieldName) {
+      const text = (raw || '').trim();
+      if (!text) return {};
+      let parsed;
+      try {
+        parsed = JSON.parse(text);
+      } catch (_) {
+        throw new Error(fieldName + '는 JSON 객체 형식이어야 합니다.');
+      }
+      if (!parsed || Array.isArray(parsed) || typeof parsed !== 'object') {
+        throw new Error(fieldName + '는 JSON 객체 형식이어야 합니다.');
+      }
+      const mapped = {};
+      for (const [key, value] of Object.entries(parsed)) {
+        if (!String(key).trim()) {
+          throw new Error(fieldName + ' key는 비어 있을 수 없습니다.');
+        }
+        if (value !== null && typeof value === 'object') {
+          throw new Error(fieldName + ' 값은 문자열/숫자/불리언만 허용됩니다.');
+        }
+        mapped[String(key)] = value == null ? '' : String(value);
+      }
+      return mapped;
+    }
+
+    function renderFcmTokenRows(tokens, page) {
+      const tbody = document.querySelector('#fcmTokenList tbody');
+      tbody.innerHTML = '';
+      if (!tokens.length) {
+        tbody.innerHTML = '<tr><td colspan="3">조회된 토큰이 없습니다.</td></tr>';
+        return;
+      }
+      const start = (page - 1) * FCM_PAGE_SIZE;
+      const slice = tokens.slice(start, start + FCM_PAGE_SIZE);
+      slice.forEach((token, idx) => {
+        const tr = document.createElement('tr');
+        tr.appendChild(document.createElement('td')).textContent = String(start + idx + 1);
+        const tokenCell = document.createElement('td');
+        tokenCell.className = 'token-cell';
+        tokenCell.title = token;
+        tokenCell.textContent = truncateMiddle(token, 20, 16);
+        tokenCell.onclick = () => {
+          navigator.clipboard.writeText(token);
+          showToast('토큰 복사됨', 'success');
+        };
+        tr.appendChild(tokenCell);
+        const btnCell = document.createElement('td');
+        btnCell.className = 'btn-cell';
+        const pickBtn = document.createElement('button');
+        pickBtn.type = 'button';
+        pickBtn.textContent = '선택';
+        pickBtn.onclick = () => {
+          document.getElementById('fcmSingleToken').value = token;
+          showToast('단건 발송 대상 토큰으로 선택됨', 'success');
+        };
+        const copyBtn = document.createElement('button');
+        copyBtn.type = 'button';
+        copyBtn.textContent = '복사';
+        copyBtn.onclick = () => {
+          navigator.clipboard.writeText(token);
+          showToast('토큰 복사됨', 'success');
+        };
+        btnCell.appendChild(pickBtn);
+        btnCell.appendChild(copyBtn);
+        tr.appendChild(btnCell);
+        tbody.appendChild(tr);
+      });
+    }
+
+    function renderFcmTokenPagination(total) {
+      const wrap = document.getElementById('fcmTokenPagination');
+      if (total <= FCM_PAGE_SIZE) {
+        wrap.classList.add('hidden');
+        wrap.innerHTML = '';
+        return;
+      }
+      wrap.classList.remove('hidden');
+      const totalPages = Math.ceil(total / FCM_PAGE_SIZE);
+      let html = '<span>총 ' + total + '개</span>';
+      if (fcmCurrentPage > 1) html += '<button type="button" id="fcmPrev">이전</button>';
+      html += '<span> ' + fcmCurrentPage + ' / ' + totalPages + ' </span>';
+      if (fcmCurrentPage < totalPages) html += '<button type="button" id="fcmNext">다음</button>';
+      wrap.innerHTML = html;
+      const prev = document.getElementById('fcmPrev');
+      const next = document.getElementById('fcmNext');
+      if (prev) prev.onclick = () => {
+        fcmCurrentPage--;
+        renderFcmTokenRows(fcmFilteredTokens, fcmCurrentPage);
+        renderFcmTokenPagination(fcmFilteredTokens.length);
+      };
+      if (next) next.onclick = () => {
+        fcmCurrentPage++;
+        renderFcmTokenRows(fcmFilteredTokens, fcmCurrentPage);
+        renderFcmTokenPagination(fcmFilteredTokens.length);
+      };
+    }
+
+    function updateFcmTokenSummary() {
+      const summary = document.getElementById('fcmTokenSummary');
+      const keyword = document.getElementById('fcmTokenSearch').value.trim();
+      if (!fcmTokens.length) {
+        summary.textContent = '조회된 토큰이 없습니다.';
+        return;
+      }
+      if (!keyword) {
+        summary.textContent = '총 ' + fcmTokens.length + '개 토큰';
+        return;
+      }
+      summary.textContent = '총 ' + fcmTokens.length + '개 중 ' + fcmFilteredTokens.length + '개 검색 결과';
+    }
+
+    function applyFcmTokenFilter(resetPage) {
+      if (resetPage) fcmCurrentPage = 1;
+      const keyword = document.getElementById('fcmTokenSearch').value.trim().toLowerCase();
+      fcmFilteredTokens = !keyword
+              ? fcmTokens.slice()
+              : fcmTokens.filter(token => String(token).toLowerCase().includes(keyword));
+      updateFcmTokenSummary();
+      renderFcmTokenRows(fcmFilteredTokens, fcmCurrentPage);
+      renderFcmTokenPagination(fcmFilteredTokens.length);
+    }
+
+    function clearFcmState() {
+      fcmTokens = [];
+      fcmFilteredTokens = [];
+      fcmCurrentPage = 1;
+      document.getElementById('fcmTokenSearch').value = '';
+      document.getElementById('fcmSingleToken').value = '';
+      document.getElementById('fcmSingleTitle').value = '';
+      document.getElementById('fcmSingleBody').value = '';
+      document.getElementById('fcmSingleData').value = '';
+      document.getElementById('fcmBatchTitle').value = '';
+      document.getElementById('fcmBatchBody').value = '';
+      document.getElementById('fcmBatchData').value = '';
+      document.getElementById('fcmSingleResult').classList.add('hidden');
+      document.getElementById('fcmBatchResult').classList.add('hidden');
+      const banner = document.getElementById('fcmBanner');
+      banner.textContent = '';
+      banner.className = 'banner hidden';
+      document.getElementById('fcmTokenSummary').textContent = '토큰 조회를 실행하세요.';
+      document.getElementById('fcmTokenPagination').classList.add('hidden');
+      document.getElementById('fcmTokenPagination').innerHTML = '';
+      document.querySelector('#fcmTokenList tbody').innerHTML = '<tr><td colspan="3">토큰 조회를 실행하세요.</td></tr>';
+    }
+
+    function loadFcmTokensIfVisible() {
+      const section = document.getElementById('fcm');
+      if (section && !section.classList.contains('hidden') && !fcmTokens.length) {
+        document.getElementById('btnLoadFcmTokens').click();
+      }
+    }
+
+    document.getElementById('btnClearFcmSelection').onclick = () => {
+      document.getElementById('fcmSingleToken').value = '';
+      document.getElementById('fcmSingleResult').classList.add('hidden');
+      showToast('단건 발송 대상 토큰이 초기화되었습니다', 'success');
+    };
+
+    document.getElementById('fcmTokenSearch').addEventListener('input', () => {
+      applyFcmTokenFilter(true);
+    });
+
+    document.getElementById('btnLoadFcmTokens').onclick = async () => {
+      const btn = document.getElementById('btnLoadFcmTokens');
+      const banner = document.getElementById('fcmBanner');
+      const summary = document.getElementById('fcmTokenSummary');
+      const loading = document.getElementById('fcmTokenLoading');
+      banner.className = 'banner hidden';
+      banner.textContent = '';
+      summary.textContent = '토큰 불러오는 중...';
+      loading.classList.remove('hidden');
+      btn.disabled = true;
+      btn.textContent = '처리 중...';
+      try {
+        const res = await fetch(API_BASE + '/api/admin/tokens', { headers: headers() });
+        if (res.status === 403) {
+          banner.textContent = '개발자 계정으로 로그인하세요.';
+          banner.className = 'banner warn';
+          banner.classList.remove('hidden');
+          fcmTokens = [];
+          applyFcmTokenFilter(true);
+          summary.textContent = '권한이 없습니다.';
+          return;
+        }
+        const data = await readJsonOrEmpty(res);
+        if (!res.ok) {
+          banner.textContent = data.message || '토큰 조회 실패 (HTTP ' + res.status + ')';
+          banner.className = 'banner error';
+          banner.classList.remove('hidden');
+          fcmTokens = [];
+          applyFcmTokenFilter(true);
+          summary.textContent = '토큰 조회에 실패했습니다.';
+          return;
+        }
+        fcmTokens = data.data?.tokens || [];
+        applyFcmTokenFilter(true);
+        if (!fcmTokens.length) {
+          banner.textContent = '저장된 토큰이 없습니다.';
+          banner.className = 'banner warn';
+          banner.classList.remove('hidden');
+          return;
+        }
+        showToast('토큰 ' + fcmTokens.length + '개를 조회했습니다', 'success');
+      } catch (e) {
+        banner.textContent = '요청 실패: ' + (e.message || '');
+        banner.className = 'banner error';
+        banner.classList.remove('hidden');
+        fcmTokens = [];
+        applyFcmTokenFilter(true);
+        summary.textContent = '토큰 조회에 실패했습니다.';
+      } finally {
+        loading.classList.add('hidden');
+        btn.disabled = false;
+        btn.textContent = '토큰 조회';
+      }
+    };
+
+    document.getElementById('btnFcmSendSingle').onclick = async () => {
+      const token = document.getElementById('fcmSingleToken').value.trim();
+      const title = document.getElementById('fcmSingleTitle').value.trim();
+      const body = document.getElementById('fcmSingleBody').value.trim();
+      let data;
+      try {
+        data = parseFcmDataMap(document.getElementById('fcmSingleData').value, '단건 data');
+      } catch (e) {
+        setMessageBox('fcmSingleResult', false, e.message || 'data 형식이 올바르지 않습니다.');
+        return;
+      }
+      if (!token) {
+        setMessageBox('fcmSingleResult', false, '대상 토큰을 입력하거나 목록에서 선택하세요.');
+        return;
+      }
+      if (!title || !body) {
+        setMessageBox('fcmSingleResult', false, '제목과 본문을 모두 입력하세요.');
+        return;
+      }
+
+      const btn = document.getElementById('btnFcmSendSingle');
+      document.getElementById('fcmSingleResult').classList.add('hidden');
+      btn.disabled = true;
+      btn.textContent = '처리 중...';
+      try {
+        const res = await fetch(API_BASE + '/api/admin/fcm/send', {
+          method: 'POST',
+          headers: headers(),
+          body: JSON.stringify({ token, title, body, data })
+        });
+        const response = await readJsonOrEmpty(res);
+        if (res.status === 403) {
+          setMessageBox('fcmSingleResult', false, '개발자 계정으로 로그인하세요.');
+          return;
+        }
+        if (!res.ok) {
+          setMessageBox('fcmSingleResult', false, response.message || 'FCM 단건 발송 실패 (HTTP ' + res.status + ')');
+          return;
+        }
+        const messageId = response.data?.messageId || '-';
+        setMessageBox('fcmSingleResult', true, (response.message || 'FCM 단건 발송 완료') + ' (messageId: ' + messageId + ')');
+        showToast('개별 메시지 전송 완료', 'success');
+      } catch (e) {
+        setMessageBox('fcmSingleResult', false, e.message || '요청 실패');
+      } finally {
+        btn.disabled = false;
+        btn.textContent = '개별 메시지 전송';
+      }
+    };
+
+    document.getElementById('btnFcmSendAll').onclick = async () => {
+      const title = document.getElementById('fcmBatchTitle').value.trim();
+      const body = document.getElementById('fcmBatchBody').value.trim();
+      let data;
+      try {
+        data = parseFcmDataMap(document.getElementById('fcmBatchData').value, '전체 data');
+      } catch (e) {
+        setMessageBox('fcmBatchResult', false, e.message || 'data 형식이 올바르지 않습니다.');
+        return;
+      }
+      if (!title || !body) {
+        setMessageBox('fcmBatchResult', false, '제목과 본문을 모두 입력하세요.');
+        return;
+      }
+
+      const btn = document.getElementById('btnFcmSendAll');
+      document.getElementById('fcmBatchResult').classList.add('hidden');
+      btn.disabled = true;
+      btn.textContent = '처리 중...';
+      try {
+        const res = await fetch(API_BASE + '/api/admin/fcm/send-all', {
+          method: 'POST',
+          headers: headers(),
+          body: JSON.stringify({ title, body, data })
+        });
+        const response = await readJsonOrEmpty(res);
+        if (res.status === 403) {
+          setMessageBox('fcmBatchResult', false, '개발자 계정으로 로그인하세요.');
+          return;
+        }
+        if (!res.ok) {
+          setMessageBox('fcmBatchResult', false, response.message || 'FCM 전체 배치 발송 실패 (HTTP ' + res.status + ')');
+          return;
+        }
+        const result = response.data || {};
+        const total = result.totalTokenCount ?? 0;
+        const success = result.successCount ?? 0;
+        const failure = result.failureCount ?? 0;
+        let detail = '총 ' + total + '건, 성공 ' + success + ', 실패 ' + failure;
+        if (Array.isArray(result.failedTokens) && result.failedTokens.length) {
+          const sample = result.failedTokens.slice(0, 2).map(t => truncateMiddle(t, 10, 6)).join(', ');
+          detail += ', 실패 토큰 샘플: ' + sample;
+        }
+        setMessageBox('fcmBatchResult', true, (response.message || 'FCM 전체 배치 발송 완료') + ' - ' + detail);
+        showToast('전체 메시지 전송 완료', 'success');
+      } catch (e) {
+        setMessageBox('fcmBatchResult', false, e.message || '요청 실패');
+      } finally {
+        btn.disabled = false;
+        btn.textContent = '전체 메시지 전송';
+      }
+    };
 
     document.getElementById('btnConversionBatch').onclick = async () => {
       const text = document.getElementById('conversionImagesJson').value.trim();

--- a/backend/src/test/java/moadong/fcm/adapter/FirebasePushNotificationAdapterTest.java
+++ b/backend/src/test/java/moadong/fcm/adapter/FirebasePushNotificationAdapterTest.java
@@ -3,6 +3,7 @@ package moadong.fcm.adapter;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.Message;
 import moadong.fcm.model.PushPayload;
+import moadong.fcm.model.TokenPushResult;
 import moadong.util.annotations.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -35,9 +36,9 @@ class FirebasePushNotificationAdapterTest {
 
         when(firebaseMessaging.send(any(Message.class))).thenReturn("message-id");
 
-        boolean result = adapter.send(payload);
+        TokenPushResult result = adapter.send(payload);
 
-        assertThat(result).isTrue();
+        assertThat(result.success()).isTrue();
         verify(firebaseMessaging).send(any(Message.class));
     }
 
@@ -52,8 +53,8 @@ class FirebasePushNotificationAdapterTest {
 
         when(firebaseMessaging.send(any(Message.class))).thenThrow(new RuntimeException("send failed"));
 
-        boolean result = adapter.send(payload);
+        TokenPushResult result = adapter.send(payload);
 
-        assertThat(result).isFalse();
+        assertThat(result.success()).isFalse();
     }
 }


### PR DESCRIPTION
> 🚀 릴리즈 PR인 경우 [**릴리즈 템플릿으로 전환**](?template=release.md)해 주세요. _(Preview 탭에서 클릭)_

## #️⃣연관된 이슈

- #1304

## 📝작업 내용

- 개발자 포털에 `FCM 알림` 섹션 추가  
- 기능 구현: `토큰 조회` → `개별 전송`, `전체 전송`  
- API 연동: `/api/admin/tokens`, `/api/admin/fcm/send`, `/api/admin/fcm/send-all`  
- 토큰 목록 개선: 검색 가능 + 20개씩 페이지네이션  
- 로그인/403/로딩/성공·실패 메시지 처리, 로그아웃 시 FCM 상태 초기화 완료  
- 수정 파일: [src/main/resources/static/dev/index.html]

## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * FCM 관리자 API 추가 - 개별 및 일괄 푸시 알림 전송 기능 지원
  * FCM 토큰 관리 및 메시지 발송을 위한 관리자 대시보드 UI 추가
  * 푸시 알림 결과 응답 강화 - 전송 상태, 메시지 ID, 실패 토큰 목록 포함

* **문서**
  * 개발자 페이지 컨벤션 및 디자인 가이드 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->