### PR TITLE
[hotfix] 홍보게시판 D-day 시작일 당일이 D-1로 표시되는 버그를 수정한다

### DIFF
--- a/frontend/src/pages/PromotionPage/utils/getDday.test.ts
+++ b/frontend/src/pages/PromotionPage/utils/getDday.test.ts
@@ -25,6 +25,22 @@ describe('getDDay', () => {
     expect(result).toBe(0);
   });
 
+  it('행사 시작일 당일 시작 시각 전이어도 D-Day (0) 반환', () => {
+    jest.setSystemTime(new Date('2026-03-25T00:01:00Z'));
+
+    const result = getDDay('2026-03-25T14:00:00Z', '2026-03-27T00:00:00Z');
+
+    expect(result).toBe(0);
+  });
+
+  it('행사 시작 하루 전이면 D-1 반환', () => {
+    jest.setSystemTime(new Date('2026-03-24T00:00:00Z'));
+
+    const result = getDDay('2026-03-25T00:00:00Z', '2026-03-27T00:00:00Z');
+
+    expect(result).toBe(1);
+  });
+
   it('행사 중간 날짜도 D-Day (0) 반환', () => {
     jest.setSystemTime(new Date('2026-03-26T12:00:00Z'));
 

--- a/frontend/src/pages/PromotionPage/utils/getDday.ts
+++ b/frontend/src/pages/PromotionPage/utils/getDday.ts
@@ -1,19 +1,21 @@
+const stripTime = (date: Date) =>
+  new Date(date.getFullYear(), date.getMonth(), date.getDate());
+
+const ONE_DAY_MS = 1000 * 60 * 60 * 24;
+
 export const getDDay = (eventStartDate: string, eventEndDate: string) => {
-  const currentTime = new Date().getTime();
-  const eventStartTime = new Date(eventStartDate).getTime();
-  const eventEndTime = new Date(eventEndDate).getTime();
+  const today = stripTime(new Date());
+  const startDate = stripTime(new Date(eventStartDate));
+  const endDate = stripTime(new Date(eventEndDate));
 
-  if (currentTime < eventStartTime) {
-    const remainingTimeUntilStart = eventStartTime - currentTime;
-
-    const remainingDays = Math.ceil(
-      remainingTimeUntilStart / (1000 * 60 * 60 * 24),
+  if (today < startDate) {
+    const remainingDays = Math.round(
+      (startDate.getTime() - today.getTime()) / ONE_DAY_MS,
     );
-
     return remainingDays;
   }
 
-  if (currentTime >= eventStartTime && currentTime <= eventEndTime) {
+  if (today >= startDate && today <= endDate) {
     return 0;
   }
 

--- a/frontend/src/pages/PromotionPage/utils/sortPromotions.test.ts
+++ b/frontend/src/pages/PromotionPage/utils/sortPromotions.test.ts
@@ -92,6 +92,26 @@ describe('sortPromotions', () => {
     expect(result[0].title).toBe('recent');
   });
 
+  it('당일 종료된 시간 이후여도 진행중으로 분류된다', () => {
+    const NOW_AFTERNOON = new Date('2026-04-10T18:00:00Z').getTime();
+
+    const endedToday = createArticle(
+      'endedToday',
+      '2026-04-10T00:00:00Z',
+      '2026-04-10T15:00:00Z',
+    );
+
+    const upcoming = createArticle(
+      'upcoming',
+      '2026-04-12T00:00:00Z',
+      '2026-04-13T00:00:00Z',
+    );
+
+    const result = sortPromotions([upcoming, endedToday], NOW_AFTERNOON);
+
+    expect(result[0].title).toBe('endedToday');
+  });
+
   it('전체 정렬 순서: 진행중 → 예정 → 종료', () => {
     const ongoing = createArticle(
       'ongoing',

--- a/frontend/src/pages/PromotionPage/utils/sortPromotions.ts
+++ b/frontend/src/pages/PromotionPage/utils/sortPromotions.ts
@@ -1,18 +1,23 @@
 import { PromotionArticle } from '@/types/promotion';
 
+const stripTime = (date: Date) =>
+  new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+
 export const sortPromotions = (
   articles: PromotionArticle[],
   now: number = Date.now(),
 ) => {
+  const today = stripTime(new Date(now));
+
   return [...articles].sort((a, b) => {
-    const aStart = new Date(a.eventStartDate).getTime();
-    const aEnd = new Date(a.eventEndDate).getTime();
-    const bStart = new Date(b.eventStartDate).getTime();
-    const bEnd = new Date(b.eventEndDate).getTime();
+    const aStart = stripTime(new Date(a.eventStartDate));
+    const aEnd = stripTime(new Date(a.eventEndDate));
+    const bStart = stripTime(new Date(b.eventStartDate));
+    const bEnd = stripTime(new Date(b.eventEndDate));
 
     const getStatusWeight = (start: number, end: number) => {
-      if (start <= now && end >= now) return 1; // 진행 중
-      if (start > now) return 2; // 예정
+      if (start <= today && end >= today) return 1; // 진행 중
+      if (start > today) return 2; // 예정
       return 3; // 종료
     };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- #1427

## 📝작업 내용

홍보 이벤트의 D-day 계산과 정렬 로직이 **시 단위**로 동작해 발생하던 버그를 **날짜 단위**로 수정했습니다.

### 수정 내용
- **D-day 계산 로직 수정** (`getDday.ts`)
  - `new Date().getTime()` 기준 밀리초 차이로 계산하던 방식을 `년/월/일`만 남긴 날짜 값으로 비교하도록 변경
  - `Math.ceil` → `Math.round` 로 변경하여 자정 직전/직후에 D-day가 달라지는 문제 해결
  - 시작 당일/하루 전 케이스가 의도대로 동작하도록 보정
- **홍보 이벤트 정렬 로직 수정** (`sortPromotions.ts`)
  - 시간까지 포함해 정렬되던 것을 날짜 단위 비교로 변경하여 같은 날짜 내 순서가 일관되게 유지되도록 수정
- **테스트 추가**
  - D-day 시작일 당일 / 하루 전 케이스
  - 홍보 이벤트 당일 종료 케이스

### 왜 생긴 문제였나
기존 코드는 `Date.getTime()`의 밀리초 값으로 비교했기 때문에, 같은 날짜라도 현재 시각에 따라 D-day 값과 정렬 순서가 달라지는 이슈가 있었습니다. 사용자 기준에서는 "날짜"로 판단하므로 시간 정보를 제거하고 비교하도록 통일했습니다.

## 중점적으로 리뷰받고 싶은 부분(선택)

## 논의하고 싶은 부분(선택)

> 없음

## 🫡 참고사항

- 변경 파일은 `PromotionPage/utils/` 하위 4개 파일이며, 테스트 2건 추가되었습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * 프로모션 상태 분류 및 D-Day 계산에 대한 테스트 케이스 추가

* **개선**
  * 프로모션 상태(진행 중/예정/종료)가 날짜 기준으로만 정확하게 분류되도록 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->