### PR TITLE
[fix] 화이트리스트 갱신 시 Race Condition 수정

### DIFF
--- a/backend/src/main/java/moadong/club/service/ClubClickService.java
+++ b/backend/src/main/java/moadong/club/service/ClubClickService.java
@@ -28,7 +28,6 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @Slf4j
@@ -46,6 +45,13 @@ public class ClubClickService {
     private static final long RATE_LIMIT_MAX_REQUESTS = 20L;
     private static final long BAN_DURATION_SECONDS = 30L;
     static final long MAX_CLICK_COUNT = 9_999_999_999L;
+
+    private static final RedisScript<Long> WHITELIST_SWAP_SCRIPT = RedisScript.of(
+            "redis.call('DEL', KEYS[1])\n" +
+            "if #ARGV > 0 then redis.call('SADD', KEYS[1], unpack(ARGV)) end\n" +
+            "return #ARGV",
+            Long.class
+    );
 
     // INCR + 조건부 EXPIRE를 원자적으로 수행 (TTL 누락 방지)
     private static final RedisScript<Long> RATE_LIMIT_SCRIPT = RedisScript.of(
@@ -69,17 +75,9 @@ public class ClubClickService {
         List<String> names = clubRepository.findAll().stream()
                 .map(Club::getName)
                 .toList();
-        if (names.isEmpty()) {
-            stringRedisTemplate.delete(WHITELIST_KEY);
-        } else {
-            String tempKey = WHITELIST_KEY + ":tmp:" + UUID.randomUUID();
-            try {
-                stringRedisTemplate.opsForSet().add(tempKey, names.toArray(String[]::new));
-                stringRedisTemplate.rename(tempKey, WHITELIST_KEY);
-            } finally {
-                stringRedisTemplate.delete(tempKey);
-            }
-        }
+        stringRedisTemplate.execute(WHITELIST_SWAP_SCRIPT,
+                List.of(WHITELIST_KEY),
+                names.toArray(String[]::new));
         log.info("동아리 화이트리스트 갱신 완료 ({}개)", names.size());
     }
 

--- a/backend/src/main/java/moadong/club/service/ClubClickService.java
+++ b/backend/src/main/java/moadong/club/service/ClubClickService.java
@@ -28,6 +28,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @Slf4j
@@ -71,10 +72,13 @@ public class ClubClickService {
         if (names.isEmpty()) {
             stringRedisTemplate.delete(WHITELIST_KEY);
         } else {
-            String tempKey = WHITELIST_KEY + ":tmp";
-            stringRedisTemplate.delete(tempKey);
-            stringRedisTemplate.opsForSet().add(tempKey, names.toArray(String[]::new));
-            stringRedisTemplate.rename(tempKey, WHITELIST_KEY);
+            String tempKey = WHITELIST_KEY + ":tmp:" + UUID.randomUUID();
+            try {
+                stringRedisTemplate.opsForSet().add(tempKey, names.toArray(String[]::new));
+                stringRedisTemplate.rename(tempKey, WHITELIST_KEY);
+            } finally {
+                stringRedisTemplate.delete(tempKey);
+            }
         }
         log.info("동아리 화이트리스트 갱신 완료 ({}개)", names.size());
     }

--- a/backend/src/main/java/moadong/club/service/ClubClickService.java
+++ b/backend/src/main/java/moadong/club/service/ClubClickService.java
@@ -68,9 +68,13 @@ public class ClubClickService {
         List<String> names = clubRepository.findAll().stream()
                 .map(Club::getName)
                 .toList();
-        stringRedisTemplate.delete(WHITELIST_KEY);
-        if (!names.isEmpty()) {
-            stringRedisTemplate.opsForSet().add(WHITELIST_KEY, names.toArray(String[]::new));
+        if (names.isEmpty()) {
+            stringRedisTemplate.delete(WHITELIST_KEY);
+        } else {
+            String tempKey = WHITELIST_KEY + ":tmp";
+            stringRedisTemplate.delete(tempKey);
+            stringRedisTemplate.opsForSet().add(tempKey, names.toArray(String[]::new));
+            stringRedisTemplate.rename(tempKey, WHITELIST_KEY);
         }
         log.info("동아리 화이트리스트 갱신 완료 ({}개)", names.size());
     }


### PR DESCRIPTION

## #️⃣연관된 이슈

> ex) #1492

## 📝작업 내용
 - Redis `delete → add` 패턴을 임시 키 + `RENAME` 원자적 교체 방식으로 변경                                             
  - 매 1시간 화이트리스트 갱신 시 `delete`와 `add` 사이 순간에 클릭 요청이 오면 실제 존재하는 동아리도 404를 반환하던 false
   negative 제거                                                                                                           
  - `names`가 비어있을 경우 `RENAME` 대상 키가 없으므로 기존 `delete` 유지  

### refreshWhitelist() Redis Cluster CROSSSLOT 대응          
                                                           
  - RENAME(tempKey, WHITELIST_KEY) 제거: Redis Cluster에서  두 키가 다른 hash slot에 배치될 경우 CROSSSLOT 오류로 실패                                                     
  - DEL + SADD를 단일 키 Lua스크립트(WHITELIST_SWAP_SCRIPT)로 원자화                 
  - 단일 키 연산이므로 Redis Cluster 토폴로지와 무관하게 동작                                                     
  - temp 키 / UUID / try-finally 전부 제거             
  - names.isEmpty() 분기를 Lua 내 #ARGV > 0 조건으로 통합

## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정 및 개선**
  * 클럽 화이트리스트 업데이트 메커니즘을 개선하여 더 안정적인 캐시 처리를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->