### PR TITLE
[feature] 동아리 클릭 게임 API 추가

### DIFF
--- a/backend/src/main/java/moadong/club/controller/ClubClickController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubClickController.java
@@ -1,0 +1,40 @@
+package moadong.club.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import moadong.club.payload.request.ClubClickRequest;
+import moadong.club.payload.response.ClubClickRankingResponse;
+import moadong.club.payload.response.ClubClickResponse;
+import moadong.club.service.ClubClickService;
+import moadong.global.payload.Response;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/game")
+@RequiredArgsConstructor
+@Tag(name = "Game", description = "동아리 클릭 게임 통계")
+public class ClubClickController {
+
+    private final ClubClickService clubClickService;
+
+    @PostMapping("/click")
+    @Operation(summary = "동아리 클릭 기록", description = "자유 입력 clubName별 클릭 수를 누적합니다. 실제 동아리 DB와 무관합니다.")
+    public ResponseEntity<?> recordClick(@RequestBody ClubClickRequest request) {
+        ClubClickResponse result = clubClickService.recordClick(request.clubName());
+        return Response.ok(result);
+    }
+
+    @GetMapping("/ranking")
+    @Operation(summary = "동아리 클릭 랭킹 조회",
+            description = "클릭 수 기준 내림차순 랭킹을 반환합니다. resetAt은 다음 자정(KST) 시간입니다.")
+    public ResponseEntity<?> getRanking() {
+        ClubClickRankingResponse result = clubClickService.getRanking();
+        return Response.ok(result);
+    }
+}

--- a/backend/src/main/java/moadong/club/payload/request/ClubClickRequest.java
+++ b/backend/src/main/java/moadong/club/payload/request/ClubClickRequest.java
@@ -1,0 +1,4 @@
+package moadong.club.payload.request;
+
+public record ClubClickRequest(String clubName, String ctAt) {
+}

--- a/backend/src/main/java/moadong/club/payload/response/ClubClickRankingResponse.java
+++ b/backend/src/main/java/moadong/club/payload/response/ClubClickRankingResponse.java
@@ -1,0 +1,9 @@
+package moadong.club.payload.response;
+
+import java.util.List;
+
+public record ClubClickRankingResponse(List<ClubRankItem> clubs, String resetAt) {
+
+    public record ClubRankItem(int rank, String clubName, long clickCount) {
+    }
+}

--- a/backend/src/main/java/moadong/club/payload/response/ClubClickResponse.java
+++ b/backend/src/main/java/moadong/club/payload/response/ClubClickResponse.java
@@ -1,0 +1,4 @@
+package moadong.club.payload.response;
+
+public record ClubClickResponse(String clubName, long clickCount) {
+}

--- a/backend/src/main/java/moadong/club/service/ClubClickScheduler.java
+++ b/backend/src/main/java/moadong/club/service/ClubClickScheduler.java
@@ -1,0 +1,30 @@
+package moadong.club.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "scheduling.enabled", havingValue = "true", matchIfMissing = true)
+public class ClubClickScheduler {
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    @SchedulerLock(name = "ClubClickReset", lockAtMostFor = "1m", lockAtLeastFor = "1s")
+    public void resetDailyClicks() {
+        Set<String> keys = stringRedisTemplate.keys(ClubClickService.CLICK_KEY_PATTERN);
+        if (keys != null && !keys.isEmpty()) {
+            stringRedisTemplate.delete(keys);
+        }
+        log.info("동아리 클릭 수 초기화 완료");
+    }
+}

--- a/backend/src/main/java/moadong/club/service/ClubClickService.java
+++ b/backend/src/main/java/moadong/club/service/ClubClickService.java
@@ -5,10 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import moadong.club.payload.response.ClubClickRankingResponse;
 import moadong.club.payload.response.ClubClickRankingResponse.ClubRankItem;
 import moadong.club.payload.response.ClubClickResponse;
-import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.time.ZoneId;
@@ -23,11 +20,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@ConditionalOnProperty(name = "scheduling.enabled", havingValue = "true", matchIfMissing = true)
 public class ClubClickService {
 
-    private static final String CLICK_KEY_PREFIX = "club:click:";
-    private static final String CLICK_KEY_PATTERN = CLICK_KEY_PREFIX + "*";
+    static final String CLICK_KEY_PREFIX = "club:click:";
+    static final String CLICK_KEY_PATTERN = CLICK_KEY_PREFIX + "*";
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
     private final StringRedisTemplate stringRedisTemplate;
@@ -62,17 +58,7 @@ public class ClubClickService {
         return new ClubClickRankingResponse(ranked, nextMidnightKst());
     }
 
-    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
-    @SchedulerLock(name = "ClubClickReset", lockAtMostFor = "1m", lockAtLeastFor = "1s")
-    public void resetDailyClicks() {
-        Set<String> keys = stringRedisTemplate.keys(CLICK_KEY_PATTERN);
-        if (keys != null && !keys.isEmpty()) {
-            stringRedisTemplate.delete(keys);
-        }
-        log.info("동아리 클릭 수 초기화 완료");
-    }
-
-    private String nextMidnightKst() {
+    public String nextMidnightKst() {
         ZonedDateTime nextMidnight = ZonedDateTime.now(KST)
                 .toLocalDate()
                 .plusDays(1)

--- a/backend/src/main/java/moadong/club/service/ClubClickService.java
+++ b/backend/src/main/java/moadong/club/service/ClubClickService.java
@@ -1,0 +1,82 @@
+package moadong.club.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import moadong.club.payload.response.ClubClickRankingResponse;
+import moadong.club.payload.response.ClubClickRankingResponse.ClubRankItem;
+import moadong.club.payload.response.ClubClickResponse;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "scheduling.enabled", havingValue = "true", matchIfMissing = true)
+public class ClubClickService {
+
+    private static final String CLICK_KEY_PREFIX = "club:click:";
+    private static final String CLICK_KEY_PATTERN = CLICK_KEY_PREFIX + "*";
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public ClubClickResponse recordClick(String clubName) {
+        String key = CLICK_KEY_PREFIX + clubName;
+        Long clickCount = stringRedisTemplate.opsForValue().increment(key);
+        return new ClubClickResponse(clubName, clickCount != null ? clickCount : 0L);
+    }
+
+    public ClubClickRankingResponse getRanking() {
+        Set<String> keys = stringRedisTemplate.keys(CLICK_KEY_PATTERN);
+        List<ClubRankItem> ranked = new ArrayList<>();
+
+        if (keys != null && !keys.isEmpty()) {
+            List<ClubRankItem> unsorted = new ArrayList<>();
+            for (String key : keys) {
+                String clubName = key.substring(CLICK_KEY_PREFIX.length());
+                String raw = stringRedisTemplate.opsForValue().get(key);
+                long count = raw != null ? Long.parseLong(raw) : 0L;
+                unsorted.add(new ClubRankItem(0, clubName, count));
+            }
+
+            unsorted.sort(Comparator.comparingLong(ClubRankItem::clickCount).reversed());
+
+            AtomicInteger rank = new AtomicInteger(1);
+            for (ClubRankItem item : unsorted) {
+                ranked.add(new ClubRankItem(rank.getAndIncrement(), item.clubName(), item.clickCount()));
+            }
+        }
+
+        return new ClubClickRankingResponse(ranked, nextMidnightKst());
+    }
+
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    @SchedulerLock(name = "ClubClickReset", lockAtMostFor = "1m", lockAtLeastFor = "1s")
+    public void resetDailyClicks() {
+        Set<String> keys = stringRedisTemplate.keys(CLICK_KEY_PATTERN);
+        if (keys != null && !keys.isEmpty()) {
+            stringRedisTemplate.delete(keys);
+        }
+        log.info("동아리 클릭 수 초기화 완료");
+    }
+
+    private String nextMidnightKst() {
+        ZonedDateTime nextMidnight = ZonedDateTime.now(KST)
+                .toLocalDate()
+                .plusDays(1)
+                .atStartOfDay(KST);
+        return nextMidnight.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+    }
+}


### PR DESCRIPTION

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

 ## Summary
                                                                                                                                                                                                                                                                      
   - `POST /api/game/click` — clubName별 클릭 수를 Redis INCR으로 원자적 누적                                
   - `GET /api/game/ranking` — 클릭 수 기준 내림차순 랭킹 반환 (rank 필드, resetAt 포함)
   - 매일 자정(KST) ShedLock 기반 분산 스케줄러로 클릭 수 자동 초기화


   ### 작업사항

   - 실제 동아리 DB와 무관한 자유 텍스트 입력 (검증 없음)
   - 인증 불필요 (public API)
   - Redis key 패턴: `club:click:{clubName}`
   - `StringRedisTemplate` 사용으로 INCR 직렬화 충돌 방지
   - **자동완성**: 입력 시 debounce(300ms) → `GET /api/club/search/?keyword=` 호출 → 매칭
   동아리명 드롭다운 표시
   - **유효성 검사**: 시작 버튼 / Enter 시 정확한 이름 일치 여부 최종 검증, 없으면 에러 메시지 표시

## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* **클럽 클릭 추적**: 사용자는 새로운 API 엔드포인트를 통해 클럽의 클릭을 기록하고 추적할 수 있습니다
* **실시간 클럽 랭킹**: 누적된 클릭 수를 기반으로 클럽의 실시간 순위를 확인할 수 있으며, 높은 순서부터 정렬됩니다
* **자동 일일 초기화**: 모든 클릭 카운터는 매일 자정(한국 표준시)에 자동으로 초기화되어 클럽 간 공정한 경쟁을 가능하게 합니다

<!-- end of auto-generated comment: release notes by coderabbit.ai -->