### PR TITLE
[feature] 관리자 캘린더 연동 탭에 Notion DB 선택/캘린더 표시 기능 추가

### DIFF
--- a/frontend/src/apis/calendarOAuth.ts
+++ b/frontend/src/apis/calendarOAuth.ts
@@ -1,39 +1,15 @@
 import API_BASE_URL from '@/constants/api';
+import type { GoogleCalendarItem, GoogleEventItem } from '@/types/google';
+import type {
+  NotionDatabaseOption,
+  NotionPagesResponse,
+  NotionSearchItem,
+} from '@/types/notion';
 import { secureFetch } from './auth/secureFetch';
 import { handleResponse } from './utils/apiHelpers';
 
-export interface GoogleCalendarItem {
-  id: string;
-  summary: string;
-  primary?: boolean;
-}
-
-export interface GoogleEventItem {
-  id: string;
-  summary?: string;
-  htmlLink?: string;
-  start?: {
-    dateTime?: string;
-    date?: string;
-  };
-  end?: {
-    dateTime?: string;
-    date?: string;
-  };
-}
-
-export interface NotionSearchItem {
-  id: string;
-  object: string;
-  url?: string;
-  last_edited_time?: string;
-  properties?: Record<string, unknown>;
-}
-
-export interface NotionDatabaseOption {
-  id: string;
-  title: string;
-}
+export type { GoogleCalendarItem, GoogleEventItem };
+export type { NotionSearchItem, NotionDatabaseOption, NotionPagesResponse };
 
 export const fetchGoogleCalendarList = async (accessToken: string) => {
   const response = await fetch(
@@ -105,12 +81,6 @@ interface NotionDatabasePayload {
   id: string;
   object?: string;
   title?: Array<{ plain_text?: string }>;
-}
-
-export interface NotionPagesResponse {
-  items: NotionSearchItem[];
-  totalResults: number;
-  databaseId?: string;
 }
 
 export const fetchNotionAuthorizeUrl = async (state?: string) => {

--- a/frontend/src/apis/calendarOAuth.ts
+++ b/frontend/src/apis/calendarOAuth.ts
@@ -1,0 +1,267 @@
+import API_BASE_URL from '@/constants/api';
+import { secureFetch } from './auth/secureFetch';
+import { handleResponse } from './utils/apiHelpers';
+
+export interface GoogleCalendarItem {
+  id: string;
+  summary: string;
+  primary?: boolean;
+}
+
+export interface GoogleEventItem {
+  id: string;
+  summary?: string;
+  htmlLink?: string;
+  start?: {
+    dateTime?: string;
+    date?: string;
+  };
+  end?: {
+    dateTime?: string;
+    date?: string;
+  };
+}
+
+export interface NotionSearchItem {
+  id: string;
+  object: string;
+  url?: string;
+  last_edited_time?: string;
+  properties?: Record<string, unknown>;
+}
+
+export interface NotionDatabaseOption {
+  id: string;
+  title: string;
+}
+
+export const fetchGoogleCalendarList = async (accessToken: string) => {
+  const response = await fetch(
+    'https://www.googleapis.com/calendar/v3/users/me/calendarList',
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error('Google 캘린더 목록 조회에 실패했습니다.');
+  }
+
+  const data = await response.json();
+  return (data.items ?? []) as GoogleCalendarItem[];
+};
+
+export const fetchGooglePrimaryEvents = async (accessToken: string) => {
+  const query = new URLSearchParams({
+    maxResults: '10',
+    singleEvents: 'true',
+    orderBy: 'startTime',
+    timeMin: new Date().toISOString(),
+  });
+
+  const response = await fetch(
+    `https://www.googleapis.com/calendar/v3/calendars/primary/events?${query.toString()}`,
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error('Google 캘린더 이벤트 조회에 실패했습니다.');
+  }
+
+  const data = await response.json();
+  return (data.items ?? []) as GoogleEventItem[];
+};
+
+interface NotionTokenRequest {
+  code: string;
+}
+
+interface NotionTokenResponse {
+  accessToken?: string;
+  workspaceName?: string;
+  workspaceId?: string;
+}
+
+interface NotionAuthorizeResponse {
+  authorizeUrl: string;
+}
+
+interface NotionPagesPayload {
+  items?: NotionSearchItem[];
+  results?: NotionSearchItem[];
+  total_results?: number;
+  totalResults?: number;
+  database_id?: string;
+  databaseId?: string;
+}
+
+interface NotionDatabasePayload {
+  id: string;
+  object?: string;
+  title?: Array<{ plain_text?: string }>;
+}
+
+export interface NotionPagesResponse {
+  items: NotionSearchItem[];
+  totalResults: number;
+  databaseId?: string;
+}
+
+export const fetchNotionAuthorizeUrl = async (state?: string) => {
+  const params = new URLSearchParams();
+  if (state) {
+    params.set('state', state);
+  }
+
+  const url = `${API_BASE_URL}/api/integration/notion/oauth/authorize${params.toString() ? `?${params.toString()}` : ''}`;
+  const response = await secureFetch(url, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+    },
+  });
+
+  const data = await handleResponse<NotionAuthorizeResponse>(
+    response,
+    'Notion 인가 URL 생성에 실패했습니다.',
+  );
+
+  if (!data?.authorizeUrl) {
+    throw new Error('Notion 인가 URL이 비어있습니다.');
+  }
+  return data.authorizeUrl;
+};
+
+export const exchangeNotionCode = async ({ code }: NotionTokenRequest) => {
+  const response = await secureFetch(
+    `${API_BASE_URL}/api/integration/notion/oauth/token`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        code,
+      }),
+    },
+  );
+
+  const data = await handleResponse<NotionTokenResponse>(
+    response,
+    'Notion 토큰 교환에 실패했습니다.',
+  );
+  return data;
+};
+
+export const fetchNotionPages = async () => {
+  const response = await secureFetch(
+    `${API_BASE_URL}/api/integration/notion/pages`,
+    {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+      },
+    },
+  );
+
+  const data = await handleResponse<NotionPagesPayload | NotionSearchItem[]>(
+    response,
+    'Notion 데이터 조회에 실패했습니다.',
+  );
+  if (Array.isArray(data)) {
+    return {
+      items: data,
+      totalResults: data.length,
+    } satisfies NotionPagesResponse;
+  }
+
+  const items = (data?.items ?? data?.results ?? []) as NotionSearchItem[];
+  const totalResults =
+    data?.total_results ?? data?.totalResults ?? items.length;
+  const databaseId = data?.database_id ?? data?.databaseId;
+  return {
+    items,
+    totalResults,
+    databaseId,
+  } satisfies NotionPagesResponse;
+};
+
+export const fetchNotionDatabasePages = async ({
+  databaseId,
+  dateProperty,
+}: {
+  databaseId: string;
+  dateProperty?: string;
+}) => {
+  const params = new URLSearchParams();
+  if (dateProperty) {
+    params.set('dateProperty', dateProperty);
+  }
+
+  const query = params.toString();
+  const response = await secureFetch(
+    `${API_BASE_URL}/api/integration/notion/databases/${databaseId}/pages${query ? `?${query}` : ''}`,
+    {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+      },
+    },
+  );
+
+  const data = await handleResponse<NotionPagesPayload | NotionSearchItem[]>(
+    response,
+    'Notion 데이터베이스 페이지 조회에 실패했습니다.',
+  );
+
+  if (Array.isArray(data)) {
+    return {
+      items: data,
+      totalResults: data.length,
+      databaseId,
+    } satisfies NotionPagesResponse;
+  }
+
+  const items = (data?.items ?? data?.results ?? []) as NotionSearchItem[];
+  const totalResults =
+    data?.total_results ?? data?.totalResults ?? items.length;
+  const resolvedDatabaseId =
+    data?.database_id ?? data?.databaseId ?? databaseId;
+  return {
+    items,
+    totalResults,
+    databaseId: resolvedDatabaseId,
+  } satisfies NotionPagesResponse;
+};
+
+export const fetchNotionDatabases = async () => {
+  const response = await secureFetch(
+    `${API_BASE_URL}/api/integration/notion/databases`,
+    {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+      },
+    },
+  );
+
+  const data = await handleResponse<
+    { results?: NotionDatabasePayload[] } | NotionDatabasePayload[]
+  >(response, 'Notion 데이터베이스 목록 조회에 실패했습니다.');
+
+  const databases = Array.isArray(data) ? data : (data?.results ?? []);
+  return databases.map((database) => ({
+    id: database.id,
+    title:
+      database.title
+        ?.map((segment) => segment.plain_text ?? '')
+        .join('')
+        .trim() || '(이름 없는 데이터베이스)',
+  })) as NotionDatabaseOption[];
+};

--- a/frontend/src/apis/club.ts
+++ b/frontend/src/apis/club.ts
@@ -49,7 +49,9 @@ export const getClubList = async (
 export const getClubCalendarEvents = async (
   clubId: string,
 ): Promise<ClubCalendarEvent[]> => {
-  const response = await fetch(`${API_BASE_URL}/api/club/${clubId}/calendar-events`);
+  const response = await fetch(
+    `${API_BASE_URL}/api/club/${clubId}/calendar-events`,
+  );
   const data = await handleResponse<{
     calendarEvents?: ClubCalendarEvent[];
   }>(response, '동아리 일정 정보를 불러오는데 실패했습니다.');

--- a/frontend/src/apis/club.ts
+++ b/frontend/src/apis/club.ts
@@ -1,5 +1,5 @@
 import API_BASE_URL from '@/constants/api';
-import { ClubDescription, ClubDetail } from '@/types/club';
+import { ClubCalendarEvent, ClubDescription, ClubDetail } from '@/types/club';
 import { secureFetch } from './auth/secureFetch';
 import { handleResponse } from './utils/apiHelpers';
 
@@ -44,6 +44,21 @@ export const getClubList = async (
     clubs: data.clubs || [],
     totalCount: data.totalCount || 0,
   };
+};
+
+export const getClubCalendarEvents = async (
+  clubId: string,
+): Promise<ClubCalendarEvent[]> => {
+  const response = await fetch(`${API_BASE_URL}/api/club/${clubId}/calendar-events`);
+  const data = await handleResponse<{
+    calendarEvents?: ClubCalendarEvent[];
+  }>(response, '동아리 일정 정보를 불러오는데 실패했습니다.');
+
+  if (!Array.isArray(data?.calendarEvents)) {
+    return [];
+  }
+
+  return data.calendarEvents;
 };
 
 export const updateClubDescription = async (

--- a/frontend/src/constants/eventName.ts
+++ b/frontend/src/constants/eventName.ts
@@ -32,6 +32,7 @@ export const USER_EVENT = {
   CLUB_CARD_CLICKED: 'ClubCard Clicked',
   CLUB_INTRO_TAB_CLICKED: 'Club Intro Tab Clicked',
   CLUB_FEED_TAB_CLICKED: 'Club Feed Tab Clicked',
+  CLUB_SCHEDULE_TAB_CLICKED: 'Club Schedule Tab Clicked',
 
   // 동아리 지원
   CLUB_APPLY_BUTTON_CLICKED: 'Club Apply Button Clicked',

--- a/frontend/src/constants/queryKeys.ts
+++ b/frontend/src/constants/queryKeys.ts
@@ -12,6 +12,8 @@ export const queryKeys = {
   club: {
     all: ['clubs'] as const,
     detail: (clubParam: string) => ['clubDetail', clubParam] as const,
+    calendarEvents: (clubParam: string) =>
+      ['clubCalendarEvents', clubParam] as const,
     list: (
       keyword: string,
       recruitmentStatus: string,

--- a/frontend/src/hooks/Queries/useClub.ts
+++ b/frontend/src/hooks/Queries/useClub.ts
@@ -44,12 +44,15 @@ export const useGetClubDetail = (clubParam: string) => {
   });
 };
 
-export const useGetClubCalendarEvents = (clubParam: string) => {
+export const useGetClubCalendarEvents = (
+  clubParam: string,
+  options?: { enabled?: boolean },
+) => {
   return useQuery<ClubCalendarEvent[]>({
     queryKey: queryKeys.club.calendarEvents(clubParam),
     queryFn: () => getClubCalendarEvents(clubParam),
-    staleTime: 60 * 1000,
-    enabled: !!clubParam,
+    staleTime: 5 * 60 * 1000,
+    enabled: (options?.enabled ?? true) && !!clubParam,
     select: (data) =>
       data.filter(
         (event): event is ClubCalendarEvent =>

--- a/frontend/src/hooks/Queries/useClub.ts
+++ b/frontend/src/hooks/Queries/useClub.ts
@@ -5,13 +5,19 @@ import {
   useQueryClient,
 } from '@tanstack/react-query';
 import {
+  getClubCalendarEvents,
   getClubDetail,
   getClubList,
   updateClubDescription,
   updateClubDetail,
 } from '@/apis/club';
 import { queryKeys } from '@/constants/queryKeys';
-import { ClubDescription, ClubDetail, ClubSearchResponse } from '@/types/club';
+import {
+  ClubCalendarEvent,
+  ClubDescription,
+  ClubDetail,
+  ClubSearchResponse,
+} from '@/types/club';
 import convertGoogleDriveUrl from '@/utils/convertGoogleDriveUrl';
 
 interface UseGetCardListProps {
@@ -35,6 +41,23 @@ export const useGetClubDetail = (clubParam: string) => {
           ? data.feeds.map(convertGoogleDriveUrl)
           : [],
       }) as ClubDetail,
+  });
+};
+
+export const useGetClubCalendarEvents = (clubParam: string) => {
+  return useQuery<ClubCalendarEvent[]>({
+    queryKey: queryKeys.club.calendarEvents(clubParam),
+    queryFn: () => getClubCalendarEvents(clubParam),
+    staleTime: 60 * 1000,
+    enabled: !!clubParam,
+    select: (data) =>
+      data.filter(
+        (event): event is ClubCalendarEvent =>
+          !!event &&
+          typeof event.id === 'string' &&
+          typeof event.title === 'string' &&
+          typeof event.start === 'string',
+      ),
   });
 };
 

--- a/frontend/src/pages/AdminPage/AdminRoutes.tsx
+++ b/frontend/src/pages/AdminPage/AdminRoutes.tsx
@@ -5,6 +5,7 @@ import ApplicantDetailPage from '@/pages/AdminPage/tabs/ApplicantsTab/ApplicantD
 import ApplicantsListTab from '@/pages/AdminPage/tabs/ApplicantsTab/ApplicantsListTab/ApplicantsListTab';
 import ApplicationEditTab from '@/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab';
 import ApplicationListTab from '@/pages/AdminPage/tabs/ApplicationListTab/ApplicationListTab';
+import CalendarSyncTab from '@/pages/AdminPage/tabs/CalendarSyncTab/CalendarSyncTab';
 import ClubInfoEditTab from '@/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTab';
 import PhotoEditTab from '@/pages/AdminPage/tabs/PhotoEditTab/PhotoEditTab';
 import RecruitEditTab from '@/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab';
@@ -18,6 +19,7 @@ export default function AdminRoutes() {
         <Route index element={<Navigate to='club-info' replace />} />
         <Route path='club-info' element={<ClubInfoEditTab />} />
         <Route path='recruit-edit' element={<RecruitEditTab />} />
+        <Route path='calendar-sync' element={<CalendarSyncTab />} />
         <Route path='photo-edit' element={<PhotoEditTab />} />
         <Route path='account-edit' element={<AccountEditTab />} />
         <Route path='application-list' element={<ApplicationListTab />} />

--- a/frontend/src/pages/AdminPage/components/SideBar/SideBar.tsx
+++ b/frontend/src/pages/AdminPage/components/SideBar/SideBar.tsx
@@ -23,6 +23,7 @@ const tabs: TabCategory[] = [
       { label: '기본 정보 수정', path: '/admin/club-info' },
       { label: '소개 정보 수정', path: '/admin/club-intro' },
       { label: '활동 사진 수정', path: '/admin/photo-edit' },
+      { label: '동아리 일정 관리', path: '/admin/calendar-sync' },
     ],
   },
   {

--- a/frontend/src/pages/AdminPage/tabs/CalendarSyncTab/CalendarSyncTab.styles.ts
+++ b/frontend/src/pages/AdminPage/tabs/CalendarSyncTab/CalendarSyncTab.styles.ts
@@ -1,0 +1,285 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+`;
+
+export const Description = styled.p`
+  font-size: 0.94rem;
+  line-height: 1.5;
+  color: #4b5563;
+`;
+
+export const ConfigGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+
+  @media (max-width: 1024px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+export const Block = styled.div`
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 14px;
+`;
+
+export const BlockTitle = styled.h4`
+  margin: 0 0 10px;
+  font-size: 1rem;
+  font-weight: 700;
+`;
+
+export const Buttons = styled.div`
+  margin-top: 12px;
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+`;
+
+export const SelectRow = styled.div`
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  margin-top: 10px;
+  flex-wrap: wrap;
+`;
+
+export const Select = styled.select`
+  min-width: 240px;
+  height: 42px;
+  border: 1px solid #d1d5db;
+  border-radius: 10px;
+  padding: 0 12px;
+  font-size: 0.9rem;
+  color: #111827;
+  background: #ffffff;
+`;
+
+export const TokenText = styled.code`
+  display: block;
+  margin-top: 10px;
+  padding: 10px;
+  border-radius: 8px;
+  background: #f8fafc;
+  font-size: 0.82rem;
+  color: #1f2937;
+  word-break: break-all;
+`;
+
+export const StatusText = styled.p`
+  margin-top: 10px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #0f766e;
+`;
+
+export const ErrorText = styled.p`
+  margin-top: 8px;
+  font-size: 0.9rem;
+  color: #b91c1c;
+  font-weight: 600;
+`;
+
+export const DataGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+
+  @media (max-width: 1024px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+export const DataCard = styled.div`
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 14px;
+  background: #ffffff;
+`;
+
+export const WideDataCard = styled(DataCard)`
+  grid-column: 1 / -1;
+`;
+
+export const DataTitle = styled.h4`
+  margin: 0 0 10px;
+  font-size: 1rem;
+  font-weight: 700;
+`;
+
+export const Empty = styled.p`
+  font-size: 0.9rem;
+  color: #6b7280;
+`;
+
+export const List = styled.ul`
+  margin: 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+export const ListItem = styled.li`
+  font-size: 0.92rem;
+  color: #111827;
+  line-height: 1.45;
+`;
+
+export const ExternalLink = styled.a`
+  color: #1d4ed8;
+`;
+
+export const CalendarBoard = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
+
+export const TogglePanel = styled.div`
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  padding: 10px;
+  background: #f9fafb;
+`;
+
+export const ToggleHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+`;
+
+export const ToggleTitle = styled.h6`
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #111827;
+`;
+
+export const ToggleActions = styled.div`
+  display: flex;
+  gap: 8px;
+`;
+
+export const ToggleActionButton = styled.button`
+  border: none;
+  background: transparent;
+  color: #1d4ed8;
+  font-size: 0.82rem;
+  font-weight: 700;
+  cursor: pointer;
+  padding: 0;
+`;
+
+export const ToggleList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-height: 180px;
+  overflow-y: auto;
+`;
+
+export const ToggleItem = styled.label`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.84rem;
+  color: #374151;
+`;
+
+export const ToggleCheckbox = styled.input`
+  width: 14px;
+  height: 14px;
+`;
+
+export const ToggleText = styled.span`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+export const CalendarHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+`;
+
+export const CalendarMonth = styled.h5`
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #111827;
+`;
+
+export const CalendarWeekRow = styled.div`
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 8px;
+`;
+
+export const CalendarWeekCell = styled.div`
+  text-align: center;
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: #4b5563;
+`;
+
+export const CalendarGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 8px;
+`;
+
+export const CalendarCell = styled.div<{ $muted: boolean }>`
+  min-height: 120px;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  padding: 8px;
+  background: ${({ $muted }) => ($muted ? '#f9fafb' : '#ffffff')};
+  opacity: ${({ $muted }) => ($muted ? 0.55 : 1)};
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  @media (max-width: 768px) {
+    min-height: 96px;
+    padding: 6px;
+  }
+`;
+
+export const CalendarDayNumber = styled.span`
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: #374151;
+`;
+
+export const CalendarEventList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`;
+
+export const CalendarEvent = styled.div`
+  font-size: 0.8rem;
+  line-height: 1.35;
+  color: #111827;
+  padding: 4px 6px;
+  border-radius: 6px;
+  background: #eff6ff;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+export const CalendarTitle = styled.span`
+  font-size: 0.82rem;
+  color: #111827;
+`;

--- a/frontend/src/pages/AdminPage/tabs/CalendarSyncTab/CalendarSyncTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/CalendarSyncTab/CalendarSyncTab.tsx
@@ -1,0 +1,281 @@
+import Button from '@/components/common/Button/Button';
+import {
+  buildDateKeyFromDate,
+  formatDateText,
+  maskToken,
+  WEEKDAY_LABELS,
+} from '@/utils/calendarSyncUtils';
+import * as Styled from './CalendarSyncTab.styles';
+import { useCalendarSync } from './hooks/useCalendarSync';
+
+const CalendarSyncTab = () => {
+  const {
+    googleToken,
+    googleCalendars,
+    googleEvents,
+    notionItems,
+    notionTotalResults,
+    notionDatabaseSourceId,
+    notionDatabaseOptions,
+    selectedNotionDatabaseId,
+    setSelectedNotionDatabaseId,
+    isNotionDatabaseApplying,
+    statusMessage,
+    errorMessage,
+    isGoogleLoading,
+    isNotionLoading,
+    notionWorkspaceName,
+    canStartGoogleOAuth,
+    notionCalendarEvents,
+    notionVisibleCalendarEvents,
+    notionEventsByDate,
+    notionEventEnabledMap,
+    notionCalendarDays,
+    notionCalendarLabel,
+    visibleMonth,
+    startGoogleOAuth,
+    startNotionOAuth,
+    goToPreviousMonth,
+    goToNextMonth,
+    toggleNotionEvent,
+    setAllNotionEventsEnabled,
+    applySelectedNotionDatabase,
+  } = useCalendarSync();
+
+  return (
+    <Styled.Container>
+      <Styled.ConfigGrid>
+        <Styled.Block>
+          <Styled.BlockTitle>Google 캘린더</Styled.BlockTitle>
+          <Styled.Buttons>
+            <Button
+              width='180px'
+              onClick={startGoogleOAuth}
+              disabled={!canStartGoogleOAuth || isGoogleLoading}
+            >
+              Google 캘린더 가져오기
+            </Button>
+          </Styled.Buttons>
+          {googleToken && (
+            <Styled.TokenText>{maskToken(googleToken)}</Styled.TokenText>
+          )}
+        </Styled.Block>
+
+        <Styled.Block>
+          <Styled.BlockTitle>Notion 캘린더</Styled.BlockTitle>
+          <Styled.Description>
+            연결할 데이터베이스를 선택하고 적용하세요.
+          </Styled.Description>
+          <Styled.SelectRow>
+            <Styled.Select
+              value={selectedNotionDatabaseId}
+              onChange={(e) => setSelectedNotionDatabaseId(e.target.value)}
+            >
+              {notionDatabaseOptions.length === 0 ? (
+                <option value=''>데이터베이스 없음</option>
+              ) : (
+                notionDatabaseOptions.map((database) => (
+                  <option key={database.id} value={database.id}>
+                    {database.title}
+                  </option>
+                ))
+              )}
+            </Styled.Select>
+            <Button
+              width='120px'
+              onClick={applySelectedNotionDatabase}
+              disabled={!selectedNotionDatabaseId || isNotionDatabaseApplying}
+            >
+              DB 적용
+            </Button>
+          </Styled.SelectRow>
+          <Styled.Buttons>
+            <Button
+              width='180px'
+              onClick={startNotionOAuth}
+              disabled={isNotionLoading}
+            >
+              Notion 캘린더 가져오기
+            </Button>
+          </Styled.Buttons>
+          {notionWorkspaceName && (
+            <Styled.StatusText>
+              연결된 워크스페이스: {notionWorkspaceName}
+            </Styled.StatusText>
+          )}
+        </Styled.Block>
+      </Styled.ConfigGrid>
+
+      {statusMessage && <Styled.StatusText>{statusMessage}</Styled.StatusText>}
+      {errorMessage && <Styled.ErrorText>{errorMessage}</Styled.ErrorText>}
+
+      <Styled.DataGrid>
+        <Styled.DataCard>
+          <Styled.DataTitle>Google 캘린더 목록</Styled.DataTitle>
+          {googleCalendars.length === 0 ? (
+            <Styled.Empty>
+              아직 데이터가 없습니다. Google 캘린더 가져오기를 먼저
+              완료해주세요.
+            </Styled.Empty>
+          ) : (
+            <Styled.List>
+              {googleCalendars.map((calendar) => (
+                <Styled.ListItem key={calendar.id}>
+                  {calendar.summary || '(제목 없음)'}
+                  {calendar.primary ? ' (기본 캘린더)' : ''}
+                </Styled.ListItem>
+              ))}
+            </Styled.List>
+          )}
+        </Styled.DataCard>
+
+        <Styled.DataCard>
+          <Styled.DataTitle>Google 캘린더 이벤트</Styled.DataTitle>
+          {googleEvents.length === 0 ? (
+            <Styled.Empty>
+              이벤트가 없거나 아직 조회되지 않았습니다.
+            </Styled.Empty>
+          ) : (
+            <Styled.List>
+              {googleEvents.map((event) => (
+                <Styled.ListItem key={event.id}>
+                  {event.summary || '(제목 없음)'} | 시작:{' '}
+                  {formatDateText(event.start?.dateTime ?? event.start?.date)}
+                  {event.htmlLink && (
+                    <>
+                      {' '}
+                      |{' '}
+                      <Styled.ExternalLink
+                        href={event.htmlLink}
+                        target='_blank'
+                        rel='noreferrer'
+                      >
+                        열기
+                      </Styled.ExternalLink>
+                    </>
+                  )}
+                </Styled.ListItem>
+              ))}
+            </Styled.List>
+          )}
+        </Styled.DataCard>
+
+        <Styled.WideDataCard>
+          <Styled.DataTitle>Notion 캘린더 일정</Styled.DataTitle>
+          <Styled.Description>
+            전체 {notionTotalResults}개 / 캘린더 표시{' '}
+            {notionVisibleCalendarEvents.length}개
+          </Styled.Description>
+          {notionDatabaseSourceId && (
+            <Styled.Description>
+              데이터베이스: {notionDatabaseSourceId}
+            </Styled.Description>
+          )}
+          {notionItems.length === 0 ? (
+            <Styled.Empty>
+              아직 데이터가 없습니다. Notion 캘린더 가져오기를 먼저
+              완료해주세요.
+            </Styled.Empty>
+          ) : notionCalendarEvents.length === 0 ? (
+            <Styled.Empty>
+              날짜 속성이 있는 Notion 페이지가 없습니다. (예: 날짜/Date 타입
+              속성)
+            </Styled.Empty>
+          ) : (
+            <Styled.CalendarBoard>
+              <Styled.TogglePanel>
+                <Styled.ToggleHeader>
+                  <Styled.ToggleTitle>표시할 페이지 선택</Styled.ToggleTitle>
+                  <Styled.ToggleActions>
+                    <Styled.ToggleActionButton
+                      type='button'
+                      onClick={() => setAllNotionEventsEnabled(true)}
+                    >
+                      전체 ON
+                    </Styled.ToggleActionButton>
+                    <Styled.ToggleActionButton
+                      type='button'
+                      onClick={() => setAllNotionEventsEnabled(false)}
+                    >
+                      전체 OFF
+                    </Styled.ToggleActionButton>
+                  </Styled.ToggleActions>
+                </Styled.ToggleHeader>
+                <Styled.ToggleList>
+                  {notionCalendarEvents.map((event) => (
+                    <Styled.ToggleItem key={event.id}>
+                      <Styled.ToggleCheckbox
+                        type='checkbox'
+                        checked={notionEventEnabledMap[event.id] !== false}
+                        onChange={() => toggleNotionEvent(event.id)}
+                      />
+                      <Styled.ToggleText>
+                        {event.title} ({event.dateKey})
+                      </Styled.ToggleText>
+                    </Styled.ToggleItem>
+                  ))}
+                </Styled.ToggleList>
+              </Styled.TogglePanel>
+              <Styled.CalendarHeader>
+                <Button width='96px' onClick={goToPreviousMonth}>
+                  이전 달
+                </Button>
+                <Styled.CalendarMonth>
+                  {notionCalendarLabel}
+                </Styled.CalendarMonth>
+                <Button width='96px' onClick={goToNextMonth}>
+                  다음 달
+                </Button>
+              </Styled.CalendarHeader>
+              <Styled.CalendarWeekRow>
+                {WEEKDAY_LABELS.map((label) => (
+                  <Styled.CalendarWeekCell key={label}>
+                    {label}
+                  </Styled.CalendarWeekCell>
+                ))}
+              </Styled.CalendarWeekRow>
+              <Styled.CalendarGrid>
+                {notionCalendarDays.map((day) => {
+                  const dateKey = buildDateKeyFromDate(day);
+                  const events = notionEventsByDate[dateKey] ?? [];
+                  const isOutsideMonth =
+                    day.getMonth() !== visibleMonth.getMonth() ||
+                    day.getFullYear() !== visibleMonth.getFullYear();
+
+                  return (
+                    <Styled.CalendarCell key={dateKey} $muted={isOutsideMonth}>
+                      <Styled.CalendarDayNumber>
+                        {day.getDate()}
+                      </Styled.CalendarDayNumber>
+                      <Styled.CalendarEventList>
+                        {events.map((event) => (
+                          <Styled.CalendarEvent key={event.id}>
+                            {event.url ? (
+                              <Styled.ExternalLink
+                                href={event.url}
+                                target='_blank'
+                                rel='noreferrer'
+                              >
+                                {event.title}
+                              </Styled.ExternalLink>
+                            ) : (
+                              <Styled.CalendarTitle>
+                                {event.title}
+                              </Styled.CalendarTitle>
+                            )}
+                          </Styled.CalendarEvent>
+                        ))}
+                      </Styled.CalendarEventList>
+                    </Styled.CalendarCell>
+                  );
+                })}
+              </Styled.CalendarGrid>
+            </Styled.CalendarBoard>
+          )}
+        </Styled.WideDataCard>
+      </Styled.DataGrid>
+    </Styled.Container>
+  );
+};
+
+export default CalendarSyncTab;

--- a/frontend/src/pages/AdminPage/tabs/CalendarSyncTab/hooks/useCalendarSync.ts
+++ b/frontend/src/pages/AdminPage/tabs/CalendarSyncTab/hooks/useCalendarSync.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useGoogleCalendarData } from './useGoogleCalendarData';
 import { useNotionCalendarData } from './useNotionCalendarData';
 import { useNotionCalendarUiState } from './useNotionCalendarUiState';
@@ -9,7 +9,7 @@ export const useCalendarSync = () => {
   const [errorMessage, setErrorMessage] = useState('');
   const [notionWorkspaceName, setNotionWorkspaceName] = useState('');
 
-  const clearError = () => setErrorMessage('');
+  const clearError = useCallback(() => setErrorMessage(''), []);
 
   const google = useGoogleCalendarData({
     onError: setErrorMessage,

--- a/frontend/src/pages/AdminPage/tabs/CalendarSyncTab/hooks/useCalendarSync.ts
+++ b/frontend/src/pages/AdminPage/tabs/CalendarSyncTab/hooks/useCalendarSync.ts
@@ -1,0 +1,73 @@
+import { useState } from 'react';
+import { useGoogleCalendarData } from './useGoogleCalendarData';
+import { useNotionCalendarData } from './useNotionCalendarData';
+import { useNotionCalendarUiState } from './useNotionCalendarUiState';
+import { useNotionOAuth } from './useNotionOAuth';
+
+export const useCalendarSync = () => {
+  const [statusMessage, setStatusMessage] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
+  const [notionWorkspaceName, setNotionWorkspaceName] = useState('');
+
+  const clearError = () => setErrorMessage('');
+
+  const google = useGoogleCalendarData({
+    onError: setErrorMessage,
+    onStatus: setStatusMessage,
+    clearError,
+  });
+
+  const notionData = useNotionCalendarData({
+    onError: setErrorMessage,
+    onStatus: setStatusMessage,
+    clearError,
+  });
+
+  const notionUi = useNotionCalendarUiState({
+    notionItems: notionData.notionItems,
+  });
+
+  const notionOAuth = useNotionOAuth({
+    loadNotionPages: notionData.loadNotionPages,
+    onWorkspaceName: setNotionWorkspaceName,
+    onError: setErrorMessage,
+    onStatus: setStatusMessage,
+    clearError,
+  });
+
+  return {
+    googleToken: google.googleToken,
+    googleCalendars: google.googleCalendars,
+    googleEvents: google.googleEvents,
+    notionItems: notionData.notionItems,
+    notionTotalResults: notionData.notionTotalResults,
+    notionDatabaseSourceId: notionData.notionDatabaseSourceId,
+    notionDatabaseOptions: notionData.notionDatabaseOptions,
+    selectedNotionDatabaseId: notionData.selectedNotionDatabaseId,
+    setSelectedNotionDatabaseId: notionData.setSelectedNotionDatabaseId,
+    isNotionDatabaseApplying: notionData.isNotionDatabaseApplying,
+    statusMessage,
+    errorMessage,
+    isGoogleLoading: google.isGoogleLoading,
+    isNotionLoading:
+      notionData.isNotionLoading ||
+      notionOAuth.isNotionOAuthLoading ||
+      notionData.isNotionDatabaseApplying,
+    notionWorkspaceName,
+    canStartGoogleOAuth: google.canStartGoogleOAuth,
+    notionCalendarEvents: notionUi.notionCalendarEvents,
+    notionVisibleCalendarEvents: notionUi.notionVisibleCalendarEvents,
+    notionEventsByDate: notionUi.notionEventsByDate,
+    notionEventEnabledMap: notionUi.notionEventEnabledMap,
+    notionCalendarDays: notionUi.notionCalendarDays,
+    notionCalendarLabel: notionUi.notionCalendarLabel,
+    visibleMonth: notionUi.visibleMonth,
+    startGoogleOAuth: google.startGoogleOAuth,
+    startNotionOAuth: notionOAuth.startNotionOAuth,
+    goToPreviousMonth: notionUi.goToPreviousMonth,
+    goToNextMonth: notionUi.goToNextMonth,
+    toggleNotionEvent: notionUi.toggleNotionEvent,
+    setAllNotionEventsEnabled: notionUi.setAllNotionEventsEnabled,
+    applySelectedNotionDatabase: notionData.applySelectedNotionDatabase,
+  };
+};

--- a/frontend/src/pages/AdminPage/tabs/CalendarSyncTab/hooks/useGoogleCalendarData.ts
+++ b/frontend/src/pages/AdminPage/tabs/CalendarSyncTab/hooks/useGoogleCalendarData.ts
@@ -76,6 +76,7 @@ export const useGoogleCalendarData = ({
     const expectedState = sessionStorage.getItem(GOOGLE_STATE_KEY);
 
     if (token && state && expectedState && state === expectedState) {
+      sessionStorage.removeItem(GOOGLE_STATE_KEY);
       setGoogleToken(token);
       sessionStorage.setItem(GOOGLE_TOKEN_KEY, token);
       onStatus('Google OAuth 인증이 완료되었습니다.');

--- a/frontend/src/pages/AdminPage/tabs/CalendarSyncTab/hooks/useGoogleCalendarData.ts
+++ b/frontend/src/pages/AdminPage/tabs/CalendarSyncTab/hooks/useGoogleCalendarData.ts
@@ -1,0 +1,119 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  fetchGoogleCalendarList,
+  fetchGooglePrimaryEvents,
+  GoogleCalendarItem,
+  GoogleEventItem,
+} from '@/apis/calendarOAuth';
+import {
+  buildDefaultRedirectUri,
+  createState,
+} from '@/utils/calendarSyncUtils';
+
+const GOOGLE_STATE_KEY = 'admin_calendar_sync_google_state';
+const GOOGLE_TOKEN_KEY = 'admin_calendar_sync_google_token';
+
+interface UseGoogleCalendarDataParams {
+  onError: (message: string) => void;
+  onStatus: (message: string) => void;
+  clearError: () => void;
+}
+
+export const useGoogleCalendarData = ({
+  onError,
+  onStatus,
+  clearError,
+}: UseGoogleCalendarDataParams) => {
+  const googleClientId = import.meta.env.VITE_GOOGLE_CLIENT_ID?.trim() ?? '';
+  const redirectUri = buildDefaultRedirectUri();
+
+  const [googleToken, setGoogleToken] = useState(
+    () => sessionStorage.getItem(GOOGLE_TOKEN_KEY) ?? '',
+  );
+  const [googleCalendars, setGoogleCalendars] = useState<GoogleCalendarItem[]>(
+    [],
+  );
+  const [googleEvents, setGoogleEvents] = useState<GoogleEventItem[]>([]);
+  const [isGoogleLoading, setIsGoogleLoading] = useState(false);
+
+  const canStartGoogleOAuth = useMemo(
+    () => googleClientId.length > 0,
+    [googleClientId],
+  );
+
+  const startGoogleOAuth = () => {
+    if (!canStartGoogleOAuth) {
+      onError('VITE_GOOGLE_CLIENT_ID 설정이 필요합니다.');
+      return;
+    }
+
+    const state = createState();
+    sessionStorage.setItem(GOOGLE_STATE_KEY, state);
+
+    const params = new URLSearchParams({
+      client_id: googleClientId,
+      redirect_uri: redirectUri,
+      response_type: 'token',
+      scope: 'https://www.googleapis.com/auth/calendar.readonly',
+      include_granted_scopes: 'true',
+      prompt: 'consent',
+      state,
+    });
+
+    window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`;
+  };
+
+  useEffect(() => {
+    const hash = window.location.hash.startsWith('#')
+      ? window.location.hash.slice(1)
+      : '';
+
+    if (!hash) return;
+
+    const params = new URLSearchParams(hash);
+    const token = params.get('access_token');
+    const state = params.get('state');
+    const expectedState = sessionStorage.getItem(GOOGLE_STATE_KEY);
+
+    if (token && state && expectedState && state === expectedState) {
+      setGoogleToken(token);
+      sessionStorage.setItem(GOOGLE_TOKEN_KEY, token);
+      onStatus('Google OAuth 인증이 완료되었습니다.');
+      clearError();
+    }
+
+    const cleanUrl = `${window.location.pathname}${window.location.search}`;
+    window.history.replaceState({}, document.title, cleanUrl);
+  }, [clearError, onStatus]);
+
+  useEffect(() => {
+    if (!googleToken) return;
+
+    setIsGoogleLoading(true);
+    clearError();
+
+    Promise.all([
+      fetchGoogleCalendarList(googleToken),
+      fetchGooglePrimaryEvents(googleToken),
+    ])
+      .then(([calendars, events]) => {
+        setGoogleCalendars(calendars);
+        setGoogleEvents(events);
+      })
+      .catch((error: Error) => {
+        onError(error.message);
+      })
+      .finally(() => {
+        setIsGoogleLoading(false);
+      });
+  }, [clearError, googleToken, onError]);
+
+  return {
+    googleToken,
+    googleCalendars,
+    googleEvents,
+    isGoogleLoading,
+    canStartGoogleOAuth,
+    startGoogleOAuth,
+  };
+};

--- a/frontend/src/pages/AdminPage/tabs/CalendarSyncTab/hooks/useNotionCalendarData.ts
+++ b/frontend/src/pages/AdminPage/tabs/CalendarSyncTab/hooks/useNotionCalendarData.ts
@@ -1,0 +1,127 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  fetchNotionDatabasePages,
+  fetchNotionDatabases,
+  fetchNotionPages,
+  NotionDatabaseOption,
+  NotionPagesResponse,
+  NotionSearchItem,
+} from '@/apis/calendarOAuth';
+
+interface UseNotionCalendarDataParams {
+  onError: (message: string) => void;
+  onStatus: (message: string) => void;
+  clearError: () => void;
+}
+
+export const useNotionCalendarData = ({
+  onError,
+  onStatus,
+  clearError,
+}: UseNotionCalendarDataParams) => {
+  const [notionItems, setNotionItems] = useState<NotionSearchItem[]>([]);
+  const [notionTotalResults, setNotionTotalResults] = useState(0);
+  const [notionDatabaseSourceId, setNotionDatabaseSourceId] = useState('');
+  const [notionDatabaseOptions, setNotionDatabaseOptions] = useState<
+    NotionDatabaseOption[]
+  >([]);
+  const [selectedNotionDatabaseId, setSelectedNotionDatabaseId] = useState('');
+  const [isNotionLoading, setIsNotionLoading] = useState(false);
+  const [isNotionDatabaseApplying, setIsNotionDatabaseApplying] =
+    useState(false);
+
+  const applyPagesResponse = useCallback((response: NotionPagesResponse) => {
+    setNotionItems(response.items);
+    setNotionTotalResults(response.totalResults);
+    setNotionDatabaseSourceId(response.databaseId ?? '');
+  }, []);
+
+  const loadNotionPages = useCallback(async () => {
+    setIsNotionLoading(true);
+    try {
+      const response = await fetchNotionPages();
+      applyPagesResponse(response);
+      return response;
+    } catch (error: unknown) {
+      const status =
+        typeof error === 'object' &&
+        error !== null &&
+        'status' in error &&
+        typeof (error as { status?: unknown }).status === 'number'
+          ? (error as { status: number }).status
+          : undefined;
+
+      if (status === 401 || status === 403) {
+        return null;
+      }
+
+      if (error instanceof Error) {
+        onError(error.message);
+      }
+      return null;
+    } finally {
+      setIsNotionLoading(false);
+    }
+  }, [applyPagesResponse, onError]);
+
+  const applySelectedNotionDatabase = useCallback(() => {
+    if (!selectedNotionDatabaseId) {
+      onError('먼저 Notion 데이터베이스를 선택해주세요.');
+      return;
+    }
+
+    setIsNotionDatabaseApplying(true);
+    clearError();
+
+    fetchNotionDatabasePages({
+      databaseId: selectedNotionDatabaseId,
+    })
+      .then((pagesResponse) => {
+        applyPagesResponse(pagesResponse);
+        onStatus('선택한 Notion 데이터베이스를 연결했습니다.');
+      })
+      .catch((error: Error) => {
+        onError(error.message);
+      })
+      .finally(() => {
+        setIsNotionDatabaseApplying(false);
+      });
+  }, [
+    applyPagesResponse,
+    clearError,
+    onError,
+    onStatus,
+    selectedNotionDatabaseId,
+  ]);
+
+  useEffect(() => {
+    fetchNotionDatabases()
+      .then((options) => {
+        setNotionDatabaseOptions(options);
+        setSelectedNotionDatabaseId(
+          (previous) => previous || options[0]?.id || '',
+        );
+      })
+      .catch(() => {
+        // OAuth 전 단계에서는 목록 실패가 자연스러울 수 있다.
+      });
+  }, []);
+
+  useEffect(() => {
+    loadNotionPages();
+  }, [loadNotionPages]);
+
+  return {
+    notionItems,
+    notionTotalResults,
+    notionDatabaseSourceId,
+    notionDatabaseOptions,
+    selectedNotionDatabaseId,
+    setSelectedNotionDatabaseId,
+    isNotionLoading,
+    isNotionDatabaseApplying,
+    applyPagesResponse,
+    loadNotionPages,
+    applySelectedNotionDatabase,
+  };
+};

--- a/frontend/src/pages/AdminPage/tabs/CalendarSyncTab/hooks/useNotionCalendarUiState.ts
+++ b/frontend/src/pages/AdminPage/tabs/CalendarSyncTab/hooks/useNotionCalendarUiState.ts
@@ -1,0 +1,125 @@
+import { useEffect, useMemo, useState } from 'react';
+import { NotionSearchItem } from '@/apis/calendarOAuth';
+import {
+  buildMonthCalendarDays,
+  dateFromKey,
+  formatMonthLabel,
+  NotionCalendarEvent,
+  parseNotionCalendarEvent,
+} from '@/utils/calendarSyncUtils';
+
+interface UseNotionCalendarUiStateParams {
+  notionItems: NotionSearchItem[];
+}
+
+export const useNotionCalendarUiState = ({
+  notionItems,
+}: UseNotionCalendarUiStateParams) => {
+  const [visibleMonth, setVisibleMonth] = useState(() => {
+    const now = new Date();
+    return new Date(now.getFullYear(), now.getMonth(), 1);
+  });
+  const [notionEventEnabledMap, setNotionEventEnabledMap] = useState<
+    Record<string, boolean>
+  >({});
+
+  const notionCalendarEvents = useMemo(
+    () =>
+      notionItems
+        .map(parseNotionCalendarEvent)
+        .filter((event): event is NotionCalendarEvent => event !== null)
+        .sort((a, b) => a.dateKey.localeCompare(b.dateKey)),
+    [notionItems],
+  );
+  const notionVisibleCalendarEvents = useMemo(
+    () =>
+      notionCalendarEvents.filter(
+        (event) => notionEventEnabledMap[event.id] !== false,
+      ),
+    [notionCalendarEvents, notionEventEnabledMap],
+  );
+  const notionEventsByDate = useMemo(
+    () =>
+      notionVisibleCalendarEvents.reduce<Record<string, NotionCalendarEvent[]>>(
+        (accumulator, event) => {
+          if (!accumulator[event.dateKey]) {
+            accumulator[event.dateKey] = [];
+          }
+          accumulator[event.dateKey].push(event);
+          return accumulator;
+        },
+        {},
+      ),
+    [notionVisibleCalendarEvents],
+  );
+  const notionCalendarDays = useMemo(
+    () => buildMonthCalendarDays(visibleMonth),
+    [visibleMonth],
+  );
+  const notionCalendarLabel = useMemo(
+    () => formatMonthLabel(visibleMonth),
+    [visibleMonth],
+  );
+
+  useEffect(() => {
+    if (notionCalendarEvents.length === 0) return;
+
+    const firstEventDate = dateFromKey(notionCalendarEvents[0].dateKey);
+    setVisibleMonth(
+      new Date(firstEventDate.getFullYear(), firstEventDate.getMonth(), 1),
+    );
+  }, [notionCalendarEvents]);
+
+  useEffect(() => {
+    setNotionEventEnabledMap((previous) => {
+      const next: Record<string, boolean> = {};
+      notionCalendarEvents.forEach((event) => {
+        next[event.id] = previous[event.id] ?? true;
+      });
+      return next;
+    });
+  }, [notionCalendarEvents]);
+
+  const goToPreviousMonth = () => {
+    setVisibleMonth(
+      new Date(visibleMonth.getFullYear(), visibleMonth.getMonth() - 1, 1),
+    );
+  };
+
+  const goToNextMonth = () => {
+    setVisibleMonth(
+      new Date(visibleMonth.getFullYear(), visibleMonth.getMonth() + 1, 1),
+    );
+  };
+
+  const toggleNotionEvent = (id: string) => {
+    setNotionEventEnabledMap((previous) => ({
+      ...previous,
+      [id]: !(previous[id] ?? true),
+    }));
+  };
+
+  const setAllNotionEventsEnabled = (enabled: boolean) => {
+    setNotionEventEnabledMap((previous) => {
+      const next = { ...previous };
+      notionCalendarEvents.forEach((event) => {
+        next[event.id] = enabled;
+      });
+      return next;
+    });
+  };
+
+  return {
+    visibleMonth,
+    notionCalendarEvents,
+    notionVisibleCalendarEvents,
+    notionEventsByDate,
+    notionEventEnabledMap,
+    notionCalendarDays,
+    notionCalendarLabel,
+    goToPreviousMonth,
+    goToNextMonth,
+    toggleNotionEvent,
+    setAllNotionEventsEnabled,
+  };
+};

--- a/frontend/src/pages/AdminPage/tabs/CalendarSyncTab/hooks/useNotionOAuth.ts
+++ b/frontend/src/pages/AdminPage/tabs/CalendarSyncTab/hooks/useNotionOAuth.ts
@@ -57,6 +57,7 @@ export const useNotionOAuth = ({
 
     if (error) {
       onError(`Notion OAuth 실패: ${error}`);
+      sessionStorage.removeItem(NOTION_STATE_KEY);
       clearOAuthParamsFromUrl();
       return;
     }
@@ -84,6 +85,7 @@ export const useNotionOAuth = ({
       })
       .finally(() => {
         setIsNotionOAuthLoading(false);
+        sessionStorage.removeItem(NOTION_STATE_KEY);
         clearOAuthParamsFromUrl();
       });
   }, [clearError, loadNotionPages, onError, onStatus, onWorkspaceName]);

--- a/frontend/src/pages/AdminPage/tabs/CalendarSyncTab/hooks/useNotionOAuth.ts
+++ b/frontend/src/pages/AdminPage/tabs/CalendarSyncTab/hooks/useNotionOAuth.ts
@@ -43,18 +43,28 @@ export const useNotionOAuth = ({
   };
 
   useEffect(() => {
+    const clearOAuthParamsFromUrl = () => {
+      const cleanUrl = window.location.pathname;
+      window.history.replaceState({}, document.title, cleanUrl);
+    };
+
     const params = new URLSearchParams(window.location.search);
     const code = params.get('code');
     const state = params.get('state');
     const error = params.get('error');
+    const hasOAuthParams = Boolean(code || state || error);
     const expectedState = sessionStorage.getItem(NOTION_STATE_KEY);
 
     if (error) {
       onError(`Notion OAuth 실패: ${error}`);
+      clearOAuthParamsFromUrl();
       return;
     }
 
     if (!code || !state || !expectedState || state !== expectedState) {
+      if (hasOAuthParams) {
+        clearOAuthParamsFromUrl();
+      }
       return;
     }
 
@@ -74,8 +84,7 @@ export const useNotionOAuth = ({
       })
       .finally(() => {
         setIsNotionOAuthLoading(false);
-        const cleanUrl = window.location.pathname;
-        window.history.replaceState({}, document.title, cleanUrl);
+        clearOAuthParamsFromUrl();
       });
   }, [clearError, loadNotionPages, onError, onStatus, onWorkspaceName]);
 

--- a/frontend/src/pages/AdminPage/tabs/CalendarSyncTab/hooks/useNotionOAuth.ts
+++ b/frontend/src/pages/AdminPage/tabs/CalendarSyncTab/hooks/useNotionOAuth.ts
@@ -1,0 +1,86 @@
+import { useEffect, useState } from 'react';
+import {
+  exchangeNotionCode,
+  fetchNotionAuthorizeUrl,
+} from '@/apis/calendarOAuth';
+import { createState } from '@/utils/calendarSyncUtils';
+
+const NOTION_STATE_KEY = 'admin_calendar_sync_notion_state';
+
+interface UseNotionOAuthParams {
+  loadNotionPages: () => Promise<unknown>;
+  onWorkspaceName: (name: string) => void;
+  onError: (message: string) => void;
+  onStatus: (message: string) => void;
+  clearError: () => void;
+}
+
+export const useNotionOAuth = ({
+  loadNotionPages,
+  onWorkspaceName,
+  onError,
+  onStatus,
+  clearError,
+}: UseNotionOAuthParams) => {
+  const [isNotionOAuthLoading, setIsNotionOAuthLoading] = useState(false);
+
+  const startNotionOAuth = () => {
+    const state = createState();
+    sessionStorage.setItem(NOTION_STATE_KEY, state);
+    setIsNotionOAuthLoading(true);
+    clearError();
+
+    fetchNotionAuthorizeUrl(state)
+      .then((authorizeUrl) => {
+        window.location.href = authorizeUrl;
+      })
+      .catch((error: Error) => {
+        onError(error.message);
+      })
+      .finally(() => {
+        setIsNotionOAuthLoading(false);
+      });
+  };
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get('code');
+    const state = params.get('state');
+    const error = params.get('error');
+    const expectedState = sessionStorage.getItem(NOTION_STATE_KEY);
+
+    if (error) {
+      onError(`Notion OAuth 실패: ${error}`);
+      return;
+    }
+
+    if (!code || !state || !expectedState || state !== expectedState) {
+      return;
+    }
+
+    setIsNotionOAuthLoading(true);
+    clearError();
+
+    exchangeNotionCode({ code })
+      .then((tokenResponse) => {
+        onWorkspaceName(tokenResponse?.workspaceName ?? '');
+        return loadNotionPages();
+      })
+      .then(() => {
+        onStatus('Notion OAuth 인증이 완료되었습니다.');
+      })
+      .catch((oauthError: Error) => {
+        onError(oauthError.message);
+      })
+      .finally(() => {
+        setIsNotionOAuthLoading(false);
+        const cleanUrl = window.location.pathname;
+        window.history.replaceState({}, document.title, cleanUrl);
+      });
+  }, [clearError, loadNotionPages, onError, onStatus, onWorkspaceName]);
+
+  return {
+    isNotionOAuthLoading,
+    startNotionOAuth,
+  };
+};

--- a/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import Footer from '@/components/common/Footer/Footer';
 import Header from '@/components/common/Header/Header';
@@ -57,6 +57,32 @@ const ClubDetailPage = () => {
     (clubName ?? clubId) || '',
   );
 
+  const hasCalendarEvents = calendarEvents.length > 0;
+
+  const tabs = useMemo(
+    () =>
+      [
+        { key: TAB_TYPE.INTRO, label: '소개 내용' },
+        { key: TAB_TYPE.PHOTOS, label: '활동사진' },
+        hasCalendarEvents
+          ? { key: TAB_TYPE.SCHEDULE, label: '일정 보기' }
+          : null,
+      ].filter(Boolean) as Array<{ key: TabType; label: string }>,
+    [hasCalendarEvents],
+  );
+
+  const topBarTabs = useMemo(
+    () =>
+      [
+        { key: TAB_TYPE.INTRO, label: '소개내용' },
+        { key: TAB_TYPE.PHOTOS, label: '활동사진' },
+        hasCalendarEvents
+          ? { key: TAB_TYPE.SCHEDULE, label: '일정 보기' }
+          : null,
+      ].filter(Boolean) as Array<{ key: TabType; label: string }>,
+    [hasCalendarEvents],
+  );
+
   useTrackPageView(PAGE_VIEW.CLUB_DETAIL_PAGE, clubDetail?.name, !clubDetail);
 
   const contentRef = useRef<HTMLDivElement>(null);
@@ -95,11 +121,7 @@ const ClubDetailPage = () => {
         <ClubDetailTopBar
           clubId={clubId || ''}
           clubName={clubDetail.name}
-          tabs={[
-            { key: TAB_TYPE.INTRO, label: '소개내용' },
-            { key: TAB_TYPE.PHOTOS, label: '활동사진' },
-            { key: TAB_TYPE.SCHEDULE, label: '일정 보기' },
-          ]}
+          tabs={topBarTabs}
           activeTab={activeTab}
           onTabClick={(tabKey) => {
             handleTabClick(tabKey as TabType);
@@ -121,11 +143,7 @@ const ClubDetailPage = () => {
 
           <Styled.RightSection ref={contentRef}>
             <UnderlineTabs
-              tabs={[
-                { key: TAB_TYPE.INTRO, label: '소개 내용' },
-                { key: TAB_TYPE.PHOTOS, label: '활동사진' },
-                { key: TAB_TYPE.SCHEDULE, label: '일정 보기' },
-              ]}
+              tabs={tabs}
               activeKey={activeTab}
               onTabClick={(tabKey) => handleTabClick(tabKey as TabType)}
               centerOnMobile
@@ -146,13 +164,15 @@ const ClubDetailPage = () => {
               >
                 <ClubFeed feed={clubDetail.feeds} clubName={clubDetail.name} />
               </div>
-              <div
-                style={{
-                  display: activeTab === TAB_TYPE.SCHEDULE ? 'block' : 'none',
-                }}
-              >
-                <ClubScheduleCalendar events={calendarEvents} />
-              </div>
+              {hasCalendarEvents && (
+                <div
+                  style={{
+                    display: activeTab === TAB_TYPE.SCHEDULE ? 'block' : 'none',
+                  }}
+                >
+                  <ClubScheduleCalendar events={calendarEvents} />
+                </div>
+              )}
             </Styled.TabContent>
           </Styled.RightSection>
         </Styled.ContentWrapper>

--- a/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
@@ -6,12 +6,16 @@ import UnderlineTabs from '@/components/common/UnderlineTabs/UnderlineTabs';
 import { PAGE_VIEW, USER_EVENT } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import useTrackPageView from '@/hooks/Mixpanel/useTrackPageView';
-import { useGetClubDetail } from '@/hooks/Queries/useClub';
+import {
+  useGetClubCalendarEvents,
+  useGetClubDetail,
+} from '@/hooks/Queries/useClub';
 import { useScrollTo } from '@/hooks/Scroll/useScrollTo';
 import useDevice from '@/hooks/useDevice';
 import ClubFeed from '@/pages/ClubDetailPage/components/ClubFeed/ClubFeed';
 import ClubIntroContent from '@/pages/ClubDetailPage/components/ClubIntroContent/ClubIntroContent';
 import ClubProfileCard from '@/pages/ClubDetailPage/components/ClubProfileCard/ClubProfileCard';
+import ClubScheduleCalendar from '@/pages/ClubDetailPage/components/ClubScheduleCalendar/ClubScheduleCalendar';
 import isInAppWebView from '@/utils/isInAppWebView';
 import * as Styled from './ClubDetailPage.styles';
 import ClubDetailFooter from './components/ClubDetailFooter/ClubDetailFooter';
@@ -20,11 +24,12 @@ import ClubDetailTopBar from './components/ClubDetailTopBar/ClubDetailTopBar';
 export const TAB_TYPE = {
   INTRO: 'intro',
   PHOTOS: 'photos',
+  SCHEDULE: 'schedule',
 } as const;
 
 type TabType = (typeof TAB_TYPE)[keyof typeof TAB_TYPE];
 
-// 소개내용/활동사진 탭 클릭 시 스크롤이 탑바 하단에 정확히 위치하도록 하는 높이 값
+// 탭 클릭 시 스크롤이 탑바 하단에 정확히 위치하도록 하는 높이 값
 const TOP_BAR_HEIGHT = 50;
 
 const ClubDetailPage = () => {
@@ -48,6 +53,9 @@ const ClubDetailPage = () => {
   const { data: clubDetail, error } = useGetClubDetail(
     (clubName ?? clubId) || '',
   );
+  const { data: calendarEvents = [] } = useGetClubCalendarEvents(
+    (clubName ?? clubId) || '',
+  );
 
   useTrackPageView(PAGE_VIEW.CLUB_DETAIL_PAGE, clubDetail?.name, !clubDetail);
 
@@ -64,7 +72,9 @@ const ClubDetailPage = () => {
       trackEvent(
         tabKey === TAB_TYPE.INTRO
           ? USER_EVENT.CLUB_INTRO_TAB_CLICKED
-          : USER_EVENT.CLUB_FEED_TAB_CLICKED,
+          : tabKey === TAB_TYPE.PHOTOS
+            ? USER_EVENT.CLUB_FEED_TAB_CLICKED
+            : USER_EVENT.CLUB_SCHEDULE_TAB_CLICKED,
       );
     },
     [setSearchParams, trackEvent],
@@ -88,6 +98,7 @@ const ClubDetailPage = () => {
           tabs={[
             { key: TAB_TYPE.INTRO, label: '소개내용' },
             { key: TAB_TYPE.PHOTOS, label: '활동사진' },
+            { key: TAB_TYPE.SCHEDULE, label: '일정 보기' },
           ]}
           activeTab={activeTab}
           onTabClick={(tabKey) => {
@@ -113,6 +124,7 @@ const ClubDetailPage = () => {
               tabs={[
                 { key: TAB_TYPE.INTRO, label: '소개 내용' },
                 { key: TAB_TYPE.PHOTOS, label: '활동사진' },
+                { key: TAB_TYPE.SCHEDULE, label: '일정 보기' },
               ]}
               activeKey={activeTab}
               onTabClick={(tabKey) => handleTabClick(tabKey as TabType)}
@@ -133,6 +145,13 @@ const ClubDetailPage = () => {
                 }}
               >
                 <ClubFeed feed={clubDetail.feeds} clubName={clubDetail.name} />
+              </div>
+              <div
+                style={{
+                  display: activeTab === TAB_TYPE.SCHEDULE ? 'block' : 'none',
+                }}
+              >
+                <ClubScheduleCalendar events={calendarEvents} />
               </div>
             </Styled.TabContent>
           </Styled.RightSection>

--- a/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
@@ -53,11 +53,13 @@ const ClubDetailPage = () => {
   const { data: clubDetail, error } = useGetClubDetail(
     (clubName ?? clubId) || '',
   );
+
+  const hasCalendarEvents = clubDetail?.hasCalendarEvents ?? false;
+
   const { data: calendarEvents = [] } = useGetClubCalendarEvents(
     (clubName ?? clubId) || '',
+    { enabled: hasCalendarEvents && activeTab === TAB_TYPE.SCHEDULE },
   );
-
-  const hasCalendarEvents = calendarEvents.length > 0;
 
   const tabs = useMemo(
     () =>

--- a/frontend/src/pages/ClubDetailPage/components/ClubScheduleCalendar/ClubScheduleCalendar.styles.ts
+++ b/frontend/src/pages/ClubDetailPage/components/ClubScheduleCalendar/ClubScheduleCalendar.styles.ts
@@ -1,0 +1,192 @@
+import styled from 'styled-components';
+import { media } from '@/styles/mediaQuery';
+import { colors } from '@/styles/theme/colors';
+
+export const Container = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;
+
+export const CalendarCard = styled.section`
+  border-radius: 20px;
+  border: 1px solid ${colors.gray[200]};
+  background-color: ${colors.base.white};
+  padding: 16px 14px;
+`;
+
+export const MonthHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 14px;
+`;
+
+export const MonthLabel = styled.h3`
+  font-size: 30px;
+  line-height: 1;
+  font-weight: 700;
+  color: ${colors.gray[900]};
+`;
+
+export const MonthMoveButton = styled.button`
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background-color: ${colors.gray[100]};
+  color: ${colors.gray[700]};
+  font-size: 16px;
+  cursor: pointer;
+`;
+
+export const WeekdayGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 6px;
+  margin-bottom: 8px;
+`;
+
+export const Weekday = styled.span<{ $dayIndex: number }>`
+  text-align: center;
+  font-size: 12px;
+  font-weight: 700;
+  color: ${({ $dayIndex }) =>
+    $dayIndex === 0
+      ? colors.secondary[1].main
+      : $dayIndex === 6
+        ? colors.secondary[4].main
+        : colors.gray[700]};
+`;
+
+export const DayGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 6px;
+`;
+
+export const DayCell = styled.button<{
+  $isCurrentMonth: boolean;
+  $isSelected: boolean;
+}>`
+  border: none;
+  border-radius: 12px;
+  min-height: 54px;
+  background-color: ${({ $isSelected }) =>
+    $isSelected ? colors.gray[100] : 'transparent'};
+  color: ${({ $isCurrentMonth }) =>
+    $isCurrentMonth ? colors.gray[900] : colors.gray[500]};
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  cursor: pointer;
+  padding: 6px 0;
+`;
+
+export const DayNumber = styled.span<{ $highlightColor?: string }>`
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  font-weight: 600;
+  background-color: ${({ $highlightColor }) =>
+    $highlightColor ?? 'transparent'};
+  color: ${({ $highlightColor }) =>
+    $highlightColor ? colors.base.white : 'inherit'};
+`;
+
+export const DotRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-height: 6px;
+`;
+
+export const Dot = styled.span<{ $color: string }>`
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background-color: ${({ $color }) => $color};
+`;
+
+export const ScheduleCard = styled.section`
+  border-radius: 20px;
+  border: 1px solid ${colors.gray[200]};
+  background-color: ${colors.base.white};
+  padding: 18px 16px;
+`;
+
+export const SectionTitle = styled.h4`
+  font-size: 20px;
+  font-weight: 700;
+  color: ${colors.gray[900]};
+  margin-bottom: 14px;
+`;
+
+export const EventList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
+export const EventItem = styled.article`
+  border-radius: 12px;
+  background-color: ${colors.gray[100]};
+  padding: 12px;
+`;
+
+export const EventHeader = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+`;
+
+export const EventTitle = styled.p`
+  font-size: 17px;
+  font-weight: 700;
+  color: ${colors.gray[900]};
+  overflow-wrap: anywhere;
+`;
+
+export const EventDescription = styled.p`
+  font-size: 14px;
+  line-height: 1.45;
+  color: ${colors.gray[700]};
+`;
+
+export const EmptyText = styled.p`
+  font-size: 15px;
+  color: ${colors.gray[600]};
+`;
+
+export const EventLink = styled.a`
+  font-size: 13px;
+  font-weight: 600;
+  color: ${colors.gray[800]};
+  text-decoration: underline;
+  text-underline-offset: 3px;
+`;
+
+export const SelectedDateLabel = styled.p`
+  font-size: 14px;
+  color: ${colors.gray[700]};
+  margin-bottom: 10px;
+`;
+
+export const MobilePanelHint = styled.p`
+  display: none;
+
+  ${media.tablet} {
+    display: block;
+    font-size: 13px;
+    color: ${colors.gray[600]};
+    margin-bottom: 8px;
+  }
+`;

--- a/frontend/src/pages/ClubDetailPage/components/ClubScheduleCalendar/ClubScheduleCalendar.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubScheduleCalendar/ClubScheduleCalendar.tsx
@@ -1,0 +1,297 @@
+import { useMemo, useState } from 'react';
+import type { ClubCalendarEvent } from '@/types/club';
+import {
+  buildDateKeyFromDate,
+  buildMonthCalendarDays,
+  dateFromKey,
+  formatMonthLabel,
+  parseDateKey,
+  WEEKDAY_LABELS,
+} from '@/utils/calendarSyncUtils';
+import * as Styled from './ClubScheduleCalendar.styles';
+
+const EVENT_COLORS = [
+  '#FF7DA4',
+  '#FFD54A',
+  '#5FD8C0',
+  '#7094FF',
+  '#FFA04D',
+  '#C379F6',
+  '#7ED957',
+  '#4FC3F7',
+] as const;
+
+interface CalendarEventItem {
+  id: string;
+  title: string;
+  description?: string;
+  url?: string;
+  dateKey: string;
+  groupKey: string;
+}
+
+interface ClubScheduleCalendarProps {
+  events: ClubCalendarEvent[];
+}
+
+const normalizeEventGroupKey = (title: string) => {
+  const normalized = title
+    .toLowerCase()
+    .replace(/[\d]+/g, '')
+    .replace(/\([^)]*\)/g, '')
+    .replace(/[^가-힣a-z\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  return normalized || title.trim().toLowerCase();
+};
+
+const hashText = (value: string) => {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) >>> 0;
+  }
+  return hash;
+};
+
+const buildSeededPalette = (seed: string) => {
+  const palette = [...EVENT_COLORS];
+  let hash = hashText(seed) || 1;
+
+  for (let index = palette.length - 1; index > 0; index -= 1) {
+    hash = (hash * 1664525 + 1013904223) >>> 0;
+    const swapIndex = hash % (index + 1);
+    [palette[index], palette[swapIndex]] = [palette[swapIndex], palette[index]];
+  }
+
+  return palette;
+};
+
+const formatSelectedDate = (dateKey: string) => {
+  const date = dateFromKey(dateKey);
+  return `${date.getMonth() + 1}월 ${date.getDate()}일`;
+};
+
+const ClubScheduleCalendar = ({ events }: ClubScheduleCalendarProps) => {
+  const parsedEvents = useMemo<CalendarEventItem[]>(() => {
+    const normalizedEvents = events.flatMap((event) => {
+      const dateKey = parseDateKey(event.start);
+      if (!dateKey) return [];
+
+      return {
+        id: event.id,
+        title: event.title,
+        description: event.description,
+        url: event.url,
+        dateKey,
+        groupKey: normalizeEventGroupKey(event.title),
+      } satisfies CalendarEventItem;
+    });
+
+    return normalizedEvents.sort((a, b) => a.dateKey.localeCompare(b.dateKey));
+  }, [events]);
+
+  const firstEventMonth = parsedEvents[0]
+    ? dateFromKey(parsedEvents[0].dateKey)
+    : new Date();
+  const [visibleMonth, setVisibleMonth] = useState<Date>(
+    new Date(firstEventMonth.getFullYear(), firstEventMonth.getMonth(), 1),
+  );
+
+  const monthKey = `${visibleMonth.getFullYear()}-${visibleMonth.getMonth() + 1}`;
+
+  const monthEvents = useMemo(() => {
+    return parsedEvents.filter((event) => {
+      const date = dateFromKey(event.dateKey);
+      return (
+        date.getFullYear() === visibleMonth.getFullYear() &&
+        date.getMonth() === visibleMonth.getMonth()
+      );
+    });
+  }, [parsedEvents, visibleMonth]);
+
+  const colorByGroup = useMemo(() => {
+    const groups = Array.from(
+      new Set(monthEvents.map((event) => event.groupKey)),
+    );
+    const palette = buildSeededPalette(monthKey);
+    return groups.reduce<Record<string, string>>(
+      (accumulator, group, index) => {
+        accumulator[group] = palette[index % palette.length];
+        return accumulator;
+      },
+      {},
+    );
+  }, [monthEvents, monthKey]);
+
+  const eventsByDate = useMemo(() => {
+    return monthEvents.reduce<Record<string, CalendarEventItem[]>>(
+      (accumulator, event) => {
+        if (!accumulator[event.dateKey]) {
+          accumulator[event.dateKey] = [];
+        }
+        accumulator[event.dateKey].push(event);
+        return accumulator;
+      },
+      {},
+    );
+  }, [monthEvents]);
+
+  const [selectedDateKey, setSelectedDateKey] = useState<string>(() => {
+    if (parsedEvents[0]) return parsedEvents[0].dateKey;
+    return buildDateKeyFromDate(new Date());
+  });
+
+  const calendarDays = useMemo(
+    () => buildMonthCalendarDays(visibleMonth),
+    [visibleMonth],
+  );
+
+  const selectedEvents = eventsByDate[selectedDateKey] ?? [];
+
+  const changeMonth = (diff: number) => {
+    const next = new Date(
+      visibleMonth.getFullYear(),
+      visibleMonth.getMonth() + diff,
+      1,
+    );
+    setVisibleMonth(next);
+
+    const firstDayKey = buildDateKeyFromDate(next);
+    const firstEventInMonth = parsedEvents.find((event) => {
+      const date = dateFromKey(event.dateKey);
+      return (
+        date.getFullYear() === next.getFullYear() &&
+        date.getMonth() === next.getMonth()
+      );
+    });
+    setSelectedDateKey(firstEventInMonth?.dateKey ?? firstDayKey);
+  };
+
+  if (parsedEvents.length === 0) {
+    return (
+      <Styled.ScheduleCard>
+        <Styled.SectionTitle>일정</Styled.SectionTitle>
+        <Styled.EmptyText>등록된 행사 일정이 없습니다.</Styled.EmptyText>
+      </Styled.ScheduleCard>
+    );
+  }
+
+  return (
+    <Styled.Container>
+      <Styled.CalendarCard>
+        <Styled.MonthHeader>
+          <Styled.MonthMoveButton
+            type='button'
+            aria-label='이전 달'
+            onClick={() => changeMonth(-1)}
+          >
+            ◀
+          </Styled.MonthMoveButton>
+          <Styled.MonthLabel>
+            {formatMonthLabel(visibleMonth)}
+          </Styled.MonthLabel>
+          <Styled.MonthMoveButton
+            type='button'
+            aria-label='다음 달'
+            onClick={() => changeMonth(1)}
+          >
+            ▶
+          </Styled.MonthMoveButton>
+        </Styled.MonthHeader>
+
+        <Styled.WeekdayGrid>
+          {WEEKDAY_LABELS.map((day, dayIndex) => (
+            <Styled.Weekday key={day} $dayIndex={dayIndex}>
+              {day}
+            </Styled.Weekday>
+          ))}
+        </Styled.WeekdayGrid>
+
+        <Styled.DayGrid>
+          {calendarDays.map((day) => {
+            const dateKey = buildDateKeyFromDate(day);
+            const dayEvents = eventsByDate[dateKey] ?? [];
+            const firstColor = dayEvents[0]
+              ? colorByGroup[dayEvents[0].groupKey]
+              : undefined;
+            const isCurrentMonth = day.getMonth() === visibleMonth.getMonth();
+            const uniqueColors = Array.from(
+              new Set(
+                dayEvents
+                  .map((event) => colorByGroup[event.groupKey])
+                  .filter((color): color is string => !!color),
+              ),
+            );
+
+            return (
+              <Styled.DayCell
+                type='button'
+                key={dateKey}
+                $isCurrentMonth={isCurrentMonth}
+                $isSelected={selectedDateKey === dateKey}
+                onClick={() => setSelectedDateKey(dateKey)}
+              >
+                <Styled.DayNumber $highlightColor={firstColor}>
+                  {day.getDate()}
+                </Styled.DayNumber>
+                <Styled.DotRow>
+                  {uniqueColors.slice(0, 3).map((color) => (
+                    <Styled.Dot key={`${dateKey}-${color}`} $color={color} />
+                  ))}
+                </Styled.DotRow>
+              </Styled.DayCell>
+            );
+          })}
+        </Styled.DayGrid>
+      </Styled.CalendarCard>
+
+      <Styled.ScheduleCard>
+        <Styled.SectionTitle>일정</Styled.SectionTitle>
+        <Styled.SelectedDateLabel>
+          {formatSelectedDate(selectedDateKey)}
+        </Styled.SelectedDateLabel>
+        <Styled.MobilePanelHint>
+          같은 이름 계열의 이벤트는 같은 색으로 표시됩니다.
+        </Styled.MobilePanelHint>
+
+        {selectedEvents.length === 0 ? (
+          <Styled.EmptyText>
+            선택한 날짜에 등록된 일정이 없습니다.
+          </Styled.EmptyText>
+        ) : (
+          <Styled.EventList>
+            {selectedEvents.map((event) => {
+              const eventColor =
+                colorByGroup[event.groupKey] ?? EVENT_COLORS[0];
+              return (
+                <Styled.EventItem key={event.id}>
+                  <Styled.EventHeader>
+                    <Styled.Dot $color={eventColor} />
+                    <Styled.EventTitle>{event.title}</Styled.EventTitle>
+                  </Styled.EventHeader>
+                  {event.description && (
+                    <Styled.EventDescription>
+                      {event.description}
+                    </Styled.EventDescription>
+                  )}
+                  {event.url && (
+                    <Styled.EventLink
+                      href={event.url}
+                      target='_blank'
+                      rel='noreferrer'
+                    >
+                      일정 상세 보기
+                    </Styled.EventLink>
+                  )}
+                </Styled.EventItem>
+              );
+            })}
+          </Styled.EventList>
+        )}
+      </Styled.ScheduleCard>
+    </Styled.Container>
+  );
+};
+
+export default ClubScheduleCalendar;

--- a/frontend/src/types/club.ts
+++ b/frontend/src/types/club.ts
@@ -34,6 +34,15 @@ export interface ClubDetail extends Club {
   externalApplicationUrl?: string;
 }
 
+export interface ClubCalendarEvent {
+  id: string;
+  title: string;
+  start: string;
+  end?: string;
+  url?: string;
+  description?: string;
+}
+
 export interface ClubDescription {
   id: string;
   recruitmentStart: string | null;

--- a/frontend/src/types/club.ts
+++ b/frontend/src/types/club.ts
@@ -32,6 +32,7 @@ export interface ClubDetail extends Club {
 
   socialLinks: Record<SNSPlatform, string>;
   externalApplicationUrl?: string;
+  hasCalendarEvents?: boolean;
 }
 
 export interface ClubCalendarEvent {

--- a/frontend/src/types/google.ts
+++ b/frontend/src/types/google.ts
@@ -1,0 +1,19 @@
+export interface GoogleCalendarItem {
+  id: string;
+  summary: string;
+  primary?: boolean;
+}
+
+export interface GoogleEventItem {
+  id: string;
+  summary?: string;
+  htmlLink?: string;
+  start?: {
+    dateTime?: string;
+    date?: string;
+  };
+  end?: {
+    dateTime?: string;
+    date?: string;
+  };
+}

--- a/frontend/src/types/notion.ts
+++ b/frontend/src/types/notion.ts
@@ -1,0 +1,18 @@
+export interface NotionSearchItem {
+  id: string;
+  object: string;
+  url?: string;
+  last_edited_time?: string;
+  properties?: Record<string, unknown>;
+}
+
+export interface NotionDatabaseOption {
+  id: string;
+  title: string;
+}
+
+export interface NotionPagesResponse {
+  items: NotionSearchItem[];
+  totalResults: number;
+  databaseId?: string;
+}

--- a/frontend/src/utils/calendarSyncUtils.test.ts
+++ b/frontend/src/utils/calendarSyncUtils.test.ts
@@ -50,7 +50,10 @@ describe('calendarSyncUtils', () => {
     });
 
     it('parseDateKey는 ISO datetime을 YYYY-MM-DD로 정규화한다', () => {
-      expect(parseDateKey('2026-03-22T06:25:00.000Z')).toBeTruthy();
+      expect(parseDateKey('2026-03-22T06:25:00.000Z')).toBe('2026-03-22');
+      expect(parseDateKey('Sun, 22 Mar 2026 06:25:00 GMT')).toBe(
+        '2026-03-22',
+      );
       expect(parseDateKey('invalid-date')).toBeNull();
     });
 

--- a/frontend/src/utils/calendarSyncUtils.test.ts
+++ b/frontend/src/utils/calendarSyncUtils.test.ts
@@ -1,0 +1,155 @@
+import type { NotionSearchItem } from '@/apis/calendarOAuth';
+import {
+  buildDateKeyFromDate,
+  buildDefaultRedirectUri,
+  buildMonthCalendarDays,
+  createState,
+  dateFromKey,
+  formatDateText,
+  formatMonthLabel,
+  maskToken,
+  parseDateKey,
+  parseNotionCalendarEvent,
+  WEEKDAY_LABELS,
+} from './calendarSyncUtils';
+
+describe('calendarSyncUtils', () => {
+  describe('기본 유틸', () => {
+    it('redirect uri는 calendar-sync 경로를 포함한다', () => {
+      expect(buildDefaultRedirectUri()).toContain('/admin/calendar-sync');
+    });
+
+    it('state 문자열을 생성한다', () => {
+      const state = createState();
+      expect(typeof state).toBe('string');
+      expect(state.length).toBeGreaterThan(0);
+    });
+
+    it('토큰 마스킹은 앞 8자리/뒤 8자리만 노출한다', () => {
+      const token = '12345678abcdefghijklmnop87654321';
+      expect(maskToken(token)).toBe('12345678...87654321');
+      expect(maskToken('short-token')).toBe('short-token');
+    });
+  });
+
+  describe('날짜 유틸', () => {
+    it('요일 라벨은 일~토 순서를 유지한다', () => {
+      expect(WEEKDAY_LABELS).toEqual([
+        '일',
+        '월',
+        '화',
+        '수',
+        '목',
+        '금',
+        '토',
+      ]);
+    });
+
+    it('parseDateKey는 YYYY-MM-DD 형식을 그대로 반환한다', () => {
+      expect(parseDateKey('2026-03-22')).toBe('2026-03-22');
+    });
+
+    it('parseDateKey는 ISO datetime을 YYYY-MM-DD로 정규화한다', () => {
+      expect(parseDateKey('2026-03-22T06:25:00.000Z')).toBeTruthy();
+      expect(parseDateKey('invalid-date')).toBeNull();
+    });
+
+    it('date key와 Date 객체 변환이 일관된다', () => {
+      const key = '2026-03-19';
+      const date = dateFromKey(key);
+      expect(buildDateKeyFromDate(date)).toBe(key);
+    });
+
+    it('월 캘린더 그리드는 주 단위(7개) 배수로 생성된다', () => {
+      const days = buildMonthCalendarDays(new Date(2026, 2, 1));
+      expect(days.length % 7).toBe(0);
+      expect(buildDateKeyFromDate(days[0])).toBe('2026-03-01');
+      expect(buildDateKeyFromDate(days[days.length - 1])).toBe('2026-04-04');
+    });
+
+    it('월 라벨은 YYYY년 MM월 형식이다', () => {
+      expect(formatMonthLabel(new Date(2026, 2, 1))).toBe('2026년 03월');
+    });
+
+    it('유효하지 않은 날짜 텍스트는 원문을 반환한다', () => {
+      expect(formatDateText(undefined)).toBe('-');
+      expect(formatDateText('not-a-date')).toBe('not-a-date');
+    });
+  });
+
+  describe('Notion 이벤트 변환', () => {
+    const createNotionItem = (
+      overrides?: Partial<NotionSearchItem>,
+    ): NotionSearchItem => ({
+      id: 'page-1',
+      object: 'page',
+      url: 'https://www.notion.so/example',
+      properties: {
+        날짜: {
+          type: 'date',
+          date: {
+            start: '2026-03-19',
+            end: null,
+          },
+        },
+        이름: {
+          type: 'title',
+          title: [{ plain_text: '캘린더 테스트' }],
+        },
+      },
+      ...overrides,
+    });
+
+    it('날짜/제목 속성이 있으면 캘린더 이벤트로 변환한다', () => {
+      const item = createNotionItem();
+      const event = parseNotionCalendarEvent(item);
+
+      expect(event).not.toBeNull();
+      expect(event?.id).toBe(item.id);
+      expect(event?.title).toBe('캘린더 테스트');
+      expect(event?.dateKey).toBe('2026-03-19');
+    });
+
+    it('title 속성이 없어도 기본 제목으로 변환한다', () => {
+      const item = createNotionItem({
+        properties: {
+          날짜: {
+            type: 'date',
+            date: {
+              start: '2026-03-19',
+              end: null,
+            },
+          },
+        } as NotionSearchItem['properties'],
+      });
+
+      const event = parseNotionCalendarEvent(item);
+      expect(event?.title).toBe('(제목 없음)');
+    });
+
+    it('date 속성이 없거나 잘못된 경우 null을 반환한다', () => {
+      const missingDate = createNotionItem({
+        properties: {
+          이름: {
+            type: 'title',
+            title: [{ plain_text: '제목만 있음' }],
+          },
+        } as NotionSearchItem['properties'],
+      });
+      const invalidDate = createNotionItem({
+        properties: {
+          날짜: {
+            type: 'date',
+            date: {
+              start: 'invalid-date',
+              end: null,
+            },
+          },
+        } as NotionSearchItem['properties'],
+      });
+
+      expect(parseNotionCalendarEvent(missingDate)).toBeNull();
+      expect(parseNotionCalendarEvent(invalidDate)).toBeNull();
+    });
+  });
+});

--- a/frontend/src/utils/calendarSyncUtils.test.ts
+++ b/frontend/src/utils/calendarSyncUtils.test.ts
@@ -51,9 +51,7 @@ describe('calendarSyncUtils', () => {
 
     it('parseDateKey는 ISO datetime을 YYYY-MM-DD로 정규화한다', () => {
       expect(parseDateKey('2026-03-22T06:25:00.000Z')).toBe('2026-03-22');
-      expect(parseDateKey('Sun, 22 Mar 2026 06:25:00 GMT')).toBe(
-        '2026-03-22',
-      );
+      expect(parseDateKey('Sun, 22 Mar 2026 06:25:00 GMT')).toBe('2026-03-22');
       expect(parseDateKey('invalid-date')).toBeNull();
     });
 

--- a/frontend/src/utils/calendarSyncUtils.ts
+++ b/frontend/src/utils/calendarSyncUtils.ts
@@ -1,0 +1,159 @@
+import type { NotionSearchItem } from '@/apis/calendarOAuth';
+
+/**
+ * CalendarSyncTab 전용 유틸 모음.
+ * - OAuth 보조 유틸(redirect/state/token 표시)
+ * - 캘린더 날짜 계산 유틸
+ * - Notion page -> 캘린더 이벤트 변환 유틸
+ */
+
+/** 캘린더 헤더 요일 라벨(일~토). */
+export const WEEKDAY_LABELS = [
+  '일',
+  '월',
+  '화',
+  '수',
+  '목',
+  '금',
+  '토',
+] as const;
+
+/** 현재 origin 기준 CalendarSync 콜백 URI를 만든다. */
+export const buildDefaultRedirectUri = () =>
+  `${window.location.origin}/admin/calendar-sync`;
+
+/** OAuth state용 난수 문자열을 생성한다. */
+export const createState = () =>
+  globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
+
+/** 토큰 표시용 마스킹 문자열을 만든다. */
+export const maskToken = (token: string) => {
+  if (token.length <= 16) return token;
+  return `${token.slice(0, 8)}...${token.slice(-8)}`;
+};
+
+/**
+ * 날짜/시간 문자열을 한국어 로케일 텍스트로 변환한다.
+ * 파싱 실패 시 원문을 그대로 반환한다.
+ */
+export const formatDateText = (dateText?: string) => {
+  if (!dateText) return '-';
+  try {
+    const date = new Date(dateText);
+    if (Number.isNaN(date.getTime())) {
+      return dateText;
+    }
+    return date.toLocaleString('ko-KR');
+  } catch {
+    return dateText;
+  }
+};
+
+/**
+ * 다양한 날짜 문자열을 `YYYY-MM-DD` 키로 정규화한다.
+ * 유효하지 않은 값이면 null을 반환한다.
+ */
+export const parseDateKey = (dateText: string) => {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(dateText)) {
+    return dateText;
+  }
+
+  const parsed = new Date(dateText);
+  if (Number.isNaN(parsed.getTime())) return null;
+
+  const localYear = parsed.getFullYear();
+  const localMonth = String(parsed.getMonth() + 1).padStart(2, '0');
+  const localDay = String(parsed.getDate()).padStart(2, '0');
+  return `${localYear}-${localMonth}-${localDay}`;
+};
+
+/** Date 객체를 `YYYY-MM-DD` 키 문자열로 변환한다. */
+export const buildDateKeyFromDate = (date: Date) =>
+  `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+
+/** `YYYY-MM-DD` 키 문자열을 Date 객체(로컬 시간대)로 변환한다. */
+export const dateFromKey = (dateKey: string) => {
+  const [year, month, day] = dateKey.split('-').map(Number);
+  return new Date(year, month - 1, day);
+};
+
+/**
+ * 월 기준 캘린더 그리드(주 시작~주 끝 포함) 날짜 배열을 생성한다.
+ * 반환 배열은 7의 배수 길이를 가진다.
+ */
+export const buildMonthCalendarDays = (month: Date) => {
+  const monthStart = new Date(month.getFullYear(), month.getMonth(), 1);
+  const monthEnd = new Date(month.getFullYear(), month.getMonth() + 1, 0);
+
+  const gridStart = new Date(monthStart);
+  gridStart.setDate(monthStart.getDate() - monthStart.getDay());
+
+  const gridEnd = new Date(monthEnd);
+  gridEnd.setDate(monthEnd.getDate() + (6 - monthEnd.getDay()));
+
+  const days: Date[] = [];
+  const cursor = new Date(gridStart);
+  while (cursor <= gridEnd) {
+    days.push(new Date(cursor));
+    cursor.setDate(cursor.getDate() + 1);
+  }
+  return days;
+};
+
+/** 월 라벨을 `YYYY년 MM월` 형식으로 포맷한다. */
+export const formatMonthLabel = (month: Date) =>
+  `${month.getFullYear()}년 ${String(month.getMonth() + 1).padStart(2, '0')}월`;
+
+/** Notion page에서 추출한 캘린더 이벤트 모델. */
+export interface NotionCalendarEvent {
+  id: string;
+  title: string;
+  start: string;
+  dateKey: string;
+  end?: string;
+  url?: string;
+}
+
+/**
+ * Notion page 응답을 캘린더 이벤트로 변환한다.
+ * - date 타입 속성이 없거나
+ * - 날짜 파싱 불가한 경우 null을 반환한다.
+ */
+export const parseNotionCalendarEvent = (
+  item: NotionSearchItem,
+): NotionCalendarEvent | null => {
+  const properties = item.properties;
+  if (!properties) return null;
+
+  const entries = Object.values(properties) as Array<Record<string, unknown>>;
+  const dateProperty = entries.find(
+    (property) =>
+      property?.type === 'date' &&
+      typeof (property.date as { start?: string } | undefined)?.start ===
+        'string',
+  ) as { date?: { start?: string; end?: string } } | undefined;
+
+  const start = dateProperty?.date?.start;
+  if (!start) return null;
+  const dateKey = parseDateKey(start);
+  if (!dateKey) return null;
+
+  const titleProperty = entries.find(
+    (property) => property?.type === 'title' && Array.isArray(property.title),
+  ) as { title?: Array<{ plain_text?: string }> } | undefined;
+
+  const title =
+    titleProperty?.title
+      ?.map((segment) => segment.plain_text ?? '')
+      .join('')
+      .trim() || '(제목 없음)';
+
+  return {
+    id: item.id,
+    title,
+    start,
+    dateKey,
+    end: dateProperty?.date?.end,
+    url: item.url,
+  };
+};

--- a/frontend/src/utils/calendarSyncUtils.ts
+++ b/frontend/src/utils/calendarSyncUtils.ts
@@ -54,17 +54,19 @@ export const formatDateText = (dateText?: string) => {
  * 유효하지 않은 값이면 null을 반환한다.
  */
 export const parseDateKey = (dateText: string) => {
-  if (/^\d{4}-\d{2}-\d{2}$/.test(dateText)) {
-    return dateText;
+  const datePart = dateText.match(/^(\d{4}-\d{2}-\d{2})/);
+  if (datePart) {
+    return datePart[1];
   }
 
   const parsed = new Date(dateText);
   if (Number.isNaN(parsed.getTime())) return null;
 
-  const localYear = parsed.getFullYear();
-  const localMonth = String(parsed.getMonth() + 1).padStart(2, '0');
-  const localDay = String(parsed.getDate()).padStart(2, '0');
-  return `${localYear}-${localMonth}-${localDay}`;
+  // 문자열에 날짜 파트가 없을 때도 시간대 영향 없이 같은 UTC 날짜 키를 유지한다.
+  const utcYear = parsed.getUTCFullYear();
+  const utcMonth = String(parsed.getUTCMonth() + 1).padStart(2, '0');
+  const utcDay = String(parsed.getUTCDate()).padStart(2, '0');
+  return `${utcYear}-${utcMonth}-${utcDay}`;
 };
 
 /** Date 객체를 `YYYY-MM-DD` 키 문자열로 변환한다. */
@@ -92,10 +94,13 @@ export const buildMonthCalendarDays = (month: Date) => {
   gridEnd.setDate(monthEnd.getDate() + (6 - monthEnd.getDay()));
 
   const days: Date[] = [];
-  const cursor = new Date(gridStart);
-  while (cursor <= gridEnd) {
-    days.push(new Date(cursor));
-    cursor.setDate(cursor.getDate() + 1);
+  const oneDayMs = 24 * 60 * 60 * 1000;
+  for (
+    let timestamp = gridStart.getTime();
+    timestamp <= gridEnd.getTime();
+    timestamp += oneDayMs
+  ) {
+    days.push(new Date(timestamp));
   }
   return days;
 };

--- a/frontend/src/utils/calendarSyncUtils.ts
+++ b/frontend/src/utils/calendarSyncUtils.ts
@@ -7,7 +7,6 @@ import type { NotionSearchItem } from '@/apis/calendarOAuth';
  * - Notion page -> 캘린더 이벤트 변환 유틸
  */
 
-/** 캘린더 헤더 요일 라벨(일~토). */
 export const WEEKDAY_LABELS = [
   '일',
   '월',
@@ -51,18 +50,20 @@ export const formatDateText = (dateText?: string) => {
 
 /**
  * 다양한 날짜 문자열을 `YYYY-MM-DD` 키로 정규화한다.
+ * - 순수 날짜 문자열(YYYY-MM-DD)은 그대로 반환
+ * - datetime 문자열은 UTC 기준으로 파싱하여 날짜 추출
  * 유효하지 않은 값이면 null을 반환한다.
  */
 export const parseDateKey = (dateText: string) => {
-  const datePart = dateText.match(/^(\d{4}-\d{2}-\d{2})/);
-  if (datePart) {
-    return datePart[1];
+  // 순수 날짜 형식(시간 없음)만 그대로 반환 - 종일 이벤트
+  if (/^\d{4}-\d{2}-\d{2}$/.test(dateText)) {
+    return dateText;
   }
 
+  // datetime 형식은 UTC 기준으로 파싱
   const parsed = new Date(dateText);
   if (Number.isNaN(parsed.getTime())) return null;
 
-  // 문자열에 날짜 파트가 없을 때도 시간대 영향 없이 같은 UTC 날짜 키를 유지한다.
   const utcYear = parsed.getUTCFullYear();
   const utcMonth = String(parsed.getUTCMonth() + 1).padStart(2, '0');
   const utcDay = String(parsed.getUTCDate()).padStart(2, '0');


### PR DESCRIPTION

## #️⃣연관된 이슈

> ex) #1350

 ## 변경 내용
  - 관리자 `CalendarSyncTab`에 Google/Notion 캘린더 연동 UI를 정리했습니다.
  - Notion 연동 흐름을 확장했습니다.
    - DB 목록 조회: `GET /api/integration/notion/databases`
    - 선택 DB 1회 적용: `GET /api/integration/notion/databases/{databaseId}/pages`
    - 이후 기본 조회: `GET /api/integration/notion/pages`

  - 로직 분리:
    - `useGoogleCalendarData`
    - `useNotionOAuth`
    - `useNotionCalendarData`
    - `useNotionCalendarUiState`
    - 조합 훅 `useCalendarSync`

  - 유틸 분리 및 문서화:
    - `src/utils/calendarSyncUtils.ts`
    - `src/utils/calendarSyncUtils.test.ts` 테스트 추가

## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관리자 대시보드에 캘린더 동기화 탭(사이드바·라우트·전체 UI) 추가
  * Google Calendar 및 Notion OAuth 연동(인증 시작/콜백 처리, 마스킹된 토큰 표시)
  * Notion 데이터베이스 선택·적용, 항목별 표시 토글, 월 단위 네비게이션과 이벤트 그리드 제공
  * 클럽 상세페이지에 일정 탭 및 월별 클럽 일정 캘린더 추가
  * 클럽 일정 조회용 API와 쿼리 훅 및 관련 상수 추가

* **테스트**
  * 캘린더 유틸리티 함수들에 대한 Jest 테스트 스위트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->