### PR TITLE
[feature] 도메인 인터페이스에 branded types 적용

### DIFF
--- a/frontend/docs/types/branded-types.md
+++ b/frontend/docs/types/branded-types.md
@@ -92,6 +92,38 @@ export interface ApplicationForm {
 }
 ```
 
+## 도입 단계
+
+branded types 도입은 3단계 브랜치로 진행한다.
+
+| 단계 | 브랜치                               | 작업 내용                                                 | 상태 |
+| ---- | ------------------------------------ | --------------------------------------------------------- | ---- |
+| 1    | `feature/branded-types/core-types`   | `Branded<T, B>` 유틸리티 및 ID 타입 정의                  | 완료 |
+| 2    | `feature/branded-types/domain-types` | 도메인 인터페이스 `id` 필드에 branded type 적용           | 완료 |
+| 3    | `feature/branded-types/api-layer`    | API 응답 파싱 시점에 캐스팅 유틸 추가 및 임시 캐스팅 정리 | 예정 |
+
+### api-layer 브랜치 작업 계획
+
+**캐스팅 유틸리티 추가**
+
+API 응답을 받는 시점에서 안전하게 branded type으로 변환하는 헬퍼를 `src/types/branded.ts`에 추가한다.
+
+```typescript
+export const asClubId = (id: string): ClubId => id as ClubId;
+export const asApplicantId = (id: string): ApplicantId => id as ApplicantId;
+export const asApplicationFormId = (id: string): ApplicationFormId =>
+  id as ApplicationFormId;
+export const asDatabaseId = (id: string): DatabaseId => id as DatabaseId;
+export const asCalendarId = (id: string): CalendarId => id as CalendarId;
+```
+
+**임시 캐스팅 정리 대상**
+
+| 파일                                                                      | 현재 임시 처리               | 개선 방향                                       |
+| ------------------------------------------------------------------------- | ---------------------------- | ----------------------------------------------- |
+| `src/pages/ClubDetailPage/components/ClubApplyButton/ClubApplyButton.tsx` | `forms as ApplicationForm[]` | API 응답 파싱 시점에 `asApplicationFormId` 적용 |
+| `src/pages/AdminPage/.../ApplicantDetailPage.tsx`                         | `questionId as ApplicantId`  | URL params 파싱 유틸 또는 훅에서 처리           |
+
 ## 확장 기준
 
 | 상황                           | 대응                                                |

--- a/frontend/src/apis/calendarOAuth.ts
+++ b/frontend/src/apis/calendarOAuth.ts
@@ -1,4 +1,5 @@
 import API_BASE_URL from '@/constants/api';
+import type { DatabaseId } from '@/types/branded';
 import type {
   GoogleCalendarEvent,
   GoogleCalendarItem,
@@ -167,7 +168,9 @@ export const fetchNotionPages = async () => {
   const items = (data?.items ?? data?.results ?? []) as NotionSearchItem[];
   const totalResults =
     data?.total_results ?? data?.totalResults ?? items.length;
-  const databaseId = data?.database_id ?? data?.databaseId;
+  const databaseId = (data?.database_id ?? data?.databaseId) as
+    | DatabaseId
+    | undefined;
   return {
     items,
     totalResults,
@@ -207,7 +210,7 @@ export const fetchNotionDatabasePages = async ({
     return {
       items: data,
       totalResults: data.length,
-      databaseId,
+      databaseId: databaseId as DatabaseId,
     } satisfies NotionPagesResponse;
   }
 
@@ -219,7 +222,7 @@ export const fetchNotionDatabasePages = async ({
   return {
     items,
     totalResults,
-    databaseId: resolvedDatabaseId,
+    databaseId: resolvedDatabaseId as DatabaseId,
   } satisfies NotionPagesResponse;
 };
 

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPage.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPage.tsx
@@ -86,7 +86,7 @@ const ApplicantDetailPage = () => {
         {
           memo,
           status,
-          applicantId: questionId,
+          applicantId: questionId as import('@/types/branded').ApplicantId,
         },
       ],
       {

--- a/frontend/src/pages/ClubDetailPage/components/ClubApplyButton/ClubApplyButton.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubApplyButton/ClubApplyButton.tsx
@@ -89,7 +89,7 @@ const ClubApplyButton = ({
         await navigateToApplicationForm(forms[0].id);
         return;
       }
-      setApplicationOptions(forms);
+      setApplicationOptions(forms as ApplicationForm[]);
       setIsApplicationModalOpen(true);
     } catch (e) {
       setApplicationOptions([]);

--- a/frontend/src/pages/IntroducePage/constants/mockData.ts
+++ b/frontend/src/pages/IntroducePage/constants/mockData.ts
@@ -1,9 +1,10 @@
 import type { Club } from '@/types/club';
+import type { ClubId } from '@/types/branded';
 
 // 동아리 목업 데이터
 export const floatingClubs: Club[] = [
   {
-    id: 'moadong',
+    id: 'moadong' as ClubId,
     name: '모아동',
     logo: '',
     tags: ['학술', '스터디'],
@@ -13,7 +14,7 @@ export const floatingClubs: Club[] = [
     introduction: '다양한 전공 학생들이 모여 학문을 함께 나누는 동아리',
   },
   {
-    id: 'moaboza',
+    id: 'moaboza' as ClubId,
     name: '모아보자',
     logo: '',
     tags: ['봉사', '지역사회'],
@@ -23,7 +24,7 @@ export const floatingClubs: Club[] = [
     introduction: '지역 사회와 함께 봉사하며 따뜻함을 전하는 동아리',
   },
   {
-    id: 'moamoa',
+    id: 'moamoa' as ClubId,
     name: '모아모아',
     logo: '',
     tags: ['취미', '교양'],
@@ -33,7 +34,7 @@ export const floatingClubs: Club[] = [
     introduction: '다양한 취미를 가진 사람들이 모여 교류하는 동아리',
   },
   {
-    id: 'moajup',
+    id: 'moajup' as ClubId,
     name: '모아운동',
     logo: '',
     tags: ['스포츠', '팀워크'],

--- a/frontend/src/pages/MainPage/components/ClubCard/ClubCard.stories.tsx
+++ b/frontend/src/pages/MainPage/components/ClubCard/ClubCard.stories.tsx
@@ -1,10 +1,11 @@
 import { MemoryRouter } from 'react-router-dom';
 import type { Meta, StoryObj } from '@storybook/react';
 import { Club } from '@/types/club';
+import type { ClubId } from '@/types/branded';
 import ClubCard from './ClubCard';
 
 const sampleClub: Club = {
-  id: 'club-1',
+  id: 'club-1' as ClubId,
   name: '모아동 밴드',
   logo: '',
   tags: ['락밴드', '공연'],
@@ -54,7 +55,7 @@ export const Closed: Story = {
   args: {
     club: {
       ...sampleClub,
-      id: 'club-2',
+      id: 'club-2' as ClubId,
       recruitmentStatus: 'CLOSED',
       name: '모아동 사진회',
       introduction: '정기 출사와 전시를 준비합니다.',

--- a/frontend/src/types/applicants.ts
+++ b/frontend/src/types/applicants.ts
@@ -1,4 +1,5 @@
 import { AnswerItem } from './application';
+import { ApplicantId, ApplicationFormId, ClubId } from './branded';
 
 export enum ApplicationStatus {
   SUBMITTED = 'SUBMITTED', // 제출 완료
@@ -16,27 +17,27 @@ export interface ApplicantsInfo {
 }
 
 export interface Applicant {
-  id: string;
+  id: ApplicantId;
   status: ApplicationStatus;
   answers: AnswerItem[];
   memo: string;
   createdAt: string;
-  applicationFormId: string;
+  applicationFormId: ApplicationFormId;
 }
 
 export interface UpdateApplicantParams {
   memo: string;
   status: ApplicationStatus;
-  applicantId: string | undefined;
+  applicantId: ApplicantId | undefined;
 }
 
 export interface ApplicantStatusEvent {
-  applicantId: string;
+  applicantId: ApplicantId;
   status: ApplicationStatus;
   memo: string;
   timestamp: string;
-  clubId: string;
-  applicationFormId: string;
+  clubId: ClubId;
+  applicationFormId: ApplicationFormId;
 }
 
 export interface ApplicantSSECallbacks {

--- a/frontend/src/types/application.ts
+++ b/frontend/src/types/application.ts
@@ -1,4 +1,5 @@
 import { QUESTION_LABEL_MAP } from '@/constants/applicationForm';
+import { ApplicationFormId } from './branded';
 
 export type QuestionType = keyof typeof QUESTION_LABEL_MAP;
 
@@ -63,12 +64,12 @@ export interface AnswerItem {
 }
 
 export interface ApplicationForm {
-  id: string;
+  id: ApplicationFormId;
   title: string;
 }
 
 export interface ApplicationFormItem {
-  id: string;
+  id: ApplicationFormId;
   title: string;
   editedAt: string;
   status: 'ACTIVE' | 'PUBLISHED' | 'UNPUBLISHED';

--- a/frontend/src/types/club.ts
+++ b/frontend/src/types/club.ts
@@ -1,9 +1,10 @@
 import { SNS_CONFIG } from '@/constants/snsConfig';
+import { ClubId } from './branded';
 
 export type RecruitmentStatus = 'OPEN' | 'CLOSED' | 'UPCOMING' | 'ALWAYS';
 
 export interface Club {
-  id: string;
+  id: ClubId;
   name: string;
   logo: string;
   cover?: string;
@@ -46,7 +47,7 @@ export interface ClubCalendarEvent {
 }
 
 export interface ClubDescription {
-  id: string;
+  id: ClubId;
   recruitmentStart: string | null;
   recruitmentEnd: string | null;
   recruitmentTarget: string;

--- a/frontend/src/types/google.ts
+++ b/frontend/src/types/google.ts
@@ -1,5 +1,7 @@
+import { CalendarId } from './branded';
+
 export interface GoogleCalendarItem {
-  id: string;
+  id: CalendarId;
   summary: string;
   primary?: boolean;
 }

--- a/frontend/src/types/notion.ts
+++ b/frontend/src/types/notion.ts
@@ -1,3 +1,5 @@
+import { DatabaseId } from './branded';
+
 export interface NotionSearchItem {
   id: string;
   object: string;
@@ -7,12 +9,12 @@ export interface NotionSearchItem {
 }
 
 export interface NotionDatabaseOption {
-  id: string;
+  id: DatabaseId;
   title: string;
 }
 
 export interface NotionPagesResponse {
   items: NotionSearchItem[];
   totalResults: number;
-  databaseId?: string;
+  databaseId?: DatabaseId;
 }


### PR DESCRIPTION

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

   - 도메인 인터페이스(`Club`, `Applicant`, `ApplicationForm` 등)의 `id` 필드를 `string`에서 branded type으로 교체
   - API 경계(응답 파싱, URL params)에서 `as BrandedType` 캐스팅 추가
   - mock 데이터 및 Storybook stories에 branded type 캐스팅 적용

   ## 변경 파일

   ### 타입 정의
   - `src/types/applicants.ts` — `ApplicantId`, `ApplicationFormId`, `ClubId` 적용
   - `src/types/application.ts` — `ApplicationFormId` 적용
   - `src/types/club.ts` — `ClubId` 적용
   - `src/types/notion.ts` — `DatabaseId` 적용
   - `src/types/google.ts` — `CalendarId` 적용 (GoogleCalendarItem만, Event ID는 별개 개념)

   ### API 경계 캐스팅
   - `src/apis/calendarOAuth.ts` — `DatabaseId` 캐스팅
   - `src/pages/AdminPage/.../ApplicantDetailPage.tsx` — `questionId as ApplicantId`
   - `src/pages/ClubDetailPage/.../ClubApplyButton.tsx` — `forms as ApplicationForm[]` (임시, api-layer 브랜치에서 정리예정)

   ### 테스트/스토리북
   - `src/pages/IntroducePage/constants/mockData.ts` — `as ClubId` 캐스팅
   - `src/pages/MainPage/components/ClubCard/ClubCard.stories.tsx` — `as ClubId` 캐스팅

   ## 참고

   `ClubApplyButton`의 `forms as ApplicationForm[]`는 API 응답 파싱을 제대로 정리하는
   `feature/branded-types/api-layer`에서 개선 예정입니다.
## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Refactor (리팩토링)**
  * 식별자(id) 필드에 브랜디드 타입 적용으로 타입 안정성 강화 (앱 전반의 내부 타입 변경)
* **Documentation**
  * 브랜디드 타입 도입 단계 및 향후 캐스팅 유틸리티(권장 마이그레이션) 문서 추가

사용자에게 보이는 기능 변경은 없습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->