### PR TITLE
fix: 불필요한 useQueryClient import 제거 (ESLint 경고)

### DIFF
--- a/frontend/src/mocks/handlers/promotion.ts
+++ b/frontend/src/mocks/handlers/promotion.ts
@@ -50,9 +50,7 @@ export const promotionHandlers = [
   }),
 
   // POST /api/promotion - 홍보게시판 글 작성
-  http.post(`${API_BASE_URL}/api/promotion`, async ({ request }) => {
-    const body = await request.json();
-
+  http.post(`${API_BASE_URL}/api/promotion`, async () => {
     return HttpResponse.json({
       data: {
         id: `article-${Date.now()}`,

--- a/frontend/src/pages/AdminPage/components/ApplicationRow/ApplicationRowItem.style.ts
+++ b/frontend/src/pages/AdminPage/components/ApplicationRow/ApplicationRowItem.style.ts
@@ -1,13 +1,5 @@
 import styled, { css } from 'styled-components';
 
-interface MenuItemProps {
-  $ActiveMenu?: boolean;
-}
-
-interface ExpandButtonProps {
-  $isExpanded: boolean;
-}
-
 // 개별 지원서 한 줄 (Row)
 export const ApplicationRow = styled.div`
   display: flex;

--- a/frontend/src/pages/AdminPage/components/SideBar/SideBar.tsx
+++ b/frontend/src/pages/AdminPage/components/SideBar/SideBar.tsx
@@ -74,7 +74,7 @@ const SideBar = () => {
 
       localStorage.removeItem('accessToken');
       navigate('/admin/login', { replace: true });
-    } catch (error) {
+    } catch (_error) {
       alert('로그아웃에 실패했습니다.');
     }
   };

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsTab.tsx
@@ -45,8 +45,6 @@ const ApplicantsTab = () => {
 
   const {
     data: fetchData,
-    isLoading,
-    isError,
   } = useGetApplicants(applicationFormId ?? '');
   const [keyword, setKeyword] = useState('');
   const [checkedItem, setCheckedItem] = useState<Map<string, boolean>>(

--- a/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.tsx
@@ -64,7 +64,7 @@ const ApplicationEditTab = () => {
     setFormData({ ...existingFormData, questions: currentQuestions });
   }, [existingFormData]);
 
-  const { mutate: createMutate, isPending: isCreating } = useMutation({
+  const { mutate: createMutate } = useMutation({
     mutationFn: (payload: ApplicationFormData) => createApplication(payload),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.application.all });

--- a/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.tsx
@@ -75,7 +75,7 @@ const ApplicationEditTab = () => {
       alert(`지원서 생성에 실패했습니다.: ${err.message}`),
   });
 
-  const { mutate: updateMutate, isPending: isUpdating } = useMutation({
+  const { mutate: updateMutate } = useMutation({
     mutationFn: ({
       data,
       applicationFormId,

--- a/frontend/src/pages/AdminPage/tabs/CalendarSyncTab/CalendarSyncTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/CalendarSyncTab/CalendarSyncTab.tsx
@@ -14,7 +14,6 @@ const CalendarSyncTab = () => {
     googleCalendars,
     selectedGoogleCalendarId,
     googleCalendarEvents,
-    notionItems,
     notionTotalResults,
     notionDatabaseSourceId,
     notionDatabaseOptions,

--- a/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
 import { useOutletContext } from 'react-router-dom';
-import { useQueryClient } from '@tanstack/react-query';
 import { setYear } from 'date-fns';
 import Button from '@/components/common/Button/Button';
 import InputField from '@/components/common/InputField/InputField';

--- a/frontend/src/pages/FestivalPage/components/BoothMapSection/BoothMapSection.tsx
+++ b/frontend/src/pages/FestivalPage/components/BoothMapSection/BoothMapSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { Swiper as SwiperType } from 'swiper';
 import { Swiper, SwiperSlide } from 'swiper/react';

--- a/frontend/src/pages/MainPage/components/Popup/Popup.tsx
+++ b/frontend/src/pages/MainPage/components/Popup/Popup.tsx
@@ -1,5 +1,4 @@
 import { MouseEvent, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import AppDownloadImage from '@/assets/images/popup/app-download.png';
 import { USER_EVENT } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';


### PR DESCRIPTION
ESLint에서 발생하는 `useQueryClient is defined but never used` 경고를 해결했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 불필요한 변수·임포트 제거와 코드 정리로 유지보수성 향상 및 내부 최적화 수행
  * 프로모션 관련 요청 처리 방식이 간소화되어 해당 관리 흐름의 응답이 보다 일관되게 동작하도록 정리됨
<!-- end of auto-generated comment: release notes by coderabbit.ai -->