### PR TITLE
[refactor] Portal 컴포넌트 모달에서 분리 및 공통컴포넌트로 변경

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -30,6 +30,11 @@ npm run storybook        # 포트 6006에서 Storybook 시작
 npm run build-storybook  # Storybook 빌드
 npm run chromatic        # Chromatic으로 시각적 테스트 배포
 
+# Storybook 사용 가이드 (공통 컴포넌트 수정 시)
+# - 개발 중: npm run storybook (dev 서버로 실시간 확인)
+# - 기존 스토리가 있는 컴포넌트 수정 후 PR 전: npm run build-storybook
+# - 스토리가 없는 신규 컴포넌트: npm run typecheck 로 충분
+
 # 유틸리티
 npm run generate:sitemap # sitemap.xml 생성
 ```

--- a/frontend/docs/features/components/Portal.md
+++ b/frontend/docs/features/components/Portal.md
@@ -1,0 +1,30 @@
+# Portal 컴포넌트 분리 및 PortalModal 리팩토링
+
+`createPortal`을 추상화한 범용 `Portal` 컴포넌트를 `common/Portal/`로 분리하고, `PortalModal`이 이를 사용하도록 리팩토링했다.
+
+## 배경
+
+기존 `PortalModal`은 `createPortal` 호출, 스크롤 잠금, 오버레이 처리를 모두 담당했다. Portal 렌더링 로직을 별도 컴포넌트로 분리해 툴팁, 토스트, 드로어 등 다른 컴포넌트에서도 재사용할 수 있도록 했다.
+
+## Portal 컴포넌트
+
+```tsx
+interface PortalProps {
+  children: ReactNode;
+  rootId?: string; // 기본값: 'modal-root'
+}
+```
+
+- `rootId` prop으로 다른 DOM root에도 렌더링 가능
+- `children`은 `ReactNode` 직접 선언 (필수값이므로 `PropsWithChildren` 미사용)
+
+## PortalModal 변경 사항
+
+- `createPortal` 직접 호출 → `<Portal>` 컴포넌트로 교체
+- `useEffect` cleanup 버그 수정: `if (!isOpen) return` 가드 추가로 불필요한 overflow 리셋 방지
+- `onClick` 핸들러 단순화: `closeOnBackdrop ? onClose : undefined`
+
+## 관련 코드
+
+- `src/components/common/Portal/Portal.tsx` — 범용 포탈 컴포넌트
+- `src/components/common/Modal/PortalModal.tsx` — Portal을 사용하는 모달 래퍼

--- a/frontend/docs/features/components/Portal.md
+++ b/frontend/docs/features/components/Portal.md
@@ -1,10 +1,10 @@
-# Portal 컴포넌트 분리 및 PortalModal 리팩토링
+# Portal 컴포넌트 분리 및 Modal 리팩토링
 
-`createPortal`을 추상화한 범용 `Portal` 컴포넌트를 `common/Portal/`로 분리하고, `PortalModal`이 이를 사용하도록 리팩토링했다.
+`createPortal`을 추상화한 범용 `Portal` 컴포넌트를 `common/Portal/`로 분리하고, `Modal`이 이를 사용하도록 리팩토링했다.
 
 ## 배경
 
-기존 `PortalModal`은 `createPortal` 호출, 스크롤 잠금, 오버레이 처리를 모두 담당했다. Portal 렌더링 로직을 별도 컴포넌트로 분리해 툴팁, 토스트, 드로어 등 다른 컴포넌트에서도 재사용할 수 있도록 했다.
+기존 `Modal`(구 `PortalModal`)은 `createPortal` 호출, 스크롤 잠금, 오버레이 처리를 모두 담당했다. Portal 렌더링 로직을 별도 컴포넌트로 분리해 툴팁, 토스트, 드로어 등 다른 컴포넌트에서도 재사용할 수 있도록 했다.
 
 ## Portal 컴포넌트
 
@@ -18,7 +18,7 @@ interface PortalProps {
 - `rootId` prop으로 다른 DOM root에도 렌더링 가능
 - `children`은 `ReactNode` 직접 선언 (필수값이므로 `PropsWithChildren` 미사용)
 
-## PortalModal 변경 사항
+## Modal 변경 사항
 
 - `createPortal` 직접 호출 → `<Portal>` 컴포넌트로 교체
 - `useEffect` cleanup 버그 수정: `if (!isOpen) return` 가드 추가로 불필요한 overflow 리셋 방지
@@ -27,4 +27,4 @@ interface PortalProps {
 ## 관련 코드
 
 - `src/components/common/Portal/Portal.tsx` — 범용 포탈 컴포넌트
-- `src/components/common/Modal/PortalModal.tsx` — Portal을 사용하는 모달 래퍼
+- `src/components/common/Modal/Modal.tsx` — Portal을 사용하는 모달 래퍼

--- a/frontend/src/components/application/modals/ApplicationSelectModal.tsx
+++ b/frontend/src/components/application/modals/ApplicationSelectModal.tsx
@@ -1,5 +1,5 @@
+import Modal from '@/components/common/Modal/Modal';
 import ModalLayout from '@/components/common/Modal/ModalLayout';
-import PortalModal from '@/components/common/Modal/PortalModal';
 import { ApplicationForm } from '@/types/application';
 import * as Styled from './ApplicationSelectModal.styles';
 
@@ -48,14 +48,14 @@ const ApplicationSelectModal = ({
   onOptionSelect,
 }: ApplicationSelectModalProps) => {
   return (
-    <PortalModal isOpen={isOpen} onClose={onClose} closeOnBackdrop={true}>
+    <Modal isOpen={isOpen} onClose={onClose} closeOnBackdrop={true}>
       <ModalLayout title='지원서 선택' onClose={onClose} width='500px'>
         <ApplicationOptions
           applicationOptions={applicationOptions}
           onOptionSelect={onOptionSelect}
         />
       </ModalLayout>
-    </PortalModal>
+    </Modal>
   );
 };
 

--- a/frontend/src/components/common/Modal/Modal.stories.tsx
+++ b/frontend/src/components/common/Modal/Modal.stories.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import Button from '../Button/Button';
-import PortalModal from './PortalModal';
+import Modal from './Modal';
 
 const meta = {
-  title: 'Components/Common/PortalModal',
-  component: PortalModal,
+  title: 'Components/Common/Modal',
+  component: Modal,
   parameters: {
     layout: 'centered',
   },
@@ -27,7 +27,7 @@ const meta = {
       description: '모달 내부에 렌더링될 컨텐츠입니다.',
     },
   },
-} satisfies Meta<typeof PortalModal>;
+} satisfies Meta<typeof Modal>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
@@ -69,12 +69,12 @@ export const Default: Story = {
     return (
       <>
         <Button onClick={() => setIsOpen(true)}>모달 열기</Button>
-        <PortalModal {...args} isOpen={isOpen} onClose={handleClose}>
+        <Modal {...args} isOpen={isOpen} onClose={handleClose}>
           <ModalContent
             text='배경 클릭 시 모달이 닫힙니다.'
             onClose={handleClose}
           />
-        </PortalModal>
+        </Modal>
       </>
     );
   },
@@ -100,12 +100,12 @@ export const NoBackdropClose: Story = {
       <>
         <Button onClick={() => setOpen(true)}>모달 열기</Button>
 
-        <PortalModal {...args} isOpen={open} onClose={handleClose}>
+        <Modal {...args} isOpen={open} onClose={handleClose}>
           <ModalContent
             text='배경을 클릭해도 모달이 닫히지 않습니다.'
             onClose={handleClose}
           />
-        </PortalModal>
+        </Modal>
       </>
     );
   },

--- a/frontend/src/components/common/Modal/Modal.tsx
+++ b/frontend/src/components/common/Modal/Modal.tsx
@@ -17,11 +17,20 @@ const Modal = ({
 }: ModalProps) => {
   useEffect(() => {
     if (!isOpen) return;
+
     document.body.style.overflow = 'hidden';
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
     return () => {
       document.body.style.overflow = '';
+      document.removeEventListener('keydown', handleKeyDown);
     };
-  }, [isOpen]);
+  }, [isOpen, onClose]);
 
   if (!isOpen) return null;
 

--- a/frontend/src/components/common/Modal/Modal.tsx
+++ b/frontend/src/components/common/Modal/Modal.tsx
@@ -2,19 +2,19 @@ import { MouseEvent, ReactNode, useEffect } from 'react';
 import Portal from '../Portal/Portal';
 import * as Styled from './Modal.styles';
 
-interface PortalModalProps {
+interface ModalProps {
   isOpen: boolean;
   onClose: () => void;
   children: ReactNode;
   closeOnBackdrop?: boolean;
 }
 
-const PortalModal = ({
+const Modal = ({
   isOpen,
   onClose,
   children,
   closeOnBackdrop = true,
-}: PortalModalProps) => {
+}: ModalProps) => {
   useEffect(() => {
     if (!isOpen) return;
     document.body.style.overflow = 'hidden';
@@ -38,4 +38,4 @@ const PortalModal = ({
   );
 };
 
-export default PortalModal;
+export default Modal;

--- a/frontend/src/components/common/Modal/PortalModal.tsx
+++ b/frontend/src/components/common/Modal/PortalModal.tsx
@@ -1,5 +1,5 @@
 import { MouseEvent, ReactNode, useEffect } from 'react';
-import { createPortal } from 'react-dom';
+import Portal from '../Portal/Portal';
 import * as Styled from './Modal.styles';
 
 interface PortalModalProps {
@@ -16,7 +16,8 @@ const PortalModal = ({
   closeOnBackdrop = true,
 }: PortalModalProps) => {
   useEffect(() => {
-    if (isOpen) document.body.style.overflow = 'hidden';
+    if (!isOpen) return;
+    document.body.style.overflow = 'hidden';
     return () => {
       document.body.style.overflow = '';
     };
@@ -24,22 +25,16 @@ const PortalModal = ({
 
   if (!isOpen) return null;
 
-  const modalRoot = document.getElementById('modal-root');
-  if (!modalRoot) return null;
-
-  return createPortal(
-    <Styled.Overlay
-      onClick={() => {
-        if (closeOnBackdrop) onClose();
-      }}
-    >
-      <Styled.ContentWrapper
-        onClick={(e: MouseEvent<HTMLDivElement>) => e.stopPropagation()}
-      >
-        {children}
-      </Styled.ContentWrapper>
-    </Styled.Overlay>,
-    modalRoot,
+  return (
+    <Portal>
+      <Styled.Overlay onClick={closeOnBackdrop ? onClose : undefined}>
+        <Styled.ContentWrapper
+          onClick={(e: MouseEvent<HTMLDivElement>) => e.stopPropagation()}
+        >
+          {children}
+        </Styled.ContentWrapper>
+      </Styled.Overlay>
+    </Portal>
   );
 };
 

--- a/frontend/src/components/common/Portal/Portal.tsx
+++ b/frontend/src/components/common/Portal/Portal.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+
+interface PortalProps {
+  children: ReactNode;
+  rootId?: string;
+}
+
+const Portal = ({ children, rootId = 'modal-root' }: PortalProps) => {
+  const root = document.getElementById(rootId);
+  if (!root) return null;
+  return createPortal(children, root);
+};
+
+export default Portal;

--- a/frontend/src/pages/AdminPage/components/PersonalInfoConsentModal/PersonalInfoConsentModal.tsx
+++ b/frontend/src/pages/AdminPage/components/PersonalInfoConsentModal/PersonalInfoConsentModal.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { allowPersonalInformation } from '@/apis/auth';
 import Button from '@/components/common/Button/Button';
-import PortalModal from '@/components/common/Modal/PortalModal';
+import Modal from '@/components/common/Modal/Modal';
 import { STORAGE_KEYS } from '@/constants/storageKeys';
 import { useAdminClubContext } from '@/context/AdminClubContext';
 import * as Styled from './PersonalInfoConsentModal.styles';
@@ -44,7 +44,7 @@ const PersonalInfoConsentModal = ({
   };
 
   return (
-    <PortalModal isOpen onClose={() => {}} closeOnBackdrop={false}>
+    <Modal isOpen onClose={() => {}} closeOnBackdrop={false}>
       <Styled.Container>
         <Styled.Title>{clubName}님, 환영합니다!</Styled.Title>
         <Styled.Subtitle>
@@ -65,7 +65,7 @@ const PersonalInfoConsentModal = ({
           {loading ? '처리 중...' : '확인하고 시작하기'}
         </Button>
       </Styled.Container>
-    </PortalModal>
+    </Modal>
   );
 };
 

--- a/frontend/src/pages/ClubDetailPage/components/PhotoModal/PhotoModal.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/PhotoModal/PhotoModal.tsx
@@ -5,7 +5,7 @@ import { Swiper, SwiperSlide } from 'swiper/react';
 import 'swiper/css/navigation';
 import NextButton from '@/assets/images/icons/next_button_icon.svg';
 import PrevButton from '@/assets/images/icons/prev_button_icon.svg';
-import PortalModal from '@/components/common/Modal/PortalModal';
+import Modal from '@/components/common/Modal/Modal';
 import * as Styled from './PhotoModal.styles';
 
 interface PhotoModalProps {
@@ -39,7 +39,7 @@ const PhotoModal = ({ isOpen, onClose, clubName, photos }: PhotoModalProps) => {
   if (!isOpen) return null;
 
   return (
-    <PortalModal isOpen={isOpen} onClose={onClose} closeOnBackdrop={true}>
+    <Modal isOpen={isOpen} onClose={onClose} closeOnBackdrop={true}>
       <Styled.ModalContent onClick={(e) => e.stopPropagation()}>
         <Styled.ModalHeader>
           <Styled.ClubName>{clubName}</Styled.ClubName>
@@ -130,7 +130,7 @@ const PhotoModal = ({ isOpen, onClose, clubName, photos }: PhotoModalProps) => {
           </Styled.ThumbnailContainer>
         </Styled.ModalBody>
       </Styled.ModalContent>
-    </PortalModal>
+    </Modal>
   );
 };
 


### PR DESCRIPTION

## #️⃣연관된 이슈

> ex) #1498

## 📝작업 내용

### 기존 모달 구조

모달이 `createPortal`로 감싸져 있었어요. Portal이 하나만 쓰인다면 지금처럼 사용할 수 있겠지만 
토스트나 툴팁 같은 `DOM에서 분리되어야 하는` 공통 컴포넌트가 추가된다면, **Portal** 또한 공통으로 분리하면 좋을 것 같다고 생각했어요.

### 개선1 - Portal 분리하기

```ts
interface PortalProps {
  children: ReactNode;
  rootId?: string;
}
```

먼저 Portal의 prop type을 정해줬어요. children을 ReactNode로 한 이유는 Portal특성 상 무조건 자식 컴포넌트가 있어야 하기 때문이에요.

자식 컴포넌트를 받을 수 있는 타입에는 `PropsWithChildren` 제네릭이 있어요. 하지만 children이 선택적이기 때문에 여기선 쓰지 않았습니다.

```ts
const Portal = ({ children, rootId = 'modal-root' }: PortalProps) => {
  const root = document.getElementById(rootId);
  if (!root) return null;
  return createPortal(children, root);
};
```

다음은 Portal 컴포넌트에요. 일단 모달이 유일하게 쓰이기 때문에 rootId에 모달을 기본값으로 설정해뒀어요.
만약 토스트 컴포넌트가 추가된다면 `rootId = 'toast-root'`라고 쓰면 됩니다.


### 개선2 - PortalModal을 Modal로 바꾸기

모달컴포넌트 이름이 PortalModal이었는데, 개발자입장에서 이 이름은 혼란을 줄 수 있다고 생각했어요.
가령 그냥 Modal이면 가져다 쓰면 되지만, Portal이 붙은 경우 뭔가 설정해야 하는게 있다는 인식을 줄 것 같았어요.

그래서 PortalModal에서 Modal로 이름을 변경했습니다.


## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 모달 닫힐 때 불필요한 페이지 스크롤 오버플로우 리셋 방지

* **Refactor**
  * 모달/포털 구조 정비 — 일관된 열림/닫힘 동작과 Esc·백드롭 닫기 동작 표준화
  * 기존 포털 기반 모달을 새 모달/포털 구현으로 전환

* **Documentation**
  * Portal 사용 가이드 추가
  * Storybook 개발·빌드 및 타입체크 권장 커맨드 문서화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->