### PR TITLE
fix: remove unused useEffect in BoothMapSection

### DIFF
--- a/frontend/src/pages/FestivalPage/components/BoothMapSection/BoothMapSection.tsx
+++ b/frontend/src/pages/FestivalPage/components/BoothMapSection/BoothMapSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { Swiper as SwiperType } from 'swiper';
 import { Swiper, SwiperSlide } from 'swiper/react';


### PR DESCRIPTION
This PR removes an unused `useEffect` import in `BoothMapSection.tsx` to resolve an ESLint warning.