### PR TITLE
[feature] Google 캘린더 이벤트 조회 API 추가

### DIFF
--- a/backend/src/main/java/moadong/calendar/google/controller/GoogleOAuthController.java
+++ b/backend/src/main/java/moadong/calendar/google/controller/GoogleOAuthController.java
@@ -68,6 +68,17 @@ public class GoogleOAuthController {
         return Response.ok("캘린더가 선택되었습니다.");
     }
 
+    @GetMapping("/calendars/{calendarId}/events")
+    @Operation(summary = "Google 캘린더 이벤트 조회", description = "선택한 Google 캘린더의 이벤트(일정) 목록을 조회합니다.")
+    @PreAuthorize("isAuthenticated()")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> getCalendarEvents(@CurrentUser CustomUserDetails user,
+                                                @PathVariable String calendarId,
+                                                @RequestParam(required = false) String timeMin,
+                                                @RequestParam(required = false) String timeMax) {
+        return Response.ok(googleOAuthService.getCalendarEvents(user, calendarId, timeMin, timeMax));
+    }
+
     @DeleteMapping("/connection")
     @Operation(summary = "Google Calendar 연결 해제", description = "Google Calendar 연결을 해제합니다.")
     @PreAuthorize("isAuthenticated()")

--- a/backend/src/main/java/moadong/calendar/google/service/GoogleOAuthService.java
+++ b/backend/src/main/java/moadong/calendar/google/service/GoogleOAuthService.java
@@ -211,6 +211,13 @@ public class GoogleOAuthService {
 
     public List<ClubCalendarEventResult> getCalendarEvents(CustomUserDetails user, String calendarId, String timeMin, String timeMax) {
         String clubId = requireAuthenticatedClubId(user);
+
+        GoogleConnection connection = googleConnectionRepository.findById(clubId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.GOOGLE_NOT_CONNECTED));
+        if (!StringUtils.hasText(connection.getCalendarId()) || !connection.getCalendarId().equals(calendarId)) {
+            throw new RestApiException(ErrorCode.GOOGLE_NOT_CONNECTED);
+        }
+
         String accessToken = getValidAccessToken(clubId);
 
         return fetchCalendarEvents(accessToken, calendarId, timeMin, timeMax);

--- a/backend/src/main/java/moadong/calendar/google/service/GoogleOAuthService.java
+++ b/backend/src/main/java/moadong/calendar/google/service/GoogleOAuthService.java
@@ -209,6 +209,13 @@ public class GoogleOAuthService {
         googleConnectionRepository.deleteById(clubId);
     }
 
+    public List<ClubCalendarEventResult> getCalendarEvents(CustomUserDetails user, String calendarId, String timeMin, String timeMax) {
+        String clubId = requireAuthenticatedClubId(user);
+        String accessToken = getValidAccessToken(clubId);
+
+        return fetchCalendarEvents(accessToken, calendarId, timeMin, timeMax);
+    }
+
     public List<ClubCalendarEventResult> getClubCalendarEvents(String clubId) {
         if (!StringUtils.hasText(clubId)) {
             return List.of();
@@ -221,7 +228,8 @@ public class GoogleOAuthService {
             }
 
             String accessToken = getValidAccessToken(clubId);
-            return fetchCalendarEvents(accessToken, connection.getCalendarId());
+            String timeMin = OffsetDateTime.now(ZoneOffset.UTC).minusMonths(1).toString();
+            return fetchCalendarEvents(accessToken, connection.getCalendarId(), timeMin, null);
         } catch (Exception e) {
             log.warn("Google 캘린더 이벤트 조회 실패. clubId={}, message={}", clubId, e.getMessage());
             return List.of();
@@ -238,7 +246,7 @@ public class GoogleOAuthService {
     }
 
     @SuppressWarnings("unchecked")
-    private List<ClubCalendarEventResult> fetchCalendarEvents(String accessToken, String calendarId) {
+    private List<ClubCalendarEventResult> fetchCalendarEvents(String accessToken, String calendarId, String timeMin, String timeMax) {
         HttpHeaders headers = new HttpHeaders();
         headers.setBearerAuth(accessToken);
 
@@ -247,17 +255,24 @@ public class GoogleOAuthService {
         try {
             List<ClubCalendarEventResult> results = new ArrayList<>();
             String pageToken = null;
-            String timeMin = OffsetDateTime.now(ZoneOffset.UTC).minusMonths(1).toString();
 
             for (int page = 0; page < MAX_GOOGLE_PAGE_REQUESTS; page++) {
-                String url = UriComponentsBuilder.fromHttpUrl(GOOGLE_CALENDAR_EVENTS_ENDPOINT)
+                UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(GOOGLE_CALENDAR_EVENTS_ENDPOINT)
                         .queryParam("maxResults", 100)
                         .queryParam("orderBy", "startTime")
-                        .queryParam("singleEvents", true)
-                        .queryParam("timeMin", timeMin)
-                        .queryParamIfPresent("pageToken", java.util.Optional.ofNullable(pageToken))
-                        .buildAndExpand(calendarId)
-                        .toUriString();
+                        .queryParam("singleEvents", true);
+
+                if (StringUtils.hasText(timeMin)) {
+                    builder.queryParam("timeMin", timeMin);
+                }
+                if (StringUtils.hasText(timeMax)) {
+                    builder.queryParam("timeMax", timeMax);
+                }
+                if (pageToken != null) {
+                    builder.queryParam("pageToken", pageToken);
+                }
+
+                String url = builder.buildAndExpand(calendarId).toUriString();
 
                 ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
                         url,

--- a/backend/src/main/java/moadong/calendar/google/service/GoogleOAuthService.java
+++ b/backend/src/main/java/moadong/calendar/google/service/GoogleOAuthService.java
@@ -218,6 +218,8 @@ public class GoogleOAuthService {
             throw new RestApiException(ErrorCode.GOOGLE_NOT_CONNECTED);
         }
 
+        validateTimeParameters(timeMin, timeMax);
+
         String accessToken = getValidAccessToken(clubId);
 
         return fetchCalendarEvents(accessToken, calendarId, timeMin, timeMax);
@@ -511,6 +513,31 @@ public class GoogleOAuthService {
             throw new RestApiException(ErrorCode.GOOGLE_CLUB_NOT_FOUND);
         }
         return club.getId();
+    }
+
+    private void validateTimeParameters(String timeMin, String timeMax) {
+        OffsetDateTime parsedTimeMin = null;
+        OffsetDateTime parsedTimeMax = null;
+
+        if (StringUtils.hasText(timeMin)) {
+            try {
+                parsedTimeMin = OffsetDateTime.parse(timeMin);
+            } catch (Exception e) {
+                throw new RestApiException(ErrorCode.GOOGLE_INVALID_TIME_FORMAT);
+            }
+        }
+
+        if (StringUtils.hasText(timeMax)) {
+            try {
+                parsedTimeMax = OffsetDateTime.parse(timeMax);
+            } catch (Exception e) {
+                throw new RestApiException(ErrorCode.GOOGLE_INVALID_TIME_FORMAT);
+            }
+        }
+
+        if (parsedTimeMin != null && parsedTimeMax != null && parsedTimeMin.isAfter(parsedTimeMax)) {
+            throw new RestApiException(ErrorCode.GOOGLE_INVALID_TIME_RANGE);
+        }
     }
 
     private String asString(Object value) {

--- a/backend/src/main/java/moadong/global/exception/ErrorCode.java
+++ b/backend/src/main/java/moadong/global/exception/ErrorCode.java
@@ -93,7 +93,9 @@ public enum ErrorCode {
     GOOGLE_NOT_CONNECTED(HttpStatus.NOT_FOUND, "960-4", "Google Calendar가 연결되지 않았습니다."),
     GOOGLE_CALENDAR_NOT_SELECTED(HttpStatus.BAD_REQUEST, "960-5", "캘린더가 선택되지 않았습니다."),
     GOOGLE_API_FAILED(HttpStatus.BAD_GATEWAY, "960-6", "Google API 호출에 실패했습니다."),
-    GOOGLE_CLUB_NOT_FOUND(HttpStatus.BAD_REQUEST, "960-7", "연동할 동아리 정보를 찾을 수 없습니다.")
+    GOOGLE_CLUB_NOT_FOUND(HttpStatus.BAD_REQUEST, "960-7", "연동할 동아리 정보를 찾을 수 없습니다."),
+    GOOGLE_INVALID_TIME_FORMAT(HttpStatus.BAD_REQUEST, "960-8", "시간 형식이 올바르지 않습니다. RFC3339 형식을 사용해주세요."),
+    GOOGLE_INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST, "960-9", "시작 시간은 종료 시간보다 이전이어야 합니다.")
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION

## #️⃣연관된 이슈

> ex) #1374 

## 📝작업 내용

- `GET /api/integration/google/calendars/{calendarId}/events` 엔드포인트를 추가하여 선택한 캘린더의 이벤트 목록을 조회할 수 있도록 구현

## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * Google Calendar에서 선택된 특정 일정의 이벤트를 조회할 수 있는 새로운 기능이 추가되었습니다.
  * 시작 날짜와 종료 날짜를 지정하여 특정 기간의 이벤트만 필터링하여 조회할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->