### PR TITLE
[feature] 동소한 팝업 제거 및 앱다운로드 팝업 추가

### DIFF
--- a/frontend/src/pages/MainPage/components/Banner/bannerData.ts
+++ b/frontend/src/pages/MainPage/components/Banner/bannerData.ts
@@ -17,20 +17,6 @@ interface BannerItem {
 
 const BANNERS: BannerItem[] = [
   {
-    id: '2026-club-fair',
-    desktopImage: ClubFairDesktopImage,
-    mobileImage: ClubFairMobileImage,
-    linkTo: '/festival-introduction',
-    alt: '2026 동아리 소개 한마당 홍보',
-  },
-  {
-    id: 'app-release-december-2025',
-    desktopImage: AppReleaseDesktopImage,
-    mobileImage: AppReleaseMobileImage,
-    linkTo: 'APP_STORE_LINK',
-    alt: '앱 다운로드 배너',
-  },
-  {
     id: 'all-clubs-in-one-place',
     desktopImage: AllClubsDesktopImage,
     mobileImage: AllClubsMobileImage,
@@ -43,6 +29,13 @@ const BANNERS: BannerItem[] = [
     mobileImage: StartNowMobileImage,
     linkTo: '/introduce',
     alt: '지금 바로 모아동에서 시작하세요',
+  },
+  {
+    id: 'app-release-december-2025',
+    desktopImage: AppReleaseDesktopImage,
+    mobileImage: AppReleaseMobileImage,
+    linkTo: 'APP_STORE_LINK',
+    alt: '앱 다운로드 배너',
   },
 ];
 

--- a/frontend/src/pages/MainPage/components/Filter/Filter.tsx
+++ b/frontend/src/pages/MainPage/components/Filter/Filter.tsx
@@ -34,9 +34,6 @@ const Filter = ({ alwaysVisible = false }: FilterProps) => {
         <Styled.FilterListContainer>
           {FILTER_OPTIONS.map((filter) => (
             <Styled.FilterButtonWrapper key={filter.path}>
-              <Styled.NotificationDot
-                $isVisible={filter.path === FESTIVAL_PATH}
-              />
               <Styled.FilterButton
                 $isActive={pathname === filter.path}
                 onClick={() => handleFilterOptionClick(filter.path)}

--- a/frontend/src/pages/MainPage/components/Popup/Popup.tsx
+++ b/frontend/src/pages/MainPage/components/Popup/Popup.tsx
@@ -1,7 +1,6 @@
 import { MouseEvent, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import AppDownloadImage from '@/assets/images/popup/app-download.png';
-import FestivalImage from '@/assets/images/popup/festival.png';
 import { USER_EVENT } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import useDevice from '@/hooks/useDevice';
@@ -24,7 +23,6 @@ export const isPopupHidden = (): boolean => {
 };
 
 const Popup = () => {
-  const navigate = useNavigate();
   const [isOpen, setIsOpen] = useState(false);
   const [imageLoaded, setImageLoaded] = useState(false);
   const { isMobile } = useDevice();
@@ -32,7 +30,7 @@ const Popup = () => {
 
   useEffect(() => {
     const img = new Image();
-    img.src = FestivalImage;
+    img.src = AppDownloadImage;
     img.onload = () => setImageLoaded(true);
     img.onerror = () => setImageLoaded(true);
   }, []);
@@ -92,13 +90,6 @@ const Popup = () => {
     window.open(storeLink, '_blank');
   };
 
-  const handleFestival = () => {
-    trackEvent(USER_EVENT.FESTIVAL_POPUP_CLICKED, {
-      popupType: 'festival',
-    });
-    navigate('/festival-introduction');
-  };
-
   const handleBackdropClick = (e: MouseEvent<HTMLDivElement>) => {
     if (e.target === e.currentTarget) {
       handleClose('backdrop_click');
@@ -118,8 +109,8 @@ const Popup = () => {
         onClick={(e: MouseEvent<HTMLDivElement>) => e.stopPropagation()}
       >
         <Styled.Container>
-          <Styled.ImageWrapper onClick={handleFestival}>
-            <Styled.PopupImage src={FestivalImage} alt='동소한' />
+          <Styled.ImageWrapper onClick={handleDownload}>
+            <Styled.PopupImage src={AppDownloadImage} alt='앱 다운로드' />
           </Styled.ImageWrapper>
 
           <Styled.ButtonGroup>


### PR DESCRIPTION
> 🚀 릴리즈 PR인 경우 [**릴리즈 템플릿으로 전환**](?template=release.md)해 주세요. _(Preview 탭에서 클릭)_

## #️⃣연관된 이슈

> ex) #1319 

## 📝작업 내용

- 3월5일에 진행된 동아리소개한마당을 위한 팝업을 제거하고 앱 다운로드 팝업을  다시 추가했습니다.
- 동소한 배너도 제거했습니다.
- 동소한 필터칩에 뜨는 알림표시를 제거했습니다.

## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 팝업 인터페이스가 앱 다운로드 플로우로 변경되었습니다. 팝업 이미지 클릭 시 앱 다운로드 페이지로 이동하며, 팝업의 이미지와 텍스트도 앱 다운로드에 맞게 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->