### PR TITLE
[feature] IP 기반 Redis 쿨다운 및 동아리명 화이트리스트 적용

### DIFF
--- a/backend/src/main/java/moadong/club/controller/ClubClickController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubClickController.java
@@ -29,7 +29,7 @@ public class ClubClickController {
     @Operation(summary = "동아리 클릭 기록", description = "실제 동아리 이름으로만 클릭 수를 누적합니다. IP당 1초 쿨다운이 적용됩니다.")
     public ResponseEntity<?> recordClick(@RequestBody ClubClickRequest request, HttpServletRequest httpRequest) {
         String clientIp = resolveClientIp(httpRequest);
-        ClubClickResponse result = clubClickService.recordClick(request.clubName(), clientIp);
+        ClubClickResponse result = clubClickService.recordClick(request.clubName(), request.count(), clientIp);
         return Response.ok(result);
     }
 

--- a/backend/src/main/java/moadong/club/controller/ClubClickController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubClickController.java
@@ -15,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.servlet.http.HttpServletRequest;
+
 @RestController
 @RequestMapping("/api/game")
 @RequiredArgsConstructor
@@ -24,10 +26,19 @@ public class ClubClickController {
     private final ClubClickService clubClickService;
 
     @PostMapping("/click")
-    @Operation(summary = "동아리 클릭 기록", description = "자유 입력 clubName별 클릭 수를 누적합니다. 실제 동아리 DB와 무관합니다.")
-    public ResponseEntity<?> recordClick(@RequestBody ClubClickRequest request) {
-        ClubClickResponse result = clubClickService.recordClick(request.clubName());
+    @Operation(summary = "동아리 클릭 기록", description = "실제 동아리 이름으로만 클릭 수를 누적합니다. IP당 1초 쿨다운이 적용됩니다.")
+    public ResponseEntity<?> recordClick(@RequestBody ClubClickRequest request, HttpServletRequest httpRequest) {
+        String clientIp = resolveClientIp(httpRequest);
+        ClubClickResponse result = clubClickService.recordClick(request.clubName(), clientIp);
         return Response.ok(result);
+    }
+
+    private String resolveClientIp(HttpServletRequest request) {
+        String forwarded = request.getHeader("X-Forwarded-For");
+        if (forwarded != null && !forwarded.isBlank()) {
+            return forwarded.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
     }
 
     @GetMapping("/ranking")

--- a/backend/src/main/java/moadong/club/entity/ClubClickCount.java
+++ b/backend/src/main/java/moadong/club/entity/ClubClickCount.java
@@ -1,0 +1,25 @@
+package moadong.club.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document("club_click_counts")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ClubClickCount {
+
+    @Id
+    private String id;
+
+    @Indexed(unique = true)
+    private String clubName;
+
+    private long clickCount;
+}

--- a/backend/src/main/java/moadong/club/payload/request/ClubClickRequest.java
+++ b/backend/src/main/java/moadong/club/payload/request/ClubClickRequest.java
@@ -1,4 +1,4 @@
 package moadong.club.payload.request;
 
-public record ClubClickRequest(String clubName, String ctAt) {
+public record ClubClickRequest(String clubName, int count, String ctAt) {
 }

--- a/backend/src/main/java/moadong/club/repository/ClubClickCountRepository.java
+++ b/backend/src/main/java/moadong/club/repository/ClubClickCountRepository.java
@@ -1,0 +1,13 @@
+package moadong.club.repository;
+
+import moadong.club.entity.ClubClickCount;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ClubClickCountRepository extends MongoRepository<ClubClickCount, String> {
+
+    List<ClubClickCount> findAllByOrderByClickCountDesc();
+}

--- a/backend/src/main/java/moadong/club/service/ClubClickScheduler.java
+++ b/backend/src/main/java/moadong/club/service/ClubClickScheduler.java
@@ -4,11 +4,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-
-import java.util.Set;
 
 @Slf4j
 @Component
@@ -16,17 +13,12 @@ import java.util.Set;
 @ConditionalOnProperty(name = "scheduling.enabled", havingValue = "true", matchIfMissing = true)
 public class ClubClickScheduler {
 
-    private final StringRedisTemplate stringRedisTemplate;
     private final ClubClickService clubClickService;
 
-    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
-    @SchedulerLock(name = "ClubClickReset", lockAtMostFor = "1m", lockAtLeastFor = "1s")
-    public void resetDailyClicks() {
-        Set<String> keys = stringRedisTemplate.keys(ClubClickService.CLICK_KEY_PATTERN);
-        if (keys != null && !keys.isEmpty()) {
-            stringRedisTemplate.delete(keys);
-        }
-        log.info("동아리 클릭 수 초기화 완료");
+    @Scheduled(cron = "0 0 0 * * MON", zone = "Asia/Seoul")
+    @SchedulerLock(name = "ClubClickWeeklyReset", lockAtMostFor = "1m", lockAtLeastFor = "1s")
+    public void resetWeeklyClicks() {
+        clubClickService.resetWeeklyClicks();
     }
 
     @Scheduled(cron = "0 0 * * * *")

--- a/backend/src/main/java/moadong/club/service/ClubClickScheduler.java
+++ b/backend/src/main/java/moadong/club/service/ClubClickScheduler.java
@@ -17,6 +17,7 @@ import java.util.Set;
 public class ClubClickScheduler {
 
     private final StringRedisTemplate stringRedisTemplate;
+    private final ClubClickService clubClickService;
 
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     @SchedulerLock(name = "ClubClickReset", lockAtMostFor = "1m", lockAtLeastFor = "1s")
@@ -26,5 +27,11 @@ public class ClubClickScheduler {
             stringRedisTemplate.delete(keys);
         }
         log.info("동아리 클릭 수 초기화 완료");
+    }
+
+    @Scheduled(cron = "0 0 * * * *")
+    @SchedulerLock(name = "ClubClickWhitelistRefresh", lockAtMostFor = "5m", lockAtLeastFor = "1s")
+    public void refreshWhitelist() {
+        clubClickService.refreshWhitelist();
     }
 }

--- a/backend/src/main/java/moadong/club/service/ClubClickService.java
+++ b/backend/src/main/java/moadong/club/service/ClubClickService.java
@@ -2,26 +2,31 @@ package moadong.club.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import moadong.club.entity.Club;
+import moadong.club.entity.ClubClickCount;
 import moadong.club.payload.response.ClubClickRankingResponse;
 import moadong.club.payload.response.ClubClickRankingResponse.ClubRankItem;
 import moadong.club.payload.response.ClubClickResponse;
-import moadong.club.entity.Club;
+import moadong.club.repository.ClubClickCountRepository;
 import moadong.club.repository.ClubRepository;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
+import org.springframework.data.mongodb.core.FindAndModifyOptions;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.time.DayOfWeek;
 import java.time.Duration;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @Slf4j
@@ -29,16 +34,16 @@ import java.util.concurrent.atomic.AtomicInteger;
 @RequiredArgsConstructor
 public class ClubClickService {
 
-    static final String CLICK_KEY_PREFIX = "club:click:";
-    static final String CLICK_KEY_PATTERN = CLICK_KEY_PREFIX + "*";
     static final String WHITELIST_KEY = "club:whitelist";
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
-
     private static final String COOLDOWN_KEY_PREFIX = "game:cooldown:";
     private static final long COOLDOWN_MILLIS = 200L;
+    static final long MAX_CLICK_COUNT = 9_999_999_999L;
 
     private final StringRedisTemplate stringRedisTemplate;
     private final ClubRepository clubRepository;
+    private final ClubClickCountRepository clickCountRepository;
+    private final MongoTemplate mongoTemplate;
 
     @EventListener(ApplicationReadyEvent.class)
     public void initWhitelist() {
@@ -56,7 +61,11 @@ public class ClubClickService {
         log.info("동아리 화이트리스트 갱신 완료 ({}개)", names.size());
     }
 
-    public ClubClickResponse recordClick(String clubName, String clientIp) {
+    public ClubClickResponse recordClick(String clubName, int count, String clientIp) {
+        if (count < 1 || count > 5) {
+            throw new RestApiException(ErrorCode.CLICK_COUNT_INVALID);
+        }
+
         Boolean isMember = stringRedisTemplate.opsForSet().isMember(WHITELIST_KEY, clubName);
         if (!Boolean.TRUE.equals(isMember)) {
             throw new RestApiException(ErrorCode.CLUB_NOT_FOUND);
@@ -69,40 +78,36 @@ public class ClubClickService {
             throw new RestApiException(ErrorCode.CLICK_COOLDOWN);
         }
 
-        String key = CLICK_KEY_PREFIX + clubName;
-        Long clickCount = stringRedisTemplate.opsForValue().increment(key);
-        return new ClubClickResponse(clubName, clickCount != null ? clickCount : 0L);
+        Query query = new Query(Criteria.where("clubName").is(clubName));
+        Update update = new Update()
+                .inc("clickCount", count)
+                .setOnInsert("clubName", clubName);
+        FindAndModifyOptions options = FindAndModifyOptions.options().upsert(true).returnNew(true);
+        ClubClickCount result = mongoTemplate.findAndModify(query, update, options, ClubClickCount.class);
+
+        long clickCount = result != null ? Math.min(result.getClickCount(), MAX_CLICK_COUNT) : (long) count;
+        return new ClubClickResponse(clubName, clickCount);
     }
 
     public ClubClickRankingResponse getRanking() {
-        Set<String> keys = stringRedisTemplate.keys(CLICK_KEY_PATTERN);
-        List<ClubRankItem> ranked = new ArrayList<>();
-
-        if (keys != null && !keys.isEmpty()) {
-            List<ClubRankItem> unsorted = new ArrayList<>();
-            for (String key : keys) {
-                String clubName = key.substring(CLICK_KEY_PREFIX.length());
-                String raw = stringRedisTemplate.opsForValue().get(key);
-                long count = raw != null ? Long.parseLong(raw) : 0L;
-                unsorted.add(new ClubRankItem(0, clubName, count));
-            }
-
-            unsorted.sort(Comparator.comparingLong(ClubRankItem::clickCount).reversed());
-
-            AtomicInteger rank = new AtomicInteger(1);
-            for (ClubRankItem item : unsorted) {
-                ranked.add(new ClubRankItem(rank.getAndIncrement(), item.clubName(), item.clickCount()));
-            }
-        }
-
-        return new ClubClickRankingResponse(ranked, nextMidnightKst());
+        List<ClubClickCount> all = clickCountRepository.findAllByOrderByClickCountDesc();
+        AtomicInteger rank = new AtomicInteger(1);
+        List<ClubRankItem> ranked = all.stream()
+                .map(c -> new ClubRankItem(rank.getAndIncrement(), c.getClubName(), c.getClickCount()))
+                .toList();
+        return new ClubClickRankingResponse(ranked, nextMondayMidnightKst());
     }
 
-    public String nextMidnightKst() {
-        ZonedDateTime nextMidnight = ZonedDateTime.now(KST)
-                .toLocalDate()
-                .plusDays(1)
-                .atStartOfDay(KST);
-        return nextMidnight.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+    public void resetWeeklyClicks() {
+        clickCountRepository.deleteAll();
+        log.info("동아리 클릭 수 주간 초기화 완료");
+    }
+
+    public String nextMondayMidnightKst() {
+        ZonedDateTime now = ZonedDateTime.now(KST);
+        int daysUntilMonday = (DayOfWeek.MONDAY.getValue() - now.getDayOfWeek().getValue() + 7) % 7;
+        if (daysUntilMonday == 0) daysUntilMonday = 7;
+        ZonedDateTime nextMonday = now.toLocalDate().plusDays(daysUntilMonday).atStartOfDay(KST);
+        return nextMonday.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
     }
 }

--- a/backend/src/main/java/moadong/club/service/ClubClickService.java
+++ b/backend/src/main/java/moadong/club/service/ClubClickService.java
@@ -37,7 +37,7 @@ public class ClubClickService {
     static final String WHITELIST_KEY = "club:whitelist";
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
     private static final String COOLDOWN_KEY_PREFIX = "game:cooldown:";
-    private static final long COOLDOWN_MILLIS = 200L;
+    private static final long COOLDOWN_MILLIS = 50L;
     static final long MAX_CLICK_COUNT = 9_999_999_999L;
 
     private final StringRedisTemplate stringRedisTemplate;

--- a/backend/src/main/java/moadong/club/service/ClubClickService.java
+++ b/backend/src/main/java/moadong/club/service/ClubClickService.java
@@ -5,9 +5,12 @@ import lombok.extern.slf4j.Slf4j;
 import moadong.club.payload.response.ClubClickRankingResponse;
 import moadong.club.payload.response.ClubClickRankingResponse.ClubRankItem;
 import moadong.club.payload.response.ClubClickResponse;
+import moadong.club.entity.Club;
 import moadong.club.repository.ClubRepository;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -28,22 +31,40 @@ public class ClubClickService {
 
     static final String CLICK_KEY_PREFIX = "club:click:";
     static final String CLICK_KEY_PATTERN = CLICK_KEY_PREFIX + "*";
+    static final String WHITELIST_KEY = "club:whitelist";
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
     private static final String COOLDOWN_KEY_PREFIX = "game:cooldown:";
-    private static final long COOLDOWN_SECONDS = 1L;
+    private static final long COOLDOWN_MILLIS = 200L;
 
     private final StringRedisTemplate stringRedisTemplate;
     private final ClubRepository clubRepository;
 
+    @EventListener(ApplicationReadyEvent.class)
+    public void initWhitelist() {
+        refreshWhitelist();
+    }
+
+    public void refreshWhitelist() {
+        List<String> names = clubRepository.findAll().stream()
+                .map(Club::getName)
+                .toList();
+        stringRedisTemplate.delete(WHITELIST_KEY);
+        if (!names.isEmpty()) {
+            stringRedisTemplate.opsForSet().add(WHITELIST_KEY, names.toArray(String[]::new));
+        }
+        log.info("동아리 화이트리스트 갱신 완료 ({}개)", names.size());
+    }
+
     public ClubClickResponse recordClick(String clubName, String clientIp) {
-        if (!clubRepository.findClubByName(clubName).isPresent()) {
+        Boolean isMember = stringRedisTemplate.opsForSet().isMember(WHITELIST_KEY, clubName);
+        if (!Boolean.TRUE.equals(isMember)) {
             throw new RestApiException(ErrorCode.CLUB_NOT_FOUND);
         }
 
         String cooldownKey = COOLDOWN_KEY_PREFIX + clientIp;
         Boolean isNew = stringRedisTemplate.opsForValue()
-                .setIfAbsent(cooldownKey, "1", Duration.ofSeconds(COOLDOWN_SECONDS));
+                .setIfAbsent(cooldownKey, "1", Duration.ofMillis(COOLDOWN_MILLIS));
         if (Boolean.FALSE.equals(isNew)) {
             throw new RestApiException(ErrorCode.CLICK_COOLDOWN);
         }

--- a/backend/src/main/java/moadong/club/service/ClubClickService.java
+++ b/backend/src/main/java/moadong/club/service/ClubClickService.java
@@ -5,9 +5,13 @@ import lombok.extern.slf4j.Slf4j;
 import moadong.club.payload.response.ClubClickRankingResponse;
 import moadong.club.payload.response.ClubClickRankingResponse.ClubRankItem;
 import moadong.club.payload.response.ClubClickResponse;
+import moadong.club.repository.ClubRepository;
+import moadong.global.exception.ErrorCode;
+import moadong.global.exception.RestApiException;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -26,9 +30,24 @@ public class ClubClickService {
     static final String CLICK_KEY_PATTERN = CLICK_KEY_PREFIX + "*";
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
-    private final StringRedisTemplate stringRedisTemplate;
+    private static final String COOLDOWN_KEY_PREFIX = "game:cooldown:";
+    private static final long COOLDOWN_SECONDS = 1L;
 
-    public ClubClickResponse recordClick(String clubName) {
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ClubRepository clubRepository;
+
+    public ClubClickResponse recordClick(String clubName, String clientIp) {
+        if (!clubRepository.findClubByName(clubName).isPresent()) {
+            throw new RestApiException(ErrorCode.CLUB_NOT_FOUND);
+        }
+
+        String cooldownKey = COOLDOWN_KEY_PREFIX + clientIp;
+        Boolean isNew = stringRedisTemplate.opsForValue()
+                .setIfAbsent(cooldownKey, "1", Duration.ofSeconds(COOLDOWN_SECONDS));
+        if (Boolean.FALSE.equals(isNew)) {
+            throw new RestApiException(ErrorCode.CLICK_COOLDOWN);
+        }
+
         String key = CLICK_KEY_PREFIX + clubName;
         Long clickCount = stringRedisTemplate.opsForValue().increment(key);
         return new ClubClickResponse(clubName, clickCount != null ? clickCount : 0L);

--- a/backend/src/main/java/moadong/global/exception/ErrorCode.java
+++ b/backend/src/main/java/moadong/global/exception/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     TOO_LONG_INTRODUCTION(HttpStatus.BAD_REQUEST, "600-10", "소개는 최대 24글자까지 입력할 수 있습니다."),
     CLUB_NAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "600-11", "이미 사용 중인 동아리 이름입니다."),
     CLICK_COOLDOWN(HttpStatus.TOO_MANY_REQUESTS, "600-12", "클릭 요청이 너무 빠릅니다. 잠시 후 다시 시도해주세요."),
+    CLICK_COUNT_INVALID(HttpStatus.BAD_REQUEST, "600-13", "클릭 수는 1 이상 5 이하이어야 합니다."),
 
     // 601xx: 파일/미디어 관련 오류
     IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "601-1", "이미지 업로드에 실패하였습니다."),

--- a/backend/src/main/java/moadong/global/exception/ErrorCode.java
+++ b/backend/src/main/java/moadong/global/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     TOO_LONG_TAG(HttpStatus.BAD_REQUEST, "600-9", "태그는 최대 5글자까지 입력할 수 있습니다."),
     TOO_LONG_INTRODUCTION(HttpStatus.BAD_REQUEST, "600-10", "소개는 최대 24글자까지 입력할 수 있습니다."),
     CLUB_NAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "600-11", "이미 사용 중인 동아리 이름입니다."),
+    CLICK_COOLDOWN(HttpStatus.TOO_MANY_REQUESTS, "600-12", "클릭 요청이 너무 빠릅니다. 잠시 후 다시 시도해주세요."),
 
     // 601xx: 파일/미디어 관련 오류
     IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "601-1", "이미지 업로드에 실패하였습니다."),


### PR DESCRIPTION

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

[기술적 의사결정 문서](https://honorable-cough-8f9.notion.site/345aad232096814d9b40d9309f6dbefa?source=copy_link)

- IP당 1초 쿨다운 적용 (game:cooldown:{ip} Redis TTL)
- 존재하지 않는 동아리명 클릭 요청 차단 (ClubRepository 화이트리스트 검증)
- CLICK_COOLDOWN 에러코드 추가 (600-12, 429 Too Many Requests)
- 화이트리스트 Redis Set 캐싱 — 클릭마다 MongoDB 조회 제거, SISMEMBER로 대체

## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항
