### PR TITLE
[feature] A/B 실험 variant를 Mixpanel super property로 등록

### DIFF
--- a/frontend/docs/features/experiments/mixpanel-super-property.md
+++ b/frontend/docs/features/experiments/mixpanel-super-property.md
@@ -1,0 +1,34 @@
+# A/B 실험 variant를 Mixpanel super property로 등록
+
+앱 시작 시 실험 배정 결과를 Mixpanel super property로 등록하여, 이후 발생하는 모든 이벤트에 variant 정보가 자동으로 포함되도록 한다.
+
+## 동작 방식
+
+`ExperimentRepository.fetchAndAssignExperiments()`가 호출될 때:
+
+- **신규 유저**: 새로 variant가 배정되면 즉시 `mixpanel.register()` 호출
+- **재방문 유저**: localStorage에 유효한 배정값이 있으면 해당 값으로 `mixpanel.register()` 호출
+
+super property key는 실험의 `key` 필드 그대로 사용한다 (예: `main_banner_v1`).
+
+## Mixpanel 대시보드 활용
+
+데이터가 쌓이면 기존 Insights/Funnel 쿼리에 breakdown만 추가하면 된다.
+
+```
+예시: ClubDetailPage Visited 이벤트
+→ Breakdown: main_banner_v1
+→ A그룹 vs B그룹 비교
+```
+
+## 주의사항
+
+- `localhost`에서는 `mixpanel.disable()`이 적용되어 super property 등록이 동작하지 않음
+- 스테이징/프로덕션 배포 후부터 데이터 수집 시작
+
+## 관련 코드
+
+- `src/experiments/ExperimentRepository.ts` — super property 등록 로직
+- `src/experiments/definitions.ts` — 실험 정의 (key, variants, weights)
+- `src/utils/initSDK.ts` — Mixpanel 초기화 (`initializeMixpanel`)
+- `src/index.tsx` — 초기화 순서: `initializeMixpanel()` → `initializeExperiments()`

--- a/frontend/docs/features/experiments/mixpanel-super-property.md
+++ b/frontend/docs/features/experiments/mixpanel-super-property.md
@@ -15,7 +15,7 @@ super property key는 실험의 `key` 필드 그대로 사용한다 (예: `main_
 
 데이터가 쌓이면 기존 Insights/Funnel 쿼리에 breakdown만 추가하면 된다.
 
-```
+```text
 예시: ClubDetailPage Visited 이벤트
 → Breakdown: main_banner_v1
 → A그룹 vs B그룹 비교

--- a/frontend/src/experiments/ExperimentRepository.ts
+++ b/frontend/src/experiments/ExperimentRepository.ts
@@ -1,3 +1,4 @@
+import mixpanel from 'mixpanel-browser';
 import type {
   ExperimentAssignments,
   ExperimentDefinition,
@@ -71,9 +72,14 @@ class ExperimentRepository {
       const isValidExisting =
         !!existing && experiment.variants.includes(existing);
 
-      if (isValidExisting) return;
+      if (isValidExisting) {
+        mixpanel.register({ [experiment.key]: existing });
+        return;
+      }
 
-      assignments[experiment.key] = pickWeightedVariant(experiment);
+      const variant = pickWeightedVariant(experiment);
+      assignments[experiment.key] = variant;
+      mixpanel.register({ [experiment.key]: variant });
     });
 
     writeAssignments(assignments);


### PR DESCRIPTION

## #️⃣연관된 이슈

> ex) #1419

## 📝작업 내용

앱 시작 시 실험 배정 결과를 `mixpanel.register()`로 등록하여이후 발생하는 모든 이벤트에 variant 정보가 자동 포함되도록 했습니다.
신규 유저(신규 배정)와 재방문 유저(기존 배정) 모두 포함됩니다.

## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * A/B 실험의 변형 할당이 분석 도구의 슈퍼 프로퍼티로 등록되는 방법을 설명하는 새 가이드 문서 추가.

* **New Features**
  * 실험 할당 시 할당된 변형을 자동으로 Mixpanel에 등록하도록 기능 추가 — 신규 사용자 즉시 등록, 기존 사용자는 저장된 할당을 사용해 등록. 로컬 개발 환경에서는 등록이 비활성화됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->