### PR TITLE
[feature] 동아리 클릭 배틀 게임 페이지

### DIFF
--- a/frontend/docs/features/game/game-page-layout.md
+++ b/frontend/docs/features/game/game-page-layout.md
@@ -1,0 +1,32 @@
+# GamePage 레이아웃 및 DotTextEffect 인터랙션 개선
+
+## 레이아웃 구조
+
+`TopRow`를 3-column grid(`1fr auto 1fr`)로 구성하여 타이틀을 절대 중앙에 고정하고 순위표를 오른쪽 끝에 배치.
+DotTextEffect는 전체 너비 가운데, 클릭 버튼은 하단(`marginTop: 40px`)에 위치.
+
+```
+┌─────────────────────────────────────────────┐
+│  [빈 공간]   동아리 클릭 배틀   [실시간 순위] │
+│                                             │
+│           [  개 발 팀  (DotText) ]          │
+│                                             │
+│                 [클릭! 버튼]                │
+└─────────────────────────────────────────────┘
+```
+
+## DotTextEffect 색상 Ripple
+
+마우스 커서 주변 `colorRadius(= hoverRadius * 1.8)` 범위 내 dot들이 거리 비례로 색상이 물드는 효과.
+
+- 파워 커브 `Math.pow(dist / colorRadius, 2.5)` 적용 → 중심만 진하고 바깥은 급격히 회색으로
+- 각 dot에 `charColors` 중 랜덤 색상 미리 배정 (글자 단위 → dot 단위 랜덤)
+- `hoverRadius: 18`, `dotR: 1.8` (겹침 방지)
+
+## 관련 코드
+
+- `src/pages/GamePage/GamePage.tsx` — 레이아웃 구조 (TopRow, DotTextEffect 중앙, 버튼 하단)
+- `src/pages/GamePage/GamePage.styles.ts` — TopRow grid 스타일
+- `src/pages/GamePage/components/DotTextEffect/DotTextEffect.tsx` — 색상 ripple 및 랜덤 색상 로직
+- `src/pages/GamePage/components/RankingBoard/RankingBoard.styles.ts` — Header column 방향 변경
+- `src/pages/GamePage/components/ClickButton/ClickButton.styles.ts` — ClubLabel 말줄임 처리

--- a/frontend/docs/features/hooks/useClubSuggestions.md
+++ b/frontend/docs/features/hooks/useClubSuggestions.md
@@ -1,0 +1,27 @@
+# useClubSuggestions — 자동완성 race condition 방지
+
+자동완성 입력에서 debounce 후 클럽 목록을 조회하는 훅. React Query의 쿼리 키 단위 상태 관리를 활용해 이전 요청 응답이 늦게 돌아와도 현재 입력 기준 결과만 렌더링에 반영된다.
+
+## 배경
+
+기존 `ClubNameInput`은 `debounceRef` + `getClubList` 직접 호출 방식으로, 응답 순서 검증 없이 `setSuggestions`를 수행했다. 네트워크 지연 시 이전 요청 결과가 최신 입력을 덮어쓰는 race condition이 발생할 수 있었다.
+
+## 해결 방식
+
+컴포넌트에서 `debouncedKeyword` state를 별도로 관리하고, `useClubSuggestions(debouncedKeyword)`에 전달한다. React Query는 쿼리 키가 바뀌는 순간 이전 쿼리 결과를 무시하므로 race condition이 원천 차단된다.
+
+```typescript
+// useEffect로 300ms debounce
+useEffect(() => {
+  const timer = setTimeout(() => setDebouncedKeyword(value.trim()), 300);
+  return () => clearTimeout(timer);
+}, [value]);
+
+const { data: suggestions = [] } = useClubSuggestions(debouncedKeyword);
+```
+
+## 관련 코드
+
+- `src/hooks/Queries/useClub.ts` — `useClubSuggestions` 훅 정의 (enabled: !!keyword.trim(), staleTime: 30s)
+- `src/constants/queryKeys.ts` — `queryKeys.club.suggestions(keyword)` 키 추가
+- `src/pages/GamePage/components/ClubNameInput/ClubNameInput.tsx` — debounceRef 제거, useClubSuggestions 적용

--- a/frontend/docs/features/hooks/useValidateClubName.md
+++ b/frontend/docs/features/hooks/useValidateClubName.md
@@ -1,0 +1,30 @@
+# useValidateClubName — 제출 검증 React Query 캐시 통합
+
+`ClubNameInput`의 submit 경로에서 동아리 이름 존재 여부를 검증하는 훅. `useClubSuggestions`와 동일한 캐시 키를 공유해 캐시 히트 시 네트워크 요청 없이 검증한다.
+
+## 배경
+
+기존 `handleSubmit`은 `getClubList(trimmed)`를 직접 호출했다. 자동완성 경로(`useClubSuggestions`)가 `queryKeys.club.suggestions(keyword)` 캐시를 사용하는 반면, 제출 검증 경로는 동일 키워드에 대해 별도 요청을 발생시키고 있었다.
+
+## 해결 방식
+
+`queryClient.ensureQueryData`로 동일한 캐시 키를 사용한다. 캐시가 유효하면 재요청 없이 반환하고, 없으면 fetch 후 캐시에 저장한다.
+
+```typescript
+export const useValidateClubName = () => {
+  const queryClient = useQueryClient();
+  return async (name: string) => {
+    const { clubs } = await queryClient.ensureQueryData({
+      queryKey: queryKeys.club.suggestions(name),
+      queryFn: () => getClubList(name),
+      staleTime: 30 * 1000,
+    });
+    return clubs.some((c) => c.name === name);
+  };
+};
+```
+
+## 관련 코드
+
+- `src/hooks/Queries/useClub.ts` — `useValidateClubName` 훅 정의
+- `src/pages/GamePage/components/ClubNameInput/ClubNameInput.tsx` — `handleSubmit`에서 `useValidateClubName` 사용

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import {
 import LegacyClubDetailPage from './pages/ClubDetailPage/LegacyClubDetailPage';
 import ErrorTestPage from './pages/ErrorTestPage/ErrorTestPage';
 import IntroductionPage from './pages/FestivalPage/IntroductionPage/IntroductionPage';
+import GamePage from './pages/GamePage/GamePage';
 import PromotionDetailPage from './pages/PromotionPage/PromotionDetailPage';
 import PromotionListPage from './pages/PromotionPage/PromotionListPage';
 
@@ -198,6 +199,14 @@ const App = () => {
                   element={
                     <ContentErrorBoundary>
                       <PromotionDetailPage />
+                    </ContentErrorBoundary>
+                  }
+                />
+                <Route
+                  path='/game'
+                  element={
+                    <ContentErrorBoundary>
+                      <GamePage />
                     </ContentErrorBoundary>
                   }
                 />

--- a/frontend/src/apis/game.ts
+++ b/frontend/src/apis/game.ts
@@ -1,0 +1,27 @@
+import API_BASE_URL from '@/constants/api';
+import { GameClickResponse, GameRankingResponse } from '@/types/game';
+import { handleResponse } from './utils/apiHelpers';
+
+export const postGameClick = async (
+  clubName: string,
+): Promise<GameClickResponse> => {
+  const response = await fetch(`${API_BASE_URL}/api/game/click`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ clubName, ctAt: new Date().toISOString() }),
+  });
+  const data = await handleResponse<GameClickResponse>(
+    response,
+    '클릭 요청에 실패했습니다.',
+  );
+  return data!;
+};
+
+export const getGameRanking = async (): Promise<GameRankingResponse> => {
+  const response = await fetch(`${API_BASE_URL}/api/game/ranking`);
+  const data = await handleResponse<GameRankingResponse>(
+    response,
+    '랭킹을 불러오는데 실패했습니다.',
+  );
+  return data!;
+};

--- a/frontend/src/apis/game.ts
+++ b/frontend/src/apis/game.ts
@@ -14,7 +14,8 @@ export const postGameClick = async (
     response,
     '클릭 요청에 실패했습니다.',
   );
-  return data!;
+  if (!data) throw new Error('클릭 요청에 실패했습니다.');
+  return data;
 };
 
 export const getGameRanking = async (): Promise<GameRankingResponse> => {
@@ -23,5 +24,6 @@ export const getGameRanking = async (): Promise<GameRankingResponse> => {
     response,
     '랭킹을 불러오는데 실패했습니다.',
   );
-  return data!;
+  if (!data) throw new Error('랭킹을 불러오는데 실패했습니다.');
+  return data;
 };

--- a/frontend/src/apis/game.ts
+++ b/frontend/src/apis/game.ts
@@ -1,21 +1,14 @@
 import API_BASE_URL from '@/constants/api';
-import { GameClickResponse, GameRankingResponse } from '@/types/game';
+import { GameRankingResponse } from '@/types/game';
 import { handleResponse } from './utils/apiHelpers';
 
-export const postGameClick = async (
-  clubName: string,
-): Promise<GameClickResponse> => {
+export const postGameClick = async (clubName: string): Promise<void> => {
   const response = await fetch(`${API_BASE_URL}/api/game/click`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ clubName, ctAt: new Date().toISOString() }),
   });
-  const data = await handleResponse<GameClickResponse>(
-    response,
-    '클릭 요청에 실패했습니다.',
-  );
-  if (!data) throw new Error('클릭 요청에 실패했습니다.');
-  return data;
+  if (!response.ok) throw new Error('클릭 요청에 실패했습니다.');
 };
 
 export const getGameRanking = async (): Promise<GameRankingResponse> => {

--- a/frontend/src/constants/queryKeys.ts
+++ b/frontend/src/constants/queryKeys.ts
@@ -36,4 +36,8 @@ export const queryKeys = {
     list: (type: 'WEB' | 'APP_HOME' | 'WEB_MOBILE') =>
       ['banner', type] as const,
   },
+  game: {
+    all: ['game'] as const,
+    ranking: () => ['game', 'ranking'] as const,
+  },
 } as const;

--- a/frontend/src/constants/queryKeys.ts
+++ b/frontend/src/constants/queryKeys.ts
@@ -26,6 +26,8 @@ export const queryKeys = {
       category: string,
       division: string,
     ) => ['clubs', keyword, recruitmentStatus, category, division] as const,
+    suggestions: (keyword: string) =>
+      ['clubs', 'suggestions', keyword] as const,
   },
   promotion: {
     all: ['promotions'] as const,

--- a/frontend/src/hooks/Queries/useClub.ts
+++ b/frontend/src/hooks/Queries/useClub.ts
@@ -90,6 +90,16 @@ export const useGetCardList = ({
   });
 };
 
+export const useClubSuggestions = (keyword: string) => {
+  return useQuery({
+    queryKey: queryKeys.club.suggestions(keyword),
+    queryFn: () => getClubList(keyword),
+    enabled: !!keyword.trim(),
+    staleTime: 30 * 1000,
+    select: (data) => data.clubs.map((c) => c.name),
+  });
+};
+
 export const useUpdateClubDescription = () => {
   const queryClient = useQueryClient();
 

--- a/frontend/src/hooks/Queries/useClub.ts
+++ b/frontend/src/hooks/Queries/useClub.ts
@@ -90,6 +90,18 @@ export const useGetCardList = ({
   });
 };
 
+export const useValidateClubName = () => {
+  const queryClient = useQueryClient();
+  return async (name: string) => {
+    const { clubs } = await queryClient.ensureQueryData({
+      queryKey: queryKeys.club.suggestions(name),
+      queryFn: () => getClubList(name),
+      staleTime: 30 * 1000,
+    });
+    return clubs.some((c) => c.name === name);
+  };
+};
+
 export const useClubSuggestions = (keyword: string) => {
   return useQuery({
     queryKey: queryKeys.club.suggestions(keyword),

--- a/frontend/src/hooks/Queries/useGame.ts
+++ b/frontend/src/hooks/Queries/useGame.ts
@@ -14,5 +14,8 @@ export const useGameRanking = () => {
 export const useClickGame = () => {
   return useMutation({
     mutationFn: (clubName: string) => postGameClick(clubName),
+    onError: (error) => {
+      console.error('Error clicking game:', error);
+    },
   });
 };

--- a/frontend/src/hooks/Queries/useGame.ts
+++ b/frontend/src/hooks/Queries/useGame.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { getGameRanking, postGameClick } from '@/apis/game';
+import { queryKeys } from '@/constants/queryKeys';
+
+export const useGameRanking = () => {
+  return useQuery({
+    queryKey: queryKeys.game.ranking(),
+    queryFn: getGameRanking,
+    refetchInterval: 2000,
+    staleTime: 0,
+  });
+};
+
+export const useClickGame = () => {
+  return useMutation({
+    mutationFn: (clubName: string) => postGameClick(clubName),
+  });
+};

--- a/frontend/src/mocks/handlers/index.ts
+++ b/frontend/src/mocks/handlers/index.ts
@@ -1,7 +1,4 @@
 import { promotionHandlers } from './promotion';
 
 // 모든 MSW 핸들러를 여기에 통합
-export const handlers = [
-  ...promotionHandlers,
-  // 다른 핸들러들을 여기에 추가
-];
+export const handlers = [...promotionHandlers];

--- a/frontend/src/pages/GamePage/GamePage.styles.ts
+++ b/frontend/src/pages/GamePage/GamePage.styles.ts
@@ -61,6 +61,22 @@ export const PageDescription = styled.p`
   margin-top: 4px;
 `;
 
+export const DesktopOnly = styled.div`
+  ${media.tablet} {
+    display: none;
+  }
+`;
+
+export const MobileOnly = styled.div`
+  display: none;
+  width: 100%;
+  margin-top: 32px;
+
+  ${media.tablet} {
+    display: block;
+  }
+`;
+
 export const TopRow = styled.div`
   display: grid;
   grid-template-columns: 1fr auto 1fr;

--- a/frontend/src/pages/GamePage/GamePage.styles.ts
+++ b/frontend/src/pages/GamePage/GamePage.styles.ts
@@ -1,0 +1,89 @@
+import styled from 'styled-components';
+import { media } from '@/styles/mediaQuery';
+
+export const PageContainer = styled.div`
+  position: relative;
+  overflow: hidden;
+  min-height: 100vh;
+  background: ${({ theme }) => theme.colors.gray[100]};
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 48px 20px 80px;
+
+  ${media.mobile} {
+    padding: 32px 16px 60px;
+  }
+`;
+
+export const Blob = styled.div<{
+  $size: number;
+  $top: string;
+  $left: string;
+  $color: string;
+}>`
+  position: absolute;
+  width: ${({ $size }) => $size}px;
+  height: ${({ $size }) => $size}px;
+  top: ${({ $top }) => $top};
+  left: ${({ $left }) => $left};
+  background: ${({ $color }) => $color};
+  border-radius: 50%;
+  filter: blur(60px);
+  pointer-events: none;
+  z-index: 0;
+`;
+
+export const Content = styled.div`
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  max-width: 1400px;
+`;
+
+export const PageTitle = styled.h1`
+  font-size: 1.75rem;
+  font-weight: 800;
+  color: ${({ theme }) => theme.colors.gray[900]};
+  margin-bottom: 4px;
+
+  ${media.mobile} {
+    font-size: 1.4rem;
+  }
+`;
+
+export const PageDescription = styled.p`
+  font-size: 0.95rem;
+  color: ${({ theme }) => theme.colors.gray[600]};
+  margin-top: 4px;
+`;
+
+export const TopRow = styled.div`
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: start;
+  width: 100%;
+  margin-bottom: 48px;
+
+  /* 타이틀은 가운데 열, 순위는 오른쪽 열 끝 */
+  & > *:first-child {
+    grid-column: 2;
+    text-align: center;
+  }
+
+  & > *:last-child {
+    grid-column: 3;
+    justify-self: end;
+  }
+
+  ${media.tablet} {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 24px;
+    margin-bottom: 32px;
+  }
+`;

--- a/frontend/src/pages/GamePage/GamePage.styles.ts
+++ b/frontend/src/pages/GamePage/GamePage.styles.ts
@@ -62,6 +62,10 @@ export const PageDescription = styled.p`
 `;
 
 export const DesktopOnly = styled.div`
+  position: absolute;
+  right: 0;
+  top: 0;
+
   ${media.tablet} {
     display: none;
   }
@@ -78,28 +82,17 @@ export const MobileOnly = styled.div`
 `;
 
 export const TopRow = styled.div`
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  align-items: start;
+  position: relative;
+  display: flex;
+  justify-content: center;
   width: 100%;
-  margin-bottom: 48px;
+  margin-bottom: 16px;
 
-  /* 타이틀은 가운데 열, 순위는 오른쪽 열 끝 */
   & > *:first-child {
-    grid-column: 2;
     text-align: center;
   }
 
-  & > *:last-child {
-    grid-column: 3;
-    justify-self: end;
-  }
-
   ${media.tablet} {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 24px;
     margin-bottom: 32px;
   }
 `;

--- a/frontend/src/pages/GamePage/GamePage.tsx
+++ b/frontend/src/pages/GamePage/GamePage.tsx
@@ -80,7 +80,7 @@ const GamePage = () => {
 
   const handleClick = () => {
     clickGame(clubName, {
-      onSuccess: (data) => setMyClickCount(data.clickCount),
+      onSuccess: () => setMyClickCount((prev) => prev + 1),
     });
   };
 

--- a/frontend/src/pages/GamePage/GamePage.tsx
+++ b/frontend/src/pages/GamePage/GamePage.tsx
@@ -1,0 +1,175 @@
+import { useState } from 'react';
+import { motion } from 'framer-motion';
+import { useClickGame, useGameRanking } from '@/hooks/Queries/useGame';
+import ClickButton from './components/ClickButton/ClickButton';
+import ClubNameInput from './components/ClubNameInput/ClubNameInput';
+import DotTextEffect from './components/DotTextEffect/DotTextEffect';
+import RankingBoard from './components/RankingBoard/RankingBoard';
+import * as S from './GamePage.styles';
+
+const STORAGE_KEY = 'game_club_name';
+
+const BLOBS = [
+  {
+    size: 320,
+    top: '-80px',
+    left: '-100px',
+    color: 'rgba(255, 84, 20, 0.12)',
+    dy: 30,
+    duration: 7,
+  },
+  {
+    size: 260,
+    top: '20%',
+    left: '75%',
+    color: 'rgba(255, 157, 124, 0.15)',
+    dy: -40,
+    duration: 9,
+  },
+  {
+    size: 200,
+    top: '55%',
+    left: '-60px',
+    color: 'rgba(255, 212, 50, 0.12)',
+    dy: 25,
+    duration: 11,
+  },
+  {
+    size: 180,
+    top: '70%',
+    left: '80%',
+    color: 'rgba(95, 216, 192, 0.13)',
+    dy: -30,
+    duration: 8,
+  },
+  {
+    size: 140,
+    top: '40%',
+    left: '45%',
+    color: 'rgba(112, 148, 255, 0.1)',
+    dy: 20,
+    duration: 13,
+  },
+];
+
+const GamePage = () => {
+  const [clubName, setClubName] = useState<string>(
+    () => sessionStorage.getItem(STORAGE_KEY) ?? '',
+  );
+  const [myClickCount, setMyClickCount] = useState(0);
+
+  const { data: rankingData } = useGameRanking();
+  const { mutate: clickGame } = useClickGame();
+
+  const top1Club = rankingData?.clubs[0];
+
+  const handleStart = (name: string) => {
+    sessionStorage.setItem(STORAGE_KEY, name);
+    setClubName(name);
+  };
+
+  const handleClick = () => {
+    clickGame(clubName, {
+      onSuccess: (data) => setMyClickCount(data.clickCount),
+    });
+  };
+
+  return (
+    <S.PageContainer>
+      {BLOBS.map((blob, i) => (
+        <motion.div
+          key={i}
+          style={{ position: 'absolute', zIndex: 0 }}
+          animate={{ y: [0, blob.dy, 0] }}
+          transition={{
+            duration: blob.duration,
+            repeat: Infinity,
+            ease: 'easeInOut',
+          }}
+        >
+          <S.Blob
+            $size={blob.size}
+            $top={blob.top}
+            $left={blob.left}
+            $color={blob.color}
+          />
+        </motion.div>
+      ))}
+
+      <S.Content>
+        {/* 상단: 타이틀(좌) + 실시간 순위(우) */}
+        <S.TopRow>
+          <motion.div
+            initial={{ opacity: 0, y: -16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5 }}
+          >
+            <S.PageTitle>동아리 클릭 배틀</S.PageTitle>
+            <S.PageDescription>
+              우리 동아리를 응원해주세요! 클릭할수록 순위가 올라가요.
+            </S.PageDescription>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, x: 24 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ duration: 0.5, delay: 0.3 }}
+          >
+            <RankingBoard
+              ranking={rankingData?.clubs ?? []}
+              resetAt={rankingData?.resetAt ?? new Date().toISOString()}
+              myClubName={clubName}
+            />
+          </motion.div>
+        </S.TopRow>
+
+        {/* 중앙: 도트 글자 */}
+        {top1Club && (
+          <motion.div
+            initial={{ opacity: 0, scale: 0.92 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ duration: 0.4, delay: 0.15 }}
+            style={{ display: 'flex', justifyContent: 'center', width: '100%' }}
+          >
+            <DotTextEffect
+              text={top1Club.clubName}
+              fontSize={100}
+              spacing={4}
+              dotR={1.8}
+              hoverRadius={18}
+              charColors={[
+                '#FF5414',
+                '#FFB300',
+                '#5FD8C0',
+                '#7094FF',
+                '#D4537E',
+                '#EF9F27',
+                '#FF9D7C',
+              ]}
+            />
+          </motion.div>
+        )}
+
+        {/* 하단: 클릭 버튼 */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4, delay: 0.25 }}
+          style={{ marginTop: '40px' }}
+        >
+          {!clubName ? (
+            <ClubNameInput onStart={handleStart} />
+          ) : (
+            <ClickButton
+              clubName={clubName}
+              clickCount={myClickCount}
+              onClickGame={handleClick}
+            />
+          )}
+        </motion.div>
+      </S.Content>
+    </S.PageContainer>
+  );
+};
+
+export default GamePage;

--- a/frontend/src/pages/GamePage/GamePage.tsx
+++ b/frontend/src/pages/GamePage/GamePage.tsx
@@ -128,7 +128,7 @@ const GamePage = () => {
             >
               <RankingBoard
                 ranking={rankingData?.clubs ?? []}
-                resetAt={rankingData?.resetAt ?? new Date().toISOString()}
+                resetAt={rankingData?.resetAt}
                 myClubName={clubName}
               />
             </motion.div>
@@ -181,7 +181,7 @@ const GamePage = () => {
           >
             <RankingBoard
               ranking={rankingData?.clubs ?? []}
-              resetAt={rankingData?.resetAt ?? new Date().toISOString()}
+              resetAt={rankingData?.resetAt}
               myClubName={clubName}
             />
           </motion.div>

--- a/frontend/src/pages/GamePage/GamePage.tsx
+++ b/frontend/src/pages/GamePage/GamePage.tsx
@@ -110,17 +110,19 @@ const GamePage = () => {
             </S.PageDescription>
           </motion.div>
 
-          <motion.div
-            initial={{ opacity: 0, x: 24 }}
-            animate={{ opacity: 1, x: 0 }}
-            transition={{ duration: 0.5, delay: 0.3 }}
-          >
-            <RankingBoard
-              ranking={rankingData?.clubs ?? []}
-              resetAt={rankingData?.resetAt ?? new Date().toISOString()}
-              myClubName={clubName}
-            />
-          </motion.div>
+          <S.DesktopOnly>
+            <motion.div
+              initial={{ opacity: 0, x: 24 }}
+              animate={{ opacity: 1, x: 0 }}
+              transition={{ duration: 0.5, delay: 0.3 }}
+            >
+              <RankingBoard
+                ranking={rankingData?.clubs ?? []}
+                resetAt={rankingData?.resetAt ?? new Date().toISOString()}
+                myClubName={clubName}
+              />
+            </motion.div>
+          </S.DesktopOnly>
         </S.TopRow>
 
         {/* 중앙: 도트 글자 */}
@@ -167,6 +169,21 @@ const GamePage = () => {
             />
           )}
         </motion.div>
+
+        {/* 모바일 전용: 순위표 최하단 */}
+        <S.MobileOnly>
+          <motion.div
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, delay: 0.3 }}
+          >
+            <RankingBoard
+              ranking={rankingData?.clubs ?? []}
+              resetAt={rankingData?.resetAt ?? new Date().toISOString()}
+              myClubName={clubName}
+            />
+          </motion.div>
+        </S.MobileOnly>
       </S.Content>
     </S.PageContainer>
   );

--- a/frontend/src/pages/GamePage/GamePage.tsx
+++ b/frontend/src/pages/GamePage/GamePage.tsx
@@ -9,6 +9,16 @@ import * as S from './GamePage.styles';
 
 const STORAGE_KEY = 'game_club_name';
 
+const CHAR_COLORS = [
+  '#FF5414',
+  '#FFB300',
+  '#5FD8C0',
+  '#7094FF',
+  '#D4537E',
+  '#EF9F27',
+  '#FF9D7C',
+];
+
 const BLOBS = [
   {
     size: 320,
@@ -139,15 +149,7 @@ const GamePage = () => {
               spacing={4}
               dotR={1.8}
               hoverRadius={18}
-              charColors={[
-                '#FF5414',
-                '#FFB300',
-                '#5FD8C0',
-                '#7094FF',
-                '#D4537E',
-                '#EF9F27',
-                '#FF9D7C',
-              ]}
+              charColors={CHAR_COLORS}
             />
           </motion.div>
         )}

--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.styles.ts
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.styles.ts
@@ -1,0 +1,79 @@
+import styled, { keyframes } from 'styled-components';
+
+const pop = keyframes`
+  0%   { transform: scale(1); }
+  40%  { transform: scale(0.92); }
+  100% { transform: scale(1); }
+`;
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+`;
+
+export const ClubLabel = styled.p`
+  font-size: 1rem;
+  font-weight: 600;
+  color: ${({ theme }) => theme.colors.gray[700]};
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: center;
+
+  @media (max-width: 500px) {
+    max-width: 140px;
+    font-size: 0.875rem;
+  }
+`;
+
+export const Button = styled.button<{ $clicking: boolean }>`
+  width: 180px;
+  height: 180px;
+  border-radius: 50%;
+  border: none;
+  background: ${({ theme }) => theme.colors.primary[900]};
+  color: #fff;
+  font-size: 1.5rem;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 8px 24px rgba(255, 84, 20, 0.35);
+  animation: ${({ $clicking }) => ($clicking ? pop : 'none')} 0.15s ease;
+  transition: box-shadow 0.2s;
+  user-select: none;
+
+  &:hover {
+    box-shadow: 0 12px 32px rgba(255, 84, 20, 0.45);
+  }
+
+  &:active {
+    transform: scale(0.92);
+  }
+
+  @media (max-width: 500px) {
+    width: 140px;
+    height: 140px;
+    font-size: 1.2rem;
+  }
+`;
+
+export const CountWrapper = styled.div`
+  display: flex;
+  align-items: baseline;
+  gap: 2px;
+`;
+
+export const Count = styled.p`
+  font-size: 2rem;
+  font-weight: 800;
+  color: ${({ theme }) => theme.colors.primary[900]};
+`;
+
+export const CountLabel = styled.span`
+  font-size: 1rem;
+  font-weight: 500;
+  color: ${({ theme }) => theme.colors.gray[600]};
+  margin-left: 4px;
+`;

--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
@@ -1,0 +1,59 @@
+import { AnimatePresence, motion } from 'framer-motion';
+import * as S from './ClickButton.styles';
+
+interface ClickButtonProps {
+  clubName: string;
+  clickCount: number;
+  onClickGame: () => void;
+}
+
+const ClickButton = ({
+  clubName,
+  clickCount,
+  onClickGame,
+}: ClickButtonProps) => {
+  return (
+    <S.Wrapper>
+      <S.ClubLabel>{clubName}</S.ClubLabel>
+      <motion.button
+        onClick={onClickGame}
+        whileTap={{ scale: 0.88 }}
+        whileHover={{ scale: 1.06 }}
+        transition={{ type: 'spring', stiffness: 400, damping: 15 }}
+        style={{
+          width: 180,
+          height: 180,
+          borderRadius: '50%',
+          border: 'none',
+          background: '#FF5414',
+          color: '#fff',
+          fontSize: '1.5rem',
+          fontWeight: 700,
+          cursor: 'pointer',
+          boxShadow: '0 8px 24px rgba(255, 84, 20, 0.35)',
+          userSelect: 'none',
+        }}
+      >
+        클릭!
+      </motion.button>
+
+      <S.CountWrapper>
+        <AnimatePresence mode='popLayout'>
+          <motion.span
+            key={clickCount}
+            initial={{ opacity: 0, y: -12, scale: 0.8 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 12, scale: 0.8 }}
+            transition={{ type: 'spring', stiffness: 300, damping: 20 }}
+            style={{ fontSize: '2rem', fontWeight: 800, color: '#FF5414' }}
+          >
+            {clickCount.toLocaleString()}
+          </motion.span>
+        </AnimatePresence>
+        <S.CountLabel>회</S.CountLabel>
+      </S.CountWrapper>
+    </S.Wrapper>
+  );
+};
+
+export default ClickButton;

--- a/frontend/src/pages/GamePage/components/ClubNameInput/ClubNameInput.styles.ts
+++ b/frontend/src/pages/GamePage/components/ClubNameInput/ClubNameInput.styles.ts
@@ -1,0 +1,62 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  max-width: 360px;
+`;
+
+export const Title = styled.h2`
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: ${({ theme }) => theme.colors.gray[900]};
+`;
+
+export const InputRow = styled.div`
+  display: flex;
+  gap: 8px;
+  width: 100%;
+`;
+
+export const Input = styled.input`
+  flex: 1;
+  padding: 12px 16px;
+  font-size: 1rem;
+  border: 2px solid ${({ theme }) => theme.colors.gray[300]};
+  border-radius: 10px;
+  outline: none;
+  transition: border-color 0.2s;
+
+  &:focus {
+    border-color: ${({ theme }) => theme.colors.primary[900]};
+  }
+
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.gray[500]};
+  }
+`;
+
+export const StartButton = styled.button`
+  padding: 12px 20px;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #fff;
+  background: ${({ theme }) => theme.colors.primary[900]};
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.2s;
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.primary[800]};
+  }
+
+  &:disabled {
+    background: ${({ theme }) => theme.colors.gray[400]};
+    cursor: not-allowed;
+  }
+`;

--- a/frontend/src/pages/GamePage/components/ClubNameInput/ClubNameInput.styles.ts
+++ b/frontend/src/pages/GamePage/components/ClubNameInput/ClubNameInput.styles.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { media } from '@/styles/mediaQuery';
 
 export const Wrapper = styled.div`
   display: flex;
@@ -36,6 +37,7 @@ export const Input = styled.input<{ $hasError: boolean }>`
   border-radius: 10px;
   outline: none;
   transition: border-color 0.2s;
+  min-width: 0;
 
   &:focus {
     border-color: ${({ theme }) => theme.colors.primary[900]};
@@ -43,6 +45,11 @@ export const Input = styled.input<{ $hasError: boolean }>`
 
   &::placeholder {
     color: ${({ theme }) => theme.colors.gray[500]};
+  }
+
+  ${media.mobile} {
+    padding: 10px 12px;
+    font-size: 0.875rem;
   }
 `;
 
@@ -65,6 +72,11 @@ export const StartButton = styled.button`
   &:disabled {
     background: ${({ theme }) => theme.colors.gray[400]};
     cursor: not-allowed;
+  }
+
+  ${media.mobile} {
+    padding: 10px 14px;
+    font-size: 0.875rem;
   }
 `;
 

--- a/frontend/src/pages/GamePage/components/ClubNameInput/ClubNameInput.styles.ts
+++ b/frontend/src/pages/GamePage/components/ClubNameInput/ClubNameInput.styles.ts
@@ -15,17 +15,24 @@ export const Title = styled.h2`
   color: ${({ theme }) => theme.colors.gray[900]};
 `;
 
+export const InputContainer = styled.div`
+  position: relative;
+  width: 100%;
+`;
+
 export const InputRow = styled.div`
   display: flex;
   gap: 8px;
   width: 100%;
 `;
 
-export const Input = styled.input`
+export const Input = styled.input<{ $hasError: boolean }>`
   flex: 1;
   padding: 12px 16px;
   font-size: 1rem;
-  border: 2px solid ${({ theme }) => theme.colors.gray[300]};
+  border: 2px solid
+    ${({ theme, $hasError }) =>
+      $hasError ? theme.colors.primary[900] : theme.colors.gray[300]};
   border-radius: 10px;
   outline: none;
   transition: border-color 0.2s;
@@ -59,4 +66,41 @@ export const StartButton = styled.button`
     background: ${({ theme }) => theme.colors.gray[400]};
     cursor: not-allowed;
   }
+`;
+
+export const Dropdown = styled.ul`
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  background: #fff;
+  border: 1.5px solid ${({ theme }) => theme.colors.gray[200]};
+  border-radius: 10px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+  list-style: none;
+  max-height: 200px;
+  overflow-y: auto;
+  z-index: 10;
+`;
+
+export const DropdownItem = styled.li`
+  padding: 10px 16px;
+  font-size: 0.95rem;
+  color: ${({ theme }) => theme.colors.gray[800]};
+  cursor: pointer;
+  transition: background 0.15s;
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.gray[100]};
+  }
+
+  & + & {
+    border-top: 1px solid ${({ theme }) => theme.colors.gray[100]};
+  }
+`;
+
+export const ErrorMessage = styled.p`
+  font-size: 0.875rem;
+  color: ${({ theme }) => theme.colors.primary[900]};
+  font-weight: 500;
 `;

--- a/frontend/src/pages/GamePage/components/ClubNameInput/ClubNameInput.tsx
+++ b/frontend/src/pages/GamePage/components/ClubNameInput/ClubNameInput.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useState } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 import {
   useClubSuggestions,
   useValidateClubName,
@@ -18,8 +18,13 @@ const ClubNameInput = ({ onStart }: ClubNameInputProps) => {
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
 
   const listboxId = useId();
+  const justSelectedRef = useRef(false);
 
   useEffect(() => {
+    if (justSelectedRef.current) {
+      justSelectedRef.current = false;
+      return;
+    }
     const trimmed = value.trim();
     const timer = setTimeout(() => setDebouncedKeyword(trimmed), 300);
     return () => clearTimeout(timer);
@@ -39,6 +44,7 @@ const ClubNameInput = ({ onStart }: ClubNameInputProps) => {
   };
 
   const handleSelect = (name: string) => {
+    justSelectedRef.current = true;
     setValue(name);
     setDebouncedKeyword('');
     setHighlightedIndex(-1);

--- a/frontend/src/pages/GamePage/components/ClubNameInput/ClubNameInput.tsx
+++ b/frontend/src/pages/GamePage/components/ClubNameInput/ClubNameInput.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useId, useState } from 'react';
-import { getClubList } from '@/apis/club';
-import { useClubSuggestions } from '@/hooks/Queries/useClub';
+import {
+  useClubSuggestions,
+  useValidateClubName,
+} from '@/hooks/Queries/useClub';
 import * as S from './ClubNameInput.styles';
 
 interface ClubNameInputProps {
@@ -8,6 +10,7 @@ interface ClubNameInputProps {
 }
 
 const ClubNameInput = ({ onStart }: ClubNameInputProps) => {
+  const validateClubName = useValidateClubName();
   const [value, setValue] = useState('');
   const [debouncedKeyword, setDebouncedKeyword] = useState('');
   const [error, setError] = useState('');
@@ -48,9 +51,8 @@ const ClubNameInput = ({ onStart }: ClubNameInputProps) => {
 
     setIsValidating(true);
     try {
-      const { clubs } = await getClubList(trimmed);
-      const exact = clubs.find((c) => c.name === trimmed);
-      if (!exact) {
+      const isValid = await validateClubName(trimmed);
+      if (!isValid) {
         setError('존재하지 않는 동아리입니다.');
         return;
       }

--- a/frontend/src/pages/GamePage/components/ClubNameInput/ClubNameInput.tsx
+++ b/frontend/src/pages/GamePage/components/ClubNameInput/ClubNameInput.tsx
@@ -1,5 +1,6 @@
-import { useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { getClubList } from '@/apis/club';
+import { useClubSuggestions } from '@/hooks/Queries/useClub';
 import * as S from './ClubNameInput.styles';
 
 interface ClubNameInputProps {
@@ -8,38 +9,26 @@ interface ClubNameInputProps {
 
 const ClubNameInput = ({ onStart }: ClubNameInputProps) => {
   const [value, setValue] = useState('');
-  const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [debouncedKeyword, setDebouncedKeyword] = useState('');
   const [error, setError] = useState('');
   const [isValidating, setIsValidating] = useState(false);
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(
-    undefined,
-  );
+
+  useEffect(() => {
+    const trimmed = value.trim();
+    const timer = setTimeout(() => setDebouncedKeyword(trimmed), 300);
+    return () => clearTimeout(timer);
+  }, [value]);
+
+  const { data: suggestions = [] } = useClubSuggestions(debouncedKeyword);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const v = e.target.value;
-    setValue(v);
+    setValue(e.target.value);
     setError('');
-
-    clearTimeout(debounceRef.current);
-
-    if (!v.trim()) {
-      setSuggestions([]);
-      return;
-    }
-
-    debounceRef.current = setTimeout(async () => {
-      try {
-        const { clubs } = await getClubList(v.trim());
-        setSuggestions(clubs.map((c) => c.name));
-      } catch {
-        setSuggestions([]);
-      }
-    }, 300);
   };
 
   const handleSelect = (name: string) => {
     setValue(name);
-    setSuggestions([]);
+    setDebouncedKeyword('');
     setError('');
   };
 

--- a/frontend/src/pages/GamePage/components/ClubNameInput/ClubNameInput.tsx
+++ b/frontend/src/pages/GamePage/components/ClubNameInput/ClubNameInput.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+import * as S from './ClubNameInput.styles';
+
+interface ClubNameInputProps {
+  onStart: (clubName: string) => void;
+}
+
+const ClubNameInput = ({ onStart }: ClubNameInputProps) => {
+  const [value, setValue] = useState('');
+
+  const handleSubmit = () => {
+    const trimmed = value.trim();
+    if (trimmed) onStart(trimmed);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') handleSubmit();
+  };
+
+  return (
+    <S.Wrapper>
+      <S.Title>동아리명을 입력해주세요</S.Title>
+      <S.InputRow>
+        <S.Input
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder='예) 모아동 개발팀'
+          maxLength={30}
+          autoFocus
+        />
+        <S.StartButton onClick={handleSubmit} disabled={!value.trim()}>
+          시작
+        </S.StartButton>
+      </S.InputRow>
+    </S.Wrapper>
+  );
+};
+
+export default ClubNameInput;

--- a/frontend/src/pages/GamePage/components/ClubNameInput/ClubNameInput.tsx
+++ b/frontend/src/pages/GamePage/components/ClubNameInput/ClubNameInput.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
+import { getClubList } from '@/apis/club';
 import * as S from './ClubNameInput.styles';
 
 interface ClubNameInputProps {
@@ -7,10 +8,59 @@ interface ClubNameInputProps {
 
 const ClubNameInput = ({ onStart }: ClubNameInputProps) => {
   const [value, setValue] = useState('');
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [error, setError] = useState('');
+  const [isValidating, setIsValidating] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
 
-  const handleSubmit = () => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const v = e.target.value;
+    setValue(v);
+    setError('');
+
+    clearTimeout(debounceRef.current);
+
+    if (!v.trim()) {
+      setSuggestions([]);
+      return;
+    }
+
+    debounceRef.current = setTimeout(async () => {
+      try {
+        const { clubs } = await getClubList(v.trim());
+        setSuggestions(clubs.map((c) => c.name));
+      } catch {
+        setSuggestions([]);
+      }
+    }, 300);
+  };
+
+  const handleSelect = (name: string) => {
+    setValue(name);
+    setSuggestions([]);
+    setError('');
+  };
+
+  const handleSubmit = async () => {
     const trimmed = value.trim();
-    if (trimmed) onStart(trimmed);
+    if (!trimmed) return;
+
+    setIsValidating(true);
+    try {
+      const { clubs } = await getClubList(trimmed);
+      const exact = clubs.find((c) => c.name === trimmed);
+      if (!exact) {
+        setError('존재하지 않는 동아리입니다.');
+        return;
+      }
+      onStart(trimmed);
+    } catch {
+      setError('동아리 확인 중 오류가 발생했습니다.');
+    } finally {
+      setIsValidating(false);
+    }
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -20,19 +70,37 @@ const ClubNameInput = ({ onStart }: ClubNameInputProps) => {
   return (
     <S.Wrapper>
       <S.Title>동아리명을 입력해주세요</S.Title>
-      <S.InputRow>
-        <S.Input
-          value={value}
-          onChange={(e) => setValue(e.target.value)}
-          onKeyDown={handleKeyDown}
-          placeholder='예) RCY'
-          maxLength={30}
-          autoFocus
-        />
-        <S.StartButton onClick={handleSubmit} disabled={!value.trim()}>
-          시작
-        </S.StartButton>
-      </S.InputRow>
+      <S.InputContainer>
+        <S.InputRow>
+          <S.Input
+            value={value}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            placeholder='예) RCY'
+            maxLength={30}
+            autoFocus
+            $hasError={!!error}
+          />
+          <S.StartButton
+            onClick={handleSubmit}
+            disabled={!value.trim() || isValidating}
+          >
+            {isValidating ? '확인 중...' : '시작'}
+          </S.StartButton>
+        </S.InputRow>
+
+        {suggestions.length > 0 && (
+          <S.Dropdown>
+            {suggestions.map((name) => (
+              <S.DropdownItem key={name} onClick={() => handleSelect(name)}>
+                {name}
+              </S.DropdownItem>
+            ))}
+          </S.Dropdown>
+        )}
+      </S.InputContainer>
+
+      {error && <S.ErrorMessage>{error}</S.ErrorMessage>}
     </S.Wrapper>
   );
 };

--- a/frontend/src/pages/GamePage/components/ClubNameInput/ClubNameInput.tsx
+++ b/frontend/src/pages/GamePage/components/ClubNameInput/ClubNameInput.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useId, useState } from 'react';
 import { getClubList } from '@/apis/club';
 import { useClubSuggestions } from '@/hooks/Queries/useClub';
 import * as S from './ClubNameInput.styles';
@@ -12,6 +12,9 @@ const ClubNameInput = ({ onStart }: ClubNameInputProps) => {
   const [debouncedKeyword, setDebouncedKeyword] = useState('');
   const [error, setError] = useState('');
   const [isValidating, setIsValidating] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+
+  const listboxId = useId();
 
   useEffect(() => {
     const trimmed = value.trim();
@@ -21,6 +24,12 @@ const ClubNameInput = ({ onStart }: ClubNameInputProps) => {
 
   const { data: suggestions = [] } = useClubSuggestions(debouncedKeyword);
 
+  useEffect(() => {
+    setHighlightedIndex(-1);
+  }, [suggestions]);
+
+  const isOpen = suggestions.length > 0;
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setValue(e.target.value);
     setError('');
@@ -29,6 +38,7 @@ const ClubNameInput = ({ onStart }: ClubNameInputProps) => {
   const handleSelect = (name: string) => {
     setValue(name);
     setDebouncedKeyword('');
+    setHighlightedIndex(-1);
     setError('');
   };
 
@@ -53,8 +63,31 @@ const ClubNameInput = ({ onStart }: ClubNameInputProps) => {
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') handleSubmit();
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setHighlightedIndex((prev) =>
+        isOpen ? Math.min(prev + 1, suggestions.length - 1) : prev,
+      );
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setHighlightedIndex((prev) => Math.max(prev - 1, -1));
+    } else if (e.key === 'Enter') {
+      if (highlightedIndex >= 0 && isOpen) {
+        e.preventDefault();
+        handleSelect(suggestions[highlightedIndex]);
+      } else {
+        handleSubmit();
+      }
+    } else if (e.key === 'Escape') {
+      setDebouncedKeyword('');
+      setHighlightedIndex(-1);
+    }
   };
+
+  const activeDescendant =
+    highlightedIndex >= 0
+      ? `${listboxId}-option-${highlightedIndex}`
+      : undefined;
 
   return (
     <S.Wrapper>
@@ -69,6 +102,11 @@ const ClubNameInput = ({ onStart }: ClubNameInputProps) => {
             maxLength={30}
             autoFocus
             $hasError={!!error}
+            role='combobox'
+            aria-autocomplete='list'
+            aria-expanded={isOpen}
+            aria-controls={listboxId}
+            aria-activedescendant={activeDescendant}
           />
           <S.StartButton
             onClick={handleSubmit}
@@ -78,10 +116,17 @@ const ClubNameInput = ({ onStart }: ClubNameInputProps) => {
           </S.StartButton>
         </S.InputRow>
 
-        {suggestions.length > 0 && (
-          <S.Dropdown>
-            {suggestions.map((name) => (
-              <S.DropdownItem key={name} onClick={() => handleSelect(name)}>
+        {isOpen && (
+          <S.Dropdown role='listbox' id={listboxId}>
+            {suggestions.map((name, index) => (
+              <S.DropdownItem
+                key={name}
+                id={`${listboxId}-option-${index}`}
+                role='option'
+                aria-selected={index === highlightedIndex}
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => handleSelect(name)}
+              >
                 {name}
               </S.DropdownItem>
             ))}

--- a/frontend/src/pages/GamePage/components/ClubNameInput/ClubNameInput.tsx
+++ b/frontend/src/pages/GamePage/components/ClubNameInput/ClubNameInput.tsx
@@ -25,7 +25,7 @@ const ClubNameInput = ({ onStart }: ClubNameInputProps) => {
           value={value}
           onChange={(e) => setValue(e.target.value)}
           onKeyDown={handleKeyDown}
-          placeholder='예) 모아동 개발팀'
+          placeholder='예) RCY'
           maxLength={30}
           autoFocus
         />

--- a/frontend/src/pages/GamePage/components/DotTextEffect/DotTextEffect.tsx
+++ b/frontend/src/pages/GamePage/components/DotTextEffect/DotTextEffect.tsx
@@ -140,6 +140,7 @@ const DotTextEffect = ({
   const mouseRef = useRef({ x: -999, y: -999 });
   const dotsRef = useRef<Dot[]>([]);
   const rafRef = useRef<number>(0);
+  const canvasSizeRef = useRef({ W: 0, H: 0 });
 
   const [isMobile, setIsMobile] = useState(() => mobileQuery.matches);
 
@@ -173,6 +174,7 @@ const DotTextEffect = ({
       canvasH = H;
       canvas.width = W;
       canvas.height = H;
+      canvasSizeRef.current = { W, H };
 
       // 컨테이너 너비를 넘으면 CSS transform으로 축소 (항상 한 줄 유지)
       const wrapper = wrapperRef.current;
@@ -303,6 +305,24 @@ const DotTextEffect = ({
     sweepSpeed,
     charColors,
   ]);
+
+  useEffect(() => {
+    const wrapper = wrapperRef.current;
+    const canvas = canvasRef.current;
+    if (!wrapper || !canvas) return;
+
+    const observer = new ResizeObserver(() => {
+      const { W, H } = canvasSizeRef.current;
+      if (W === 0) return;
+      const scale = Math.min(1, wrapper.clientWidth / W);
+      canvas.style.transform = `scale(${scale})`;
+      canvas.style.transformOrigin = 'center top';
+      wrapper.style.height = `${H * scale}px`;
+    });
+
+    observer.observe(wrapper);
+    return () => observer.disconnect();
+  }, []);
 
   const handleMouseMove = (e: React.MouseEvent<HTMLCanvasElement>) => {
     const r = canvasRef.current!.getBoundingClientRect();

--- a/frontend/src/pages/GamePage/components/DotTextEffect/DotTextEffect.tsx
+++ b/frontend/src/pages/GamePage/components/DotTextEffect/DotTextEffect.tsx
@@ -135,9 +135,14 @@ const DotTextEffect = ({
   charColors = DEFAULT_CHAR_COLORS,
 }: DotTextEffectProps) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
   const mouseRef = useRef({ x: -999, y: -999 });
   const dotsRef = useRef<Dot[]>([]);
   const rafRef = useRef<number>(0);
+
+  // 모바일에서 더 큰 폰트 사이즈 사용
+  const effectiveFontSize =
+    window.innerWidth < 700 ? Math.round(fontSize * 1.4) : fontSize;
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -151,11 +156,26 @@ const DotTextEffect = ({
     document.fonts.ready.then(() => {
       if (!active) return;
 
-      const { dots, W, H } = buildDots(text, fontSize, spacing, charGap);
+      const { dots, W, H } = buildDots(
+        text,
+        effectiveFontSize,
+        spacing,
+        charGap,
+      );
       canvasW = W;
       canvasH = H;
       canvas.width = W;
       canvas.height = H;
+
+      // 컨테이너 너비를 넘으면 CSS transform으로 축소 (항상 한 줄 유지)
+      const wrapper = wrapperRef.current;
+      if (wrapper) {
+        const availW = wrapper.clientWidth;
+        const scale = Math.min(1, availW / W);
+        canvas.style.transform = `scale(${scale})`;
+        canvas.style.transformOrigin = 'center top';
+        wrapper.style.height = `${H * scale}px`;
+      }
       dots.forEach((d) => {
         d.color = charColors[Math.floor(Math.random() * charColors.length)];
       });
@@ -164,24 +184,42 @@ const DotTextEffect = ({
       rafRef.current = requestAnimationFrame(animate);
     });
 
+    const colorRadius = hoverRadius * 1.8;
+    const hoverR2 = hoverRadius * hoverRadius;
+    const colorR2 = colorRadius * colorRadius;
+
     const animate = () => {
       const mouse = mouseRef.current;
       const ds = dotsRef.current;
+      const inactive = mouse.x < -900;
 
       ctx.clearRect(0, 0, canvasW, canvasH);
 
-      const colorRadius = hoverRadius * 1.8;
+      // 인터랙션 없을 때: 전체 dot을 단일 path로 배치 렌더 (성능 최적화)
+      if (inactive && ds.every((d) => !d.swept)) {
+        ctx.beginPath();
+        ctx.fillStyle = DOT_COLOR;
+        for (const d of ds) {
+          ctx.moveTo(d.ox + dotR, d.oy);
+          ctx.arc(d.ox, d.oy, dotR, 0, Math.PI * 2);
+        }
+        ctx.fill();
+        rafRef.current = requestAnimationFrame(animate);
+        return;
+      }
 
       for (const d of ds) {
         const sweptColor = d.color;
         const dx = d.x - mouse.x;
         const dy = d.y - mouse.y;
-        const dist = Math.sqrt(dx * dx + dy * dy);
+        const dist2 = dx * dx + dy * dy;
 
-        if (dist < hoverRadius && !d.swept) {
+        if (dist2 < hoverR2 && !d.swept) {
           d.swept = true;
           d.t = 0;
-          const angle = Math.atan2(dy, dx) + (Math.random() - 0.5) * 1.4;
+          const dist = Math.sqrt(dist2);
+          const angle =
+            Math.atan2(dy / dist, dx / dist) + (Math.random() - 0.5) * 1.4;
           const speed = 2.5 + Math.random() * 4;
           d.vx = Math.cos(angle) * speed;
           d.vy = Math.sin(angle) * speed;
@@ -211,13 +249,12 @@ const DotTextEffect = ({
           ctx.fillStyle = lerpColor(sweptColor, DOT_COLOR, d.t);
           ctx.fill();
         } else {
-          // 커서 주변 colorRadius 안 공들은 거리 비례로 색이 물듦
           const proximityColor =
-            dist < colorRadius
+            dist2 < colorR2
               ? lerpColor(
                   sweptColor,
                   DOT_COLOR,
-                  Math.pow(dist / colorRadius, 2.5),
+                  Math.pow(Math.sqrt(dist2) / colorRadius, 2.5),
                 )
               : DOT_COLOR;
 
@@ -228,8 +265,8 @@ const DotTextEffect = ({
         }
       }
 
-      // 커스텀 커서
-      if (mouse.x > 0) {
+      // 커스텀 커서 (데스크탑만)
+      if (!inactive) {
         ctx.beginPath();
         ctx.arc(mouse.x, mouse.y, 5, 0, Math.PI * 2);
         ctx.fillStyle = '#FF5414';
@@ -269,13 +306,44 @@ const DotTextEffect = ({
     mouseRef.current = { x: -999, y: -999 };
   };
 
+  const handleTouchMove = (e: React.TouchEvent<HTMLCanvasElement>) => {
+    e.preventDefault();
+    const touch = e.touches[0];
+    const r = canvasRef.current!.getBoundingClientRect();
+    mouseRef.current = { x: touch.clientX - r.left, y: touch.clientY - r.top };
+  };
+
+  const handleTouchStart = (e: React.TouchEvent<HTMLCanvasElement>) => {
+    e.preventDefault();
+    const touch = e.touches[0];
+    const r = canvasRef.current!.getBoundingClientRect();
+    mouseRef.current = { x: touch.clientX - r.left, y: touch.clientY - r.top };
+  };
+
+  const handleTouchEnd = () => {
+    mouseRef.current = { x: -999, y: -999 };
+  };
+
   return (
-    <canvas
-      ref={canvasRef}
-      onMouseMove={handleMouseMove}
-      onMouseLeave={handleMouseLeave}
-      style={{ cursor: 'none', display: 'block' }}
-    />
+    <div
+      ref={wrapperRef}
+      style={{
+        width: '100%',
+        overflow: 'hidden',
+        display: 'flex',
+        justifyContent: 'center',
+      }}
+    >
+      <canvas
+        ref={canvasRef}
+        onMouseMove={handleMouseMove}
+        onMouseLeave={handleMouseLeave}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+        style={{ cursor: 'none', display: 'block', touchAction: 'none' }}
+      />
+    </div>
   );
 };
 

--- a/frontend/src/pages/GamePage/components/DotTextEffect/DotTextEffect.tsx
+++ b/frontend/src/pages/GamePage/components/DotTextEffect/DotTextEffect.tsx
@@ -1,0 +1,282 @@
+import { useEffect, useRef } from 'react';
+
+interface Dot {
+  x: number;
+  y: number;
+  ox: number;
+  oy: number;
+  vx: number;
+  vy: number;
+  swept: boolean;
+  t: number;
+  charIndex: number;
+  color: string;
+}
+
+interface DotTextEffectProps {
+  text: string;
+  fontSize?: number;
+  dotR?: number;
+  spacing?: number;
+  charGap?: number;
+  hoverRadius?: number;
+  sweepSpeed?: number;
+  charColors?: string[];
+}
+
+const DOT_COLOR = '#888780';
+
+const DEFAULT_CHAR_COLORS = [
+  '#FF5414',
+  '#FFB300',
+  '#5FD8C0',
+  '#7094FF',
+  '#D4537E',
+  '#EF9F27',
+  '#FF9D7C',
+];
+
+function lerpColor(a: string, b: string, t: number): string {
+  const ah = parseInt(a.replace('#', ''), 16);
+  const bh = parseInt(b.replace('#', ''), 16);
+  const ar = (ah >> 16) & 255,
+    ag = (ah >> 8) & 255,
+    ab = ah & 255;
+  const br = (bh >> 16) & 255,
+    bg = (bh >> 8) & 255,
+    bb = bh & 255;
+  return `rgb(${Math.round(ar + (br - ar) * t)},${Math.round(ag + (bg - ag) * t)},${Math.round(ab + (bb - ab) * t)})`;
+}
+
+function buildDots(
+  text: string,
+  fontSize: number,
+  spacing: number,
+  charGap: number,
+): { dots: Dot[]; W: number; H: number } {
+  const font = `900 ${fontSize}px "Pretendard", Arial, sans-serif`;
+  const H = Math.round(fontSize * 1.5);
+
+  // 각 글자 너비 측정
+  const measurer = document.createElement('canvas');
+  const mCtx = measurer.getContext('2d')!;
+  mCtx.font = font;
+  const chars = [...text]; // 유니코드 글자 단위로 분리
+  const charWidths = chars.map((ch) => mCtx.measureText(ch).width);
+  const totalW =
+    charWidths.reduce((a, b) => a + b, 0) + charGap * (chars.length - 1);
+  const W = Math.ceil(totalW) + fontSize; // 좌우 여백
+
+  // 오프스크린 캔버스에 글자별로 개별 렌더
+  const oc = document.createElement('canvas');
+  oc.width = W;
+  oc.height = H;
+  const ctx = oc.getContext('2d')!;
+  ctx.font = font;
+  ctx.textBaseline = 'middle';
+  ctx.fillStyle = '#fff';
+
+  // 글자별 x 시작 위치 계산 (전체 중앙 정렬)
+  const startX = (W - totalW) / 2;
+  const charStarts: number[] = [];
+  let curX = startX;
+  for (let i = 0; i < chars.length; i++) {
+    charStarts.push(curX);
+    ctx.fillText(chars[i], curX, H / 2);
+    curX += charWidths[i] + charGap;
+  }
+
+  // 글자별 x 경계 (end = 다음 글자 start - charGap)
+  const charEnds = charStarts.map((s, i) => s + charWidths[i]);
+
+  // 픽셀 샘플링 → Dot 생성
+  const { data } = ctx.getImageData(0, 0, W, H);
+  const dots: Dot[] = [];
+
+  for (let y = 0; y < H; y += spacing) {
+    for (let x = 0; x < W; x += spacing) {
+      const alpha = data[(y * W + x) * 4 + 3];
+      if (alpha > 100) {
+        // 어느 글자에 속하는지 판별
+        let charIndex = chars.length - 1;
+        for (let ci = 0; ci < chars.length; ci++) {
+          if (x >= charStarts[ci] && x <= charEnds[ci]) {
+            charIndex = ci;
+            break;
+          }
+        }
+        dots.push({
+          x,
+          y,
+          ox: x,
+          oy: y,
+          vx: 0,
+          vy: 0,
+          swept: false,
+          t: 0,
+          charIndex,
+          color: '',
+        });
+      }
+    }
+  }
+
+  return { dots, W, H };
+}
+
+const DotTextEffect = ({
+  text,
+  fontSize = 80,
+  dotR = 2.2,
+  spacing = 4,
+  charGap = 14,
+  hoverRadius = 28,
+  sweepSpeed = 0.15,
+  charColors = DEFAULT_CHAR_COLORS,
+}: DotTextEffectProps) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const mouseRef = useRef({ x: -999, y: -999 });
+  const dotsRef = useRef<Dot[]>([]);
+  const rafRef = useRef<number>(0);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d')!;
+
+    let active = true;
+    let canvasW = 0;
+    let canvasH = 0;
+
+    document.fonts.ready.then(() => {
+      if (!active) return;
+
+      const { dots, W, H } = buildDots(text, fontSize, spacing, charGap);
+      canvasW = W;
+      canvasH = H;
+      canvas.width = W;
+      canvas.height = H;
+      dots.forEach((d) => {
+        d.color = charColors[Math.floor(Math.random() * charColors.length)];
+      });
+      dotsRef.current = dots;
+
+      rafRef.current = requestAnimationFrame(animate);
+    });
+
+    const animate = () => {
+      const mouse = mouseRef.current;
+      const ds = dotsRef.current;
+
+      ctx.clearRect(0, 0, canvasW, canvasH);
+
+      const colorRadius = hoverRadius * 1.8;
+
+      for (const d of ds) {
+        const sweptColor = d.color;
+        const dx = d.x - mouse.x;
+        const dy = d.y - mouse.y;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+
+        if (dist < hoverRadius && !d.swept) {
+          d.swept = true;
+          d.t = 0;
+          const angle = Math.atan2(dy, dx) + (Math.random() - 0.5) * 1.4;
+          const speed = 2.5 + Math.random() * 4;
+          d.vx = Math.cos(angle) * speed;
+          d.vy = Math.sin(angle) * speed;
+        }
+
+        if (d.swept) {
+          d.t = Math.min(d.t + sweepSpeed, 1);
+          d.x += d.vx * (1 - d.t);
+          d.y += d.vy * (1 - d.t);
+
+          if (d.t > 0.55) {
+            d.x += (d.ox - d.x) * 0.06;
+            d.y += (d.oy - d.y) * 0.06;
+            const backDist = Math.sqrt((d.x - d.ox) ** 2 + (d.y - d.oy) ** 2);
+            if (backDist < 0.5) {
+              d.x = d.ox;
+              d.y = d.oy;
+              d.swept = false;
+              d.t = 0;
+              d.vx = 0;
+              d.vy = 0;
+            }
+          }
+
+          ctx.beginPath();
+          ctx.arc(d.x, d.y, dotR * (1 + (1 - d.t) * 0.8), 0, Math.PI * 2);
+          ctx.fillStyle = lerpColor(sweptColor, DOT_COLOR, d.t);
+          ctx.fill();
+        } else {
+          // 커서 주변 colorRadius 안 공들은 거리 비례로 색이 물듦
+          const proximityColor =
+            dist < colorRadius
+              ? lerpColor(
+                  sweptColor,
+                  DOT_COLOR,
+                  Math.pow(dist / colorRadius, 2.5),
+                )
+              : DOT_COLOR;
+
+          ctx.beginPath();
+          ctx.arc(d.x, d.y, dotR, 0, Math.PI * 2);
+          ctx.fillStyle = proximityColor;
+          ctx.fill();
+        }
+      }
+
+      // 커스텀 커서
+      if (mouse.x > 0) {
+        ctx.beginPath();
+        ctx.arc(mouse.x, mouse.y, 5, 0, Math.PI * 2);
+        ctx.fillStyle = '#FF5414';
+        ctx.fill();
+
+        ctx.beginPath();
+        ctx.arc(mouse.x, mouse.y, hoverRadius, 0, Math.PI * 2);
+        ctx.strokeStyle = 'rgba(255,84,20,0.18)';
+        ctx.lineWidth = 1;
+        ctx.stroke();
+      }
+
+      rafRef.current = requestAnimationFrame(animate);
+    };
+
+    return () => {
+      active = false;
+      cancelAnimationFrame(rafRef.current);
+    };
+  }, [
+    text,
+    fontSize,
+    dotR,
+    spacing,
+    charGap,
+    hoverRadius,
+    sweepSpeed,
+    charColors,
+  ]);
+
+  const handleMouseMove = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    const r = canvasRef.current!.getBoundingClientRect();
+    mouseRef.current = { x: e.clientX - r.left, y: e.clientY - r.top };
+  };
+
+  const handleMouseLeave = () => {
+    mouseRef.current = { x: -999, y: -999 };
+  };
+
+  return (
+    <canvas
+      ref={canvasRef}
+      onMouseMove={handleMouseMove}
+      onMouseLeave={handleMouseLeave}
+      style={{ cursor: 'none', display: 'block' }}
+    />
+  );
+};
+
+export default DotTextEffect;

--- a/frontend/src/pages/GamePage/components/DotTextEffect/DotTextEffect.tsx
+++ b/frontend/src/pages/GamePage/components/DotTextEffect/DotTextEffect.tsx
@@ -339,6 +339,8 @@ const DotTextEffect = ({
         onTouchStart={handleTouchStart}
         onTouchMove={handleTouchMove}
         onTouchEnd={handleTouchEnd}
+        role='img'
+        aria-label={text}
         style={{ cursor: 'none', display: 'block', touchAction: 'none' }}
       />
     </div>

--- a/frontend/src/pages/GamePage/components/DotTextEffect/DotTextEffect.tsx
+++ b/frontend/src/pages/GamePage/components/DotTextEffect/DotTextEffect.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 interface Dot {
   x: number;
@@ -25,6 +25,7 @@ interface DotTextEffectProps {
 }
 
 const DOT_COLOR = '#888780';
+const mobileQuery = window.matchMedia('(max-width: 699px)');
 
 const DEFAULT_CHAR_COLORS = [
   '#FF5414',
@@ -140,9 +141,15 @@ const DotTextEffect = ({
   const dotsRef = useRef<Dot[]>([]);
   const rafRef = useRef<number>(0);
 
-  // 모바일에서 더 큰 폰트 사이즈 사용
-  const effectiveFontSize =
-    window.innerWidth < 700 ? Math.round(fontSize * 1.4) : fontSize;
+  const [isMobile, setIsMobile] = useState(() => mobileQuery.matches);
+
+  useEffect(() => {
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mobileQuery.addEventListener('change', handler);
+    return () => mobileQuery.removeEventListener('change', handler);
+  }, []);
+
+  const effectiveFontSize = isMobile ? Math.round(fontSize * 1.4) : fontSize;
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -288,7 +295,7 @@ const DotTextEffect = ({
     };
   }, [
     text,
-    fontSize,
+    effectiveFontSize,
     dotR,
     spacing,
     charGap,

--- a/frontend/src/pages/GamePage/components/DotTextEffect/DotTextEffect.tsx
+++ b/frontend/src/pages/GamePage/components/DotTextEffect/DotTextEffect.tsx
@@ -307,14 +307,12 @@ const DotTextEffect = ({
   };
 
   const handleTouchMove = (e: React.TouchEvent<HTMLCanvasElement>) => {
-    e.preventDefault();
     const touch = e.touches[0];
     const r = canvasRef.current!.getBoundingClientRect();
     mouseRef.current = { x: touch.clientX - r.left, y: touch.clientY - r.top };
   };
 
   const handleTouchStart = (e: React.TouchEvent<HTMLCanvasElement>) => {
-    e.preventDefault();
     const touch = e.touches[0];
     const r = canvasRef.current!.getBoundingClientRect();
     mouseRef.current = { x: touch.clientX - r.left, y: touch.clientY - r.top };

--- a/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.styles.ts
+++ b/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.styles.ts
@@ -1,0 +1,80 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled.div`
+  width: 100%;
+  max-width: 480px;
+`;
+
+export const Header = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 12px;
+`;
+
+export const Title = styled.h3`
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: ${({ theme }) => theme.colors.gray[900]};
+`;
+
+export const ResetInfo = styled.p`
+  font-size: 0.75rem;
+  color: ${({ theme }) => theme.colors.gray[600]};
+`;
+
+export const List = styled.ol`
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+export const Item = styled.li<{ $isMe: boolean; $rank: number }>`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  border-radius: 10px;
+  background: ${({ $isMe, theme }) =>
+    $isMe ? theme.colors.primary[500] : theme.colors.gray[100]};
+  border: ${({ $isMe, theme }) =>
+    $isMe ? `2px solid ${theme.colors.primary[900]}` : '2px solid transparent'};
+  transition: background 0.3s;
+`;
+
+export const Rank = styled.span<{ $rank: number }>`
+  width: 28px;
+  text-align: center;
+  font-size: 1rem;
+  font-weight: 800;
+  color: ${({ $rank, theme }) => {
+    if ($rank === 1) return '#FFB300';
+    if ($rank === 2) return '#9E9E9E';
+    if ($rank === 3) return '#CD7F32';
+    return theme.colors.gray[600];
+  }};
+`;
+
+export const ClubName = styled.span`
+  flex: 1;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: ${({ theme }) => theme.colors.gray[900]};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+export const ClickCount = styled.span`
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: ${({ theme }) => theme.colors.primary[900]};
+`;
+
+export const EmptyMessage = styled.p`
+  text-align: center;
+  padding: 40px 0;
+  color: ${({ theme }) => theme.colors.gray[500]};
+  font-size: 0.95rem;
+`;

--- a/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.tsx
+++ b/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.tsx
@@ -4,23 +4,25 @@ import * as S from './RankingBoard.styles';
 
 interface RankingBoardProps {
   ranking: GameRankingEntry[];
-  resetAt: string;
+  resetAt?: string;
   myClubName?: string;
 }
 
 const MEDAL = ['🥇', '🥈', '🥉'];
 
 const RankingBoard = ({ ranking, resetAt, myClubName }: RankingBoardProps) => {
-  const resetTime = new Date(resetAt).toLocaleTimeString('ko-KR', {
-    hour: '2-digit',
-    minute: '2-digit',
-  });
+  const resetTime = resetAt
+    ? new Date(resetAt).toLocaleTimeString('ko-KR', {
+        hour: '2-digit',
+        minute: '2-digit',
+      })
+    : null;
 
   return (
     <S.Wrapper>
       <S.Header>
         <S.Title>🏆 Top 20 실시간 순위</S.Title>
-        <S.ResetInfo>매일 {resetTime} 초기화</S.ResetInfo>
+        {resetTime && <S.ResetInfo>매일 {resetTime} 초기화</S.ResetInfo>}
       </S.Header>
       {ranking.length === 0 ? (
         <S.EmptyMessage>

--- a/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.tsx
+++ b/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.tsx
@@ -1,0 +1,63 @@
+import { AnimatePresence, motion } from 'framer-motion';
+import { GameRankingEntry } from '@/types/game';
+import * as S from './RankingBoard.styles';
+
+interface RankingBoardProps {
+  ranking: GameRankingEntry[];
+  resetAt: string;
+  myClubName?: string;
+}
+
+const MEDAL = ['🥇', '🥈', '🥉'];
+
+const RankingBoard = ({ ranking, resetAt, myClubName }: RankingBoardProps) => {
+  const resetTime = new Date(resetAt).toLocaleTimeString('ko-KR', {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+
+  return (
+    <S.Wrapper>
+      <S.Header>
+        <S.Title>🏆 Top 20 실시간 순위</S.Title>
+        <S.ResetInfo>매일 {resetTime} 초기화</S.ResetInfo>
+      </S.Header>
+      {ranking.length === 0 ? (
+        <S.EmptyMessage>
+          아직 참여한 동아리가 없어요. 첫 번째로 클릭해보세요!
+        </S.EmptyMessage>
+      ) : (
+        <S.List>
+          <AnimatePresence initial={false}>
+            {ranking.map((entry, i) => (
+              <motion.li
+                key={entry.clubName}
+                layout
+                initial={{ opacity: 0, x: -20 }}
+                animate={{ opacity: 1, x: 0 }}
+                exit={{ opacity: 0, x: 20 }}
+                transition={{ duration: 0.3, delay: i * 0.04 }}
+                style={{ listStyle: 'none' }}
+              >
+                <S.Item
+                  $isMe={entry.clubName === myClubName}
+                  $rank={entry.rank}
+                >
+                  <S.Rank $rank={entry.rank}>
+                    {MEDAL[entry.rank - 1] ?? entry.rank}
+                  </S.Rank>
+                  <S.ClubName>{entry.clubName}</S.ClubName>
+                  <S.ClickCount>
+                    {entry.clickCount.toLocaleString()}회
+                  </S.ClickCount>
+                </S.Item>
+              </motion.li>
+            ))}
+          </AnimatePresence>
+        </S.List>
+      )}
+    </S.Wrapper>
+  );
+};
+
+export default RankingBoard;

--- a/frontend/src/types/game.ts
+++ b/frontend/src/types/game.ts
@@ -1,8 +1,3 @@
-export interface GameClickResponse {
-  clubName: string;
-  clickCount: number;
-}
-
 export interface GameRankingEntry {
   rank: number;
   clubName: string;

--- a/frontend/src/types/game.ts
+++ b/frontend/src/types/game.ts
@@ -1,0 +1,15 @@
+export interface GameClickResponse {
+  clubName: string;
+  clickCount: number;
+}
+
+export interface GameRankingEntry {
+  rank: number;
+  clubName: string;
+  clickCount: number;
+}
+
+export interface GameRankingResponse {
+  clubs: GameRankingEntry[];
+  resetAt: string; // ISO 8601
+}


### PR DESCRIPTION

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

   - `/game` 라우트에 동아리 클릭 배틀 게임 페이지 신규 구현
   - DotTextEffect: 1위 동아리명을 도트 픽셀 글자로 표시, 마우스 hover 시 dot 색상 ripple 효과
   - 실시간 순위 보드(Top 20), 클릭 버튼, 동아리명 입력 UI 구현


## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 동아리 클릭 배틀 전용 게임 페이지 추가(경기 시작, 세션 저장, 클릭 전송)
  * 실시간 Top20 순위판(데스크탑/모바일별 노출) 및 2초 자동 갱신·초기화 정보 표시
  * 클릭 버튼 애니메이션·클릭수 전환 애니메이션, 입력형 자동완성(추천)과 키보드 지원 UI
  * 마우스/터치 반응 점 기반 텍스트 이펙트(원색·거리 기반 페이드·스윕 애니메이션) 추가
  * 프론트엔드 라우트 및 게임 관련 API/타입/쿼리 훅 추가

* **문서**
  * 게임 레이아웃, 인터랙션, 추천/검증 훅 동작 문서화 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->