### PR TITLE
[feature] IP 기반 Rate Limiting 및 임시 차단 기능 추가

### DIFF
--- a/backend/src/main/java/moadong/club/service/ClubClickService.java
+++ b/backend/src/main/java/moadong/club/service/ClubClickService.java
@@ -71,11 +71,6 @@ public class ClubClickService {
             throw new RestApiException(ErrorCode.CLICK_COUNT_INVALID);
         }
 
-        Boolean isMember = stringRedisTemplate.opsForSet().isMember(WHITELIST_KEY, clubName);
-        if (!Boolean.TRUE.equals(isMember)) {
-            throw new RestApiException(ErrorCode.CLUB_NOT_FOUND);
-        }
-
         String banKey = BAN_KEY_PREFIX + clientIp;
         if (Boolean.TRUE.equals(stringRedisTemplate.hasKey(banKey))) {
             throw new RestApiException(ErrorCode.CLICK_RATE_LIMITED);
@@ -96,6 +91,11 @@ public class ClubClickService {
                 .setIfAbsent(cooldownKey, "1", Duration.ofMillis(COOLDOWN_MILLIS));
         if (Boolean.FALSE.equals(isNew)) {
             throw new RestApiException(ErrorCode.CLICK_COOLDOWN);
+        }
+
+        Boolean isMember = stringRedisTemplate.opsForSet().isMember(WHITELIST_KEY, clubName);
+        if (!Boolean.TRUE.equals(isMember)) {
+            throw new RestApiException(ErrorCode.CLUB_NOT_FOUND);
         }
 
         Query query = new Query(Criteria.where("clubName").is(clubName));

--- a/backend/src/main/java/moadong/club/service/ClubClickService.java
+++ b/backend/src/main/java/moadong/club/service/ClubClickService.java
@@ -37,7 +37,12 @@ public class ClubClickService {
     static final String WHITELIST_KEY = "club:whitelist";
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
     private static final String COOLDOWN_KEY_PREFIX = "game:cooldown:";
+    private static final String RATE_LIMIT_KEY_PREFIX = "game:ratelimit:";
+    private static final String BAN_KEY_PREFIX = "game:banned:";
     private static final long COOLDOWN_MILLIS = 50L;
+    private static final long RATE_LIMIT_WINDOW_SECONDS = 10L;
+    private static final long RATE_LIMIT_MAX_REQUESTS = 20L;
+    private static final long BAN_DURATION_SECONDS = 30L;
     static final long MAX_CLICK_COUNT = 9_999_999_999L;
 
     private final StringRedisTemplate stringRedisTemplate;
@@ -69,6 +74,21 @@ public class ClubClickService {
         Boolean isMember = stringRedisTemplate.opsForSet().isMember(WHITELIST_KEY, clubName);
         if (!Boolean.TRUE.equals(isMember)) {
             throw new RestApiException(ErrorCode.CLUB_NOT_FOUND);
+        }
+
+        String banKey = BAN_KEY_PREFIX + clientIp;
+        if (Boolean.TRUE.equals(stringRedisTemplate.hasKey(banKey))) {
+            throw new RestApiException(ErrorCode.CLICK_RATE_LIMITED);
+        }
+
+        String rateLimitKey = RATE_LIMIT_KEY_PREFIX + clientIp;
+        Long requestCount = stringRedisTemplate.opsForValue().increment(rateLimitKey);
+        if (requestCount != null && requestCount == 1) {
+            stringRedisTemplate.expire(rateLimitKey, Duration.ofSeconds(RATE_LIMIT_WINDOW_SECONDS));
+        }
+        if (requestCount != null && requestCount > RATE_LIMIT_MAX_REQUESTS) {
+            stringRedisTemplate.opsForValue().set(banKey, "1", Duration.ofSeconds(BAN_DURATION_SECONDS));
+            throw new RestApiException(ErrorCode.CLICK_RATE_LIMITED);
         }
 
         String cooldownKey = COOLDOWN_KEY_PREFIX + clientIp;

--- a/backend/src/main/java/moadong/club/service/ClubClickService.java
+++ b/backend/src/main/java/moadong/club/service/ClubClickService.java
@@ -19,6 +19,7 @@ import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Service;
 
 import java.time.DayOfWeek;
@@ -44,6 +45,14 @@ public class ClubClickService {
     private static final long RATE_LIMIT_MAX_REQUESTS = 20L;
     private static final long BAN_DURATION_SECONDS = 30L;
     static final long MAX_CLICK_COUNT = 9_999_999_999L;
+
+    // INCR + 조건부 EXPIRE를 원자적으로 수행 (TTL 누락 방지)
+    private static final RedisScript<Long> RATE_LIMIT_SCRIPT = RedisScript.of(
+            "local c = redis.call('INCR', KEYS[1])\n" +
+            "if c == 1 then redis.call('EXPIRE', KEYS[1], ARGV[1]) end\n" +
+            "return c",
+            Long.class
+    );
 
     private final StringRedisTemplate stringRedisTemplate;
     private final ClubRepository clubRepository;
@@ -77,10 +86,11 @@ public class ClubClickService {
         }
 
         String rateLimitKey = RATE_LIMIT_KEY_PREFIX + clientIp;
-        Long requestCount = stringRedisTemplate.opsForValue().increment(rateLimitKey);
-        if (requestCount != null && requestCount == 1) {
-            stringRedisTemplate.expire(rateLimitKey, Duration.ofSeconds(RATE_LIMIT_WINDOW_SECONDS));
-        }
+        Long requestCount = stringRedisTemplate.execute(
+                RATE_LIMIT_SCRIPT,
+                List.of(rateLimitKey),
+                String.valueOf(RATE_LIMIT_WINDOW_SECONDS)
+        );
         if (requestCount != null && requestCount > RATE_LIMIT_MAX_REQUESTS) {
             stringRedisTemplate.opsForValue().set(banKey, "1", Duration.ofSeconds(BAN_DURATION_SECONDS));
             throw new RestApiException(ErrorCode.CLICK_RATE_LIMITED);

--- a/backend/src/main/java/moadong/global/exception/ErrorCode.java
+++ b/backend/src/main/java/moadong/global/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     CLUB_NAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "600-11", "이미 사용 중인 동아리 이름입니다."),
     CLICK_COOLDOWN(HttpStatus.TOO_MANY_REQUESTS, "600-12", "클릭 요청이 너무 빠릅니다. 잠시 후 다시 시도해주세요."),
     CLICK_COUNT_INVALID(HttpStatus.BAD_REQUEST, "600-13", "클릭 수는 1 이상 5 이하이어야 합니다."),
+    CLICK_RATE_LIMITED(HttpStatus.TOO_MANY_REQUESTS, "600-14", "비정상적인 요청이 감지되었습니다. 30초 후 다시 시도해주세요."),
 
     // 601xx: 파일/미디어 관련 오류
     IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "601-1", "이미지 업로드에 실패하였습니다."),


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #1474 

## 📝작업 내용

- 10초 윈도우 내 20회 초과 요청 시 30초 임시 차단
- game:ratelimit:{ip} 키로 요청 카운트, game:banned:{ip} 키로 차단 관리
- CLICK_RATE_LIMITED 에러코드 추가 (600-14)

### 동작흐름

  1. 차단된 IP 여부 확인 → 차단 시 즉시 429 응답
  2. 10초 내 요청 횟수 카운트
  3. 20회 초과 시 ban 키 설정 후 429 응답
  4. 30초 후 자동 해제


30초로 설정한 것은 사용자 다수가 공인 ip (학교 와이파이)를 사용할 가능성이 높다고 생각했습니다.
5분도 생각해봤는데 사용자경험이 극히 떨어질 것 같아서 일단 30초로 설정해 두었습니다.

## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 클릭 요청에 대한 IP별 속도 제한 및 임시 차단 도입: 일정 횟수 초과 시 잠시 요청이 차단되고 "비정상적인 요청" 안내가 표시됩니다.
  * 기존 클릭 쿨다운 동작 유지: 쿨다운 기간 중에는 동일한 안내로 재시도 유도.
  * 화이트리스트 처리 흐름이 일부 조정되어 예외 처리 순서가 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->