### PR TITLE
[chore] BE PR 자동 리뷰봇 워크플로우 추가

### DIFF
--- a/.github/BE_PR_REVIEW_BOT.md
+++ b/.github/BE_PR_REVIEW_BOT.md
@@ -1,0 +1,44 @@
+# BE PR Review Bot
+
+`💾 BE` 라벨이 붙은 `develop/be` 대상 PR을 자동 리뷰하는 워크플로우입니다.
+
+## 동작 조건
+
+아래 조건을 모두 만족할 때만 실행/리뷰합니다.
+
+- PR 상태: `open`
+- PR base branch: `develop/be`
+- PR label 포함: `💾 BE`
+- Draft PR 아님
+
+트리거 이벤트:
+
+- `opened`
+- `reopened`
+- `synchronize`
+- `labeled`
+- `ready_for_review`
+
+## 리뷰 정책
+
+- 테스트 실행은 포함하지 않습니다.
+- 시니어 관점의 정적 리스크 체크(휴리스틱)만 수행합니다.
+- 리뷰 상태는 `APPROVE`로 등록합니다.
+- 잠재 리스크가 감지되면 Approve 본문에 경고 항목을 함께 남깁니다.
+
+현재 휴리스틱(예시):
+
+1. AES-GCM 고정 IV 사용 패턴
+2. 검증 전 DB ID 저장 가능성
+3. 페이지네이션 상한 시 has_more/next_cursor 왜곡 가능성
+
+## 파일 위치
+
+- 워크플로우: `.github/workflows/be-pr-review-bot.yml`
+- 문서(현재 파일): `.github/BE_PR_REVIEW_BOT.md`
+
+## 운영 팁
+
+- 휴리스틱은 오탐/미탐이 있을 수 있습니다. 팀 규칙에 맞게 패턴을 추가/수정하세요.
+- 브랜치 보호 규칙에서 bot approval 인정 여부를 사전에 확인하세요.
+- "조건 만족 PR만 자동 승인" 정책이므로, 라벨 운영 기준(`💾 BE`)을 명확히 유지하세요.

--- a/.github/workflows/be-pr-review-bot.yml
+++ b/.github/workflows/be-pr-review-bot.yml
@@ -1,0 +1,118 @@
+name: BE PR Review Bot
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, ready_for_review]
+    branches: ["develop/be"]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: be-pr-review-bot-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  senior-review:
+    if: ${{ github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Run conditional senior review (label=💾 BE, base=develop/be, open)
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const labels = (pr.labels || []).map(l => l.name);
+            const hasBeLabel = labels.includes('💾 BE');
+            const isOpen = pr.state === 'open';
+            const isTargetBase = pr.base?.ref === 'develop/be';
+
+            if (!(hasBeLabel && isOpen && isTargetBase)) {
+              core.info(`Skip review. hasBeLabel=${hasBeLabel}, isOpen=${isOpen}, base=${pr.base?.ref}`);
+              return;
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+
+            const findings = [];
+
+            for (const f of files) {
+              const patch = f.patch || '';
+
+              // Critical: AES/GCM + fixed IV usage heuristic
+              if (patch.includes('GCMParameterSpec') && patch.includes('.iv()')) {
+                findings.push({
+                  severity: 'Critical',
+                  file: f.filename,
+                  message: 'AES-GCM에서 고정 IV를 사용하는 패턴이 감지되었습니다. 암호화마다 랜덤 IV를 생성하고 (iv+ciphertext) 형태로 저장/복호화해야 합니다.'
+                });
+              }
+
+              // High: possible persistence before validation heuristic
+              if (patch.includes('saveDatabaseId(') && patch.includes('queryNotionDatabase(')) {
+                findings.push({
+                  severity: 'High',
+                  file: f.filename,
+                  message: 'databaseId 저장 시점이 검증/쿼리 성공 이전인지 확인이 필요합니다. 잘못된 ID를 저장하면 이후 API 동작이 오염될 수 있습니다.'
+                });
+              }
+
+              // Medium: pagination truncation masking heuristic
+              if (patch.includes('requestCount') && patch.includes('has_more') && patch.includes('next_cursor')) {
+                findings.push({
+                  severity: 'Medium',
+                  file: f.filename,
+                  message: '페이지네이션 상한 도달 시 has_more/next_cursor를 고정값으로 덮어쓰는지 확인하세요. partial 응답 여부를 클라이언트가 식별 가능해야 합니다.'
+                });
+              }
+            }
+
+            const header = [
+              '시니어 관점 자동 리뷰입니다 (테스트 제외).',
+              '',
+              `- 대상 조건: base=\`develop/be\`, label=\`💾 BE\`, state=open`,
+              `- 변경 파일 수: ${files.length}`,
+              ''
+            ];
+
+            let body = '';
+
+            if (findings.length === 0) {
+              body = [
+                ...header,
+                '구조/책임 분리 관점에서 치명적인 잠재 리스크 패턴은 감지되지 않았습니다.',
+                '',
+                '확인 체크리스트:',
+                '- API contract와 실제 반환 의미 일치 여부',
+                '- 저장 시점(검증 전/후) 적절성',
+                '- 암호화 IV/키 관리 방식',
+                '- 페이지네이션 종료 상태의 정확한 전달',
+                '- 동시성 업데이트 충돌 가능성',
+              ].join('\n');
+            } else {
+              const rows = findings.map((f, i) => `${i + 1}. [${f.severity}] \`${f.file}\` - ${f.message}`);
+              body = [
+                ...header,
+                '잠재 버그/운영 리스크 후보를 감지했습니다:',
+                ...rows,
+                '',
+                '코멘트는 예방 관점이며, 현재 구현 의도와 다르면 API 문서/명세를 함께 정렬해 주세요.'
+              ].join('\n');
+            }
+
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              event: 'APPROVE',
+              body,
+            });
+
+            core.info(`Approved PR #${pr.number} with ${findings.length} finding(s).`);


### PR DESCRIPTION
## 개요
`💾 BE` 라벨 + `develop/be` 대상 open PR에 대해 자동으로 시니어 관점 리뷰(테스트 제외)를 등록하는 GitHub Actions 워크플로우를 추가합니다.

## 변경 사항
- `.github/workflows/be-pr-review-bot.yml` 추가
  - 트리거: opened/reopened/synchronize/labeled/ready_for_review
  - 조건: open + base=develop/be + label=💾 BE + non-draft
  - 동작: 정적 휴리스틱 기반 리뷰 본문 생성 후 `APPROVE` 리뷰 등록
- `.github/BE_PR_REVIEW_BOT.md` 추가
  - 운영 조건, 정책, 확장 포인트 문서화

## 비고
- 테스트 실행은 의도적으로 제외했습니다.
- 휴리스틱은 팀 정책에 맞춰 지속적으로 보정 가능합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 백엔드 풀 리퀘스트 검토 자동화를 위한 내부 개발 도구 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->