### PR TITLE
fix: remove unused notionItems variable in CalendarSyncTab

### DIFF
--- a/frontend/src/mocks/handlers/promotion.ts
+++ b/frontend/src/mocks/handlers/promotion.ts
@@ -50,9 +50,7 @@ export const promotionHandlers = [
   }),
 
   // POST /api/promotion - 홍보게시판 글 작성
-  http.post(`${API_BASE_URL}/api/promotion`, async ({ request }) => {
-    const body = await request.json();
-
+  http.post(`${API_BASE_URL}/api/promotion`, async () => {
     return HttpResponse.json({
       data: {
         id: `article-${Date.now()}`,

--- a/frontend/src/pages/AdminPage/components/ApplicationRow/ApplicationRowItem.style.ts
+++ b/frontend/src/pages/AdminPage/components/ApplicationRow/ApplicationRowItem.style.ts
@@ -1,13 +1,5 @@
 import styled, { css } from 'styled-components';
 
-interface MenuItemProps {
-  $ActiveMenu?: boolean;
-}
-
-interface ExpandButtonProps {
-  $isExpanded: boolean;
-}
-
 // 개별 지원서 한 줄 (Row)
 export const ApplicationRow = styled.div`
   display: flex;

--- a/frontend/src/pages/AdminPage/tabs/CalendarSyncTab/CalendarSyncTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/CalendarSyncTab/CalendarSyncTab.tsx
@@ -14,7 +14,6 @@ const CalendarSyncTab = () => {
     googleCalendars,
     selectedGoogleCalendarId,
     googleCalendarEvents,
-    notionItems,
     notionTotalResults,
     notionDatabaseSourceId,
     notionDatabaseOptions,

--- a/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
 import { useOutletContext } from 'react-router-dom';
-import { useQueryClient } from '@tanstack/react-query';
 import { setYear } from 'date-fns';
 import Button from '@/components/common/Button/Button';
 import InputField from '@/components/common/InputField/InputField';

--- a/frontend/src/pages/FestivalPage/components/BoothMapSection/BoothMapSection.tsx
+++ b/frontend/src/pages/FestivalPage/components/BoothMapSection/BoothMapSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { Swiper as SwiperType } from 'swiper';
 import { Swiper, SwiperSlide } from 'swiper/react';

--- a/frontend/src/pages/MainPage/components/Popup/Popup.tsx
+++ b/frontend/src/pages/MainPage/components/Popup/Popup.tsx
@@ -1,5 +1,4 @@
 import { MouseEvent, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import AppDownloadImage from '@/assets/images/popup/app-download.png';
 import { USER_EVENT } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';


### PR DESCRIPTION
Automated technical debt resolution: Removed an unused `notionItems` variable that was triggering an ESLint warning in CalendarSyncTab.tsx.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 불필요한 임포트 제거로 코드베이스 정리
  * 미사용 인터페이스 및 변수 제거
  * 요청 처리 로직 단순화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->