### PR TITLE
fix: remove unused useNavigate import in Popup component

### DIFF
--- a/frontend/src/pages/MainPage/components/Popup/Popup.tsx
+++ b/frontend/src/pages/MainPage/components/Popup/Popup.tsx
@@ -1,5 +1,4 @@
 import { MouseEvent, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import AppDownloadImage from '@/assets/images/popup/app-download.png';
 import { USER_EVENT } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';


### PR DESCRIPTION
## Description
Fixes an ESLint warning about an unused `useNavigate` import in the `Popup` component.

## Changes
- Removed `useNavigate` import from `frontend/src/pages/MainPage/components/Popup/Popup.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 내부 코드 정리: 사용하지 않는 import를 제거하여 코드 품질을 개선했습니다.

---

**참고**: 이번 변경사항은 내부 코드 정리이며 사용자에게 영향을 주는 기능 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->