### PR TITLE
[feature] 대동제 팝업 추가 및 팝업 로직 개선

### DIFF
--- a/frontend/docs/features/main/popup.md
+++ b/frontend/docs/features/main/popup.md
@@ -18,6 +18,7 @@
 | `daysToHide`   | `number?`              | 숨김 유지 일수 (기본 7, 0이면 항상 표시) |
 | `image`        | `string`               | 팝업 이미지 경로                         |
 | `mobileOnly`   | `boolean?`             | 모바일 전용 여부                         |
+| `to`           | `string?`              | 이미지 클릭 시 내부 라우팅 경로          |
 | `onImageClick` | `(trackEvent) => void` | 이미지 클릭 핸들러 (트래킹 포함)         |
 
 ## 새 팝업 추가 방법

--- a/frontend/docs/features/main/popup.md
+++ b/frontend/docs/features/main/popup.md
@@ -1,0 +1,33 @@
+# Popup — 다중 팝업 지원 구조
+
+메인 페이지에서 노출되는 팝업 시스템. `PopupConfig` 배열로 여러 팝업을 관리하며, 첫 번째 eligible 팝업을 자동으로 표시한다.
+
+## 구조
+
+- `configs: PopupConfig[]`를 prop으로 받아, 조건을 통과하는 첫 번째 팝업을 표시
+- 각 팝업은 독립적인 `storageKey` / `sessionKey`를 가짐
+- `daysToHide: 0`으로 설정하면 "다시 보지 않기" 클릭 후에도 항상 재표시
+
+## PopupConfig 필드
+
+| 필드           | 타입                   | 설명                                     |
+| -------------- | ---------------------- | ---------------------------------------- |
+| `id`           | `string`               | Mixpanel `popupType` 값으로 사용         |
+| `storageKey`   | `string`               | "다시 보지 않기" localStorage 키         |
+| `sessionKey`   | `string`               | "닫기" sessionStorage 키                 |
+| `daysToHide`   | `number?`              | 숨김 유지 일수 (기본 7, 0이면 항상 표시) |
+| `image`        | `string`               | 팝업 이미지 경로                         |
+| `mobileOnly`   | `boolean?`             | 모바일 전용 여부                         |
+| `onImageClick` | `(trackEvent) => void` | 이미지 클릭 핸들러 (트래킹 포함)         |
+
+## 새 팝업 추가 방법
+
+1. `popupConfigs.ts`에 `PopupConfig` 객체 추가
+2. `MainPage.tsx`의 `configs` 배열에 삽입 (앞에 넣을수록 우선 표시)
+
+## 관련 코드
+
+- `src/utils/popupUtils.ts` — `PopupConfig` 인터페이스, `isPopupHidden`, `DAYS_TO_HIDE`
+- `src/pages/MainPage/components/Popup/Popup.tsx` — 팝업 렌더링 컴포넌트
+- `src/pages/MainPage/components/Popup/popupConfigs.ts` — 팝업 config 정의 (`APP_DOWNLOAD_POPUP`)
+- `src/pages/MainPage/components/Popup/Popup.test.tsx` — `isPopupHidden` 유틸 테스트

--- a/frontend/src/pages/MainPage/MainPage.tsx
+++ b/frontend/src/pages/MainPage/MainPage.tsx
@@ -52,6 +52,7 @@ const MainPage = () => {
   return (
     <>
       <Popup configs={[DAEDONG_POPUP]} />
+      {/* <Popup configs={[APP_DOWNLOAD_POPUP]} /> */}
       <Header />
       <Filter hasNotification={hasNotification} />
       <Banner />

--- a/frontend/src/pages/MainPage/MainPage.tsx
+++ b/frontend/src/pages/MainPage/MainPage.tsx
@@ -11,7 +11,7 @@ import Banner from '@/pages/MainPage/components/Banner/Banner';
 import CategoryButtonList from '@/pages/MainPage/components/CategoryButtonList/CategoryButtonList';
 import ClubCard from '@/pages/MainPage/components/ClubCard/ClubCard';
 import Popup from '@/pages/MainPage/components/Popup/Popup';
-import { APP_DOWNLOAD_POPUP } from '@/pages/MainPage/components/Popup/popupConfigs';
+import { DAEDONG_POPUP } from '@/pages/MainPage/components/Popup/popupConfigs';
 import { useSelectedCategory } from '@/store/useCategoryStore';
 import { useSearchIsSearching, useSearchKeyword } from '@/store/useSearchStore';
 import { Club } from '@/types/club';
@@ -51,7 +51,7 @@ const MainPage = () => {
 
   return (
     <>
-      <Popup configs={[APP_DOWNLOAD_POPUP]} />
+      <Popup configs={[DAEDONG_POPUP]} />
       <Header />
       <Filter hasNotification={hasNotification} />
       <Banner />

--- a/frontend/src/pages/MainPage/MainPage.tsx
+++ b/frontend/src/pages/MainPage/MainPage.tsx
@@ -11,6 +11,7 @@ import Banner from '@/pages/MainPage/components/Banner/Banner';
 import CategoryButtonList from '@/pages/MainPage/components/CategoryButtonList/CategoryButtonList';
 import ClubCard from '@/pages/MainPage/components/ClubCard/ClubCard';
 import Popup from '@/pages/MainPage/components/Popup/Popup';
+import { APP_DOWNLOAD_POPUP } from '@/pages/MainPage/components/Popup/popupConfigs';
 import { useSelectedCategory } from '@/store/useCategoryStore';
 import { useSearchIsSearching, useSearchKeyword } from '@/store/useSearchStore';
 import { Club } from '@/types/club';
@@ -50,7 +51,7 @@ const MainPage = () => {
 
   return (
     <>
-      <Popup />
+      <Popup configs={[APP_DOWNLOAD_POPUP]} />
       <Header />
       <Filter hasNotification={hasNotification} />
       <Banner />

--- a/frontend/src/pages/MainPage/components/Popup/Popup.stories.tsx
+++ b/frontend/src/pages/MainPage/components/Popup/Popup.stories.tsx
@@ -1,11 +1,12 @@
 import { MemoryRouter } from 'react-router-dom';
 import type { Meta, StoryObj } from '@storybook/react';
 import { INITIAL_VIEWPORTS } from 'storybook/viewport';
-import Popup, { POPUP_SESSION_KEY, POPUP_STORAGE_KEY } from './Popup';
+import Popup from './Popup';
+import { APP_DOWNLOAD_POPUP } from './popupConfigs';
 
-const setMobilePopupState = () => {
-  sessionStorage.removeItem(POPUP_SESSION_KEY);
-  localStorage.removeItem(POPUP_STORAGE_KEY);
+const clearPopupState = () => {
+  sessionStorage.removeItem(APP_DOWNLOAD_POPUP.sessionKey);
+  localStorage.removeItem(APP_DOWNLOAD_POPUP.storageKey);
 };
 
 const meta = {
@@ -25,7 +26,7 @@ const meta = {
   },
   decorators: [
     (Story) => {
-      setMobilePopupState();
+      clearPopupState();
       return (
         <MemoryRouter>
           <Story />
@@ -39,4 +40,8 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  args: {
+    configs: [APP_DOWNLOAD_POPUP],
+  },
+};

--- a/frontend/src/pages/MainPage/components/Popup/Popup.test.tsx
+++ b/frontend/src/pages/MainPage/components/Popup/Popup.test.tsx
@@ -1,64 +1,90 @@
-import { DAYS_TO_HIDE, isPopupHidden, POPUP_STORAGE_KEY } from './Popup';
+import { DAYS_TO_HIDE, isPopupHidden, PopupConfig } from '@/utils/popupUtils';
+
+const mockConfig: PopupConfig = {
+  id: 'test_popup',
+  storageKey: 'test_popup_hidden_date',
+  sessionKey: 'test_popup_closed',
+  image: '',
+  imageAlt: '',
+};
 
 describe('Popup 유틸 함수 테스트', () => {
   beforeEach(() => {
     localStorage.clear();
+    sessionStorage.clear();
   });
 
   afterEach(() => {
     localStorage.clear();
+    sessionStorage.clear();
   });
 
   describe('isPopupHidden', () => {
     it('저장된 날짜가 없으면 false를 반환한다', () => {
-      expect(isPopupHidden()).toBe(false);
+      expect(isPopupHidden(mockConfig)).toBe(false);
     });
 
     it('7일 미만이면 true를 반환한다 (1일 전)', () => {
       const oneDayAgo = Date.now() - 1 * 24 * 60 * 60 * 1000;
-      localStorage.setItem(POPUP_STORAGE_KEY, oneDayAgo.toString());
+      localStorage.setItem(mockConfig.storageKey, oneDayAgo.toString());
 
-      expect(isPopupHidden()).toBe(true);
+      expect(isPopupHidden(mockConfig)).toBe(true);
     });
 
     it('7일 미만이면 true를 반환한다 (6일 전)', () => {
       const sixDaysAgo = Date.now() - 6 * 24 * 60 * 60 * 1000;
-      localStorage.setItem(POPUP_STORAGE_KEY, sixDaysAgo.toString());
+      localStorage.setItem(mockConfig.storageKey, sixDaysAgo.toString());
 
-      expect(isPopupHidden()).toBe(true);
+      expect(isPopupHidden(mockConfig)).toBe(true);
     });
 
     it('정확히 7일이면 false를 반환한다', () => {
       const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
-      localStorage.setItem(POPUP_STORAGE_KEY, sevenDaysAgo.toString());
+      localStorage.setItem(mockConfig.storageKey, sevenDaysAgo.toString());
 
-      expect(isPopupHidden()).toBe(false);
+      expect(isPopupHidden(mockConfig)).toBe(false);
     });
 
     it('7일 이상이면 false를 반환한다 (8일 전)', () => {
       const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000;
-      localStorage.setItem(POPUP_STORAGE_KEY, eightDaysAgo.toString());
+      localStorage.setItem(mockConfig.storageKey, eightDaysAgo.toString());
 
-      expect(isPopupHidden()).toBe(false);
+      expect(isPopupHidden(mockConfig)).toBe(false);
     });
 
     it('7일 이상이면 false를 반환한다 (30일 전)', () => {
       const thirtyDaysAgo = Date.now() - 30 * 24 * 60 * 60 * 1000;
-      localStorage.setItem(POPUP_STORAGE_KEY, thirtyDaysAgo.toString());
+      localStorage.setItem(mockConfig.storageKey, thirtyDaysAgo.toString());
 
-      expect(isPopupHidden()).toBe(false);
+      expect(isPopupHidden(mockConfig)).toBe(false);
     });
 
     it('방금 저장한 경우 true를 반환한다', () => {
-      localStorage.setItem(POPUP_STORAGE_KEY, Date.now().toString());
+      localStorage.setItem(mockConfig.storageKey, Date.now().toString());
 
-      expect(isPopupHidden()).toBe(true);
+      expect(isPopupHidden(mockConfig)).toBe(true);
     });
 
     it('잘못된 형식의 날짜는 NaN으로 처리되어 false를 반환한다', () => {
-      localStorage.setItem(POPUP_STORAGE_KEY, 'invalid_date');
+      localStorage.setItem(mockConfig.storageKey, 'invalid_date');
 
-      expect(isPopupHidden()).toBe(false);
+      expect(isPopupHidden(mockConfig)).toBe(false);
+    });
+
+    it('daysToHide가 0이면 "다시 보지 않기" 후에도 항상 표시된다', () => {
+      const alwaysShowConfig: PopupConfig = {
+        ...mockConfig,
+        daysToHide: 0,
+      };
+      localStorage.setItem(alwaysShowConfig.storageKey, Date.now().toString());
+
+      expect(isPopupHidden(alwaysShowConfig)).toBe(false);
+    });
+
+    it('sessionStorage에 닫힘 상태가 있으면 true를 반환한다', () => {
+      sessionStorage.setItem(mockConfig.sessionKey, 'true');
+
+      expect(isPopupHidden(mockConfig)).toBe(true);
     });
   });
 
@@ -68,30 +94,24 @@ describe('Popup 유틸 함수 테스트', () => {
     });
   });
 
-  describe('localStorage 키', () => {
-    it('POPUP_STORAGE_KEY가 올바르게 정의되어 있다', () => {
-      expect(POPUP_STORAGE_KEY).toBe('mainpage_popup_hidden_date');
-    });
-  });
-
   describe('통합 시나리오', () => {
     it('시나리오: 첫 방문 → 다시 보지 않기 → 6일 후 방문 → 7일 후 방문', () => {
       // 1. 첫 방문
-      expect(isPopupHidden()).toBe(false);
+      expect(isPopupHidden(mockConfig)).toBe(false);
 
       // 2. "다시 보지 않기" 클릭
-      localStorage.setItem(POPUP_STORAGE_KEY, Date.now().toString());
-      expect(isPopupHidden()).toBe(true);
+      localStorage.setItem(mockConfig.storageKey, Date.now().toString());
+      expect(isPopupHidden(mockConfig)).toBe(true);
 
       // 3. 6일 후 방문 (아직 숨김)
       const sixDaysAgo = Date.now() - 6 * 24 * 60 * 60 * 1000;
-      localStorage.setItem(POPUP_STORAGE_KEY, sixDaysAgo.toString());
-      expect(isPopupHidden()).toBe(true);
+      localStorage.setItem(mockConfig.storageKey, sixDaysAgo.toString());
+      expect(isPopupHidden(mockConfig)).toBe(true);
 
       // 4. 7일 후 방문 (다시 표시)
       const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
-      localStorage.setItem(POPUP_STORAGE_KEY, sevenDaysAgo.toString());
-      expect(isPopupHidden()).toBe(false);
+      localStorage.setItem(mockConfig.storageKey, sevenDaysAgo.toString());
+      expect(isPopupHidden(mockConfig)).toBe(false);
     });
   });
 });

--- a/frontend/src/pages/MainPage/components/Popup/Popup.tsx
+++ b/frontend/src/pages/MainPage/components/Popup/Popup.tsx
@@ -1,56 +1,43 @@
 import { MouseEvent, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import AppDownloadImage from '@/assets/images/popup/app-download.png';
 import { USER_EVENT } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import useDevice from '@/hooks/useDevice';
-import { detectPlatform, getAppStoreLink } from '@/utils/appStoreLink';
+import { isPopupHidden, PopupConfig } from '@/utils/popupUtils';
 import * as Styled from './Popup.styles';
 
-export const POPUP_STORAGE_KEY = 'mainpage_popup_hidden_date';
-export const POPUP_SESSION_KEY = 'mainpage_popup_closed';
-export const DAYS_TO_HIDE = 7;
+interface PopupProps {
+  configs: PopupConfig[];
+}
 
-export const isPopupHidden = (): boolean => {
-  if (sessionStorage.getItem(POPUP_SESSION_KEY)) return true;
-
-  const hiddenDate = localStorage.getItem(POPUP_STORAGE_KEY);
-  if (!hiddenDate) return false;
-
-  const daysSinceHidden =
-    (Date.now() - parseInt(hiddenDate)) / (1000 * 60 * 60 * 24);
-  return daysSinceHidden < DAYS_TO_HIDE;
-};
-
-const Popup = () => {
+const Popup = ({ configs }: PopupProps) => {
+  const trackEvent = useMixpanelTrack();
+  const { isMobile } = useDevice();
+  const [activeConfig, setActiveConfig] = useState<PopupConfig | null>(null);
   const [isOpen, setIsOpen] = useState(false);
   const [imageLoaded, setImageLoaded] = useState(false);
-  const { isMobile } = useDevice();
-  const trackEvent = useMixpanelTrack();
 
   useEffect(() => {
+    const eligible = configs.find((config) => {
+      if (config.mobileOnly && !isMobile) return false;
+      return !isPopupHidden(config);
+    });
+    setActiveConfig(eligible ?? null);
+  }, [configs, isMobile]);
+
+  useEffect(() => {
+    if (!activeConfig) return;
+    setImageLoaded(false);
     const img = new Image();
-    img.src = AppDownloadImage;
+    img.src = activeConfig.image;
     img.onload = () => setImageLoaded(true);
     img.onerror = () => setImageLoaded(true);
-  }, []);
+  }, [activeConfig]);
 
   useEffect(() => {
-    if (!imageLoaded) return;
-
-    const isHidden = isPopupHidden();
-
-    if (isMobile && !isHidden && imageLoaded) {
-      setIsOpen(true);
-      trackEvent(USER_EVENT.MAIN_POPUP_VIEWED, {
-        popupType: 'app_download',
-      });
-    } else {
-      trackEvent(USER_EVENT.MAIN_POPUP_NOT_SHOWN, {
-        popupType: 'app_download',
-      });
-    }
-  }, [isMobile, trackEvent, imageLoaded]);
+    if (!imageLoaded || !activeConfig) return;
+    setIsOpen(true);
+    trackEvent(USER_EVENT.MAIN_POPUP_VIEWED, { popupType: activeConfig.id });
+  }, [imageLoaded, activeConfig, trackEvent]);
 
   useEffect(() => {
     if (isOpen) {
@@ -64,39 +51,30 @@ const Popup = () => {
   const handleClose = (
     action: 'close_button' | 'backdrop_click' = 'close_button',
   ) => {
+    if (!activeConfig) return;
     trackEvent(USER_EVENT.MAIN_POPUP_CLOSED, {
-      popupType: 'app_download',
-      action: action,
+      popupType: activeConfig.id,
+      action,
     });
-    sessionStorage.setItem(POPUP_SESSION_KEY, 'true');
+    sessionStorage.setItem(activeConfig.sessionKey, 'true');
     setIsOpen(false);
   };
 
   const handleDontShowAgain = () => {
+    if (!activeConfig) return;
     trackEvent(USER_EVENT.MAIN_POPUP_CLOSED, {
-      popupType: 'app_download',
+      popupType: activeConfig.id,
       action: 'dont_show_again',
     });
-    localStorage.setItem(POPUP_STORAGE_KEY, Date.now().toString());
+    localStorage.setItem(activeConfig.storageKey, Date.now().toString());
     setIsOpen(false);
   };
 
-  const handleDownload = () => {
-    const storeLink = getAppStoreLink();
-    trackEvent(USER_EVENT.APP_DOWNLOAD_POPUP_CLICKED, {
-      popupType: 'app_download',
-      platform: detectPlatform(),
-    });
-    window.open(storeLink, '_blank');
-  };
-
   const handleBackdropClick = (e: MouseEvent<HTMLDivElement>) => {
-    if (e.target === e.currentTarget) {
-      handleClose('backdrop_click');
-    }
+    if (e.target === e.currentTarget) handleClose('backdrop_click');
   };
 
-  if (!isOpen) return null;
+  if (!isOpen || !activeConfig) return null;
 
   return (
     <Styled.Overlay
@@ -109,8 +87,13 @@ const Popup = () => {
         onClick={(e: MouseEvent<HTMLDivElement>) => e.stopPropagation()}
       >
         <Styled.Container>
-          <Styled.ImageWrapper onClick={handleDownload}>
-            <Styled.PopupImage src={AppDownloadImage} alt='앱 다운로드' />
+          <Styled.ImageWrapper
+            onClick={() => activeConfig.onImageClick?.(trackEvent)}
+          >
+            <Styled.PopupImage
+              src={activeConfig.image}
+              alt={activeConfig.imageAlt}
+            />
           </Styled.ImageWrapper>
 
           <Styled.ButtonGroup>

--- a/frontend/src/pages/MainPage/components/Popup/Popup.tsx
+++ b/frontend/src/pages/MainPage/components/Popup/Popup.tsx
@@ -24,7 +24,10 @@ const Popup = ({ configs }: PopupProps) => {
       return !isPopupHidden(config);
     });
     setActiveConfig(eligible ?? null);
-  }, [configs, isMobile]);
+    if (!eligible) {
+      trackEvent(USER_EVENT.MAIN_POPUP_NOT_SHOWN);
+    }
+  }, [configs, isMobile, trackEvent]);
 
   useEffect(() => {
     if (!activeConfig) return;

--- a/frontend/src/pages/MainPage/components/Popup/Popup.tsx
+++ b/frontend/src/pages/MainPage/components/Popup/Popup.tsx
@@ -1,4 +1,5 @@
 import { MouseEvent, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { USER_EVENT } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import useDevice from '@/hooks/useDevice';
@@ -10,6 +11,7 @@ interface PopupProps {
 }
 
 const Popup = ({ configs }: PopupProps) => {
+  const navigate = useNavigate();
   const trackEvent = useMixpanelTrack();
   const { isMobile } = useDevice();
   const [activeConfig, setActiveConfig] = useState<PopupConfig | null>(null);
@@ -88,7 +90,10 @@ const Popup = ({ configs }: PopupProps) => {
       >
         <Styled.Container>
           <Styled.ImageWrapper
-            onClick={() => activeConfig.onImageClick?.(trackEvent)}
+            onClick={() => {
+              activeConfig.onImageClick?.(trackEvent);
+              if (activeConfig.to) navigate(activeConfig.to);
+            }}
           >
             <Styled.PopupImage
               src={activeConfig.image}

--- a/frontend/src/pages/MainPage/components/Popup/popupConfigs.ts
+++ b/frontend/src/pages/MainPage/components/Popup/popupConfigs.ts
@@ -1,4 +1,5 @@
 import AppDownloadImage from '@/assets/images/popup/app-download.png';
+import DaedongImage from '@/assets/images/popup/daedong.png';
 import { USER_EVENT } from '@/constants/eventName';
 import { detectPlatform, getAppStoreLink } from '@/utils/appStoreLink';
 import { PopupConfig } from '@/utils/popupUtils';
@@ -18,4 +19,14 @@ export const APP_DOWNLOAD_POPUP: PopupConfig = {
     });
     window.open(getAppStoreLink(), '_blank');
   },
+};
+
+export const DAEDONG_POPUP: PopupConfig = {
+  id: 'daedong_2026',
+  storageKey: 'mainpage_daedong_popup_hidden_date',
+  sessionKey: 'mainpage_daedong_popup_closed',
+  daysToHide: 7,
+  image: DaedongImage,
+  imageAlt: '2026 대동제',
+  to: '/festival-busking',
 };

--- a/frontend/src/pages/MainPage/components/Popup/popupConfigs.ts
+++ b/frontend/src/pages/MainPage/components/Popup/popupConfigs.ts
@@ -1,0 +1,21 @@
+import AppDownloadImage from '@/assets/images/popup/app-download.png';
+import { USER_EVENT } from '@/constants/eventName';
+import { detectPlatform, getAppStoreLink } from '@/utils/appStoreLink';
+import { PopupConfig } from '@/utils/popupUtils';
+
+export const APP_DOWNLOAD_POPUP: PopupConfig = {
+  id: 'app_download',
+  storageKey: 'mainpage_popup_hidden_date',
+  sessionKey: 'mainpage_popup_closed',
+  daysToHide: 7,
+  image: AppDownloadImage,
+  imageAlt: '앱 다운로드',
+  mobileOnly: true,
+  onImageClick: (trackEvent) => {
+    trackEvent(USER_EVENT.APP_DOWNLOAD_POPUP_CLICKED, {
+      popupType: 'app_download',
+      platform: detectPlatform(),
+    });
+    window.open(getAppStoreLink(), '_blank');
+  },
+};

--- a/frontend/src/utils/popupUtils.ts
+++ b/frontend/src/utils/popupUtils.ts
@@ -11,6 +11,7 @@ export interface PopupConfig {
   image: string;
   imageAlt: string;
   mobileOnly?: boolean;
+  to?: string;
   onImageClick?: (trackEvent: TrackEventFn) => void;
 }
 

--- a/frontend/src/utils/popupUtils.ts
+++ b/frontend/src/utils/popupUtils.ts
@@ -1,0 +1,30 @@
+type TrackEventFn = (
+  eventName: string,
+  properties?: Record<string, any>,
+) => void;
+
+export interface PopupConfig {
+  id: string;
+  storageKey: string;
+  sessionKey: string;
+  daysToHide?: number;
+  image: string;
+  imageAlt: string;
+  mobileOnly?: boolean;
+  onImageClick?: (trackEvent: TrackEventFn) => void;
+}
+
+export const DAYS_TO_HIDE = 7;
+
+export const isPopupHidden = (config: PopupConfig): boolean => {
+  if (sessionStorage.getItem(config.sessionKey)) return true;
+
+  const hiddenDate = localStorage.getItem(config.storageKey);
+  if (!hiddenDate) return false;
+
+  const daysSinceHidden =
+    (Date.now() - parseInt(hiddenDate)) / (1000 * 60 * 60 * 24);
+  const daysToHide =
+    config.daysToHide !== undefined ? config.daysToHide : DAYS_TO_HIDE;
+  return daysSinceHidden < daysToHide;
+};


### PR DESCRIPTION

## #️⃣연관된 이슈

> ex) #1517

## 📝작업 내용

  ###Popup 다중 팝업 지원 구조 리팩토링
  - `PopupConfig` 인터페이스 도입: 팝업별 `storageKey` / `sessionKey` / `daysToHide` 분리
  - `configs: PopupConfig[]` prop으로 첫 번째 eligible 팝업 자동 표시
  - `to?: string` 필드로 React Router 내부 라우팅 지원
  - `daysToHide: 0` 버그 수정 (`??` → `!== undefined`)

  ### 대동제 팝업
  - 이미지 클릭 시 `/festival-busking` 이동
  - 기존 앱 다운로드 팝업을 축제 기간 임시 교체


## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 다중 팝업 지원으로 더욱 유연한 팝업 관리 가능
  * 사용자 기기 및 환경에 맞춘 팝업 자동 선택 표시
  * 팝업별 독립적인 '다시 보지 않기' 설정 지원
  * 새로운 대동제 페스티벌 팝업 추가

* **문서**
  * 팝업 시스템 설정 및 확장 가이드 문서 작성

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Moadong/moadong/pull/1519)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->