### PR TITLE
fix: resolve ESLint no-console warnings in utils

### DIFF
--- a/frontend/src/hooks/Mixpanel/useMixpanelTrack.ts
+++ b/frontend/src/hooks/Mixpanel/useMixpanelTrack.ts
@@ -12,6 +12,7 @@ const useMixpanelTrack = () => {
           url: window.location.href,
         });
       } catch (error) {
+        // eslint-disable-next-line no-console
         console.warn('Failed to track event:', eventName, error);
       }
     },

--- a/frontend/src/utils/webviewBridge.ts
+++ b/frontend/src/utils/webviewBridge.ts
@@ -41,6 +41,7 @@ export const postMessageToApp = (message: WebViewMessage): boolean => {
     }
     return true;
   } catch (error) {
+    // eslint-disable-next-line no-console
     console.error('[WebViewBridge] 전송 실패:', error);
     return false;
   }


### PR DESCRIPTION
## What
- Resolved `no-console` ESLint warnings in `useMixpanelTrack.ts` and `webviewBridge.ts`.
- Added `// eslint-disable-next-line no-console` to intentionally log errors while keeping the CI/build clean.

## Why
- '무제한/영구 전권 모드'를 통해 기술 부채(정적 분석 경고)를 해결합니다.