### PR TITLE
[feature] 프로퍼티 주입 방식 변경

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -45,3 +45,4 @@ moadong.json
 firebase.json
 
 /.cursor
+/.infisical.json

--- a/backend/src/main/java/moadong/MoadongApplication.java
+++ b/backend/src/main/java/moadong/MoadongApplication.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -13,6 +14,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableScheduling
 @EnableRetry
 @EnableAsync
+@ConfigurationPropertiesScan
 public class MoadongApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/moadong/fcm/service/FcmAsyncService.java
+++ b/backend/src/main/java/moadong/fcm/service/FcmAsyncService.java
@@ -7,9 +7,9 @@ import com.google.firebase.messaging.TopicManagementResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import moadong.fcm.util.FcmTopicResolver;
+import moadong.global.config.properties.FcmProperties;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
@@ -33,8 +33,7 @@ public class FcmAsyncService {
 
     private final FcmTopicResolver fcmTopicResolver;
 
-    @Value("${fcm.topic.timeout-seconds:5}")
-    private int timeoutSeconds;
+    private final FcmProperties fcmProperties;
 
     /**
      * @deprecated
@@ -73,6 +72,11 @@ public class FcmAsyncService {
             Runnable notRegisteredTokenHandler,
             Runnable tokenUpdater
     ) {
+        if (firebaseMessaging == null) {
+            log.warn("FCM feature disabled. Skipping subscription update.");
+            return CompletableFuture.completedFuture(null);
+        }
+
         List<ApiFuture<TopicManagementResponse>> futures = new ArrayList<>();
 
         // 새로운 동아리 구독
@@ -94,7 +98,7 @@ public class FcmAsyncService {
         try {
             if (futures.isEmpty()) return CompletableFuture.completedFuture(null);
 
-            List<TopicManagementResponse> responses = ApiFutures.allAsList(futures).get(timeoutSeconds, TimeUnit.SECONDS);
+            List<TopicManagementResponse> responses = ApiFutures.allAsList(futures).get(fcmProperties.timeoutSeconds(), TimeUnit.SECONDS);
 
             for (TopicManagementResponse response : responses) {
                 if (response.getFailureCount() > 0) {

--- a/backend/src/main/java/moadong/gemma/service/GemmaService.java
+++ b/backend/src/main/java/moadong/gemma/service/GemmaService.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import moadong.gemma.dto.AIRequest;
 import moadong.gemma.dto.AIResponse;
-import org.springframework.beans.factory.annotation.Value;
+import moadong.global.config.properties.GemmaProperties;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
@@ -16,15 +16,10 @@ public class GemmaService {
 
     private final RestTemplate restTemplate;
     private final ObjectMapper objectMapper;
-
-    @Value("${gemma.server.host}")
-    private String gemmaServerHost;
-
-    @Value("${gemma.server.port}")
-    private String gemmaServerPort;
+    private final GemmaProperties gemmaProperties;
 
     public AIResponse getSummarizeContent(String system, String prompt) {
-        String gemmaServerUrl = "http://" + gemmaServerHost + ":" + gemmaServerPort + "/api/generate";
+        String gemmaServerUrl = "http://" + gemmaProperties.server().host() + ":" + gemmaProperties.server().port() + "/api/generate";
         
         try {
             log.info("Starting content summarization request to Gemma server at {}", gemmaServerUrl);

--- a/backend/src/main/java/moadong/global/config/RabbitMQConfig.java
+++ b/backend/src/main/java/moadong/global/config/RabbitMQConfig.java
@@ -1,5 +1,7 @@
 package moadong.global.config;
 
+import lombok.RequiredArgsConstructor;
+import moadong.global.config.properties.RabbitMqProperties;
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.DirectExchange;
@@ -10,7 +12,7 @@ import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.amqp.RabbitProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -18,21 +20,11 @@ import java.util.Map;
 
 @Configuration
 @EnableRabbit
+@RequiredArgsConstructor
 public class RabbitMQConfig {
 
-    @Value("${spring.rabbitmq.host}") private String host;
-    @Value("${spring.rabbitmq.port}") private int port;
-    @Value("${spring.rabbitmq.username}") private String username;
-    @Value("${spring.rabbitmq.password}") private String password;
-
-    @Value("${rabbitmq.summary.queue}")
-    private String APPLICANT_ID_QUEUE_NAME;
-
-    @Value("${rabbitmq.summary.exchange}")
-    private String APPLICANT_ID_EXCHANGE_NAME;
-
-    @Value("${rabbitmq.summary.routingKey}")
-    private String APPLICANT_ID_ROUTING_KEY;
+    private final RabbitMqProperties rabbitMqProperties;
+    private final RabbitProperties springRabbitProperties;
 
     private static final String DEAD_LETTER_EXCHANGE_NAME = "dead.letter.exchange";
     private static final String DEAD_LETTER_QUEUE_NAME = "dead.letter.queue";
@@ -40,7 +32,7 @@ public class RabbitMQConfig {
 
     @Bean
     public Queue applicantIdQueue() {
-        return new Queue(APPLICANT_ID_QUEUE_NAME, true, false, false,
+        return new Queue(rabbitMqProperties.summary().queue(), true, false, false,
             Map.of(
                 "x-dead-letter-exchange", DEAD_LETTER_EXCHANGE_NAME,
                 "x-dead-letter-routing-key", DEAD_LETTER_ROUTING_KEY
@@ -50,12 +42,12 @@ public class RabbitMQConfig {
 
     @Bean
     public DirectExchange applicantIdExchange() {
-        return new DirectExchange(APPLICANT_ID_EXCHANGE_NAME);
+        return new DirectExchange(rabbitMqProperties.summary().exchange());
     }
 
     @Bean
     public Binding applicantIdBinding(Queue applicantIdQueue, DirectExchange applicantIdExchange) {
-        return BindingBuilder.bind(applicantIdQueue).to(applicantIdExchange).with(APPLICANT_ID_ROUTING_KEY);
+        return BindingBuilder.bind(applicantIdQueue).to(applicantIdExchange).with(rabbitMqProperties.summary().routingKey());
     }
 
     @Bean
@@ -77,8 +69,8 @@ public class RabbitMQConfig {
     public RabbitTemplate applicantIdTemplate(ConnectionFactory connectionFactory) {
         RabbitTemplate template = new RabbitTemplate(connectionFactory);
         template.setMessageConverter(Jackson2JsonMessageConverter());
-        template.setExchange(APPLICANT_ID_EXCHANGE_NAME);
-        template.setRoutingKey(APPLICANT_ID_ROUTING_KEY);
+        template.setExchange(rabbitMqProperties.summary().exchange());
+        template.setRoutingKey(rabbitMqProperties.summary().routingKey());
 
         return template;
     }
@@ -90,9 +82,9 @@ public class RabbitMQConfig {
 
     @Bean
     public ConnectionFactory connectionFactory() {
-        CachingConnectionFactory cf = new CachingConnectionFactory(host, port);
-        cf.setUsername(username);
-        cf.setPassword(password);
+        CachingConnectionFactory cf = new CachingConnectionFactory(springRabbitProperties.getHost(), springRabbitProperties.getPort());
+        cf.setUsername(springRabbitProperties.getUsername());
+        cf.setPassword(springRabbitProperties.getPassword());
         return cf;
     }
 }

--- a/backend/src/main/java/moadong/global/config/SwaggerConfig.java
+++ b/backend/src/main/java/moadong/global/config/SwaggerConfig.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.servers.Server;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import moadong.global.config.properties.ServerDomainProperties;
+import moadong.global.config.properties.ServerProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -13,7 +13,7 @@ import org.springframework.context.annotation.Configuration;
 @RequiredArgsConstructor
 public class SwaggerConfig {
 
-    private final ServerDomainProperties serverDomainProperties;
+    private final ServerProperties serverProperties;
 
     @Bean
     public OpenAPI openAPI() {
@@ -23,7 +23,7 @@ public class SwaggerConfig {
             .description("moadong API specification");
 
         Server server = new Server();
-        server.setUrl(serverDomainProperties.domain()); // https://에 접근 가능하게 설정
+        server.setUrl(serverProperties.domain()); // https://에 접근 가능하게 설정
 
         return new OpenAPI()
             .info(info)

--- a/backend/src/main/java/moadong/global/config/SwaggerConfig.java
+++ b/backend/src/main/java/moadong/global/config/SwaggerConfig.java
@@ -4,25 +4,26 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.servers.Server;
 import java.util.List;
-import org.springframework.beans.factory.annotation.Value;
+import lombok.RequiredArgsConstructor;
+import moadong.global.config.properties.ServerDomainProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@RequiredArgsConstructor
 public class SwaggerConfig {
 
-    @Value("${server.domain}")
-    private String serverDomain;
+    private final ServerDomainProperties serverDomainProperties;
 
     @Bean
     public OpenAPI openAPI() {
         Info info = new Info()
             .version("1.0")
             .title("moadong API")
-            .description("moadong API sepcification");
+            .description("moadong API specification");
 
         Server server = new Server();
-        server.setUrl(serverDomain); // https://에 접근 가능하게 설정
+        server.setUrl(serverDomainProperties.domain()); // https://에 접근 가능하게 설정
 
         return new OpenAPI()
             .info(info)

--- a/backend/src/main/java/moadong/global/config/WebConfig.java
+++ b/backend/src/main/java/moadong/global/config/WebConfig.java
@@ -1,29 +1,23 @@
 package moadong.global.config;
 
-import java.util.Arrays;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
+import moadong.global.config.properties.AppProperties;
 import moadong.global.util.OctetStreamReadMsgConverter;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
-    private OctetStreamReadMsgConverter octetStreamReadMsgConverter;
+
+    private final OctetStreamReadMsgConverter octetStreamReadMsgConverter;
+    private final AppProperties appProperties;
 
     private final long MAX_AGE_SECS = 3600;
-
-    @Value("${app.cors.allowedOrigins}")
-    private String[] allowedOrigins;
-
-    @Autowired
-    public WebConfig(OctetStreamReadMsgConverter octetStreamReadMsgConverter) {
-        this.octetStreamReadMsgConverter = octetStreamReadMsgConverter;
-    }
 
     @Override
     public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
@@ -32,6 +26,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
+        String[] allowedOrigins = appProperties.cors().allowedOrigins().toArray(new String[0]);
         registry.addMapping("/**")
             .allowedOriginPatterns(allowedOrigins)
             .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")

--- a/backend/src/main/java/moadong/global/config/properties/AppProperties.java
+++ b/backend/src/main/java/moadong/global/config/properties/AppProperties.java
@@ -1,0 +1,14 @@
+package moadong.global.config.properties;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app")
+public record AppProperties(
+    String devRegistrationSecret,
+    Encryption encryption,
+    Cors cors
+) {
+    public record Encryption(String key, String iv) {}
+    public record Cors(List<String> allowedOrigins) {}
+}

--- a/backend/src/main/java/moadong/global/config/properties/AwsProperties.java
+++ b/backend/src/main/java/moadong/global/config/properties/AwsProperties.java
@@ -1,0 +1,12 @@
+package moadong.global.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "cloud.aws")
+public record AwsProperties(
+    Credentials credentials,
+    S3 s3
+) {
+    public record Credentials(String accessKey, String secretKey) {}
+    public record S3(String bucket, String endpoint, String viewEndpoint) {}
+}

--- a/backend/src/main/java/moadong/global/config/properties/FcmProperties.java
+++ b/backend/src/main/java/moadong/global/config/properties/FcmProperties.java
@@ -1,0 +1,9 @@
+package moadong.global.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+@ConfigurationProperties(prefix = "fcm.topic")
+public record FcmProperties(
+    @DefaultValue("5") int timeoutSeconds
+) {}

--- a/backend/src/main/java/moadong/global/config/properties/FirebaseProperties.java
+++ b/backend/src/main/java/moadong/global/config/properties/FirebaseProperties.java
@@ -1,0 +1,10 @@
+package moadong.global.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+import org.springframework.core.io.Resource;
+
+@ConfigurationProperties(prefix = "firebase.config")
+public record FirebaseProperties(
+    @DefaultValue("classpath:firebase.json") Resource path
+) {}

--- a/backend/src/main/java/moadong/global/config/properties/GemmaProperties.java
+++ b/backend/src/main/java/moadong/global/config/properties/GemmaProperties.java
@@ -1,0 +1,8 @@
+package moadong.global.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "gemma")
+public record GemmaProperties(Server server) {
+    public record Server(String host, int port) {}
+}

--- a/backend/src/main/java/moadong/global/config/properties/JwtProperties.java
+++ b/backend/src/main/java/moadong/global/config/properties/JwtProperties.java
@@ -1,0 +1,14 @@
+package moadong.global.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(
+    String secretKey,
+    AccessToken accessToken,
+    RefreshToken refreshToken
+) {
+    public record AccessToken(Expiration expiration) {}
+    public record RefreshToken(Expiration expiration) {}
+    public record Expiration(long min, long hour) {}
+}

--- a/backend/src/main/java/moadong/global/config/properties/MediaProperties.java
+++ b/backend/src/main/java/moadong/global/config/properties/MediaProperties.java
@@ -1,0 +1,19 @@
+package moadong.global.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+import org.springframework.util.unit.DataSize;
+
+@ConfigurationProperties(prefix = "server")
+public record MediaProperties(
+    Feed feed,
+    Image image,
+    FileUrl fileUrl
+) {
+    public record Feed(int maxCount) {}
+    public record Image(DataSize maxSize) {}
+    public record FileUrl(
+        @DefaultValue("200") int maxLength,
+        @DefaultValue("10") int expirationTime
+    ) {}
+}

--- a/backend/src/main/java/moadong/global/config/properties/RabbitMqProperties.java
+++ b/backend/src/main/java/moadong/global/config/properties/RabbitMqProperties.java
@@ -1,0 +1,8 @@
+package moadong.global.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "rabbitmq")
+public record RabbitMqProperties(Summary summary) {
+    public record Summary(String queue, String exchange, String routingKey) {}
+}

--- a/backend/src/main/java/moadong/global/config/properties/ServerDomainProperties.java
+++ b/backend/src/main/java/moadong/global/config/properties/ServerDomainProperties.java
@@ -1,0 +1,6 @@
+package moadong.global.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "server")
+public record ServerDomainProperties(String domain) {}

--- a/backend/src/main/java/moadong/global/config/properties/ServerDomainProperties.java
+++ b/backend/src/main/java/moadong/global/config/properties/ServerDomainProperties.java
@@ -1,6 +1,0 @@
-package moadong.global.config.properties;
-
-import org.springframework.boot.context.properties.ConfigurationProperties;
-
-@ConfigurationProperties(prefix = "server")
-public record ServerDomainProperties(String domain) {}

--- a/backend/src/main/java/moadong/global/config/properties/ServerProperties.java
+++ b/backend/src/main/java/moadong/global/config/properties/ServerProperties.java
@@ -5,7 +5,8 @@ import org.springframework.boot.context.properties.bind.DefaultValue;
 import org.springframework.util.unit.DataSize;
 
 @ConfigurationProperties(prefix = "server")
-public record MediaProperties(
+public record ServerProperties(
+    String domain,
     Feed feed,
     Image image,
     FileUrl fileUrl

--- a/backend/src/main/java/moadong/global/util/AESCipher.java
+++ b/backend/src/main/java/moadong/global/util/AESCipher.java
@@ -5,17 +5,15 @@ import java.util.Base64;
 import javax.crypto.Cipher;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
-import org.springframework.beans.factory.annotation.Value;
+import lombok.RequiredArgsConstructor;
+import moadong.global.config.properties.AppProperties;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class AESCipher {
 
-    @Value("${application.encryption.key}")
-    private String key;
-
-    @Value("${application.encryption.iv}")
-    private String iv;
+    private final AppProperties appProperties;
 
     /**
      * 문자열을 AES-256 알고리즘으로 암호화합니다.
@@ -26,8 +24,8 @@ public class AESCipher {
      */
     public String encrypt(String text) throws Exception {
         Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
-        SecretKeySpec keySpec = new SecretKeySpec(key.getBytes(StandardCharsets.UTF_8), "AES");
-        GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(128, iv.getBytes(StandardCharsets.UTF_8));
+        SecretKeySpec keySpec = new SecretKeySpec(appProperties.encryption().key().getBytes(StandardCharsets.UTF_8), "AES");
+        GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(128, appProperties.encryption().iv().getBytes(StandardCharsets.UTF_8));
         cipher.init(Cipher.ENCRYPT_MODE, keySpec, gcmParameterSpec);
 
         byte[] encrypted = cipher.doFinal(text.getBytes(StandardCharsets.UTF_8));
@@ -43,8 +41,8 @@ public class AESCipher {
      */
     public String decrypt(String cipherText) throws Exception {
         Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
-        SecretKeySpec keySpec = new SecretKeySpec(key.getBytes(StandardCharsets.UTF_8), "AES");
-        GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(128, iv.getBytes(StandardCharsets.UTF_8));
+        SecretKeySpec keySpec = new SecretKeySpec(appProperties.encryption().key().getBytes(StandardCharsets.UTF_8), "AES");
+        GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(128, appProperties.encryption().iv().getBytes(StandardCharsets.UTF_8));
         cipher.init(Cipher.DECRYPT_MODE, keySpec, gcmParameterSpec);
 
         byte[] decodedBytes = Base64.getDecoder().decode(cipherText);

--- a/backend/src/main/java/moadong/global/util/FcmInitializer.java
+++ b/backend/src/main/java/moadong/global/util/FcmInitializer.java
@@ -5,28 +5,30 @@ import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.messaging.FirebaseMessaging;
 import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
+import moadong.global.config.properties.FirebaseProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
 import java.io.InputStream;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class FcmInitializer {
 
-    @Value("${firebase.config.path:classpath:firebase.json}")
-    private Resource firebaseConfigResource;
+    private final FirebaseProperties firebaseProperties;
 
     @PostConstruct
-    public void init() throws IOException {
+    public void init() {
         try {
-            if (!firebaseConfigResource.exists()) {
-                log.error("Firebase config file not found at: {}", firebaseConfigResource.getDescription());
-                throw new IOException("Firebase service account file not found");
+            Resource firebaseConfigResource = firebaseProperties.path();
+            if (firebaseConfigResource == null || !firebaseConfigResource.exists()) {
+                log.warn("Firebase config file not found at: {}. FCM features will be disabled.",
+                         firebaseConfigResource != null ? firebaseConfigResource.getDescription() : "null");
+                return;
             }
 
             try (InputStream in = firebaseConfigResource.getInputStream()) {
@@ -40,12 +42,14 @@ public class FcmInitializer {
             }
         } catch (Exception e) {
             log.error("Firebase app initialization failed", e);
-            throw e;
         }
     }
 
     @Bean
     public FirebaseMessaging firebaseMessaging() {
-        return FirebaseMessaging.getInstance();
+        if (FirebaseApp.getApps().isEmpty()) {
+            log.warn("FirebaseApp is not initialized. FirebaseMessaging bean might not work properly.");
+        }
+        return FirebaseApp.getApps().isEmpty() ? null : FirebaseMessaging.getInstance();
     }
 }

--- a/backend/src/main/java/moadong/global/util/JwtProvider.java
+++ b/backend/src/main/java/moadong/global/util/JwtProvider.java
@@ -5,30 +5,28 @@ import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import moadong.global.config.properties.JwtProperties;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
 import moadong.user.entity.RefreshToken;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
 import java.util.Date;
 
 @Component
+@RequiredArgsConstructor
 public class JwtProvider {
-    @Value("${jwt.access.token.expiration.min}")
-    private int ACCESS_EXPIRATION_MIN;
-    @Value("${jwt.refresh.token.expiration.hour}")
-    private int REFRESH_EXPIRATION_HOUR;
-    @Value("${jwt.secret.key}")
-    private String SECRET_KEY;
+
+    private final JwtProperties jwtProperties;
 
     public String generateAccessToken(String username) {
         return Jwts.builder()
                 .setSubject(username)
                 .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + (long) ACCESS_EXPIRATION_MIN * 1000 * 60))
-                .signWith(SignatureAlgorithm.HS256, SECRET_KEY)
+                .setExpiration(new Date(System.currentTimeMillis() + (long) jwtProperties.accessToken().expiration().min() * 1000 * 60))
+                .signWith(SignatureAlgorithm.HS256, jwtProperties.secretKey())
                 .compact();
     }
 
@@ -36,17 +34,17 @@ public class JwtProvider {
         return Jwts.builder()
                 .setSubject(subject)
                 .setIssuedAt(new Date())
-                .signWith(SignatureAlgorithm.HS256, SECRET_KEY)
+                .signWith(SignatureAlgorithm.HS256, jwtProperties.secretKey())
                 .compact();
     }
 
     public RefreshToken generateRefreshToken(String username) {
-        Date expiresAt = new Date(System.currentTimeMillis() + (long) REFRESH_EXPIRATION_HOUR * 1000 * 60 * 60);
+        Date expiresAt = new Date(System.currentTimeMillis() + (long) jwtProperties.refreshToken().expiration().hour() * 1000 * 60 * 60);
         String refreshToken = Jwts.builder()
                 .setSubject(username)
                 .setIssuedAt(new Date())
                 .setExpiration(expiresAt)
-                .signWith(SignatureAlgorithm.HS256, SECRET_KEY)
+                .signWith(SignatureAlgorithm.HS256, jwtProperties.secretKey())
                 .compact();
         return new RefreshToken(refreshToken,expiresAt);
     }
@@ -70,7 +68,7 @@ public class JwtProvider {
     private Claims getClaims(String token) {
         try {
             return Jwts.parser()
-                    .setSigningKey(SECRET_KEY)
+                    .setSigningKey(jwtProperties.secretKey())
                     .parseClaimsJws(token)
                     .getBody();
         } catch (JwtException e){
@@ -79,6 +77,6 @@ public class JwtProvider {
     }
 
     private Key getSigningKey() {
-        return Keys.hmacShaKeyFor(SECRET_KEY.getBytes());
+        return Keys.hmacShaKeyFor(jwtProperties.secretKey().getBytes());
     }
 }

--- a/backend/src/main/java/moadong/media/service/CloudflareImageService.java
+++ b/backend/src/main/java/moadong/media/service/CloudflareImageService.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import moadong.club.entity.Club;
 import moadong.club.repository.ClubRepository;
+import moadong.global.config.properties.AwsProperties;
+import moadong.global.config.properties.MediaProperties;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
 import moadong.global.util.ObjectIdConverter;
@@ -19,7 +21,6 @@ import moadong.media.domain.FileType;
 import moadong.media.dto.PresignedUploadResponse;
 import moadong.media.dto.UploadUrlRequest;
 import org.bson.types.ObjectId;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -38,27 +39,16 @@ import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignReques
 public class CloudflareImageService implements ClubImageService{
 
     private final ClubRepository clubRepository;
-
     private final S3Client s3Client;
-
     private final S3Presigner s3Presigner;
+    private final AwsProperties awsProperties;
+    private final MediaProperties mediaProperties;
 
-    @Value("${server.feed.max-count}")
-    private int MAX_FEED_COUNT;
-    @Value("${cloud.aws.s3.bucket}")
-    private String bucketName;
-    @Value("${cloud.aws.s3.view-endpoint}")
-    private String viewEndpoint;
-    @Value("${server.image.max-size}")
-    private long maxImageSizeBytes;
-    @Value("${server.file-url.max-length:200}")
-    private int maxFileUrlLength;
-    @Value("${server.file-url.expiration-time:10}")
-    private int expirationTime;
     private String normalizedViewEndpoint;
 
     @PostConstruct
     private void init() {
+        String viewEndpoint = awsProperties.s3().viewEndpoint();
         if (viewEndpoint == null || viewEndpoint.isEmpty()) {
             throw new IllegalStateException("cloud.aws.s3.view-endpoint must be configured");
         }
@@ -89,7 +79,7 @@ public class CloudflareImageService implements ClubImageService{
 			newFeedImageList = java.util.Collections.emptyList();
 		}
 
-		if (newFeedImageList.size() > MAX_FEED_COUNT) {
+		if (newFeedImageList.size() > mediaProperties.feed().maxCount()) {
 			throw new RestApiException(ErrorCode.TOO_MANY_FILES);
 		}
 
@@ -142,7 +132,7 @@ public class CloudflareImageService implements ClubImageService{
         }
 
         DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
-                .bucket(bucketName)
+                .bucket(awsProperties.s3().bucket())
                 .key(key)
                 .build();
 
@@ -183,7 +173,7 @@ public class CloudflareImageService implements ClubImageService{
         int existingCount = (club.getClubRecruitmentInformation().getFeedImages() == null)
             ? 0
             : club.getClubRecruitmentInformation().getFeedImages().size();
-        int remaining = Math.max(0, MAX_FEED_COUNT - existingCount);
+        int remaining = Math.max(0, mediaProperties.feed().maxCount() - existingCount);
         if (remaining == 0) {
             return java.util.List.of(errorResponse(ErrorCode.TOO_MANY_FILES));
         }
@@ -247,7 +237,7 @@ public class CloudflareImageService implements ClubImageService{
 
 
     private void validateFileConstraints(String clubId, FileType fileType, String fileUrl) {
-        if (fileUrl == null || fileUrl.length() > maxFileUrlLength) {
+        if (fileUrl == null || fileUrl.length() > mediaProperties.fileUrl().maxLength()) {
             throw new RestApiException(ErrorCode.INVALID_FILE_URL);
         }
         String key = extractKeyOrNull(fileUrl);
@@ -258,15 +248,15 @@ public class CloudflareImageService implements ClubImageService{
         // R2 HEAD로 사이즈 확인
         try {
             HeadObjectRequest headReq = HeadObjectRequest.builder()
-                .bucket(bucketName)
+                .bucket(awsProperties.s3().bucket())
                 .key(key)
                 .build();
             long contentLength = s3Client.headObject(headReq).contentLength();
-            if (contentLength > maxImageSizeBytes) {
+            if (contentLength > mediaProperties.image().maxSize().toBytes()) {
                 // 초과 시 삭제 후 예외
                 try {
                     DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
-                        .bucket(bucketName)
+                        .bucket(awsProperties.s3().bucket())
                         .key(key)
                         .build();
                     s3Client.deleteObject(deleteRequest);
@@ -306,14 +296,14 @@ public class CloudflareImageService implements ClubImageService{
 
         // PutObjectRequest 생성
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-                .bucket(bucketName)
+                .bucket(awsProperties.s3().bucket())
                 .key(key)
                 .contentType(contentType)
                 .build();
 
         // Presigned URL 생성 (10분 유효)
         PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
-                .signatureDuration(Duration.ofMinutes(expirationTime))
+                .signatureDuration(Duration.ofMinutes(mediaProperties.fileUrl().expirationTime()))
                 .putObjectRequest(putObjectRequest)
                 .build();
 

--- a/backend/src/main/java/moadong/media/service/CloudflareImageService.java
+++ b/backend/src/main/java/moadong/media/service/CloudflareImageService.java
@@ -12,7 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import moadong.club.entity.Club;
 import moadong.club.repository.ClubRepository;
 import moadong.global.config.properties.AwsProperties;
-import moadong.global.config.properties.MediaProperties;
+import moadong.global.config.properties.ServerProperties;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
 import moadong.global.util.ObjectIdConverter;
@@ -42,7 +42,7 @@ public class CloudflareImageService implements ClubImageService{
     private final S3Client s3Client;
     private final S3Presigner s3Presigner;
     private final AwsProperties awsProperties;
-    private final MediaProperties mediaProperties;
+    private final ServerProperties serverProperties;
 
     private String normalizedViewEndpoint;
 
@@ -79,7 +79,7 @@ public class CloudflareImageService implements ClubImageService{
 			newFeedImageList = java.util.Collections.emptyList();
 		}
 
-		if (newFeedImageList.size() > mediaProperties.feed().maxCount()) {
+		if (newFeedImageList.size() > serverProperties.feed().maxCount()) {
 			throw new RestApiException(ErrorCode.TOO_MANY_FILES);
 		}
 
@@ -173,7 +173,7 @@ public class CloudflareImageService implements ClubImageService{
         int existingCount = (club.getClubRecruitmentInformation().getFeedImages() == null)
             ? 0
             : club.getClubRecruitmentInformation().getFeedImages().size();
-        int remaining = Math.max(0, mediaProperties.feed().maxCount() - existingCount);
+        int remaining = Math.max(0, serverProperties.feed().maxCount() - existingCount);
         if (remaining == 0) {
             return java.util.List.of(errorResponse(ErrorCode.TOO_MANY_FILES));
         }
@@ -237,7 +237,7 @@ public class CloudflareImageService implements ClubImageService{
 
 
     private void validateFileConstraints(String clubId, FileType fileType, String fileUrl) {
-        if (fileUrl == null || fileUrl.length() > mediaProperties.fileUrl().maxLength()) {
+        if (fileUrl == null || fileUrl.length() > serverProperties.fileUrl().maxLength()) {
             throw new RestApiException(ErrorCode.INVALID_FILE_URL);
         }
         String key = extractKeyOrNull(fileUrl);
@@ -252,7 +252,7 @@ public class CloudflareImageService implements ClubImageService{
                 .key(key)
                 .build();
             long contentLength = s3Client.headObject(headReq).contentLength();
-            if (contentLength > mediaProperties.image().maxSize().toBytes()) {
+            if (contentLength > serverProperties.image().maxSize().toBytes()) {
                 // 초과 시 삭제 후 예외
                 try {
                     DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
@@ -303,7 +303,7 @@ public class CloudflareImageService implements ClubImageService{
 
         // Presigned URL 생성 (10분 유효)
         PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
-                .signatureDuration(Duration.ofMinutes(mediaProperties.fileUrl().expirationTime()))
+                .signatureDuration(Duration.ofMinutes(serverProperties.fileUrl().expirationTime()))
                 .putObjectRequest(putObjectRequest)
                 .build();
 

--- a/backend/src/main/java/moadong/media/util/S3Config.java
+++ b/backend/src/main/java/moadong/media/util/S3Config.java
@@ -1,7 +1,8 @@
 package moadong.media.util;
 
 import java.net.URI;
-import org.springframework.beans.factory.annotation.Value;
+import lombok.RequiredArgsConstructor;
+import moadong.global.config.properties.AwsProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -12,23 +13,22 @@ import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
+@RequiredArgsConstructor
 public class S3Config {
 
-    @Value("${cloud.aws.credentials.accessKey}")
-    private String accessKey;
-
-    @Value("${cloud.aws.credentials.secretKey}")
-    private String secretKey;
-
-    @Value("${cloud.aws.s3.endpoint}")
-    private String endpoint;
+    private final AwsProperties awsProperties;
 
     @Bean
     public S3Client s3Client() {
         validateCredentials();
         return S3Client.builder()
-                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
-                .endpointOverride(URI.create(endpoint))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(
+                        awsProperties.credentials().accessKey(), 
+                        awsProperties.credentials().secretKey()
+                    )
+                ))
+                .endpointOverride(URI.create(awsProperties.s3().endpoint()))
                 .region(Region.US_EAST_1)
                 .serviceConfiguration(S3Configuration.builder()
                         .pathStyleAccessEnabled(true) // Cloudflare R2에서 필수
@@ -41,20 +41,24 @@ public class S3Config {
         validateCredentials();
         return S3Presigner.builder()
                 .credentialsProvider(StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(accessKey, secretKey)))
-                .endpointOverride(URI.create(endpoint))
+                        AwsBasicCredentials.create(
+                            awsProperties.credentials().accessKey(), 
+                            awsProperties.credentials().secretKey()
+                        )
+                ))
+                .endpointOverride(URI.create(awsProperties.s3().endpoint()))
                 .region(Region.US_EAST_1)
                 .build();
     }
     
     private void validateCredentials() {
-        if (accessKey == null || accessKey.isEmpty() || secretKey == null || secretKey.isEmpty()) {
+        if (awsProperties.credentials().accessKey() == null || awsProperties.credentials().accessKey().isEmpty() || 
+            awsProperties.credentials().secretKey() == null || awsProperties.credentials().secretKey().isEmpty()) {
             throw new IllegalStateException("AWS credentials (accessKey, secretKey) must be configured");
         }
-        if (endpoint == null || endpoint.isEmpty()) {
+        if (awsProperties.s3().endpoint() == null || awsProperties.s3().endpoint().isEmpty()) {
             throw new IllegalStateException("AWS S3 endpoint must be configured");
         }
     }
 
 }
-

--- a/backend/src/main/java/moadong/media/webhook/ImageConversionCompletedWebhookService.java
+++ b/backend/src/main/java/moadong/media/webhook/ImageConversionCompletedWebhookService.java
@@ -8,9 +8,9 @@ import lombok.extern.slf4j.Slf4j;
 import moadong.club.entity.Club;
 import moadong.club.entity.ClubRecruitmentInformation;
 import moadong.club.repository.ClubRepository;
+import moadong.global.config.properties.AwsProperties;
 import moadong.media.webhook.dto.ImageConversionCompletedRequest;
 import moadong.media.webhook.dto.ImageEntry;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -19,14 +19,13 @@ import org.springframework.stereotype.Service;
 public class ImageConversionCompletedWebhookService {
 
     private final ClubRepository clubRepository;
-
-    @Value("${cloud.aws.s3.view-endpoint}")
-    private String viewEndpoint;
+    private final AwsProperties awsProperties;
 
     private String normalizedViewEndpoint;
 
     @PostConstruct
     private void init() {
+        String viewEndpoint = awsProperties.s3().viewEndpoint();
         if (viewEndpoint == null || viewEndpoint.isEmpty()) {
             throw new IllegalStateException("cloud.aws.s3.view-endpoint must be configured");
         }

--- a/backend/src/main/java/moadong/media/webhook/WebpMigrationService.java
+++ b/backend/src/main/java/moadong/media/webhook/WebpMigrationService.java
@@ -9,8 +9,8 @@ import lombok.extern.slf4j.Slf4j;
 import moadong.club.entity.Club;
 import moadong.club.entity.ClubRecruitmentInformation;
 import moadong.club.repository.ClubRepository;
+import moadong.global.config.properties.AwsProperties;
 import moadong.media.webhook.dto.WebpMigrationResult;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
@@ -27,17 +27,13 @@ public class WebpMigrationService {
     private final ClubRepository clubRepository;
     private final S3Client s3Client;
     private final ImageConversionCompletedWebhookService imageConversionCompletedWebhookService;
-
-    @Value("${cloud.aws.s3.bucket}")
-    private String bucket;
-
-    @Value("${cloud.aws.s3.view-endpoint}")
-    private String viewEndpoint;
+    private final AwsProperties awsProperties;
 
     private String normalizedViewEndpoint;
 
     @PostConstruct
     private void init() {
+        String viewEndpoint = awsProperties.s3().viewEndpoint();
         if (viewEndpoint == null || viewEndpoint.isEmpty()) {
             throw new IllegalStateException("cloud.aws.s3.view-endpoint must be configured");
         }
@@ -180,17 +176,17 @@ public class WebpMigrationService {
     private boolean headObjectExists(String destKey) {
         try {
             HeadObjectRequest request = HeadObjectRequest.builder()
-                    .bucket(bucket)
+                    .bucket(awsProperties.s3().bucket())
                     .key(destKey)
                     .build();
-            log.info("R2 HEAD request: bucket={}, key={}", bucket, destKey);
+            log.info("R2 HEAD request: bucket={}, key={}", awsProperties.s3().bucket(), destKey);
             s3Client.headObject(request);
             return true;
         } catch (NoSuchKeyException e) {
-            log.info("R2 HEAD 404 (no such key): bucket={}, key={}", bucket, destKey);
+            log.info("R2 HEAD 404 (no such key): bucket={}, key={}", awsProperties.s3().bucket(), destKey);
             return false;
         } catch (S3Exception e) {
-            log.info("R2 HEAD failed: bucket={}, key={}, error={}", bucket, destKey, e.getMessage());
+            log.info("R2 HEAD failed: bucket={}, key={}, error={}", awsProperties.s3().bucket(), destKey, e.getMessage());
             return false;
         }
     }

--- a/backend/src/main/java/moadong/user/service/UserCommandService.java
+++ b/backend/src/main/java/moadong/user/service/UserCommandService.java
@@ -9,6 +9,7 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import moadong.club.entity.Club;
 import moadong.club.repository.ClubRepository;
+import moadong.global.config.properties.AppProperties;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
 import moadong.global.util.JwtProvider;
@@ -32,7 +33,6 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -47,9 +47,7 @@ public class UserCommandService {
     private final ClubRepository clubRepository;
     private final CookieMaker cookieMaker;
     private final SecurePasswordGenerator securePasswordGenerator;
-
-    @Value("${app.dev-registration-secret:}")
-    private String devRegistrationSecret; // set by Spring after construction (field injection)
+    private final AppProperties appProperties;
 
     @Transactional
     public User registerUser(UserRegisterRequest userRegisterRequest) {
@@ -68,8 +66,8 @@ public class UserCommandService {
 
     @Transactional
     public User registerDeveloper(DevRegisterRequest request) {
-        if (devRegistrationSecret == null || devRegistrationSecret.isBlank()
-                || !devRegistrationSecret.equals(request.secret())) {
+        String secret = appProperties.devRegistrationSecret();
+        if (secret == null || secret.isBlank() || !secret.equals(request.secret())) {
             throw new RestApiException(ErrorCode.USER_UNAUTHORIZED);
         }
         UserRegisterRequest baseRequest = new UserRegisterRequest(

--- a/backend/src/main/java/moadong/user/util/CookieMaker.java
+++ b/backend/src/main/java/moadong/user/util/CookieMaker.java
@@ -1,19 +1,21 @@
 package moadong.user.util;
 
-import org.springframework.beans.factory.annotation.Value;
+import lombok.RequiredArgsConstructor;
+import moadong.global.config.properties.JwtProperties;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class CookieMaker {
-    @Value("${jwt.refresh.token.expiration.hour}")
-    private int refreshTokenExpirationHour;
+
+    private final JwtProperties jwtProperties;
 
     public ResponseCookie makeRefreshTokenCookie(String refreshToken) {
         return ResponseCookie.from("refreshToken", refreshToken)
                 .httpOnly(true)
                 .path("/")
-                .maxAge((long) refreshTokenExpirationHour * 60 * 60)
+                .maxAge(jwtProperties.refreshToken().expiration().hour() * 60 * 60)
                 .secure(true)
                 .domain(".moadong.com")
                 .sameSite("None")

--- a/backend/src/test/java/moadong/media/service/CloudFlareImageServiceTest.java
+++ b/backend/src/test/java/moadong/media/service/CloudFlareImageServiceTest.java
@@ -2,6 +2,8 @@ package moadong.media.service;
 
 import moadong.club.entity.Club;
 import moadong.club.repository.ClubRepository;
+import moadong.global.config.properties.AwsProperties;
+import moadong.global.config.properties.ServerProperties;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
 import moadong.util.annotations.UnitTest;
@@ -21,8 +23,7 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
@@ -41,10 +42,23 @@ public class CloudFlareImageServiceTest {
     @Mock
     private S3Presigner s3Presigner;
 
+    @Mock
+    private AwsProperties awsProperties;
+
+    @Mock
+    private ServerProperties serverProperties;
+
+    @Mock
+    private AwsProperties.S3 awsS3;
+
     @BeforeEach
     void setUp() {
-        ReflectionTestUtils.setField(cloudflareImageService, "viewEndpoint", "https://cdn.example.com/");
-        ReflectionTestUtils.setField(cloudflareImageService, "bucketName", "test-bucket");
+        // AwsProperties Mock 설정
+        lenient().when(awsProperties.s3()).thenReturn(awsS3);
+        lenient().when(awsS3.viewEndpoint()).thenReturn("https://cdn.example.com/");
+        lenient().when(awsS3.bucket()).thenReturn("test-bucket");
+        
+        // init 메서드 호출을 통해 normalizedViewEndpoint 초기화
         ReflectionTestUtils.invokeMethod(cloudflareImageService, "init");
     }
 

--- a/backend/src/test/java/moadong/media/service/CloudflareImageServiceUpdateFeedsLimitTest.java
+++ b/backend/src/test/java/moadong/media/service/CloudflareImageServiceUpdateFeedsLimitTest.java
@@ -3,6 +3,7 @@ package moadong.media.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
@@ -11,6 +12,8 @@ import java.util.Optional;
 import moadong.club.entity.Club;
 import moadong.club.entity.ClubRecruitmentInformation;
 import moadong.club.repository.ClubRepository;
+import moadong.global.config.properties.AwsProperties;
+import moadong.global.config.properties.ServerProperties;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
 import moadong.util.annotations.UnitTest;
@@ -22,6 +25,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
@@ -42,6 +46,18 @@ class CloudflareImageServiceUpdateFeedsLimitTest {
 	@Mock
 	private S3Presigner s3Presigner;
 
+	@Mock
+	private AwsProperties awsProperties;
+
+	@Mock
+	private ServerProperties serverProperties;
+
+	@Mock
+	private AwsProperties.S3 awsS3;
+
+	@Mock
+	private ServerProperties.Feed feedProperties;
+
 	private final int MAX_FEED_COUNT = 15;
 
 	private Club club;
@@ -49,6 +65,16 @@ class CloudflareImageServiceUpdateFeedsLimitTest {
 
 	@BeforeEach
 	void setUp() {
+		// Properties Mock 설정
+		lenient().when(awsProperties.s3()).thenReturn(awsS3);
+		lenient().when(awsS3.viewEndpoint()).thenReturn("https://cdn.example.com/");
+		
+		lenient().when(serverProperties.feed()).thenReturn(feedProperties);
+		lenient().when(feedProperties.maxCount()).thenReturn(MAX_FEED_COUNT);
+
+		// init 메서드 호출을 통해 normalizedViewEndpoint 초기화
+		ReflectionTestUtils.invokeMethod(cloudflareImageService, "init");
+
 		ClubRecruitmentInformation info = ClubRecruitmentInformation.builder()
 			.feedImages(List.of())
 			.build();
@@ -59,9 +85,9 @@ class CloudflareImageServiceUpdateFeedsLimitTest {
 	@Test
 	void MAX_FEED_COUNT_이상의_피드를_업로드하면_TOO_MANY_FILES를_반환한다() {
 		// given
-		List<String> tooMany = Arrays.asList(new String[MAX_FEED_COUNT]);
+		List<String> tooMany = Arrays.asList(new String[MAX_FEED_COUNT + 1]);
 		ClubRecruitmentInformation info = ClubRecruitmentInformation.builder()
-				.feedImages(tooMany)
+				.feedImages(java.util.Collections.emptyList())
 				.build();
 		club = Club.builder().userId("").clubRecruitmentInformation(info).build();
 
@@ -74,5 +100,3 @@ class CloudflareImageServiceUpdateFeedsLimitTest {
 		assertEquals(ErrorCode.TOO_MANY_FILES, exception.getErrorCode());
 	}
 }
-
-

--- a/backend/src/test/java/moadong/media/webhook/ImageConversionCompletedWebhookServiceTest.java
+++ b/backend/src/test/java/moadong/media/webhook/ImageConversionCompletedWebhookServiceTest.java
@@ -2,6 +2,7 @@ package moadong.media.webhook;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -10,6 +11,7 @@ import moadong.club.entity.Club;
 import moadong.club.entity.ClubRecruitmentInformation;
 import moadong.club.enums.ClubRecruitmentStatus;
 import moadong.club.repository.ClubRepository;
+import moadong.global.config.properties.AwsProperties;
 import moadong.media.webhook.dto.ImageConversionCompletedRequest;
 import moadong.media.webhook.dto.ImageEntry;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,12 +30,22 @@ class ImageConversionCompletedWebhookServiceTest {
     @Mock
     private ClubRepository clubRepository;
 
+    @Mock
+    private AwsProperties awsProperties;
+
+    @Mock
+    private AwsProperties.S3 awsS3;
+
     @InjectMocks
     private ImageConversionCompletedWebhookService imageConversionCompletedWebhookService;
 
     @BeforeEach
     void setUp() {
-        ReflectionTestUtils.setField(imageConversionCompletedWebhookService, "viewEndpoint", VIEW_ENDPOINT);
+        // AwsProperties Mock 설정
+        lenient().when(awsProperties.s3()).thenReturn(awsS3);
+        lenient().when(awsS3.viewEndpoint()).thenReturn(VIEW_ENDPOINT);
+        
+        // init 메서드 호출을 통해 normalizedViewEndpoint 초기화
         ReflectionTestUtils.invokeMethod(imageConversionCompletedWebhookService, "init");
     }
 

--- a/backend/src/test/java/moadong/media/webhook/WebpMigrationServiceTest.java
+++ b/backend/src/test/java/moadong/media/webhook/WebpMigrationServiceTest.java
@@ -1,17 +1,10 @@
 package moadong.media.webhook;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.util.List;
 import moadong.club.entity.Club;
 import moadong.club.entity.ClubRecruitmentInformation;
 import moadong.club.enums.ClubRecruitmentStatus;
 import moadong.club.repository.ClubRepository;
+import moadong.global.config.properties.AwsProperties;
 import moadong.media.webhook.dto.WebpMigrationResult;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,6 +18,13 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class WebpMigrationServiceTest {
@@ -42,13 +42,23 @@ class WebpMigrationServiceTest {
     @Mock
     private ImageConversionCompletedWebhookService imageConversionCompletedWebhookService;
 
+    @Mock
+    private AwsProperties awsProperties;
+
+    @Mock
+    private AwsProperties.S3 awsS3;
+
     @InjectMocks
     private WebpMigrationService webpMigrationService;
 
     @BeforeEach
     void setUp() {
-        ReflectionTestUtils.setField(webpMigrationService, "viewEndpoint", VIEW_ENDPOINT);
-        ReflectionTestUtils.setField(webpMigrationService, "bucket", BUCKET);
+        // AwsProperties Mock 설정
+        lenient().when(awsProperties.s3()).thenReturn(awsS3);
+        lenient().when(awsS3.viewEndpoint()).thenReturn(VIEW_ENDPOINT);
+        lenient().when(awsS3.bucket()).thenReturn(BUCKET);
+        
+        // init 메서드 호출을 통해 normalizedViewEndpoint 초기화
         ReflectionTestUtils.invokeMethod(webpMigrationService, "init");
     }
 


### PR DESCRIPTION
> 🚀 릴리즈 PR인 경우 [**릴리즈 템플릿으로 전환**](?template=release.md)해 주세요. _(Preview 탭에서 클릭)_

## #️⃣연관된 이슈

- #1340 

## 📝작업 내용

* 설정 파편화 해소: 프로젝트 전반에 @Value로 흩어져 있던 설정값들을 도메인별(JWT, AWS, FCM 등)로 그룹화하여 관리 효율성을 높였습니다.
* 시크릿 관리 일원화: Infisical 도입에 따라 환경 변수(SNAKE_CASE)와 애플리케이션 프로퍼티(dot.notation) 간의 유연한 바인딩(Relaxed Binding)을 지원하는 구조가 필요했습니다.

* ``@ConfigurationProperties`` (Java 17 Record) 도입: 
   * ``@Value`` 기반의 필드 주입을 제거하고, 불변(Immutable) 객체인 record를 사용한 타입 세이프한 설정 구조를 구축했습니다.
   * JwtProperties, AwsProperties, MediaProperties, FcmProperties 등 도메인별 분리.

## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 설정을 구조화된 프로퍼티로 중앙화해 환경별 바인딩과 유효성 검사를 지원합니다.
* **Chores**
  * Firebase/FCM 초기화를 더 안전하게 처리하고 구성 기반 타임아웃 및 비활성화 경로를 추가했습니다.
  * 비동기 스트리밍(SSE) 타임아웃을 명시적으로 구성(30초)했습니다.
  * 이미지 업로드, 파일 URL 검증, JWT·쿠키 만료 등 운영 설정을 프로퍼티로 이전해 관리 편의성을 개선했습니다.
* **Documentation**
  * API 설명 문구 오타를 수정하고 서버 정보에 서버 URL을 포함시켰습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->