### PR TITLE
[feature] 브랜드 타입 정의 추가

### DIFF
--- a/frontend/docs/types/branded-types.md
+++ b/frontend/docs/types/branded-types.md
@@ -42,7 +42,7 @@ src/types/branded.ts       ← Branded<T, B> 유틸리티 + 모든 ID 타입
 
 ID 타입이 늘어나고 도메인 경계가 명확해지면 도메인 파일로 분리한다. 한 파일에 모으면 도메인 간 결합도가 높아지고 변경 이유가 달라지기 때문이다.
 
-```
+```text
 src/types/branded.ts       ← Branded<T, B> 유틸리티만
 src/types/club.ts          ← ClubId, CalendarId
 src/types/application.ts   ← ApplicationFormId

--- a/frontend/docs/types/branded-types.md
+++ b/frontend/docs/types/branded-types.md
@@ -30,9 +30,17 @@ type Brand<B> = { [__brand]: B };
 export type Branded<T, B> = T & Brand<B>;
 ```
 
-## 도메인별 ID 타입 위치
+## 현재 구조
 
-도메인 ID 타입은 해당 도메인 파일에 정의한다. 타입 수가 늘어날수록 한 파일에 모으면 도메인 간 결합도가 높아지므로 아래 구조를 따른다.
+ID 타입이 5개 이하로 적으므로 `branded.ts`에 모두 정의한다.
+
+```
+src/types/branded.ts       ← Branded<T, B> 유틸리티 + 모든 ID 타입
+```
+
+## 향후 확장 시 권장 구조
+
+ID 타입이 늘어나고 도메인 경계가 명확해지면 도메인 파일로 분리한다. 한 파일에 모으면 도메인 간 결합도가 높아지고 변경 이유가 달라지기 때문이다.
 
 ```
 src/types/branded.ts       ← Branded<T, B> 유틸리티만
@@ -42,13 +50,20 @@ src/types/applicants.ts    ← ApplicantId
 src/types/notion.ts        ← DatabaseId
 ```
 
-### 새 ID 타입 추가 방법
+### 새 ID 타입 추가 방법 (현재: 중앙 집중)
 
-1. 해당 도메인 타입 파일을 연다 (없으면 `src/types/<domain>.ts` 생성)
-2. `Branded`를 import하고 타입을 정의한다
+현재는 `branded.ts`에 직접 추가한다.
 
 ```typescript
-// src/types/club.ts
+// src/types/branded.ts
+export type ClubId = Branded<string, 'ClubId'>;
+export type NewDomainId = Branded<string, 'NewDomainId'>; // 추가
+```
+
+도메인 파일 분리 단계로 전환한 후에는 해당 도메인 파일에 정의한다.
+
+```typescript
+// src/types/club.ts (향후 분리 시)
 import { Branded } from '@/types/branded';
 
 export type ClubId = Branded<string, 'ClubId'>;

--- a/frontend/docs/types/branded-types.md
+++ b/frontend/docs/types/branded-types.md
@@ -1,0 +1,86 @@
+# Branded Types
+
+타입 안전성을 높이기 위해 primitive 타입에 고유한 브랜드를 부여하는 패턴.
+
+## 개요
+
+`string`처럼 범용적인 타입은 컴파일러가 오용을 잡아주지 못한다.
+
+```typescript
+// ClubId 자리에 ApplicantId를 넘겨도 타입 에러 없음
+function fetchClub(id: string) { ... }
+fetchClub(applicantId); // 런타임 버그
+```
+
+Branded 타입을 사용하면 컴파일 타임에 잡을 수 있다.
+
+```typescript
+function fetchClub(id: ClubId) { ... }
+fetchClub(applicantId); // TS 에러: ApplicantId는 ClubId에 할당 불가
+```
+
+## 유틸리티 타입
+
+`src/types/branded.ts`에 인프라 레이어만 정의한다.
+
+```typescript
+declare const __brand: unique symbol;
+type Brand<B> = { [__brand]: B };
+
+export type Branded<T, B> = T & Brand<B>;
+```
+
+## 도메인별 ID 타입 위치
+
+도메인 ID 타입은 해당 도메인 파일에 정의한다. 타입 수가 늘어날수록 한 파일에 모으면 도메인 간 결합도가 높아지므로 아래 구조를 따른다.
+
+```
+src/types/branded.ts       ← Branded<T, B> 유틸리티만
+src/types/club.ts          ← ClubId, CalendarId
+src/types/application.ts   ← ApplicationFormId
+src/types/applicants.ts    ← ApplicantId
+src/types/notion.ts        ← DatabaseId
+```
+
+### 새 ID 타입 추가 방법
+
+1. 해당 도메인 타입 파일을 연다 (없으면 `src/types/<domain>.ts` 생성)
+2. `Branded`를 import하고 타입을 정의한다
+
+```typescript
+// src/types/club.ts
+import { Branded } from '@/types/branded';
+
+export type ClubId = Branded<string, 'ClubId'>;
+```
+
+3. API 응답을 받는 시점에 캐스팅한다
+
+```typescript
+const clubId = data.id as ClubId;
+```
+
+## 크로스 도메인 참조
+
+다른 도메인 파일에서 ID 타입을 참조할 때는 해당 도메인 파일에서 직접 import한다. 순환 의존성이 생긴다면 `branded.ts`에 임시로 모아두고 도메인 파일에서 re-export하는 방식을 사용한다.
+
+```typescript
+// src/types/application.ts
+import { Branded } from '@/types/branded';
+import type { ClubId } from '@/types/club';
+
+export type ApplicationFormId = Branded<string, 'ApplicationFormId'>;
+
+export interface ApplicationForm {
+  id: ApplicationFormId;
+  clubId: ClubId;
+}
+```
+
+## 확장 기준
+
+| 상황                           | 대응                                                |
+| ------------------------------ | --------------------------------------------------- |
+| ID 타입 5개 이하               | `branded.ts`에 모두 정의해도 무방                   |
+| ID 타입 증가, 도메인 경계 명확 | 도메인 파일로 분리                                  |
+| 크로스 도메인 순환 의존 발생   | `branded.ts`에 공통 ID만 유지, 나머지는 도메인 파일 |

--- a/frontend/src/types/branded.ts
+++ b/frontend/src/types/branded.ts
@@ -1,0 +1,10 @@
+declare const __brand: unique symbol;
+type Brand<B> = { [__brand]: B };
+
+export type Branded<T, B> = T & Brand<B>;
+
+export type ClubId = Branded<string, 'ClubId'>;
+export type ApplicationFormId = Branded<string, 'ApplicationFormId'>;
+export type ApplicantId = Branded<string, 'ApplicantId'>;
+export type CalendarId = Branded<string, 'CalendarId'>;
+export type DatabaseId = Branded<string, 'DatabaseId'>;


### PR DESCRIPTION

## #️⃣연관된 이슈

> ex) #1396

## 📝작업 내용

TypeScript Branded Type 패턴을 API 코드에 도입하기 위한 기반 타입을 정의합니다.

여기서 Branded Type이란 원시 타입에 의미를 부여하기 위한 개념입니다.

  ## 변경 사항

  - `src/types/branded.ts` 신규 생성
    - `Branded<T, B>` 유틸리티 타입 정의 (`unique symbol` 기반)
    - `ClubId`, `ApplicationFormId`, `ApplicantId`, `CalendarId`, `DatabaseId` 타입 정의

  ## 배경

  현재 모든 ID가 `string`으로 선언되어 있어 아래와 같은 상황에서 컴파일 타임 에러를 잡을 수 없습니다.

  ```typescript
  // clubId 자리에 applicationFormId가 들어가도 에러 없음
  applyToClub(applicationFormId, clubId, answers)
```

  Branded Type을 적용하면 서로 다른 ID 타입을 혼용할 경우 컴파일 에러로 잡아낼 수 있어요.


[참고자료](https://siosio3103.medium.com/typescript-branded-types%EB%A1%9C-%EB%9F%B0%ED%83%80%EC%9E%84-%ED%83%80%EC%9E%85-%EC%95%88%EC%A0%95%EC%84%B1-%EA%B0%9C%EC%84%A0%ED%95%98%EA%B8%B0-768222c8df0d)

## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **리팩토링**
  * 내부 타입 시스템에 브랜딩된 ID 개념 도입으로 타입 안전성과 유지보수성 향상

* **문서**
  * 브랜딩 타입 패턴과 도입/운용 지침을 설명하는 새 문서 추가(도메인별 분리·중앙화 가이드, ID 추가 절차 및 순환 의존 대응 포함)

---

참고: 최종 사용자에게는 직접적인 기능 변화가 없습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->