### PR TITLE
chore: remove unused useEffect import in BoothMapSection

### DIFF
--- a/frontend/src/pages/FestivalPage/components/BoothMapSection/BoothMapSection.tsx
+++ b/frontend/src/pages/FestivalPage/components/BoothMapSection/BoothMapSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { Swiper as SwiperType } from 'swiper';
 import { Swiper, SwiperSlide } from 'swiper/react';


### PR DESCRIPTION
Fixes an ESLint warning for an unused `useEffect` import in `BoothMapSection.tsx`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

이 업데이트는 내부 코드 정리만 포함하며 사용자에게 표시되는 기능 변경 사항은 없습니다.

* **리팩토링**
  * 사용하지 않는 코드 정리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->