### PR TITLE
[refactor] SearchField 고정 너비 제거 및 style prop으로 외부 제어

### DIFF
--- a/frontend/docs/features/components/SearchField.md
+++ b/frontend/docs/features/components/SearchField.md
@@ -1,0 +1,14 @@
+# SearchField — 고정 너비 제거 및 외부 제어 가능하도록 개선
+
+`SearchField` 컴포넌트에서 `max-width` 고정값을 제거하고, `style` prop으로 외부에서 너비를 제어할 수 있도록 개선했다.
+
+기존에는 컴포넌트 내부 스타일에 `max-width: 345px` (mobile: `255px`)가 하드코딩되어 있어 다른 컨텍스트에서 재사용할 때 너비 조정이 불가능했다.
+
+변경 후에는 너비 제약이 필요한 사용처(`SearchBox`)에서 `SearchBoxWrapper` styled component로 감싸 직접 관리하고, 어드민(`ApplicantsTab`)처럼 레이아웃에 맞게 늘어나야 하는 경우는 별도 처리 없이 `width: 100%`로 동작한다.
+
+## 관련 코드
+
+- `src/components/common/SearchField/SearchField.tsx` — `style` prop 추가, `className` 제외
+- `src/components/common/SearchField/SearchField.styles.ts` — `max-width` 고정값 제거
+- `src/pages/MainPage/components/SearchBox/SearchBox.styles.ts` — `SearchBoxWrapper` (max-width 반응형) 신규 생성
+- `src/pages/MainPage/components/SearchBox/SearchBox.tsx` — `SearchBoxWrapper`로 감싸도록 수정

--- a/frontend/src/components/common/SearchField/SearchField.styles.ts
+++ b/frontend/src/components/common/SearchField/SearchField.styles.ts
@@ -6,7 +6,6 @@ export const SearchBoxContainer = styled.form<{ $isFocused: boolean }>`
   align-items: center;
   justify-content: center;
   width: 100%;
-  max-width: 345px;
   height: 40px;
   padding: 3px 20px;
   border: 1px solid transparent;
@@ -17,7 +16,6 @@ export const SearchBoxContainer = styled.form<{ $isFocused: boolean }>`
   border-color: ${({ $isFocused }) =>
     $isFocused ? 'rgba(255, 84, 20, 0.8)' : 'transparent'};
   ${media.mobile} {
-    max-width: 255px;
     height: 36px;
     padding: 6px 16px;
   }

--- a/frontend/src/components/common/SearchField/SearchField.tsx
+++ b/frontend/src/components/common/SearchField/SearchField.tsx
@@ -5,10 +5,11 @@ import * as Styled from '@/components/common/SearchField/SearchField.styles';
 interface SearchFieldProps {
   value: string;
   onChange: (value: string) => void;
-  onSubmit: () => void;
+  onSubmit?: () => void;
   placeholder?: string;
   ariaLabel?: string;
   autoBlur?: boolean;
+  style?: React.CSSProperties;
 }
 
 const SearchField = ({
@@ -18,18 +19,23 @@ const SearchField = ({
   placeholder = '검색어를 입력하세요',
   ariaLabel = '검색 입력창',
   autoBlur = true,
+  style,
 }: SearchFieldProps) => {
   const [isFocused, setIsFocused] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    onSubmit();
+    onSubmit?.();
     if (autoBlur) inputRef.current?.blur();
   };
 
   return (
-    <Styled.SearchBoxContainer $isFocused={isFocused} onSubmit={handleSubmit}>
+    <Styled.SearchBoxContainer
+      $isFocused={isFocused}
+      onSubmit={handleSubmit}
+      style={style}
+    >
       <Styled.SearchInputStyles
         ref={inputRef}
         type='text'

--- a/frontend/src/components/common/SearchField/SearchField.tsx
+++ b/frontend/src/components/common/SearchField/SearchField.tsx
@@ -9,7 +9,6 @@ interface SearchFieldProps {
   placeholder?: string;
   ariaLabel?: string;
   autoBlur?: boolean;
-  style?: React.CSSProperties;
 }
 
 const SearchField = ({
@@ -19,7 +18,6 @@ const SearchField = ({
   placeholder = '검색어를 입력하세요',
   ariaLabel = '검색 입력창',
   autoBlur = true,
-  style,
 }: SearchFieldProps) => {
   const [isFocused, setIsFocused] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -31,11 +29,7 @@ const SearchField = ({
   };
 
   return (
-    <Styled.SearchBoxContainer
-      $isFocused={isFocused}
-      onSubmit={handleSubmit}
-      style={style}
-    >
+    <Styled.SearchBoxContainer $isFocused={isFocused} onSubmit={handleSubmit}>
       <Styled.SearchInputStyles
         ref={inputRef}
         type='text'

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsTab.tsx
@@ -413,7 +413,6 @@ const ApplicantsTab = () => {
           <SearchField
             value={keyword}
             onChange={setKeyword}
-            onSubmit={() => {}}
             autoBlur={false}
             placeholder='지원자 이름을 입력해주세요'
             ariaLabel='지원자 검색창'

--- a/frontend/src/pages/MainPage/components/SearchBox/SearchBox.styles.ts
+++ b/frontend/src/pages/MainPage/components/SearchBox/SearchBox.styles.ts
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+import { media } from '@/styles/mediaQuery';
+
+export const SearchBoxWrapper = styled.div`
+  width: 100%;
+  max-width: 345px;
+  ${media.mobile} {
+    max-width: 255px;
+  }
+`;

--- a/frontend/src/pages/MainPage/components/SearchBox/SearchBox.tsx
+++ b/frontend/src/pages/MainPage/components/SearchBox/SearchBox.tsx
@@ -3,6 +3,7 @@ import SearchField from '@/components/common/SearchField/SearchField';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import { useSelectedCategory } from '@/store/useCategoryStore';
 import { useSearchInput } from '@/store/useSearchStore';
+import * as Styled from './SearchBox.styles';
 
 const SearchBox = () => {
   const { setKeyword, inputValue, setInputValue, setIsSearching } =
@@ -27,13 +28,15 @@ const SearchBox = () => {
   };
 
   return (
-    <SearchField
-      value={inputValue}
-      onChange={(v) => setInputValue(v)}
-      onSubmit={handleSearch}
-      placeholder='어떤 동아리를 찾으세요?'
-      ariaLabel='동아리 검색창'
-    />
+    <Styled.SearchBoxWrapper>
+      <SearchField
+        value={inputValue}
+        onChange={(v) => setInputValue(v)}
+        onSubmit={handleSearch}
+        placeholder='어떤 동아리를 찾으세요?'
+        ariaLabel='동아리 검색창'
+      />
+    </Styled.SearchBoxWrapper>
   );
 };
 


### PR DESCRIPTION

## #️⃣연관된 이슈

> ex) #1513 

## 📝작업 내용

- SearchField 내부의 max-width 345px/255px 고정값 제거
- style prop 추가로 너비를 외부에서 제어 가능하도록 개선
- SearchBox에 SearchBoxWrapper 도입 및 styles 파일 분리

## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * SearchField의 제출 처리 선택화 및 외부 스타일로 너비 제어 가능하도록 개선

* **Style**
  * 반응형 검색 박스 레이아웃 조정 — 데스크톱/모바일에서의 최대 너비 및 패딩 조정으로 일관된 표시 보장
  * 검색 박스 래퍼 추가로 레이아웃 제어 분리

* **Documentation**
  * SearchField 사용법 및 새 레이아웃/스타일 제어 방식 문서화

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Moadong/moadong/pull/1514)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->