### PR TITLE
[fix] 지도 모달 닫을 때 오류 페이지로 이동하는 현상 수정

### DIFF
--- a/frontend/src/hooks/Map/useNaverMap.ts
+++ b/frontend/src/hooks/Map/useNaverMap.ts
@@ -122,7 +122,11 @@ export const useNaverMap = (
 
     return () => {
       isCleaned = true;
-      mapInstance?.destroy();
+      try {
+        mapInstance?.destroy();
+      } catch {
+        // noop
+      }
       if (externalRef) externalRef.current = null;
     };
   }, [

--- a/frontend/src/hooks/Map/useNaverMap.ts
+++ b/frontend/src/hooks/Map/useNaverMap.ts
@@ -80,9 +80,10 @@ export const useNaverMap = (
     if (!active) return;
 
     let mapInstance: NaverMapInstance | null = null;
+    let isCleaned = false;
 
     loadNaverMapScript().then(() => {
-      if (!mapRef.current || !window.naver) return;
+      if (isCleaned || !mapRef.current || !window.naver) return;
 
       const { naver } = window;
       const position = new naver.maps.LatLng(lat, lng);
@@ -120,6 +121,7 @@ export const useNaverMap = (
     });
 
     return () => {
+      isCleaned = true;
       mapInstance?.destroy();
       if (externalRef) externalRef.current = null;
     };


### PR DESCRIPTION
## #️⃣연관된 이슈

> #1521 

## 📝작업 내용
> 지도 모달을 닫을 때 간헐적으로 에러 페이지로 이동하는 현상을 수정합니다.

- **unmount 후 맵 생성 방지**: 모달이 빠르게 열리고 닫힐 때, 네이버 맵 스크립트 로딩 완료 후 이미 unmount된 컴포넌트에 맵이 생성되는 race condition 차단
- **destroy() 크래시 방지**: 네이버 맵 API 인증 실패 시 불완전한 맵 객체의 destroy() 호출에서 발생하는 TypeError가 ErrorBoundary까지 전파되지 않도록 처리

## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항
간헐적 발생 버그라 재현이 어렵지만, 네이버 맵 API 인증 실패 상황에서 모달 닫기 시 크래시가 발생할 수 있는 코드 경로를 방어적으로 처리했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 지도 컴포넌트 언마운트 시 발생할 수 있는 오류 처리 개선
  * 지도 초기화 로직의 안정성 강화

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Moadong/moadong/pull/1522)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->