### PR TITLE
chore: remove unused interfaces to fix ESLint warnings

### DIFF
--- a/frontend/src/pages/AdminPage/components/ApplicationRow/ApplicationRowItem.style.ts
+++ b/frontend/src/pages/AdminPage/components/ApplicationRow/ApplicationRowItem.style.ts
@@ -1,13 +1,5 @@
 import styled, { css } from 'styled-components';
 
-interface MenuItemProps {
-  $ActiveMenu?: boolean;
-}
-
-interface ExpandButtonProps {
-  $isExpanded: boolean;
-}
-
 // 개별 지원서 한 줄 (Row)
 export const ApplicationRow = styled.div`
   display: flex;


### PR DESCRIPTION
ESLint 경고 제거를 위해 미사용 인터페이스(MenuItemProps, ExpandButtonProps)를 삭제했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 내부 스타일 인터페이스 선언을 정리했습니다. 사용자에게 보이는 기능이나 동작에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->