### PR TITLE
fix(webview): 웹뷰 좌우 스크롤 방지 및 렌더링 개선

### DIFF
--- a/frontend/src/styles/WebviewGlobal.styles.ts
+++ b/frontend/src/styles/WebviewGlobal.styles.ts
@@ -1,8 +1,13 @@
 import { createGlobalStyle } from 'styled-components';
 
 const WebviewGlobalStyles = createGlobalStyle`
+  html {
+    overflow-x: hidden;
+  }
   body {
     overscroll-behavior: none;
+    -webkit-font-smoothing: antialiased;
+    -webkit-text-size-adjust: 100%;
     user-select: none;
     -webkit-user-select: none;
     -webkit-touch-callout: none;


### PR DESCRIPTION
## Summary

- `html`에 `overflow-x: hidden` 추가 — 네거티브 마진(`CategoryButtonList`)으로 인한 좌우 스크롤 방지
- `body`에 `-webkit-font-smoothing: antialiased` 추가 — WebView 폰트 렌더링 개선
- `body`에 `-webkit-text-size-adjust: 100%` 추가 — 화면 회전 시 iOS 자동 폰트 크기 증가 방지

## 참고

`overflow-x: hidden`을 `body` 대신 `html`에 적용한 이유: `body`에 적용 시 일부 브라우저에서 스크롤 컨테이너가 생성되어 `position: sticky` (`CategoryButtonList`, `SearchBarArea`, `ClubDetailFooter`)가 동작하지 않는 문제 방지

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 웹뷰에서 가로 스크롤이 표시되지 않도록 개선했습니다. 기존의 스크롤 동작 및 상호작용 관련 스타일은 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->