### PR TITLE
chore(frontend): remove unused variables and imports to fix lint warnings

### DIFF
--- a/frontend/src/mocks/handlers/promotion.ts
+++ b/frontend/src/mocks/handlers/promotion.ts
@@ -51,7 +51,7 @@ export const promotionHandlers = [
 
   // POST /api/promotion - 홍보게시판 글 작성
   http.post(`${API_BASE_URL}/api/promotion`, async ({ request }) => {
-    const body = await request.json();
+    await request.json();
 
     return HttpResponse.json({
       data: {

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsTab.tsx
@@ -45,8 +45,6 @@ const ApplicantsTab = () => {
 
   const {
     data: fetchData,
-    isLoading,
-    isError,
   } = useGetApplicants(applicationFormId ?? '');
   const [keyword, setKeyword] = useState('');
   const [checkedItem, setCheckedItem] = useState<Map<string, boolean>>(

--- a/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
 import { useOutletContext } from 'react-router-dom';
-import { useQueryClient } from '@tanstack/react-query';
 import { setYear } from 'date-fns';
 import Button from '@/components/common/Button/Button';
 import InputField from '@/components/common/InputField/InputField';

--- a/frontend/src/pages/FestivalPage/components/BoothMapSection/BoothMapSection.tsx
+++ b/frontend/src/pages/FestivalPage/components/BoothMapSection/BoothMapSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { Swiper as SwiperType } from 'swiper';
 import { Swiper, SwiperSlide } from 'swiper/react';

--- a/frontend/src/pages/MainPage/components/Banner/bannerData.ts
+++ b/frontend/src/pages/MainPage/components/Banner/bannerData.ts
@@ -1,11 +1,9 @@
 import AllClubsDesktopImage from '@/assets/images/banners/banner_desktop1.png';
 import StartNowDesktopImage from '@/assets/images/banners/banner_desktop2.png';
 import AppReleaseDesktopImage from '@/assets/images/banners/banner_desktop4.png';
-import ClubFairDesktopImage from '@/assets/images/banners/banner_desktop5.png';
 import AllClubsMobileImage from '@/assets/images/banners/banner_mobile1.png';
 import StartNowMobileImage from '@/assets/images/banners/banner_mobile2.png';
 import AppReleaseMobileImage from '@/assets/images/banners/banner_mobile4.png';
-import ClubFairMobileImage from '@/assets/images/banners/banner_mobile5.png';
 
 interface BannerItem {
   id: string;


### PR DESCRIPTION
- Removed unused useEffect import from BoothMapSection.tsx.\n- Removed unused useQueryClient import from RecruitEditTab.tsx.\n- Removed unused image imports (ClubFairDesktopImage, ClubFairMobileImage) from bannerData.ts.\n- Removed unused 'body' variable assignment in promotion.ts.\n- Removed unused 'isLoading' and 'isError' variables in ApplicantsTab.tsx.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 사용하지 않는 변수 및 import 정리로 코드 품질 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->