### PR TITLE
[feature] 배너이미지 관리자 페이지 추가

### DIFF
--- a/backend/src/main/java/moadong/media/controller/BannerImagesController.java
+++ b/backend/src/main/java/moadong/media/controller/BannerImagesController.java
@@ -5,14 +5,18 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import moadong.global.payload.Response;
+import moadong.media.dto.BannerImageUploadResponse;
 import moadong.media.dto.BannerImagesRequest;
 import moadong.media.dto.BannerImagesResponse;
 import moadong.media.enums.PlatformType;
+import moadong.media.service.BannerImageUploadService;
 import moadong.media.service.BannerImagesService;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/banner")
@@ -21,6 +25,7 @@ import org.springframework.web.bind.annotation.*;
 public class BannerImagesController {
 
     private final BannerImagesService bannerImagesService;
+    private final BannerImageUploadService bannerImageUploadService;
 
     @PutMapping
     @PreAuthorize("hasRole('DEVELOPER')")
@@ -36,5 +41,15 @@ public class BannerImagesController {
     public ResponseEntity<?> getBannerImages(@RequestParam(value = "type", required = false, defaultValue = "WEB") PlatformType type) {
         BannerImagesResponse response = bannerImagesService.getBannerImages(type);
         return Response.ok(response);
+    }
+
+    @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PreAuthorize("hasRole('DEVELOPER')")
+    @SecurityRequirement(name = "BearerAuth")
+    @Operation(summary = "배너 이미지 업로드", description = "배너 이미지를 Cloudflare R2 배너 버킷에 업로드하고 최종 URL을 반환합니다.")
+    public ResponseEntity<?> uploadBannerImage(@RequestPart("file") MultipartFile file,
+                                               @RequestParam("type") PlatformType type) {
+        BannerImageUploadResponse response = bannerImageUploadService.upload(file, type);
+        return Response.ok("배너 이미지가 업로드되었습니다.", response);
     }
 }

--- a/backend/src/main/java/moadong/media/dto/BannerImageUploadResponse.java
+++ b/backend/src/main/java/moadong/media/dto/BannerImageUploadResponse.java
@@ -1,0 +1,6 @@
+package moadong.media.dto;
+
+public record BannerImageUploadResponse(
+    String imageUrl
+) {
+}

--- a/backend/src/main/java/moadong/media/service/BannerImageUploadService.java
+++ b/backend/src/main/java/moadong/media/service/BannerImageUploadService.java
@@ -1,0 +1,128 @@
+package moadong.media.service;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import moadong.global.exception.ErrorCode;
+import moadong.global.exception.RestApiException;
+import moadong.media.dto.BannerImageUploadResponse;
+import moadong.media.enums.PlatformType;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Locale;
+
+import static moadong.media.util.ClubImageUtil.isImageExtension;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BannerImageUploadService {
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bannerbucket}")
+    private String bannerBucketName;
+
+    @Value("${cloud.aws.s3.banner-view-endpoint}")
+    private String bannerViewEndpoint;
+
+    @Value("${server.image.max-size}")
+    private long maxImageSizeBytes;
+
+    private String normalizedViewEndpoint;
+
+    @PostConstruct
+    private void init() {
+        if (!StringUtils.hasText(bannerBucketName)) {
+            throw new IllegalStateException("cloud.aws.s3.bannerbucket must be configured");
+        }
+        if (!StringUtils.hasText(bannerViewEndpoint)) {
+            throw new IllegalStateException("cloud.aws.s3.banner-view-endpoint must be configured");
+        }
+        normalizedViewEndpoint = bannerViewEndpoint.replaceAll("/+$", "");
+    }
+
+    public BannerImageUploadResponse upload(MultipartFile file, PlatformType type) {
+        validateFile(file);
+
+        String originalFilename = extractFileName(file);
+        String extension = getFileExtension(originalFilename);
+        String contentType = resolveContentType(file.getContentType(), extension);
+        String key = type.name().toLowerCase(Locale.ROOT) + "/" + originalFilename;
+
+        PutObjectRequest request = PutObjectRequest.builder()
+            .bucket(bannerBucketName)
+            .key(key)
+            .contentType(contentType)
+            .build();
+
+        try (InputStream inputStream = file.getInputStream()) {
+            s3Client.putObject(request, RequestBody.fromInputStream(inputStream, file.getSize()));
+            return new BannerImageUploadResponse(normalizedViewEndpoint + "/" + key);
+        } catch (IOException | S3Exception e) {
+            log.error("Failed to upload banner image: bucket={}, key={}", bannerBucketName, key, e);
+            throw new RestApiException(ErrorCode.IMAGE_UPLOAD_FAILED);
+        }
+    }
+
+    private void validateFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new RestApiException(ErrorCode.FILE_NOT_FOUND);
+        }
+
+        String originalFilename = extractFileName(file);
+        if (!isImageExtension(originalFilename)) {
+            throw new RestApiException(ErrorCode.UNSUPPORTED_FILE_TYPE);
+        }
+
+        if (file.getSize() > maxImageSizeBytes) {
+            throw new RestApiException(ErrorCode.FILE_TOO_LARGE);
+        }
+
+        String contentType = file.getContentType();
+        if (StringUtils.hasText(contentType) && !contentType.matches("^image/(jpeg|jpg|png|gif|bmp|webp)$")) {
+            throw new RestApiException(ErrorCode.UNSUPPORTED_FILE_TYPE);
+        }
+    }
+
+    private String extractFileName(MultipartFile file) {
+        String cleanedPath = StringUtils.cleanPath(file.getOriginalFilename() == null ? "" : file.getOriginalFilename());
+        String fileName = StringUtils.getFilename(cleanedPath);
+        if (!StringUtils.hasText(fileName)) {
+            throw new RestApiException(ErrorCode.FILE_NOT_FOUND);
+        }
+        return fileName;
+    }
+
+    private String getFileExtension(String fileName) {
+        String extension = StringUtils.getFilenameExtension(fileName);
+        if (!StringUtils.hasText(extension)) {
+            throw new RestApiException(ErrorCode.UNSUPPORTED_FILE_TYPE);
+        }
+        return "." + extension.toLowerCase();
+    }
+
+    private String resolveContentType(String rawContentType, String extension) {
+        if (StringUtils.hasText(rawContentType)) {
+            return "image/jpg".equalsIgnoreCase(rawContentType) ? "image/jpeg" : rawContentType;
+        }
+
+        return switch (extension) {
+            case ".jpg", ".jpeg" -> "image/jpeg";
+            case ".png" -> "image/png";
+            case ".gif" -> "image/gif";
+            case ".bmp" -> "image/bmp";
+            case ".webp" -> "image/webp";
+            default -> throw new RestApiException(ErrorCode.UNSUPPORTED_FILE_TYPE);
+        };
+    }
+}

--- a/backend/src/main/resources/static/dev/index.html
+++ b/backend/src/main/resources/static/dev/index.html
@@ -255,7 +255,7 @@
         </div>
       </div>
       <div id="bannerBanner" class="banner hidden"></div>
-      <p class="sub" style="margin-bottom:12px;">타입별 배너 배열을 조회하고 수정할 수 있습니다. 각 항목의 위/아래 버튼으로 순서를 변경하세요.</p>
+      <p class="sub" style="margin-bottom:12px;">타입별 배너 배열을 조회하고 수정할 수 있습니다. 이미지를 업로드하면 현재 배열에 바로 추가되고, 각 항목의 위/아래 버튼으로 순서를 변경할 수 있습니다.</p>
       <div class="form-grid" style="margin-bottom:8px;">
         <div class="form-row">
           <label for="bannerType">배너 타입</label>
@@ -265,13 +265,20 @@
             <option value="WEB_MOBILE">WEB_MOBILE</option>
           </select>
         </div>
+        <div>
+          <div class="form-row">
+            <label for="bannerUploadFile">배너 이미지 업로드</label>
+            <input type="file" id="bannerUploadFile" accept="image/jpeg,image/png,image/gif,image/bmp,image/webp">
+          </div>
+          <button type="button" id="btnUploadBannerImage">업로드 후 배열에 추가</button>
+        </div>
       </div>
       <div class="banner-toolbar">
         <p id="bannerSummary" class="banner-summary">WEB 타입 목록을 불러오세요.</p>
         <button type="button" id="btnAddBannerItem">배너 추가</button>
       </div>
       <div id="bannerListLoading" class="hidden">목록 불러오는 중...</div>
-      <div id="bannerEmpty" class="banner-empty hidden">저장된 배너가 없습니다. 새 배너를 추가하거나 다른 타입을 선택해 보세요.</div>
+      <div id="bannerEmpty" class="banner-empty hidden">저장된 배너가 없습니다. 새 배너를 추가하거나 이미지를 업로드해 보세요.</div>
       <div id="bannerList" class="banner-editor-list"></div>
       <div id="bannerSaveResult" class="message-box hidden"></div>
       <div class="card-grid" style="margin-top:16px;">
@@ -393,6 +400,7 @@
     let bannerHasLoaded = false;
     let bannerIsLoading = false;
     let bannerIsSaving = false;
+    let bannerIsUploading = false;
 
     function getToken() { return sessionStorage.getItem('devPortalToken') || ''; }
     function setToken(t) { sessionStorage.setItem('devPortalToken', t); }
@@ -850,17 +858,20 @@
     }
 
     function updateBannerControls() {
-      document.getElementById('bannerType').disabled = bannerIsLoading || bannerIsSaving;
-      document.getElementById('btnLoadBanner').disabled = bannerIsLoading || bannerIsSaving;
-      document.getElementById('btnAddBannerItem').disabled = bannerIsLoading || bannerIsSaving;
-      document.getElementById('btnSaveBanner').disabled = bannerIsLoading || bannerIsSaving || !bannerHasLoaded;
+      const busy = bannerIsLoading || bannerIsSaving || bannerIsUploading;
+      document.getElementById('bannerType').disabled = busy;
+      document.getElementById('bannerUploadFile').disabled = busy;
+      document.getElementById('btnUploadBannerImage').disabled = busy;
+      document.getElementById('btnLoadBanner').disabled = busy;
+      document.getElementById('btnAddBannerItem').disabled = busy;
+      document.getElementById('btnSaveBanner').disabled = busy || !bannerHasLoaded;
     }
 
     function updateBannerSummary() {
       const summary = document.getElementById('bannerSummary');
       let text = bannerActiveType + ' 타입';
       if (!bannerHasLoaded && !bannerImages.length) {
-        text += ' 목록을 불러오거나 새 배너를 추가하세요.';
+        text += ' 목록을 불러오거나 새 배너를 추가/업로드하세요.';
       } else {
         text += ' 총 ' + bannerImages.length + '개';
       }
@@ -888,6 +899,27 @@
         if (!alt) throw new Error((index + 1) + '번째 배너의 alt를 입력하세요.');
         return { id, imageUrl, linkTo: linkTo || null, alt };
       });
+    }
+
+    function buildBannerUploadHeaders() {
+      const token = getToken();
+      return token ? { 'Authorization': 'Bearer ' + token } : {};
+    }
+
+    function createBannerItemFromUpload(fileName, imageUrl) {
+      const baseName = String(fileName || '')
+        .replace(/\.[^.]+$/, '')
+        .trim();
+      const idCandidate = baseName
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+      return {
+        id: idCandidate || 'banner-' + Date.now(),
+        imageUrl,
+        linkTo: '',
+        alt: baseName || '배너 이미지'
+      };
     }
 
     function moveBannerItem(fromIndex, toIndex) {
@@ -1085,7 +1117,9 @@
       bannerHasLoaded = false;
       bannerIsLoading = false;
       bannerIsSaving = false;
+      bannerIsUploading = false;
       document.getElementById('bannerType').value = DEFAULT_BANNER_TYPE;
+      document.getElementById('bannerUploadFile').value = '';
       document.getElementById('bannerListLoading').classList.add('hidden');
       clearBannerBanner();
       hideBannerSaveResult();
@@ -1110,6 +1144,8 @@
       bannerImages = [];
       bannerDirty = false;
       bannerHasLoaded = false;
+      bannerIsUploading = false;
+      document.getElementById('bannerUploadFile').value = '';
       clearBannerBanner();
       hideBannerSaveResult();
       renderBannerList();
@@ -1120,6 +1156,61 @@
       bannerHasLoaded = true;
       markBannerDirty();
       renderBannerList();
+    };
+
+    document.getElementById('btnUploadBannerImage').onclick = async () => {
+      const fileInput = document.getElementById('bannerUploadFile');
+      if (!fileInput.files || !fileInput.files.length) {
+        showToast('업로드할 이미지를 선택하세요.', 'error');
+        return;
+      }
+
+      const file = fileInput.files[0];
+      const btn = document.getElementById('btnUploadBannerImage');
+      const formData = new FormData();
+      formData.append('file', file);
+      formData.append('type', bannerActiveType);
+
+      bannerIsUploading = true;
+      updateBannerControls();
+      clearBannerBanner();
+      hideBannerSaveResult();
+      btn.textContent = '처리 중...';
+      try {
+        const res = await fetch(API_BASE + '/api/banner/upload', {
+          method: 'POST',
+          headers: buildBannerUploadHeaders(),
+          body: formData
+        });
+        const data = await readJsonOrEmpty(res);
+        if (res.status === 403) {
+          setBannerBanner('개발자 계정으로 로그인하세요.', 'warn');
+          return;
+        }
+        if (!res.ok) {
+          setBannerBanner(data.message || '배너 이미지 업로드 실패 (HTTP ' + res.status + ')', 'error');
+          return;
+        }
+
+        const imageUrl = data.data?.imageUrl;
+        if (!imageUrl) {
+          setBannerBanner('업로드 결과 URL을 확인할 수 없습니다.', 'error');
+          return;
+        }
+
+        bannerImages.push(createBannerItemFromUpload(file.name, imageUrl));
+        bannerHasLoaded = true;
+        markBannerDirty();
+        renderBannerList();
+        fileInput.value = '';
+        showToast('이미지를 업로드하고 배열에 추가했습니다.', 'success');
+      } catch (e) {
+        setBannerBanner('요청 실패: ' + (e.message || ''), 'error');
+      } finally {
+        bannerIsUploading = false;
+        btn.textContent = '업로드 후 배열에 추가';
+        updateBannerControls();
+      }
     };
 
     document.getElementById('btnLoadBanner').onclick = async () => {

--- a/backend/src/main/resources/static/dev/index.html
+++ b/backend/src/main/resources/static/dev/index.html
@@ -906,16 +906,19 @@
       return token ? { 'Authorization': 'Bearer ' + token } : {};
     }
 
+    function generateBannerItemId() {
+      if (window.crypto && typeof window.crypto.randomUUID === 'function') {
+        return 'banner-' + window.crypto.randomUUID().replace(/-/g, '').slice(0, 12);
+      }
+      return 'banner-' + Math.random().toString(36).slice(2, 14);
+    }
+
     function createBannerItemFromUpload(fileName, imageUrl) {
       const baseName = String(fileName || '')
         .replace(/\.[^.]+$/, '')
         .trim();
-      const idCandidate = baseName
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, '-')
-        .replace(/^-+|-+$/g, '');
       return {
-        id: idCandidate || 'banner-' + Date.now(),
+        id: generateBannerItemId(),
         imageUrl,
         linkTo: '',
         alt: baseName || '배너 이미지'

--- a/backend/src/main/resources/static/dev/index.html
+++ b/backend/src/main/resources/static/dev/index.html
@@ -77,6 +77,21 @@
     .section-head { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px; margin-bottom: 12px; }
     .section-head h2 { margin: 0; }
     .section-head-actions { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+    .banner-toolbar { display: flex; justify-content: space-between; align-items: center; gap: 12px; flex-wrap: wrap; margin-bottom: 12px; }
+    .banner-summary { margin: 0; color: #666; font-size: 0.9rem; }
+    .banner-editor-list { display: grid; gap: 12px; }
+    .banner-item { border: 1px solid #e5e7eb; border-radius: 8px; padding: 12px; background: #fff; }
+    .banner-item-head { display: flex; justify-content: space-between; align-items: center; gap: 12px; flex-wrap: wrap; margin-bottom: 12px; }
+    .banner-item-meta { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+    .banner-order { display: inline-flex; align-items: center; justify-content: center; min-width: 48px; padding: 4px 10px; border-radius: 999px; background: #dbeafe; color: #1d4ed8; font-size: 0.85rem; font-weight: 600; }
+    .banner-item-body { display: grid; grid-template-columns: minmax(160px, 200px) minmax(0, 1fr); gap: 12px 16px; align-items: start; }
+    .banner-preview { border: 1px solid #e5e7eb; border-radius: 8px; background: #f9fafb; min-height: 120px; overflow: hidden; display: flex; align-items: center; justify-content: center; color: #666; font-size: 0.9rem; text-align: center; }
+    .banner-preview img { display: block; width: 100%; height: 120px; object-fit: cover; background: #f3f4f6; }
+    .banner-preview.is-empty { padding: 16px; }
+    .banner-item-grid { margin-bottom: 0; }
+    .banner-item-grid .form-row input { max-width: none; }
+    .banner-item-actions { display: flex; justify-content: flex-end; gap: 8px; flex-wrap: wrap; }
+    .banner-empty { padding: 16px; border: 1px dashed #d1d5db; border-radius: 8px; background: #f9fafb; color: #666; text-align: center; }
     .pagination { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; font-size: 0.9rem; }
     .pagination button { margin: 0; padding: 6px 12px; }
     .token-cell {
@@ -92,6 +107,9 @@
     .toast.success { background: #166534; color: #fff; }
     .toast.error { background: #dc2626; color: #fff; }
     @keyframes fadeOut { 0%, 70% { opacity: 1; } 100% { opacity: 0; visibility: hidden; } }
+    @media (max-width: 720px) {
+      .banner-item-body { grid-template-columns: 1fr; }
+    }
   </style>
 </head>
 <body>
@@ -103,6 +121,7 @@
         <a href="#api-docs">API 문서</a>
         <a href="#club">동아리</a>
         <a href="#dict">단어사전</a>
+        <a href="#banner">배너 이미지</a>
         <a href="#fcm">FCM 알림</a>
         <a href="#conversion-batch">이미지 변환 배치</a>
       </nav>
@@ -227,6 +246,42 @@
       </div>
     </section>
 
+    <section id="banner" class="hidden">
+      <div class="section-head">
+        <h2>배너 이미지 관리</h2>
+        <div class="section-head-actions">
+          <button type="button" id="btnLoadBanner">목록 불러오기</button>
+          <button type="button" id="btnSaveBanner">현재 배열 저장</button>
+        </div>
+      </div>
+      <div id="bannerBanner" class="banner hidden"></div>
+      <p class="sub" style="margin-bottom:12px;">타입별 배너 배열을 조회하고 수정할 수 있습니다. 각 항목의 위/아래 버튼으로 순서를 변경하세요.</p>
+      <div class="form-grid" style="margin-bottom:8px;">
+        <div class="form-row">
+          <label for="bannerType">배너 타입</label>
+          <select id="bannerType">
+            <option value="WEB">WEB</option>
+            <option value="APP_HOME">APP_HOME</option>
+            <option value="WEB_MOBILE">WEB_MOBILE</option>
+          </select>
+        </div>
+      </div>
+      <div class="banner-toolbar">
+        <p id="bannerSummary" class="banner-summary">WEB 타입 목록을 불러오세요.</p>
+        <button type="button" id="btnAddBannerItem">배너 추가</button>
+      </div>
+      <div id="bannerListLoading" class="hidden">목록 불러오는 중...</div>
+      <div id="bannerEmpty" class="banner-empty hidden">저장된 배너가 없습니다. 새 배너를 추가하거나 다른 타입을 선택해 보세요.</div>
+      <div id="bannerList" class="banner-editor-list"></div>
+      <div id="bannerSaveResult" class="message-box hidden"></div>
+      <div class="card-grid" style="margin-top:16px;">
+        <a href="/swagger-ui.html#/Banner" target="_blank" rel="noopener" class="card">
+          <strong>Banner API</strong>
+          <span>조회 및 전체 배열 저장</span>
+        </a>
+      </div>
+    </section>
+
     <section id="fcm" class="hidden">
       <div class="section-head">
         <h2>FCM 알림 관리</h2>
@@ -328,9 +383,16 @@
     const API_BASE = '';
     const PAGE_SIZE = 50;
     const FCM_PAGE_SIZE = 20;
+    const DEFAULT_BANNER_TYPE = 'WEB';
     let fcmTokens = [];
     let fcmFilteredTokens = [];
     let fcmCurrentPage = 1;
+    let bannerImages = [];
+    let bannerActiveType = DEFAULT_BANNER_TYPE;
+    let bannerDirty = false;
+    let bannerHasLoaded = false;
+    let bannerIsLoading = false;
+    let bannerIsSaving = false;
 
     function getToken() { return sessionStorage.getItem('devPortalToken') || ''; }
     function setToken(t) { sessionStorage.setItem('devPortalToken', t); }
@@ -359,6 +421,7 @@
       document.getElementById('tokenArea').classList.toggle('hidden', !show);
       document.getElementById('club').classList.toggle('hidden', !show);
       document.getElementById('dict').classList.toggle('hidden', !show);
+      document.getElementById('banner').classList.toggle('hidden', !show);
       document.getElementById('fcm').classList.toggle('hidden', !show);
       document.getElementById('conversion-batch').classList.toggle('hidden', !show);
       const headerStatus = document.getElementById('headerStatus');
@@ -402,6 +465,7 @@
           showLogin(true);
           loadClubsIfVisible();
           loadDictIfVisible();
+          loadBannerIfVisible();
           loadFcmTokensIfVisible();
         } else {
           errEl.textContent = '토큰 없음';
@@ -435,6 +499,7 @@
       document.getElementById('clubBanner').classList.add('hidden');
       document.getElementById('dictList').querySelector('tbody').innerHTML = '';
       document.getElementById('dictBanner').classList.add('hidden');
+      clearBannerState();
       clearFcmState();
     }
 
@@ -449,6 +514,7 @@
       showLogin(true);
       loadClubsIfVisible();
       loadDictIfVisible();
+      loadBannerIfVisible();
       loadFcmTokensIfVisible();
     }
 
@@ -756,6 +822,398 @@
         showToast(e.message || '요청 실패', 'error');
       }
     }
+
+    function createEmptyBannerItem() {
+      return { id: '', imageUrl: '', linkTo: '', alt: '' };
+    }
+
+    function clearBannerBanner() {
+      const banner = document.getElementById('bannerBanner');
+      banner.textContent = '';
+      banner.className = 'banner hidden';
+    }
+
+    function setBannerBanner(message, tone) {
+      const banner = document.getElementById('bannerBanner');
+      banner.textContent = message;
+      banner.className = 'banner ' + tone;
+      banner.classList.remove('hidden');
+    }
+
+    function hideBannerSaveResult() {
+      document.getElementById('bannerSaveResult').classList.add('hidden');
+    }
+
+    function showBannerSaveResult(ok, message) {
+      setMessageBox('bannerSaveResult', ok, message);
+      if (ok) setTimeout(() => document.getElementById('bannerSaveResult').classList.add('hidden'), 3000);
+    }
+
+    function updateBannerControls() {
+      document.getElementById('bannerType').disabled = bannerIsLoading || bannerIsSaving;
+      document.getElementById('btnLoadBanner').disabled = bannerIsLoading || bannerIsSaving;
+      document.getElementById('btnAddBannerItem').disabled = bannerIsLoading || bannerIsSaving;
+      document.getElementById('btnSaveBanner').disabled = bannerIsLoading || bannerIsSaving || !bannerHasLoaded;
+    }
+
+    function updateBannerSummary() {
+      const summary = document.getElementById('bannerSummary');
+      let text = bannerActiveType + ' 타입';
+      if (!bannerHasLoaded && !bannerImages.length) {
+        text += ' 목록을 불러오거나 새 배너를 추가하세요.';
+      } else {
+        text += ' 총 ' + bannerImages.length + '개';
+      }
+      if (bannerDirty) {
+        text += ' (저장되지 않은 변경사항 있음)';
+      }
+      summary.textContent = text;
+    }
+
+    function markBannerDirty() {
+      bannerDirty = true;
+      hideBannerSaveResult();
+      updateBannerSummary();
+      updateBannerControls();
+    }
+
+    function normalizeBannerImagesForSave() {
+      return bannerImages.map((item, index) => {
+        const id = String(item.id || '').trim();
+        const imageUrl = String(item.imageUrl || '').trim();
+        const linkTo = String(item.linkTo || '').trim();
+        const alt = String(item.alt || '').trim();
+        if (!id) throw new Error((index + 1) + '번째 배너의 id를 입력하세요.');
+        if (!imageUrl) throw new Error((index + 1) + '번째 배너의 imageUrl을 입력하세요.');
+        if (!alt) throw new Error((index + 1) + '번째 배너의 alt를 입력하세요.');
+        return { id, imageUrl, linkTo: linkTo || null, alt };
+      });
+    }
+
+    function moveBannerItem(fromIndex, toIndex) {
+      if (fromIndex == null || fromIndex < 0 || fromIndex >= bannerImages.length) return;
+      if (toIndex == null || toIndex < 0 || toIndex >= bannerImages.length) return;
+      if (toIndex === fromIndex) return;
+      const next = bannerImages.slice();
+      const moved = next.splice(fromIndex, 1)[0];
+      next.splice(toIndex, 0, moved);
+      bannerImages = next;
+      markBannerDirty();
+      renderBannerList();
+    }
+
+    function createBannerPreview(item) {
+      const preview = document.createElement('div');
+      preview.className = 'banner-preview is-empty';
+      const img = document.createElement('img');
+      img.alt = item.alt || '배너 미리보기';
+      img.classList.add('hidden');
+      const placeholder = document.createElement('span');
+      placeholder.textContent = '이미지 URL을 입력하면 미리보기가 표시됩니다.';
+
+      function updatePreview() {
+        const imageUrl = String(item.imageUrl || '').trim();
+        img.alt = item.alt || '배너 미리보기';
+        if (!imageUrl) {
+          img.removeAttribute('src');
+          img.classList.add('hidden');
+          placeholder.textContent = '이미지 URL을 입력하면 미리보기가 표시됩니다.';
+          placeholder.classList.remove('hidden');
+          preview.classList.add('is-empty');
+          return;
+        }
+        img.classList.add('hidden');
+        placeholder.textContent = '이미지를 불러오는 중...';
+        placeholder.classList.remove('hidden');
+        preview.classList.add('is-empty');
+        img.src = imageUrl;
+      }
+
+      img.addEventListener('load', () => {
+        img.classList.remove('hidden');
+        placeholder.classList.add('hidden');
+        preview.classList.remove('is-empty');
+      });
+      img.addEventListener('error', () => {
+        img.classList.add('hidden');
+        placeholder.textContent = '이미지를 불러올 수 없습니다.';
+        placeholder.classList.remove('hidden');
+        preview.classList.add('is-empty');
+      });
+
+      preview.appendChild(img);
+      preview.appendChild(placeholder);
+      updatePreview();
+
+      return { preview, updatePreview };
+    }
+
+    function createBannerField(config) {
+      const row = document.createElement('div');
+      row.className = 'form-row';
+      const label = document.createElement('label');
+      label.htmlFor = config.id;
+      label.textContent = config.label;
+      const input = document.createElement('input');
+      input.type = 'text';
+      input.id = config.id;
+      input.value = config.value;
+      input.placeholder = config.placeholder;
+      input.addEventListener('input', config.onInput);
+      row.appendChild(label);
+      row.appendChild(input);
+      return row;
+    }
+
+    function createBannerItemElement(item, index) {
+      const article = document.createElement('article');
+      article.className = 'banner-item';
+
+      const head = document.createElement('div');
+      head.className = 'banner-item-head';
+
+      const meta = document.createElement('div');
+      meta.className = 'banner-item-meta';
+      const order = document.createElement('span');
+      order.className = 'banner-order';
+      order.textContent = '#' + (index + 1);
+      meta.appendChild(order);
+
+      const actions = document.createElement('div');
+      actions.className = 'banner-item-actions';
+      const upBtn = document.createElement('button');
+      upBtn.type = 'button';
+      upBtn.textContent = '위로';
+      upBtn.disabled = index === 0;
+      upBtn.addEventListener('click', () => moveBannerItem(index, index - 1));
+      const downBtn = document.createElement('button');
+      downBtn.type = 'button';
+      downBtn.textContent = '아래로';
+      downBtn.disabled = index === bannerImages.length - 1;
+      downBtn.addEventListener('click', () => moveBannerItem(index, index + 1));
+      const removeBtn = document.createElement('button');
+      removeBtn.type = 'button';
+      removeBtn.textContent = '제거';
+      removeBtn.addEventListener('click', () => {
+        bannerImages.splice(index, 1);
+        markBannerDirty();
+        renderBannerList();
+      });
+      actions.appendChild(upBtn);
+      actions.appendChild(downBtn);
+      actions.appendChild(removeBtn);
+
+      head.appendChild(meta);
+      head.appendChild(actions);
+
+      const body = document.createElement('div');
+      body.className = 'banner-item-body';
+      const previewState = createBannerPreview(item);
+      const grid = document.createElement('div');
+      grid.className = 'form-grid banner-item-grid';
+
+      grid.appendChild(createBannerField({
+        label: '배너 ID',
+        id: 'bannerItemId' + index,
+        value: item.id || '',
+        placeholder: 'main-banner-1',
+        onInput: (e) => {
+          item.id = e.target.value;
+          markBannerDirty();
+        }
+      }));
+      grid.appendChild(createBannerField({
+        label: '이미지 URL',
+        id: 'bannerItemImageUrl' + index,
+        value: item.imageUrl || '',
+        placeholder: 'https://...',
+        onInput: (e) => {
+          item.imageUrl = e.target.value;
+          previewState.updatePreview();
+          markBannerDirty();
+        }
+      }));
+      grid.appendChild(createBannerField({
+        label: '클릭 링크 (선택)',
+        id: 'bannerItemLinkTo' + index,
+        value: item.linkTo || '',
+        placeholder: 'https://...',
+        onInput: (e) => {
+          item.linkTo = e.target.value;
+          markBannerDirty();
+        }
+      }));
+      grid.appendChild(createBannerField({
+        label: '대체 텍스트',
+        id: 'bannerItemAlt' + index,
+        value: item.alt || '',
+        placeholder: '배너 설명',
+        onInput: (e) => {
+          item.alt = e.target.value;
+          previewState.updatePreview();
+          markBannerDirty();
+        }
+      }));
+
+      body.appendChild(previewState.preview);
+      body.appendChild(grid);
+      article.appendChild(head);
+      article.appendChild(body);
+      return article;
+    }
+
+    function renderBannerList() {
+      const list = document.getElementById('bannerList');
+      const empty = document.getElementById('bannerEmpty');
+      list.innerHTML = '';
+      if (!bannerImages.length) {
+        empty.classList.toggle('hidden', !bannerHasLoaded);
+      } else {
+        empty.classList.add('hidden');
+        bannerImages.forEach((item, index) => {
+          list.appendChild(createBannerItemElement(item, index));
+        });
+      }
+      updateBannerSummary();
+      updateBannerControls();
+    }
+
+    function clearBannerState() {
+      bannerActiveType = DEFAULT_BANNER_TYPE;
+      bannerImages = [];
+      bannerDirty = false;
+      bannerHasLoaded = false;
+      bannerIsLoading = false;
+      bannerIsSaving = false;
+      document.getElementById('bannerType').value = DEFAULT_BANNER_TYPE;
+      document.getElementById('bannerListLoading').classList.add('hidden');
+      clearBannerBanner();
+      hideBannerSaveResult();
+      renderBannerList();
+    }
+
+    function loadBannerIfVisible() {
+      const section = document.getElementById('banner');
+      if (section && !section.classList.contains('hidden') && !bannerHasLoaded) {
+        document.getElementById('btnLoadBanner').click();
+      }
+    }
+
+    document.getElementById('bannerType').addEventListener('change', (e) => {
+      const nextType = e.target.value;
+      if (nextType === bannerActiveType) return;
+      if (bannerDirty && !confirm('저장하지 않은 배너 변경사항이 사라집니다. 계속할까요?')) {
+        e.target.value = bannerActiveType;
+        return;
+      }
+      bannerActiveType = nextType;
+      bannerImages = [];
+      bannerDirty = false;
+      bannerHasLoaded = false;
+      clearBannerBanner();
+      hideBannerSaveResult();
+      renderBannerList();
+    });
+
+    document.getElementById('btnAddBannerItem').onclick = () => {
+      bannerImages.push(createEmptyBannerItem());
+      bannerHasLoaded = true;
+      markBannerDirty();
+      renderBannerList();
+    };
+
+    document.getElementById('btnLoadBanner').onclick = async () => {
+      if (bannerDirty && !confirm('현재 수정 중인 배너 내용이 덮어써집니다. 계속할까요?')) return;
+      const btn = document.getElementById('btnLoadBanner');
+      const loading = document.getElementById('bannerListLoading');
+      bannerIsLoading = true;
+      updateBannerControls();
+      clearBannerBanner();
+      hideBannerSaveResult();
+      loading.classList.remove('hidden');
+      btn.textContent = '처리 중...';
+      try {
+        const res = await fetch(API_BASE + '/api/banner?type=' + encodeURIComponent(bannerActiveType), { headers: headers() });
+        const data = await readJsonOrEmpty(res);
+        if (res.status === 403) {
+          setBannerBanner('개발자 계정으로 로그인하세요.', 'warn');
+          return;
+        }
+        if (!res.ok) {
+          setBannerBanner(data.message || '배너 목록 조회 실패 (HTTP ' + res.status + ')', 'error');
+          return;
+        }
+        bannerImages = (data.data?.images || data.images || []).map((item) => ({
+          id: item.id || '',
+          imageUrl: item.imageUrl || '',
+          linkTo: item.linkTo || '',
+          alt: item.alt || ''
+        }));
+        bannerDirty = false;
+        bannerHasLoaded = true;
+        renderBannerList();
+        showToast('배너 ' + bannerImages.length + '개를 불러왔습니다', 'success');
+      } catch (e) {
+        setBannerBanner('요청 실패: ' + (e.message || ''), 'error');
+      } finally {
+        bannerIsLoading = false;
+        loading.classList.add('hidden');
+        btn.textContent = '목록 불러오기';
+        updateBannerControls();
+      }
+    };
+
+    document.getElementById('btnSaveBanner').onclick = async () => {
+      let images;
+      try {
+        images = normalizeBannerImagesForSave();
+      } catch (e) {
+        showBannerSaveResult(false, e.message || '배너 입력값을 확인하세요.');
+        return;
+      }
+      const btn = document.getElementById('btnSaveBanner');
+      bannerIsSaving = true;
+      updateBannerControls();
+      clearBannerBanner();
+      hideBannerSaveResult();
+      btn.textContent = '처리 중...';
+      try {
+        const res = await fetch(API_BASE + '/api/banner', {
+          method: 'PUT',
+          headers: headers(),
+          body: JSON.stringify({ type: bannerActiveType, images })
+        });
+        const data = await readJsonOrEmpty(res);
+        if (res.status === 403) {
+          showBannerSaveResult(false, '개발자 계정으로 로그인하세요.');
+          return;
+        }
+        if (!res.ok) {
+          showBannerSaveResult(false, data.message || '배너 저장 실패 (HTTP ' + res.status + ')');
+          return;
+        }
+        bannerImages = images.map((item) => ({
+          id: item.id,
+          imageUrl: item.imageUrl,
+          linkTo: item.linkTo || '',
+          alt: item.alt
+        }));
+        bannerDirty = false;
+        bannerHasLoaded = true;
+        renderBannerList();
+        showBannerSaveResult(true, data.message || '배너 이미지가 저장되었습니다.');
+        showToast('배너 이미지 저장 완료', 'success');
+      } catch (e) {
+        showBannerSaveResult(false, e.message || '요청 실패');
+      } finally {
+        bannerIsSaving = false;
+        btn.textContent = '현재 배열 저장';
+        updateBannerControls();
+      }
+    };
+
+    clearBannerState();
+    if (getToken()) loadBannerIfVisible();
 
     async function readJsonOrEmpty(res) {
       try {

--- a/backend/src/test/java/moadong/media/service/BannerImageUploadServiceTest.java
+++ b/backend/src/test/java/moadong/media/service/BannerImageUploadServiceTest.java
@@ -1,0 +1,93 @@
+package moadong.media.service;
+
+import moadong.global.exception.ErrorCode;
+import moadong.global.exception.RestApiException;
+import moadong.media.dto.BannerImageUploadResponse;
+import moadong.media.enums.PlatformType;
+import moadong.util.annotations.UnitTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class BannerImageUploadServiceTest {
+
+    @Spy
+    @InjectMocks
+    private BannerImageUploadService bannerImageUploadService;
+
+    @Mock
+    private S3Client s3Client;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(bannerImageUploadService, "bannerBucketName", "banner-bucket");
+        ReflectionTestUtils.setField(bannerImageUploadService, "bannerViewEndpoint", "https://cdn.example.com/");
+        ReflectionTestUtils.setField(bannerImageUploadService, "maxImageSizeBytes", 1024L);
+        ReflectionTestUtils.invokeMethod(bannerImageUploadService, "init");
+    }
+
+    @Test
+    void 정상_이미지를_업로드하면_배너_버킷_URL을_반환한다() {
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "banner.png",
+            "image/png",
+            "banner-image".getBytes()
+        );
+
+        BannerImageUploadResponse response = bannerImageUploadService.upload(file, PlatformType.WEB);
+
+        ArgumentCaptor<PutObjectRequest> requestCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
+        verify(s3Client).putObject(requestCaptor.capture(), any(RequestBody.class));
+
+        assertEquals("banner-bucket", requestCaptor.getValue().bucket());
+        assertEquals("image/png", requestCaptor.getValue().contentType());
+        assertEquals("web/banner.png", requestCaptor.getValue().key());
+        assertEquals("https://cdn.example.com/web/banner.png", response.imageUrl());
+    }
+
+    @Test
+    void 확장자가_이미지가_아니면_UNSUPPORTED_FILE_TYPE을_반환한다() {
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "banner.txt",
+            "text/plain",
+            "not-image".getBytes()
+        );
+
+        RestApiException exception = assertThrows(RestApiException.class, () -> bannerImageUploadService.upload(file, PlatformType.WEB));
+
+        assertEquals(ErrorCode.UNSUPPORTED_FILE_TYPE, exception.getErrorCode());
+    }
+
+    @Test
+    void 최대_용량을_초과하면_FILE_TOO_LARGE를_반환한다() {
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "banner.webp",
+            "image/webp",
+            new byte[2048]
+        );
+
+        RestApiException exception = assertThrows(RestApiException.class, () -> bannerImageUploadService.upload(file, PlatformType.WEB));
+
+        assertEquals(ErrorCode.FILE_TOO_LARGE, exception.getErrorCode());
+    }
+}


### PR DESCRIPTION
> 🚀 릴리즈 PR인 경우 [**릴리즈 템플릿으로 전환**](?template=release.md)해 주세요. _(Preview 탭에서 클릭)_

## #️⃣연관된 이슈

- #1323

## 📝작업 내용

<img width="839" height="791" alt="스크린샷 2026-03-07 23 22 07" src="https://github.com/user-attachments/assets/d09aa384-76c5-46e9-9bd3-8a374c719ecd"/>

배너이미지 추가/수정할 수 있는 관리자 기능 추가했습니다

## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 배너 이미지 업로드용 API 엔드포인트 추가
  * 플랫폼별 배너 이미지 관리 UI 추가(로드, 업로드, 순서 변경, 편집, 삭제, 저장, 미리보기)
  * 업로드 후 접근 가능한 이미지 URL 반환

* **버그 픽스 / 보안**
  * 파일 확장자·콘텐츠타입·파일 크기 검증 강화 및 오류 처리 개선

* **테스트**
  * 배너 이미지 업로드 서비스 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->