### PR TITLE
[release] FE v1.7.0

### DIFF
--- a/frontend/docs/features/festival/busking-timetable.md
+++ b/frontend/docs/features/festival/busking-timetable.md
@@ -10,9 +10,12 @@
 
 ```
 BuskingPage
-├── DayTabsNav (variant: 'tabs')     — UnderlineTabs로 날짜 4개 탭
+├── DayTabsNav (variant: 'tabs')     — UnderlineTabs로 날짜 탭
 ├── DayArrowsNav (variant: 'arrows') — ‹ 날짜 › 화살표 네비게이션
-└── PerformanceList                  — 날짜별 공연 목록 (공통 컴포넌트)
+├── SectionLabel "동아리 공연"        — 두 섹션 모두 있을 때만 표시
+├── PerformanceList (performances)   — 동아리 공연 목록
+├── SectionLabel "🎤 아티스트 공연"
+└── PerformanceList (mainStagePerformances, hideSongs) — 아티스트 공연 목록
     └── TimelineRow + PerformanceCard
 ```
 
@@ -41,14 +44,24 @@ BuskingPage
 
 `src/pages/FestivalPage/data/buskingDays.ts` — `BUSKING_DAYS: FestivalDay[]`
 
-- `performances: []`인 날짜는 자동으로 탭/화살표에서 제외
+- `performances: []`이고 `mainStagePerformances`도 없는 날짜는 탭/화살표에서 제외
 - 오늘 날짜가 축제 기간이면 해당 날짜로 자동 진입
+- `mainStagePerformances`: 동아리 공연 종료 후 진행되는 아티스트 공연 (Day1~4 모두 포함)
+
+### 아티스트 공연 라인업
+
+| 날짜 | 아티스트            |
+| ---- | ------------------- |
+| Day1 | YB                  |
+| Day2 | 최예나, 이창섭      |
+| Day3 | FIFTY FIFTY, 비와이 |
+| Day4 | V.O.S, 청하         |
 
 ## 관련 코드
 
 - `src/pages/FestivalPage/BuskingPage/BuskingPage.tsx` — 메인 페이지, 실험 분기 및 이벤트 트래킹
 - `src/pages/FestivalPage/components/DayTabsNav/DayTabsNav.tsx` — tabs variant
 - `src/pages/FestivalPage/components/DayArrowsNav/DayArrowsNav.tsx` — arrows variant
-- `src/pages/FestivalPage/data/buskingDays.ts` — 4일치 공연 데이터
-- `src/pages/FestivalPage/components/PerformanceList/PerformanceList.tsx` — `performances`, `festivalDate` props 지원 (기존 IntroductionPage와 공유)
-- `src/pages/FestivalPage/components/PerformanceCard/PerformanceCard.tsx` — `songs: []`이면 "🎵 추후 공개 예정" 표시
+- `src/pages/FestivalPage/data/buskingDays.ts` — 4일치 공연 데이터 (`performances` + `mainStagePerformances`)
+- `src/pages/FestivalPage/components/PerformanceList/PerformanceList.tsx` — `performances`, `festivalDate`, `hideSongs` props 지원
+- `src/pages/FestivalPage/components/PerformanceCard/PerformanceCard.tsx` — `hideSongs`이면 곡목 영역 숨김, `songs: []`이면 "🎵 추후 공개 예정" 표시

--- a/frontend/docs/features/festival/busking-timetable.md
+++ b/frontend/docs/features/festival/busking-timetable.md
@@ -1,0 +1,54 @@
+# 2026 대동제 버스킹 시간표 페이지
+
+4일간 진행되는 버스킹 공연 시간표를 제공하는 페이지. 날짜 네비게이션 방식을 A/B 테스트로 검증한다.
+
+## 라우트
+
+`/festival-busking` → `BuskingPage`
+
+## 페이지 구조
+
+```
+BuskingPage
+├── DayTabsNav (variant: 'tabs')     — UnderlineTabs로 날짜 4개 탭
+├── DayArrowsNav (variant: 'arrows') — ‹ 날짜 › 화살표 네비게이션
+└── PerformanceList                  — 날짜별 공연 목록 (공통 컴포넌트)
+    └── TimelineRow + PerformanceCard
+```
+
+## A/B 실험
+
+| 항목      | 내용                        |
+| --------- | --------------------------- |
+| 실험 키   | `festival_timetable_nav_v1` |
+| Variant A | `tabs` — 날짜 4개 탭        |
+| Variant B | `arrows` — 화살표 순차 이동 |
+| 비율      | 50 : 50                     |
+
+실험 정의: `src/experiments/definitions.ts` → `festivalTimetableNavExperiment`
+
+## Mixpanel 이벤트
+
+| 이벤트명                            | 트리거                  | 주요 속성                                          |
+| ----------------------------------- | ----------------------- | -------------------------------------------------- |
+| `2026-daedong 버스킹 시간표 페이지` | 페이지 진입             | —                                                  |
+| `2026-daedong Day Changed`          | 날짜 전환               | `from_day`, `to_day`, `nav_variant`, `interaction` |
+| `2026-daedong Day Duration`         | 날짜 이탈 / 페이지 이탈 | `day`, `nav_variant`, `duration_seconds`           |
+
+`interaction` 값: `'click'` (버튼) / `'swipe'` (터치 제스처)
+
+## 데이터
+
+`src/pages/FestivalPage/data/buskingDays.ts` — `BUSKING_DAYS: FestivalDay[]`
+
+- `performances: []`인 날짜는 자동으로 탭/화살표에서 제외
+- 오늘 날짜가 축제 기간이면 해당 날짜로 자동 진입
+
+## 관련 코드
+
+- `src/pages/FestivalPage/BuskingPage/BuskingPage.tsx` — 메인 페이지, 실험 분기 및 이벤트 트래킹
+- `src/pages/FestivalPage/components/DayTabsNav/DayTabsNav.tsx` — tabs variant
+- `src/pages/FestivalPage/components/DayArrowsNav/DayArrowsNav.tsx` — arrows variant
+- `src/pages/FestivalPage/data/buskingDays.ts` — 4일치 공연 데이터
+- `src/pages/FestivalPage/components/PerformanceList/PerformanceList.tsx` — `performances`, `festivalDate` props 지원 (기존 IntroductionPage와 공유)
+- `src/pages/FestivalPage/components/PerformanceCard/PerformanceCard.tsx` — `songs: []`이면 "🎵 추후 공개 예정" 표시

--- a/frontend/docs/features/main/filter.md
+++ b/frontend/docs/features/main/filter.md
@@ -1,0 +1,12 @@
+# Filter 칩 NotificationDot — 대동제 세션 기반 표시
+
+`Filter` 컴포넌트의 `NotificationDot`은 두 가지 조건으로 표시된다.
+
+- `홍보`: `usePromotionNotification` 훅이 반환하는 서버 데이터 기반
+- `대동제`: 세션 기반 — 첫 방문 시 항상 표시, 칩 클릭 시 사라짐 (탭 종료 후 재표시)
+
+`대동제` dot 상태는 `Filter` 내부에서 `sessionStorage('daedong_filter_seen')`으로 자체 관리하며, `MainPage.tsx`나 Filter props 변경 없이 동작한다.
+
+## 관련 코드
+
+- `src/components/common/Filter/Filter.tsx` — `daedongDotSeen` state, `handleFilterOptionClick` 내 sessionStorage 처리

--- a/frontend/docs/features/main/popup.md
+++ b/frontend/docs/features/main/popup.md
@@ -18,6 +18,7 @@
 | `daysToHide`   | `number?`              | 숨김 유지 일수 (기본 7, 0이면 항상 표시) |
 | `image`        | `string`               | 팝업 이미지 경로                         |
 | `mobileOnly`   | `boolean?`             | 모바일 전용 여부                         |
+| `to`           | `string?`              | 이미지 클릭 시 내부 라우팅 경로          |
 | `onImageClick` | `(trackEvent) => void` | 이미지 클릭 핸들러 (트래킹 포함)         |
 
 ## 새 팝업 추가 방법

--- a/frontend/docs/features/main/popup.md
+++ b/frontend/docs/features/main/popup.md
@@ -1,0 +1,33 @@
+# Popup — 다중 팝업 지원 구조
+
+메인 페이지에서 노출되는 팝업 시스템. `PopupConfig` 배열로 여러 팝업을 관리하며, 첫 번째 eligible 팝업을 자동으로 표시한다.
+
+## 구조
+
+- `configs: PopupConfig[]`를 prop으로 받아, 조건을 통과하는 첫 번째 팝업을 표시
+- 각 팝업은 독립적인 `storageKey` / `sessionKey`를 가짐
+- `daysToHide: 0`으로 설정하면 "다시 보지 않기" 클릭 후에도 항상 재표시
+
+## PopupConfig 필드
+
+| 필드           | 타입                   | 설명                                     |
+| -------------- | ---------------------- | ---------------------------------------- |
+| `id`           | `string`               | Mixpanel `popupType` 값으로 사용         |
+| `storageKey`   | `string`               | "다시 보지 않기" localStorage 키         |
+| `sessionKey`   | `string`               | "닫기" sessionStorage 키                 |
+| `daysToHide`   | `number?`              | 숨김 유지 일수 (기본 7, 0이면 항상 표시) |
+| `image`        | `string`               | 팝업 이미지 경로                         |
+| `mobileOnly`   | `boolean?`             | 모바일 전용 여부                         |
+| `onImageClick` | `(trackEvent) => void` | 이미지 클릭 핸들러 (트래킹 포함)         |
+
+## 새 팝업 추가 방법
+
+1. `popupConfigs.ts`에 `PopupConfig` 객체 추가
+2. `MainPage.tsx`의 `configs` 배열에 삽입 (앞에 넣을수록 우선 표시)
+
+## 관련 코드
+
+- `src/utils/popupUtils.ts` — `PopupConfig` 인터페이스, `isPopupHidden`, `DAYS_TO_HIDE`
+- `src/pages/MainPage/components/Popup/Popup.tsx` — 팝업 렌더링 컴포넌트
+- `src/pages/MainPage/components/Popup/popupConfigs.ts` — 팝업 config 정의 (`APP_DOWNLOAD_POPUP`)
+- `src/pages/MainPage/components/Popup/Popup.test.tsx` — `isPopupHidden` 유틸 테스트

--- a/frontend/src/components/common/Filter/Filter.tsx
+++ b/frontend/src/components/common/Filter/Filter.tsx
@@ -7,11 +7,13 @@ import * as Styled from './Filter.styles';
 const WEB_FILTER_OPTIONS = [
   { label: '동아리', path: '/' },
   { label: '홍보', path: '/promotions' },
+  { label: '대동제', path: '/festival-busking' },
 ] as const;
 
 const WEBVIEW_FILTER_OPTIONS = [
   { label: '동아리', path: '/webview/main' },
   { label: '홍보', path: '/webview/promotions' },
+  { label: '대동제', path: '/webview/festival-busking' },
 ] as const;
 
 interface FilterProps {

--- a/frontend/src/components/common/Filter/Filter.tsx
+++ b/frontend/src/components/common/Filter/Filter.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { USER_EVENT } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
@@ -27,12 +28,20 @@ const Filter = ({ alwaysVisible = false, hasNotification }: FilterProps) => {
   const { pathname } = useLocation();
   const trackEvent = useMixpanelTrack();
 
+  const [daedongDotSeen, setDaedongDotSeen] = useState(
+    () => sessionStorage.getItem('daedong_filter_seen') === 'true',
+  );
+
   const isWebview = pathname.startsWith('/webview');
   const filterOptions = isWebview ? WEBVIEW_FILTER_OPTIONS : WEB_FILTER_OPTIONS;
   const shouldShow = alwaysVisible || isMobile || isWebview;
 
   const handleFilterOptionClick = (path: string) => {
     trackEvent(USER_EVENT.FILTER_OPTION_CLICKED, { path });
+    if (path.includes('festival-busking')) {
+      sessionStorage.setItem('daedong_filter_seen', 'true');
+      setDaedongDotSeen(true);
+    }
     navigate(path);
   };
 
@@ -43,7 +52,10 @@ const Filter = ({ alwaysVisible = false, hasNotification }: FilterProps) => {
           {filterOptions.map((filter) => (
             <Styled.FilterButtonWrapper key={filter.path}>
               <Styled.NotificationDot
-                $isVisible={hasNotification && filter.label === '홍보'}
+                $isVisible={
+                  (hasNotification && filter.label === '홍보') ||
+                  (filter.label === '대동제' && !daedongDotSeen)
+                }
               />
               <Styled.FilterButton
                 $isActive={pathname === filter.path}

--- a/frontend/src/constants/eventName.ts
+++ b/frontend/src/constants/eventName.ts
@@ -129,7 +129,7 @@ export const PAGE_VIEW = {
   INTRODUCE_PAGE: 'IntroducePage',
   CLUB_UNION_PAGE: 'ClubUnionPage',
   FESTIVAL_INTRODUCTION_PAGE: '동소한 페이지',
-  DAEDONG2026_BUSKING_PAGE: '2026-daedong 버스킹 시간표 페이지',
+  DAEDONG2026_BUSKING_PAGE: '2026 대동제 버스킹 시간표 페이지',
   PROMOTION_LIST_PAGE: '홍보 목록 페이지',
   PROMOTION_DETAIL_PAGE: '홍보 상세 페이지',
 

--- a/frontend/src/constants/eventName.ts
+++ b/frontend/src/constants/eventName.ts
@@ -61,6 +61,10 @@ export const USER_EVENT = {
   FESTIVAL_PERFORMANCE_CARD_CLICKED: 'Festival PerformanceCard Clicked',
   FESTIVAL_TAB_DURATION: 'Festival Tab Duration',
 
+  // 버스킹 시간표
+  DAEDONG2026_DAY_CHANGED: '2026-daedong Day Changed',
+  DAEDONG2026_DAY_DURATION: '2026-daedong Day Duration',
+
   // 홍보
   PROMOTION_BUTTON_CLICKED: 'Promotion Button Clicked',
   PROMOTION_CARD_CLICKED: 'Promotion Card Clicked',
@@ -125,6 +129,7 @@ export const PAGE_VIEW = {
   INTRODUCE_PAGE: 'IntroducePage',
   CLUB_UNION_PAGE: 'ClubUnionPage',
   FESTIVAL_INTRODUCTION_PAGE: '동소한 페이지',
+  DAEDONG2026_BUSKING_PAGE: '2026-daedong 버스킹 시간표 페이지',
   PROMOTION_LIST_PAGE: '홍보 목록 페이지',
   PROMOTION_DETAIL_PAGE: '홍보 상세 페이지',
 

--- a/frontend/src/experiments/definitions.ts
+++ b/frontend/src/experiments/definitions.ts
@@ -1,26 +1,13 @@
 import type { ExperimentDefinition } from './types';
 
-export const mainBannerExperiment = {
-  key: 'main_banner_v1',
-  variants: ['A', 'B'] as const,
-  defaultVariant: 'A',
+export const festivalTimetableNavExperiment = {
+  key: 'festival_timetable_nav_v1',
+  variants: ['tabs', 'arrows'] as const,
+  defaultVariant: 'tabs',
   weights: {
-    A: 50,
-    B: 50,
+    tabs: 50,
+    arrows: 50,
   },
-} satisfies ExperimentDefinition<'A' | 'B'>;
+} satisfies ExperimentDefinition<'tabs' | 'arrows'>;
 
-export const applyButtonCopyExperiment = {
-  key: 'apply_button_copy_v1',
-  variants: ['A', 'B'] as const,
-  defaultVariant: 'A',
-  weights: {
-    A: 50,
-    B: 50,
-  },
-} satisfies ExperimentDefinition<'A' | 'B'>;
-
-export const ALL_EXPERIMENTS = [
-  mainBannerExperiment,
-  applyButtonCopyExperiment,
-] as const;
+export const ALL_EXPERIMENTS = [festivalTimetableNavExperiment] as const;

--- a/frontend/src/hooks/Map/useNaverMap.ts
+++ b/frontend/src/hooks/Map/useNaverMap.ts
@@ -122,7 +122,11 @@ export const useNaverMap = (
 
     return () => {
       isCleaned = true;
-      mapInstance?.destroy();
+      try {
+        mapInstance?.destroy();
+      } catch {
+        // noop
+      }
       if (externalRef) externalRef.current = null;
     };
   }, [

--- a/frontend/src/hooks/Map/useNaverMap.ts
+++ b/frontend/src/hooks/Map/useNaverMap.ts
@@ -80,9 +80,10 @@ export const useNaverMap = (
     if (!active) return;
 
     let mapInstance: NaverMapInstance | null = null;
+    let isCleaned = false;
 
     loadNaverMapScript().then(() => {
-      if (!mapRef.current || !window.naver) return;
+      if (isCleaned || !mapRef.current || !window.naver) return;
 
       const { naver } = window;
       const position = new naver.maps.LatLng(lat, lng);
@@ -120,6 +121,7 @@ export const useNaverMap = (
     });
 
     return () => {
+      isCleaned = true;
       mapInstance?.destroy();
       if (externalRef) externalRef.current = null;
     };

--- a/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.styles.ts
+++ b/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.styles.ts
@@ -1,15 +1,9 @@
 import styled from 'styled-components';
-import { media } from '@/styles/mediaQuery';
 
 export const Container = styled.div`
   width: 100%;
   max-width: 550px;
   margin: 0 auto;
-  padding-top: 92px;
-
-  ${media.mobile} {
-    padding-top: 70px;
-  }
 `;
 
 export const NavWrapper = styled.div`

--- a/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.styles.ts
+++ b/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.styles.ts
@@ -46,3 +46,21 @@ export const TimetableLocation = styled.p`
   font-size: 12px;
   font-weight: 600;
 `;
+
+export const SectionLabel = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 8px 20px 12px;
+  color: #7a7a7a;
+  font-size: 12px;
+  font-weight: 600;
+
+  &::before,
+  &::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: #e8e8e8;
+  }
+`;

--- a/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.styles.ts
+++ b/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.styles.ts
@@ -51,7 +51,7 @@ export const SectionLabel = styled.div`
   display: flex;
   align-items: center;
   gap: 10px;
-  margin: 8px 20px 12px;
+  margin: 20px 20px 12px;
   color: #7a7a7a;
   font-size: 12px;
   font-weight: 600;

--- a/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.styles.ts
+++ b/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.styles.ts
@@ -1,0 +1,48 @@
+import styled from 'styled-components';
+import { media } from '@/styles/mediaQuery';
+
+export const Container = styled.div`
+  width: 100%;
+  max-width: 550px;
+  margin: 0 auto;
+  padding-top: 92px;
+
+  ${media.mobile} {
+    padding-top: 70px;
+  }
+`;
+
+export const NavWrapper = styled.div`
+  margin-bottom: 16px;
+`;
+
+export const TimetableSection = styled.section`
+  width: 100%;
+  max-width: 500px;
+  margin: 0 auto 20px;
+`;
+
+export const TimetableHeader = styled.div`
+  margin: 10px 20px 14px;
+  padding: 14px 16px;
+  border-radius: 14px;
+  background: #fff7f3;
+  border: 1px solid #ffe0d4;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`;
+
+export const TimetableDate = styled.p`
+  margin: 0;
+  color: #3a3a3a;
+  font-size: 14px;
+  font-weight: 700;
+`;
+
+export const TimetableLocation = styled.p`
+  margin: 0;
+  color: #7a7a7a;
+  font-size: 12px;
+  font-weight: 600;
+`;

--- a/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.tsx
+++ b/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
+import Filter from '@/components/common/Filter/Filter';
 import Footer from '@/components/common/Footer/Footer';
 import Header from '@/components/common/Header/Header';
 import { PAGE_VIEW, USER_EVENT } from '@/constants/eventName';
@@ -7,6 +8,7 @@ import { festivalTimetableNavExperiment } from '@/experiments/definitions';
 import { useExperimentVariant } from '@/hooks/Experiment/useExperimentVariant';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import useTrackPageView from '@/hooks/Mixpanel/useTrackPageView';
+import usePromotionNotification from '@/hooks/Queries/usePromotionNotification';
 import isInAppWebView from '@/utils/isInAppWebView';
 import DayArrowsNav from '../components/DayArrowsNav/DayArrowsNav';
 import DayTabsNav from '../components/DayTabsNav/DayTabsNav';
@@ -34,6 +36,7 @@ const BuskingPage = () => {
   const trackEvent = useMixpanelTrack();
   const navVariant = useExperimentVariant(festivalTimetableNavExperiment);
 
+  const hasNotification = usePromotionNotification();
   const [activeDayId, setActiveDayId] = useState(getInitialDayId);
   const dayStartTime = useRef(Date.now());
   const activeDayIdRef = useRef(activeDayId);
@@ -89,6 +92,7 @@ const BuskingPage = () => {
   return (
     <>
       <Header hideOn={['webview']} />
+      <Filter hasNotification={hasNotification} />
       <Styled.Container>
         <Styled.NavWrapper>
           {navVariant === 'tabs' ? (

--- a/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.tsx
+++ b/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { format } from 'date-fns';
 import { motion } from 'framer-motion';
 import Filter from '@/components/common/Filter/Filter';
 import Footer from '@/components/common/Footer/Footer';
@@ -23,7 +24,7 @@ const availableDays = BUSKING_DAYS.filter(
 
 const getInitialDayId = (): string => {
   const now = new Date();
-  const todayStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+  const todayStr = format(now, 'yyyy-MM-dd');
   return (
     availableDays.find((d) => d.date === todayStr)?.id ??
     availableDays[0]?.id ??

--- a/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.tsx
+++ b/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useRef, useState } from 'react';
+import { motion } from 'framer-motion';
+import Footer from '@/components/common/Footer/Footer';
+import Header from '@/components/common/Header/Header';
+import { PAGE_VIEW, USER_EVENT } from '@/constants/eventName';
+import { festivalTimetableNavExperiment } from '@/experiments/definitions';
+import { useExperimentVariant } from '@/hooks/Experiment/useExperimentVariant';
+import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
+import useTrackPageView from '@/hooks/Mixpanel/useTrackPageView';
+import isInAppWebView from '@/utils/isInAppWebView';
+import DayArrowsNav from '../components/DayArrowsNav/DayArrowsNav';
+import DayTabsNav from '../components/DayTabsNav/DayTabsNav';
+import PerformanceList from '../components/PerformanceList/PerformanceList';
+import { BUSKING_DAYS } from '../data/buskingDays';
+import * as Styled from './BuskingPage.styles';
+
+const availableDays = BUSKING_DAYS.filter((d) => d.performances.length > 0);
+
+const getInitialDayId = (): string => {
+  const now = new Date();
+  const todayStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+  return (
+    availableDays.find((d) => d.date === todayStr)?.id ??
+    availableDays[0]?.id ??
+    BUSKING_DAYS[0].id
+  );
+};
+
+const BuskingPage = () => {
+  useTrackPageView(PAGE_VIEW.DAEDONG2026_BUSKING_PAGE);
+  const trackEvent = useMixpanelTrack();
+  const navVariant = useExperimentVariant(festivalTimetableNavExperiment);
+
+  const [activeDayId, setActiveDayId] = useState(getInitialDayId);
+  const dayStartTime = useRef(Date.now());
+  const activeDayIdRef = useRef(activeDayId);
+
+  const activeDay = BUSKING_DAYS.find((d) => d.id === activeDayId)!;
+
+  useEffect(() => {
+    activeDayIdRef.current = activeDayId;
+  }, [activeDayId]);
+
+  useEffect(() => {
+    return () => {
+      const duration = Date.now() - dayStartTime.current;
+      trackEvent(USER_EVENT.DAEDONG2026_DAY_DURATION, {
+        day: activeDayIdRef.current,
+        nav_variant: navVariant,
+        duration,
+        duration_seconds: Math.round(duration / 1000),
+      });
+    };
+  }, []);
+
+  const handleDayChange = (
+    dayId: string,
+    interaction: 'click' | 'swipe' = 'click',
+  ) => {
+    const duration = Date.now() - dayStartTime.current;
+    trackEvent(USER_EVENT.DAEDONG2026_DAY_DURATION, {
+      day: activeDayId,
+      nav_variant: navVariant,
+      duration,
+      duration_seconds: Math.round(duration / 1000),
+    });
+    trackEvent(USER_EVENT.DAEDONG2026_DAY_CHANGED, {
+      from_day: activeDayId,
+      to_day: dayId,
+      nav_variant: navVariant,
+      interaction,
+    });
+    dayStartTime.current = Date.now();
+    setActiveDayId(dayId);
+  };
+
+  const handleSwipe = (direction: 'left' | 'right') => {
+    const currentIndex = availableDays.findIndex((d) => d.id === activeDayId);
+    if (direction === 'left' && currentIndex < availableDays.length - 1) {
+      handleDayChange(availableDays[currentIndex + 1].id, 'swipe');
+    } else if (direction === 'right' && currentIndex > 0) {
+      handleDayChange(availableDays[currentIndex - 1].id, 'swipe');
+    }
+  };
+
+  return (
+    <>
+      <Header hideOn={['webview']} />
+      <Styled.Container>
+        <Styled.NavWrapper>
+          {navVariant === 'tabs' ? (
+            <DayTabsNav
+              days={availableDays}
+              activeDayId={activeDayId}
+              onChange={handleDayChange}
+            />
+          ) : (
+            <DayArrowsNav
+              days={availableDays}
+              activeDayId={activeDayId}
+              onChange={handleDayChange}
+            />
+          )}
+        </Styled.NavWrapper>
+        <motion.div
+          onPanEnd={(_, info) => {
+            const SWIPE_THRESHOLD = 50;
+            if (info.offset.x < -SWIPE_THRESHOLD) handleSwipe('left');
+            else if (info.offset.x > SWIPE_THRESHOLD) handleSwipe('right');
+          }}
+        >
+          <Styled.TimetableSection>
+            <Styled.TimetableHeader>
+              <Styled.TimetableDate>
+                {activeDay.fullDateLabel} {activeDay.timeRange}
+              </Styled.TimetableDate>
+              <Styled.TimetableLocation>
+                공연 장소: {activeDay.location}
+              </Styled.TimetableLocation>
+            </Styled.TimetableHeader>
+            <PerformanceList
+              key={activeDayId}
+              performances={activeDay.performances}
+              festivalDate={activeDay.date}
+            />
+          </Styled.TimetableSection>
+        </motion.div>
+      </Styled.Container>
+      {!isInAppWebView() && <Footer />}
+    </>
+  );
+};
+
+export default BuskingPage;

--- a/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.tsx
+++ b/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.tsx
@@ -14,7 +14,10 @@ import PerformanceList from '../components/PerformanceList/PerformanceList';
 import { BUSKING_DAYS } from '../data/buskingDays';
 import * as Styled from './BuskingPage.styles';
 
-const availableDays = BUSKING_DAYS.filter((d) => d.performances.length > 0);
+const availableDays = BUSKING_DAYS.filter(
+  (d) =>
+    d.performances.length > 0 || (d.mainStagePerformances?.length ?? 0) > 0,
+);
 
 const getInitialDayId = (): string => {
   const now = new Date();
@@ -118,11 +121,29 @@ const BuskingPage = () => {
                 공연 장소: {activeDay.location}
               </Styled.TimetableLocation>
             </Styled.TimetableHeader>
-            <PerformanceList
-              key={activeDayId}
-              performances={activeDay.performances}
-              festivalDate={activeDay.date}
-            />
+            {activeDay.performances.length > 0 && (
+              <>
+                {(activeDay.mainStagePerformances?.length ?? 0) > 0 && (
+                  <Styled.SectionLabel>동아리 공연</Styled.SectionLabel>
+                )}
+                <PerformanceList
+                  key={`${activeDayId}-club`}
+                  performances={activeDay.performances}
+                  festivalDate={activeDay.date}
+                />
+              </>
+            )}
+            {(activeDay.mainStagePerformances?.length ?? 0) > 0 && (
+              <>
+                <Styled.SectionLabel>🎤 아티스트 공연</Styled.SectionLabel>
+                <PerformanceList
+                  key={`${activeDayId}-main`}
+                  performances={activeDay.mainStagePerformances!}
+                  festivalDate={activeDay.date}
+                  hideSongs
+                />
+              </>
+            )}
           </Styled.TimetableSection>
         </motion.div>
       </Styled.Container>

--- a/frontend/src/pages/FestivalPage/components/DayArrowsNav/DayArrowsNav.styles.ts
+++ b/frontend/src/pages/FestivalPage/components/DayArrowsNav/DayArrowsNav.styles.ts
@@ -1,0 +1,44 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  padding: 10px 0 14px;
+  box-shadow: inset 0 -1px 0 #e0e0e0;
+`;
+
+export const ArrowButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: none;
+  font-size: 28px;
+  line-height: 1;
+  color: #3a3a3a;
+  cursor: pointer;
+  transition: color 0.15s ease-in-out;
+
+  &:hover:not(:disabled) {
+    color: #ff5414;
+  }
+
+  &:disabled {
+    color: #d0d0d0;
+    cursor: default;
+  }
+`;
+
+export const DayLabel = styled.span`
+  min-width: 160px;
+  text-align: center;
+  font-size: 16px;
+  font-weight: 700;
+  color: #3a3a3a;
+`;

--- a/frontend/src/pages/FestivalPage/components/DayArrowsNav/DayArrowsNav.tsx
+++ b/frontend/src/pages/FestivalPage/components/DayArrowsNav/DayArrowsNav.tsx
@@ -9,14 +9,18 @@ interface DayArrowsNavProps {
 
 const DayArrowsNav = ({ days, activeDayId, onChange }: DayArrowsNavProps) => {
   const currentIndex = days.findIndex((d) => d.id === activeDayId);
-  const activeDay = days[currentIndex];
+  const activeDay = currentIndex !== -1 ? days[currentIndex] : days[0];
+
+  if (!activeDay) return null;
+
+  const safeIndex = currentIndex !== -1 ? currentIndex : 0;
 
   return (
     <Styled.Container>
       <Styled.ArrowButton
         type='button'
-        onClick={() => onChange(days[currentIndex - 1].id)}
-        disabled={currentIndex === 0}
+        onClick={() => onChange(days[safeIndex - 1].id)}
+        disabled={safeIndex === 0}
         aria-label='이전 날'
       >
         ‹
@@ -24,8 +28,8 @@ const DayArrowsNav = ({ days, activeDayId, onChange }: DayArrowsNavProps) => {
       <Styled.DayLabel>{activeDay.fullDateLabel}</Styled.DayLabel>
       <Styled.ArrowButton
         type='button'
-        onClick={() => onChange(days[currentIndex + 1].id)}
-        disabled={currentIndex === days.length - 1}
+        onClick={() => onChange(days[safeIndex + 1].id)}
+        disabled={safeIndex === days.length - 1}
         aria-label='다음 날'
       >
         ›

--- a/frontend/src/pages/FestivalPage/components/DayArrowsNav/DayArrowsNav.tsx
+++ b/frontend/src/pages/FestivalPage/components/DayArrowsNav/DayArrowsNav.tsx
@@ -1,0 +1,37 @@
+import type { FestivalDay } from '../../data/buskingDays';
+import * as Styled from './DayArrowsNav.styles';
+
+interface DayArrowsNavProps {
+  days: FestivalDay[];
+  activeDayId: string;
+  onChange: (dayId: string) => void;
+}
+
+const DayArrowsNav = ({ days, activeDayId, onChange }: DayArrowsNavProps) => {
+  const currentIndex = days.findIndex((d) => d.id === activeDayId);
+  const activeDay = days[currentIndex];
+
+  return (
+    <Styled.Container>
+      <Styled.ArrowButton
+        type='button'
+        onClick={() => onChange(days[currentIndex - 1].id)}
+        disabled={currentIndex === 0}
+        aria-label='이전 날'
+      >
+        ‹
+      </Styled.ArrowButton>
+      <Styled.DayLabel>{activeDay.fullDateLabel}</Styled.DayLabel>
+      <Styled.ArrowButton
+        type='button'
+        onClick={() => onChange(days[currentIndex + 1].id)}
+        disabled={currentIndex === days.length - 1}
+        aria-label='다음 날'
+      >
+        ›
+      </Styled.ArrowButton>
+    </Styled.Container>
+  );
+};
+
+export default DayArrowsNav;

--- a/frontend/src/pages/FestivalPage/components/DayTabsNav/DayTabsNav.tsx
+++ b/frontend/src/pages/FestivalPage/components/DayTabsNav/DayTabsNav.tsx
@@ -1,0 +1,19 @@
+import UnderlineTabs from '@/components/common/UnderlineTabs/UnderlineTabs';
+import type { FestivalDay } from '../../data/buskingDays';
+
+interface DayTabsNavProps {
+  days: FestivalDay[];
+  activeDayId: string;
+  onChange: (dayId: string) => void;
+}
+
+const DayTabsNav = ({ days, activeDayId, onChange }: DayTabsNavProps) => (
+  <UnderlineTabs
+    tabs={days.map((day) => ({ key: day.id, label: day.label }))}
+    activeKey={activeDayId}
+    onTabClick={onChange}
+    centerOnMobile
+  />
+);
+
+export default DayTabsNav;

--- a/frontend/src/pages/FestivalPage/components/PerformanceCard/PerformanceCard.stories.tsx
+++ b/frontend/src/pages/FestivalPage/components/PerformanceCard/PerformanceCard.stories.tsx
@@ -3,7 +3,7 @@ import PerformanceCard from './PerformanceCard';
 
 const samplePerformance = {
   id: 2,
-  clubName: '매니아',
+  name: '매니아',
   startTime: '13:00',
   endTime: '13:30',
   songs: [
@@ -16,7 +16,7 @@ const samplePerformance = {
 
 const singleSongPerformance = {
   id: 1,
-  clubName: '터',
+  name: '터',
   startTime: '12:30',
   endTime: '13:00',
   songs: ['차선농악 - 9명'],

--- a/frontend/src/pages/FestivalPage/components/PerformanceCard/PerformanceCard.stories.tsx
+++ b/frontend/src/pages/FestivalPage/components/PerformanceCard/PerformanceCard.stories.tsx
@@ -3,7 +3,7 @@ import PerformanceCard from './PerformanceCard';
 
 const samplePerformance = {
   id: 2,
-  name: '매니아',
+  clubName: '매니아',
   startTime: '13:00',
   endTime: '13:30',
   songs: [
@@ -16,7 +16,7 @@ const samplePerformance = {
 
 const singleSongPerformance = {
   id: 1,
-  name: '터',
+  clubName: '터',
   startTime: '12:30',
   endTime: '13:00',
   songs: ['차선농악 - 9명'],

--- a/frontend/src/pages/FestivalPage/components/PerformanceCard/PerformanceCard.tsx
+++ b/frontend/src/pages/FestivalPage/components/PerformanceCard/PerformanceCard.tsx
@@ -26,7 +26,7 @@ const PerformanceCard = ({
   const toggleExpanded = () => {
     const nextExpanded = !expanded;
     trackEvent(USER_EVENT.FESTIVAL_PERFORMANCE_CARD_CLICKED, {
-      clubName: performance.name,
+      clubName: performance.clubName,
       expanded: nextExpanded,
       active,
     });
@@ -40,7 +40,7 @@ const PerformanceCard = ({
       $active={active}
       onClick={!hideSongs && hasSongs ? toggleExpanded : undefined}
     >
-      <Styled.ClubName $active={active}>{performance.name}</Styled.ClubName>
+      <Styled.ClubName $active={active}>{performance.clubName}</Styled.ClubName>
 
       {!hideSongs && (
         <Styled.SongArea $active={active}>

--- a/frontend/src/pages/FestivalPage/components/PerformanceCard/PerformanceCard.tsx
+++ b/frontend/src/pages/FestivalPage/components/PerformanceCard/PerformanceCard.tsx
@@ -28,16 +28,21 @@ const PerformanceCard = ({ performance, active }: PerformanceCardProps) => {
     setExpanded(nextExpanded);
   };
 
+  const hasSongs = performance.songs.length > 0;
+
   return (
-    <Styled.Card $active={active} onClick={toggleExpanded}>
+    <Styled.Card
+      $active={active}
+      onClick={hasSongs ? toggleExpanded : undefined}
+    >
       <Styled.ClubName $active={active}>{performance.clubName}</Styled.ClubName>
 
       <Styled.SongArea $active={active}>
         <div style={{ flex: 1, overflow: 'hidden' }}>
           <Styled.SongItem $collapsed={!expanded}>
-            {performance.songs[0]}
+            {hasSongs ? performance.songs[0] : '🎵 추후 공개 예정'}
           </Styled.SongItem>
-          {performance.songs.length > 1 && (
+          {hasSongs && performance.songs.length > 1 && (
             <motion.div
               initial={false}
               animate={{ height: expanded ? 'auto' : 0 }}
@@ -53,19 +58,21 @@ const PerformanceCard = ({ performance, active }: PerformanceCardProps) => {
           )}
         </div>
 
-        <Styled.ChevronWrapper>
-          <Styled.ChevronIcon
-            $expanded={expanded}
-            $active={active}
-            viewBox='0 0 10 5'
-            fill='none'
-            strokeWidth={2}
-            strokeLinecap='round'
-            strokeLinejoin='round'
-          >
-            <path d='M1 1L5 4.5L9 1' />
-          </Styled.ChevronIcon>
-        </Styled.ChevronWrapper>
+        {hasSongs && (
+          <Styled.ChevronWrapper>
+            <Styled.ChevronIcon
+              $expanded={expanded}
+              $active={active}
+              viewBox='0 0 10 5'
+              fill='none'
+              strokeWidth={2}
+              strokeLinecap='round'
+              strokeLinejoin='round'
+            >
+              <path d='M1 1L5 4.5L9 1' />
+            </Styled.ChevronIcon>
+          </Styled.ChevronWrapper>
+        )}
       </Styled.SongArea>
     </Styled.Card>
   );

--- a/frontend/src/pages/FestivalPage/components/PerformanceCard/PerformanceCard.tsx
+++ b/frontend/src/pages/FestivalPage/components/PerformanceCard/PerformanceCard.tsx
@@ -8,9 +8,14 @@ import * as Styled from './PerformanceCard.styles';
 interface PerformanceCardProps {
   performance: Performance;
   active: boolean;
+  hideSongs?: boolean;
 }
 
-const PerformanceCard = ({ performance, active }: PerformanceCardProps) => {
+const PerformanceCard = ({
+  performance,
+  active,
+  hideSongs = false,
+}: PerformanceCardProps) => {
   const trackEvent = useMixpanelTrack();
   const [expanded, setExpanded] = useState(active);
 
@@ -21,7 +26,7 @@ const PerformanceCard = ({ performance, active }: PerformanceCardProps) => {
   const toggleExpanded = () => {
     const nextExpanded = !expanded;
     trackEvent(USER_EVENT.FESTIVAL_PERFORMANCE_CARD_CLICKED, {
-      clubName: performance.clubName,
+      clubName: performance.name,
       expanded: nextExpanded,
       active,
     });
@@ -33,47 +38,49 @@ const PerformanceCard = ({ performance, active }: PerformanceCardProps) => {
   return (
     <Styled.Card
       $active={active}
-      onClick={hasSongs ? toggleExpanded : undefined}
+      onClick={!hideSongs && hasSongs ? toggleExpanded : undefined}
     >
-      <Styled.ClubName $active={active}>{performance.clubName}</Styled.ClubName>
+      <Styled.ClubName $active={active}>{performance.name}</Styled.ClubName>
 
-      <Styled.SongArea $active={active}>
-        <div style={{ flex: 1, overflow: 'hidden' }}>
-          <Styled.SongItem $collapsed={!expanded}>
-            {hasSongs ? performance.songs[0] : '🎵 추후 공개 예정'}
-          </Styled.SongItem>
-          {hasSongs && performance.songs.length > 1 && (
-            <motion.div
-              initial={false}
-              animate={{ height: expanded ? 'auto' : 0 }}
-              transition={{ duration: 0.2, ease: 'easeInOut' }}
-              style={{ overflow: 'hidden' }}
-            >
-              <Styled.SongList>
-                {performance.songs.slice(1).map((song) => (
-                  <Styled.SongItem key={song}>{song}</Styled.SongItem>
-                ))}
-              </Styled.SongList>
-            </motion.div>
+      {!hideSongs && (
+        <Styled.SongArea $active={active}>
+          <div style={{ flex: 1, overflow: 'hidden' }}>
+            <Styled.SongItem $collapsed={!expanded}>
+              {hasSongs ? performance.songs[0] : '🎵 추후 공개 예정'}
+            </Styled.SongItem>
+            {hasSongs && performance.songs.length > 1 && (
+              <motion.div
+                initial={false}
+                animate={{ height: expanded ? 'auto' : 0 }}
+                transition={{ duration: 0.2, ease: 'easeInOut' }}
+                style={{ overflow: 'hidden' }}
+              >
+                <Styled.SongList>
+                  {performance.songs.slice(1).map((song) => (
+                    <Styled.SongItem key={song}>{song}</Styled.SongItem>
+                  ))}
+                </Styled.SongList>
+              </motion.div>
+            )}
+          </div>
+
+          {hasSongs && (
+            <Styled.ChevronWrapper>
+              <Styled.ChevronIcon
+                $expanded={expanded}
+                $active={active}
+                viewBox='0 0 10 5'
+                fill='none'
+                strokeWidth={2}
+                strokeLinecap='round'
+                strokeLinejoin='round'
+              >
+                <path d='M1 1L5 4.5L9 1' />
+              </Styled.ChevronIcon>
+            </Styled.ChevronWrapper>
           )}
-        </div>
-
-        {hasSongs && (
-          <Styled.ChevronWrapper>
-            <Styled.ChevronIcon
-              $expanded={expanded}
-              $active={active}
-              viewBox='0 0 10 5'
-              fill='none'
-              strokeWidth={2}
-              strokeLinecap='round'
-              strokeLinejoin='round'
-            >
-              <path d='M1 1L5 4.5L9 1' />
-            </Styled.ChevronIcon>
-          </Styled.ChevronWrapper>
-        )}
-      </Styled.SongArea>
+        </Styled.SongArea>
+      )}
     </Styled.Card>
   );
 };

--- a/frontend/src/pages/FestivalPage/components/PerformanceList/PerformanceList.tsx
+++ b/frontend/src/pages/FestivalPage/components/PerformanceList/PerformanceList.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import styled from 'styled-components';
-import { performances } from '../../data/performances';
+import type { Performance } from '../../data/performances';
+import { performances as defaultPerformances } from '../../data/performances';
 import { useCurrentTime } from '../../hooks/useCurrentTime';
 import PerformanceCard from '../PerformanceCard/PerformanceCard';
 import TimelineRow from '../TimelineRow/TimelineRow';
@@ -31,13 +32,25 @@ const List = styled.div`
   gap: 8px;
 `;
 
-const PerformanceList = () => {
+interface PerformanceListProps {
+  performances?: Performance[];
+  festivalDate?: string; // 'YYYY-MM-DD', 생략 시 2026-03-05 기본값
+}
+
+const PerformanceList = ({
+  performances = defaultPerformances,
+  festivalDate = '2026-03-05',
+}: PerformanceListProps) => {
   const currentTime = useCurrentTime();
   const currentMinutes = toMinutes(currentTime);
   const activeRef = useRef<HTMLDivElement>(null);
+
   const now = new Date();
+  const [year, month, day] = festivalDate.split('-').map(Number);
   const isFestivalDate =
-    now.getFullYear() === 2026 && now.getMonth() === 2 && now.getDate() === 5;
+    now.getFullYear() === year &&
+    now.getMonth() === month - 1 &&
+    now.getDate() === day;
 
   useEffect(() => {
     if (activeRef.current) {

--- a/frontend/src/pages/FestivalPage/components/PerformanceList/PerformanceList.tsx
+++ b/frontend/src/pages/FestivalPage/components/PerformanceList/PerformanceList.tsx
@@ -35,11 +35,13 @@ const List = styled.div`
 interface PerformanceListProps {
   performances?: Performance[];
   festivalDate?: string; // 'YYYY-MM-DD', 생략 시 2026-03-05 기본값
+  hideSongs?: boolean;
 }
 
 const PerformanceList = ({
   performances = defaultPerformances,
   festivalDate = '2026-03-05',
+  hideSongs = false,
 }: PerformanceListProps) => {
   const currentTime = useCurrentTime();
   const currentMinutes = toMinutes(currentTime);
@@ -73,7 +75,11 @@ const PerformanceList = ({
         return (
           <div key={performance.id} ref={isActive ? activeRef : null}>
             <TimelineRow time={performance.startTime} status={status}>
-              <PerformanceCard performance={performance} active={isActive} />
+              <PerformanceCard
+                performance={performance}
+                active={isActive}
+                hideSongs={hideSongs}
+              />
             </TimelineRow>
           </div>
         );

--- a/frontend/src/pages/FestivalPage/components/TimelineRow/TimelineRow.stories.tsx
+++ b/frontend/src/pages/FestivalPage/components/TimelineRow/TimelineRow.stories.tsx
@@ -4,7 +4,7 @@ import TimelineRow from './TimelineRow';
 
 const pastPerformance = {
   id: 1,
-  clubName: '터',
+  name: '터',
   startTime: '12:30',
   endTime: '13:00',
   songs: ['차선농악 - 9명'],
@@ -12,7 +12,7 @@ const pastPerformance = {
 
 const activePerformance = {
   id: 2,
-  clubName: '매니아',
+  name: '매니아',
   startTime: '13:00',
   endTime: '13:30',
   songs: [
@@ -25,7 +25,7 @@ const activePerformance = {
 
 const upcomingPerformance = {
   id: 3,
-  clubName: '씨사운드',
+  name: '씨사운드',
   startTime: '13:30',
   endTime: '14:00',
   songs: [

--- a/frontend/src/pages/FestivalPage/components/TimelineRow/TimelineRow.stories.tsx
+++ b/frontend/src/pages/FestivalPage/components/TimelineRow/TimelineRow.stories.tsx
@@ -4,7 +4,7 @@ import TimelineRow from './TimelineRow';
 
 const pastPerformance = {
   id: 1,
-  name: '터',
+  clubName: '터',
   startTime: '12:30',
   endTime: '13:00',
   songs: ['차선농악 - 9명'],
@@ -12,7 +12,7 @@ const pastPerformance = {
 
 const activePerformance = {
   id: 2,
-  name: '매니아',
+  clubName: '매니아',
   startTime: '13:00',
   endTime: '13:30',
   songs: [
@@ -25,7 +25,7 @@ const activePerformance = {
 
 const upcomingPerformance = {
   id: 3,
-  name: '씨사운드',
+  clubName: '씨사운드',
   startTime: '13:30',
   endTime: '14:00',
   songs: [

--- a/frontend/src/pages/FestivalPage/data/buskingDays.ts
+++ b/frontend/src/pages/FestivalPage/data/buskingDays.ts
@@ -8,6 +8,7 @@ export interface FestivalDay {
   timeRange: string; // e.g. '12:30 - 18:00'
   location: string;
   performances: Performance[];
+  mainStagePerformances?: Performance[];
 }
 
 export const BUSKING_DAYS: FestivalDay[] = [
@@ -16,9 +17,18 @@ export const BUSKING_DAYS: FestivalDay[] = [
     date: '2026-05-11',
     label: 'Day1',
     fullDateLabel: '2026.05.11 (월)',
-    timeRange: '12:30 - 18:00',
-    location: '',
+    timeRange: '19:30 ~ 20:30',
+    location: '잔디광장 무대',
     performances: [],
+    mainStagePerformances: [
+      {
+        id: 101,
+        name: 'YB',
+        startTime: '',
+        endTime: '',
+        songs: [],
+      },
+    ],
   },
   {
     id: 'day2',
@@ -30,21 +40,21 @@ export const BUSKING_DAYS: FestivalDay[] = [
     performances: [
       {
         id: 1,
-        clubName: '국제교류부 공연',
+        name: '국제교류부 공연',
         startTime: '14:30',
         endTime: '16:00',
         songs: [],
       },
       {
         id: 2,
-        clubName: '전통예술연구회 터',
+        name: '전통예술연구회 터',
         startTime: '16:00',
         endTime: '16:25',
         songs: ['청도 차산농악', '웃다리 사물놀이'],
       },
       {
         id: 3,
-        clubName: '송웨이브',
+        name: '송웨이브',
         startTime: '16:25',
         endTime: '16:55',
         songs: [
@@ -57,14 +67,14 @@ export const BUSKING_DAYS: FestivalDay[] = [
       },
       {
         id: 4,
-        clubName: '테크니칼',
+        name: '테크니칼',
         startTime: '16:55',
         endTime: '17:20',
         songs: ['군청일화', '작은 사랑의 노래', 'Holiday', '비냄새'],
       },
       {
         id: 5,
-        clubName: '씨사운드',
+        name: '씨사운드',
         startTime: '17:20',
         endTime: '17:50',
         songs: [
@@ -77,13 +87,29 @@ export const BUSKING_DAYS: FestivalDay[] = [
       },
       {
         id: 6,
-        clubName: '백경이의 스케치북 with 한누리',
+        name: '백경이의 스케치북 with 한누리',
         startTime: '18:00',
         endTime: '19:30',
         songs: [
           '군 입대 앞에서 갈린 이별과 약속',
           '짝사랑, 실패와 현재의 두 감정',
         ],
+      },
+    ],
+    mainStagePerformances: [
+      {
+        id: 101,
+        name: '최예나',
+        startTime: '19:40',
+        endTime: '',
+        songs: [],
+      },
+      {
+        id: 102,
+        name: '이창섭',
+        startTime: '',
+        endTime: '',
+        songs: [],
       },
     ],
   },
@@ -97,14 +123,14 @@ export const BUSKING_DAYS: FestivalDay[] = [
     performances: [
       {
         id: 1,
-        clubName: '올림',
+        name: '올림',
         startTime: '15:30',
         endTime: '15:55',
         songs: ["Can't Stop", '해초', 'Loveholic', 'Love Song'],
       },
       {
         id: 2,
-        clubName: 'PKNUO',
+        name: 'PKNUO',
         startTime: '15:55',
         endTime: '16:25',
         songs: [
@@ -118,7 +144,7 @@ export const BUSKING_DAYS: FestivalDay[] = [
       },
       {
         id: 3,
-        clubName: '한누리',
+        name: '한누리',
         startTime: '16:25',
         endTime: '16:55',
         songs: [
@@ -131,7 +157,7 @@ export const BUSKING_DAYS: FestivalDay[] = [
       },
       {
         id: 4,
-        clubName: '모비딕스',
+        name: '모비딕스',
         startTime: '16:55',
         endTime: '17:20',
         songs: [
@@ -145,7 +171,7 @@ export const BUSKING_DAYS: FestivalDay[] = [
       },
       {
         id: 5,
-        clubName: 'UCDC',
+        name: 'UCDC',
         startTime: '17:30',
         endTime: '18:00',
         songs: [
@@ -163,7 +189,7 @@ export const BUSKING_DAYS: FestivalDay[] = [
       },
       {
         id: 6,
-        clubName: '부경가왕',
+        name: '부경가왕',
         startTime: '18:00',
         endTime: '19:30',
         songs: [
@@ -172,6 +198,22 @@ export const BUSKING_DAYS: FestivalDay[] = [
           '짱구는 5학년 "끝사랑" vs 트롯 가왕 "안동역에서"',
           '지금부터가 반전 "Beautiful things" vs 햇님이 "요즘 바쁜가봐"',
         ],
+      },
+    ],
+    mainStagePerformances: [
+      {
+        id: 101,
+        name: 'FIFTY FIFTY',
+        startTime: '20:00',
+        endTime: '',
+        songs: [],
+      },
+      {
+        id: 102,
+        name: '비와이',
+        startTime: '',
+        endTime: '',
+        songs: [],
       },
     ],
   },
@@ -185,14 +227,14 @@ export const BUSKING_DAYS: FestivalDay[] = [
     performances: [
       {
         id: 1,
-        clubName: '매니아',
+        name: '매니아',
         startTime: '16:05',
         endTime: '16:30',
         songs: ['질주', '사포닌 같은 너', 'Time is Running Out', '멋진 헛간'],
       },
       {
         id: 2,
-        clubName: '보블리스',
+        name: '보블리스',
         startTime: '16:30',
         endTime: '16:50',
         songs: [
@@ -204,14 +246,14 @@ export const BUSKING_DAYS: FestivalDay[] = [
       },
       {
         id: 3,
-        clubName: '쇳물결',
+        name: '쇳물결',
         startTime: '16:50',
         endTime: '17:20',
         songs: ['GET LUCKY!', '좋은날', '맨정신', '삐딱하게', 'What’s up'],
       },
       {
         id: 4,
-        clubName: '네오쇼크',
+        name: '네오쇼크',
         startTime: '17:20',
         endTime: '18:00',
         songs: [
@@ -229,7 +271,7 @@ export const BUSKING_DAYS: FestivalDay[] = [
       },
       {
         id: 5,
-        clubName: '부경듀엣',
+        name: '부경듀엣',
         startTime: '18:00',
         endTime: '19:30',
         songs: [
@@ -240,6 +282,22 @@ export const BUSKING_DAYS: FestivalDay[] = [
           '홍루비비디바비디부 - Die With A Smile',
           '강태동그는감히전설이라고할수있다 - 집에가지마',
         ],
+      },
+    ],
+    mainStagePerformances: [
+      {
+        id: 101,
+        name: 'V.O.S',
+        startTime: '19:40',
+        endTime: '',
+        songs: [],
+      },
+      {
+        id: 102,
+        name: '청하',
+        startTime: '',
+        endTime: '',
+        songs: [],
       },
     ],
   },

--- a/frontend/src/pages/FestivalPage/data/buskingDays.ts
+++ b/frontend/src/pages/FestivalPage/data/buskingDays.ts
@@ -23,7 +23,7 @@ export const BUSKING_DAYS: FestivalDay[] = [
     mainStagePerformances: [
       {
         id: 101,
-        name: 'YB',
+        clubName: 'YB',
         startTime: '19:30',
         endTime: '',
         songs: [],
@@ -40,21 +40,21 @@ export const BUSKING_DAYS: FestivalDay[] = [
     performances: [
       {
         id: 1,
-        name: '국제교류부 공연',
+        clubName: '국제교류부 공연',
         startTime: '14:30',
         endTime: '16:00',
         songs: [],
       },
       {
         id: 2,
-        name: '전통예술연구회 터',
+        clubName: '전통예술연구회 터',
         startTime: '16:00',
         endTime: '16:25',
         songs: ['청도 차산농악', '웃다리 사물놀이'],
       },
       {
         id: 3,
-        name: '송웨이브',
+        clubName: '송웨이브',
         startTime: '16:25',
         endTime: '16:55',
         songs: [
@@ -67,14 +67,14 @@ export const BUSKING_DAYS: FestivalDay[] = [
       },
       {
         id: 4,
-        name: '테크니칼',
+        clubName: '테크니칼',
         startTime: '16:55',
         endTime: '17:20',
         songs: ['군청일화', '작은 사랑의 노래', 'Holiday', '비냄새'],
       },
       {
         id: 5,
-        name: '씨사운드',
+        clubName: '씨사운드',
         startTime: '17:20',
         endTime: '17:50',
         songs: [
@@ -87,7 +87,7 @@ export const BUSKING_DAYS: FestivalDay[] = [
       },
       {
         id: 6,
-        name: '백경이의 스케치북 with 한누리',
+        clubName: '백경이의 스케치북 with 한누리',
         startTime: '18:00',
         endTime: '19:30',
         songs: [
@@ -99,14 +99,14 @@ export const BUSKING_DAYS: FestivalDay[] = [
     mainStagePerformances: [
       {
         id: 101,
-        name: '최예나',
+        clubName: '최예나',
         startTime: '19:40',
         endTime: '',
         songs: [],
       },
       {
         id: 102,
-        name: '이창섭',
+        clubName: '이창섭',
         startTime: '',
         endTime: '',
         songs: [],
@@ -123,14 +123,14 @@ export const BUSKING_DAYS: FestivalDay[] = [
     performances: [
       {
         id: 1,
-        name: '올림',
+        clubName: '올림',
         startTime: '15:30',
         endTime: '15:55',
         songs: ["Can't Stop", '해초', 'Loveholic', 'Love Song'],
       },
       {
         id: 2,
-        name: 'PKNUO',
+        clubName: 'PKNUO',
         startTime: '15:55',
         endTime: '16:25',
         songs: [
@@ -144,7 +144,7 @@ export const BUSKING_DAYS: FestivalDay[] = [
       },
       {
         id: 3,
-        name: '한누리',
+        clubName: '한누리',
         startTime: '16:25',
         endTime: '16:55',
         songs: [
@@ -157,7 +157,7 @@ export const BUSKING_DAYS: FestivalDay[] = [
       },
       {
         id: 4,
-        name: '모비딕스',
+        clubName: '모비딕스',
         startTime: '16:55',
         endTime: '17:20',
         songs: [
@@ -171,7 +171,7 @@ export const BUSKING_DAYS: FestivalDay[] = [
       },
       {
         id: 5,
-        name: 'UCDC',
+        clubName: 'UCDC',
         startTime: '17:30',
         endTime: '18:00',
         songs: [
@@ -189,7 +189,7 @@ export const BUSKING_DAYS: FestivalDay[] = [
       },
       {
         id: 6,
-        name: '부경가왕',
+        clubName: '부경가왕',
         startTime: '18:00',
         endTime: '19:30',
         songs: [
@@ -203,14 +203,14 @@ export const BUSKING_DAYS: FestivalDay[] = [
     mainStagePerformances: [
       {
         id: 101,
-        name: 'FIFTY FIFTY',
+        clubName: 'FIFTY FIFTY',
         startTime: '20:00',
         endTime: '',
         songs: [],
       },
       {
         id: 102,
-        name: '비와이',
+        clubName: '비와이',
         startTime: '',
         endTime: '',
         songs: [],
@@ -227,14 +227,14 @@ export const BUSKING_DAYS: FestivalDay[] = [
     performances: [
       {
         id: 1,
-        name: '매니아',
+        clubName: '매니아',
         startTime: '16:05',
         endTime: '16:30',
         songs: ['질주', '사포닌 같은 너', 'Time is Running Out', '멋진 헛간'],
       },
       {
         id: 2,
-        name: '보블리스',
+        clubName: '보블리스',
         startTime: '16:30',
         endTime: '16:50',
         songs: [
@@ -246,14 +246,14 @@ export const BUSKING_DAYS: FestivalDay[] = [
       },
       {
         id: 3,
-        name: '쇳물결',
+        clubName: '쇳물결',
         startTime: '16:50',
         endTime: '17:20',
         songs: ['GET LUCKY!', '좋은날', '맨정신', '삐딱하게', 'What’s up'],
       },
       {
         id: 4,
-        name: '네오쇼크',
+        clubName: '네오쇼크',
         startTime: '17:20',
         endTime: '18:00',
         songs: [
@@ -271,7 +271,7 @@ export const BUSKING_DAYS: FestivalDay[] = [
       },
       {
         id: 5,
-        name: '부경듀엣',
+        clubName: '부경듀엣',
         startTime: '18:00',
         endTime: '19:30',
         songs: [
@@ -287,14 +287,14 @@ export const BUSKING_DAYS: FestivalDay[] = [
     mainStagePerformances: [
       {
         id: 101,
-        name: 'V.O.S',
+        clubName: 'V.O.S',
         startTime: '19:40',
         endTime: '',
         songs: [],
       },
       {
         id: 102,
-        name: '청하',
+        clubName: '청하',
         startTime: '',
         endTime: '',
         songs: [],

--- a/frontend/src/pages/FestivalPage/data/buskingDays.ts
+++ b/frontend/src/pages/FestivalPage/data/buskingDays.ts
@@ -24,7 +24,7 @@ export const BUSKING_DAYS: FestivalDay[] = [
       {
         id: 101,
         name: 'YB',
-        startTime: '',
+        startTime: '19:30',
         endTime: '',
         songs: [],
       },

--- a/frontend/src/pages/FestivalPage/data/buskingDays.ts
+++ b/frontend/src/pages/FestivalPage/data/buskingDays.ts
@@ -1,0 +1,246 @@
+import type { Performance } from './performances';
+
+export interface FestivalDay {
+  id: string;
+  date: string; // 'YYYY-MM-DD'
+  label: string; // 탭 레이블 e.g. '5/14'
+  fullDateLabel: string; // 헤더 날짜 e.g. '2026.05.14 (목)'
+  timeRange: string; // e.g. '12:30 - 18:00'
+  location: string;
+  performances: Performance[];
+}
+
+export const BUSKING_DAYS: FestivalDay[] = [
+  {
+    id: 'day1',
+    date: '2026-05-11',
+    label: 'Day1',
+    fullDateLabel: '2026.05.11 (월)',
+    timeRange: '12:30 - 18:00',
+    location: '',
+    performances: [],
+  },
+  {
+    id: 'day2',
+    date: '2026-05-12',
+    label: 'Day2',
+    fullDateLabel: '2026.05.12 (화)',
+    timeRange: '14:30 - 19:30',
+    location: '잔디광장 무대',
+    performances: [
+      {
+        id: 1,
+        clubName: '국제교류부 공연',
+        startTime: '14:30',
+        endTime: '16:00',
+        songs: [],
+      },
+      {
+        id: 2,
+        clubName: '전통예술연구회 터',
+        startTime: '16:00',
+        endTime: '16:25',
+        songs: ['청도 차산농악', '웃다리 사물놀이'],
+      },
+      {
+        id: 3,
+        clubName: '송웨이브',
+        startTime: '16:25',
+        endTime: '16:55',
+        songs: [
+          '대화가필요해',
+          '오늘부터1일',
+          '행복한 나를',
+          '오늘도 빛나는 너에게',
+          'Congratulations',
+        ],
+      },
+      {
+        id: 4,
+        clubName: '테크니칼',
+        startTime: '16:55',
+        endTime: '17:20',
+        songs: ['군청일화', '작은 사랑의 노래', 'Holiday', '비냄새'],
+      },
+      {
+        id: 5,
+        clubName: '씨사운드',
+        startTime: '17:20',
+        endTime: '17:50',
+        songs: [
+          '사랑이죄야?',
+          'All For You',
+          '밥만 잘 먹더라',
+          "Don't Look Back In Anger",
+          '예뻤어',
+        ],
+      },
+      {
+        id: 6,
+        clubName: '백경이의 스케치북 with 한누리',
+        startTime: '18:00',
+        endTime: '19:30',
+        songs: [
+          '군 입대 앞에서 갈린 이별과 약속',
+          '짝사랑, 실패와 현재의 두 감정',
+        ],
+      },
+    ],
+  },
+  {
+    id: 'day3',
+    date: '2026-05-13',
+    label: 'Day3',
+    fullDateLabel: '2026.05.13 (수)',
+    timeRange: '15:30 - 19:30',
+    location: '잔디광장 무대',
+    performances: [
+      {
+        id: 1,
+        clubName: '올림',
+        startTime: '15:30',
+        endTime: '15:55',
+        songs: ["Can't Stop", '해초', 'Loveholic', 'Love Song'],
+      },
+      {
+        id: 2,
+        clubName: 'PKNUO',
+        startTime: '15:55',
+        endTime: '16:25',
+        songs: [
+          'When you wish upon a star',
+          '인생의 회전목마',
+          '봄바람',
+          '꿈빛 파티시엘',
+          '5월의 마을',
+          '붉은노을',
+        ],
+      },
+      {
+        id: 3,
+        clubName: '한누리',
+        startTime: '16:25',
+        endTime: '16:55',
+        songs: [
+          '초록',
+          '아직도 사랑하면 안 되는 건가요',
+          'Stay with me',
+          '우주의 여름',
+          'Alive',
+        ],
+      },
+      {
+        id: 4,
+        clubName: '모비딕스',
+        startTime: '16:55',
+        endTime: '17:20',
+        songs: [
+          '20s',
+          'Stand Up!',
+          'SEASON IN THE SUN',
+          '군청일화',
+          '게임 오버 ?',
+          '보수공사',
+        ],
+      },
+      {
+        id: 5,
+        clubName: 'UCDC',
+        startTime: '17:30',
+        endTime: '18:00',
+        songs: [
+          'Hip-Hop',
+          'body',
+          '다시만난오늘',
+          'LIKE YOU BETTER',
+          'Breaking',
+          'Locking',
+          '404',
+          'Waacking',
+          'I NEED YOU',
+          'All Genre',
+        ],
+      },
+      {
+        id: 6,
+        clubName: '부경가왕',
+        startTime: '18:00',
+        endTime: '19:30',
+        songs: [
+          '금곡동 황소개구리 "중독된 사랑" vs 내 꿈은 3대 500 "가수가 된 이유"',
+          '고막청소기 "꿈에" vs 설계실 탈출 "Rolling in the deep"',
+          '짱구는 5학년 "끝사랑" vs 트롯 가왕 "안동역에서"',
+          '지금부터가 반전 "Beautiful things" vs 햇님이 "요즘 바쁜가봐"',
+        ],
+      },
+    ],
+  },
+  {
+    id: 'day4',
+    date: '2026-05-14',
+    label: 'Day4',
+    fullDateLabel: '2026.05.14 (목)',
+    timeRange: '16:05 - 19:30',
+    location: '잔디광장 무대',
+    performances: [
+      {
+        id: 1,
+        clubName: '매니아',
+        startTime: '16:05',
+        endTime: '16:30',
+        songs: ['질주', '사포닌 같은 너', 'Time is Running Out', '멋진 헛간'],
+      },
+      {
+        id: 2,
+        clubName: '보블리스',
+        startTime: '16:30',
+        endTime: '16:50',
+        songs: [
+          'Another Day of Sun',
+          '하늘을 달리다',
+          '서울살이 몇핸가요',
+          'Can’t help falling in love',
+        ],
+      },
+      {
+        id: 3,
+        clubName: '쇳물결',
+        startTime: '16:50',
+        endTime: '17:20',
+        songs: ['GET LUCKY!', '좋은날', '맨정신', '삐딱하게', 'What’s up'],
+      },
+      {
+        id: 4,
+        clubName: '네오쇼크',
+        startTime: '17:20',
+        endTime: '18:00',
+        songs: [
+          'drip',
+          'play',
+          '캐치캐치',
+          'BLACKHOLE',
+          'ETA',
+          'TAP+ Smoothie',
+          'GGUM',
+          'Standing next to you',
+          '소원을 말해봐',
+          "that's a no no",
+        ],
+      },
+      {
+        id: 5,
+        clubName: '부경듀엣',
+        startTime: '18:00',
+        endTime: '19:30',
+        songs: [
+          '장도연과 박나래 - 기다리다',
+          '음주 - 술이문제야',
+          '순자씨 - 날봐,귀순',
+          '피어나 내 도도독 - 라라라',
+          '홍루비비디바비디부 - Die With A Smile',
+          '강태동그는감히전설이라고할수있다 - 집에가지마',
+        ],
+      },
+    ],
+  },
+];

--- a/frontend/src/pages/FestivalPage/data/performances.ts
+++ b/frontend/src/pages/FestivalPage/data/performances.ts
@@ -1,6 +1,6 @@
 export interface Performance {
   id: number;
-  name: string;
+  clubName: string;
   startTime: string; // "HH:mm"
   endTime: string; // "HH:mm"
   songs: string[];
@@ -9,16 +9,16 @@ export interface Performance {
 export const performances: Performance[] = [
   {
     id: 1,
-    name: '터',
-    startTime: '12:30',
-    endTime: '13:00',
+    clubName: '터',
+    startTime: '13:00',
+    endTime: '13:30',
     songs: ['차선농악'],
   },
   {
     id: 2,
-    name: '매니아',
-    startTime: '13:00',
-    endTime: '13:30',
+    clubName: '매니아',
+    startTime: '13:30',
+    endTime: '14:00',
     songs: [
       'Blur - Song 2',
       'OASIS - Supersonic',
@@ -28,9 +28,9 @@ export const performances: Performance[] = [
   },
   {
     id: 3,
-    name: '씨사운드',
-    startTime: '13:30',
-    endTime: '14:00',
+    clubName: '씨사운드',
+    startTime: '14:00',
+    endTime: '14:30',
     songs: [
       'Best part (feat. H.E.R) - Daniel Caesar, H.E.R.',
       '좋은 밤 좋은 꿈 - 너드커넥션',
@@ -40,9 +40,9 @@ export const performances: Performance[] = [
   },
   {
     id: 4,
-    name: '송웨이브',
-    startTime: '14:00',
-    endTime: '14:30',
+    clubName: '송웨이브',
+    startTime: '14:30',
+    endTime: '15:00',
     songs: [
       'Like my father - Jax',
       '오르트구름 - 윤하',
@@ -52,9 +52,9 @@ export const performances: Performance[] = [
   },
   {
     id: 5,
-    name: '쇳물결',
-    startTime: '14:30',
-    endTime: '15:00',
+    clubName: '쇳물결',
+    startTime: '15:00',
+    endTime: '15:30',
     songs: [
       "isn't she lovely",
       '사랑비 (어쿠)',
@@ -65,9 +65,9 @@ export const performances: Performance[] = [
   },
   {
     id: 6,
-    name: '테크니칼',
-    startTime: '15:00',
-    endTime: '15:30',
+    clubName: '테크니칼',
+    startTime: '15:30',
+    endTime: '16:00',
     songs: [
       '나는 나비 - yb',
       'Material Girl - the volunteers',
@@ -77,9 +77,9 @@ export const performances: Performance[] = [
   },
   {
     id: 7,
-    name: '모비딕스',
-    startTime: '15:30',
-    endTime: '16:00',
+    clubName: '모비딕스',
+    startTime: '16:00',
+    endTime: '16:30',
     songs: [
       '공중정원 - 보아',
       '러브홀릭 - 러브홀릭',
@@ -89,9 +89,9 @@ export const performances: Performance[] = [
   },
   {
     id: 8,
-    name: '한누리',
-    startTime: '16:00',
-    endTime: '16:30',
+    clubName: '한누리',
+    startTime: '16:30',
+    endTime: '17:00',
     songs: [
       '청춘 - Tokai',
       'Rules - 더 발룬티어스',
@@ -101,9 +101,9 @@ export const performances: Performance[] = [
   },
   {
     id: 9,
-    name: '네오쇼크',
-    startTime: '16:30',
-    endTime: '17:00',
+    clubName: '네오쇼크',
+    startTime: '17:00',
+    endTime: '17:30',
     songs: [
       '샤랄라 - 세이마이네임',
       '404 (New Era) - 키키',
@@ -118,9 +118,9 @@ export const performances: Performance[] = [
   },
   {
     id: 10,
-    name: 'UCDC',
-    startTime: '17:00',
-    endTime: '17:30',
+    clubName: 'UCDC',
+    startTime: '17:30',
+    endTime: '18:00',
     songs: [
       'Locking',
       '르세라핌 - SPAGHETTI',
@@ -138,9 +138,9 @@ export const performances: Performance[] = [
   },
   {
     id: 11,
-    name: '보블리스',
-    startTime: '17:30',
-    endTime: '18:00',
+    clubName: '보블리스',
+    startTime: '18:00',
+    endTime: '18:30',
     songs: [
       '우리는 로렐라이 언덕의 여인들',
       'Seasons of love',

--- a/frontend/src/pages/FestivalPage/data/performances.ts
+++ b/frontend/src/pages/FestivalPage/data/performances.ts
@@ -1,6 +1,6 @@
 export interface Performance {
   id: number;
-  clubName: string;
+  name: string;
   startTime: string; // "HH:mm"
   endTime: string; // "HH:mm"
   songs: string[];
@@ -9,14 +9,14 @@ export interface Performance {
 export const performances: Performance[] = [
   {
     id: 1,
-    clubName: '터',
+    name: '터',
     startTime: '12:30',
     endTime: '13:00',
     songs: ['차선농악'],
   },
   {
     id: 2,
-    clubName: '매니아',
+    name: '매니아',
     startTime: '13:00',
     endTime: '13:30',
     songs: [
@@ -28,7 +28,7 @@ export const performances: Performance[] = [
   },
   {
     id: 3,
-    clubName: '씨사운드',
+    name: '씨사운드',
     startTime: '13:30',
     endTime: '14:00',
     songs: [
@@ -40,7 +40,7 @@ export const performances: Performance[] = [
   },
   {
     id: 4,
-    clubName: '송웨이브',
+    name: '송웨이브',
     startTime: '14:00',
     endTime: '14:30',
     songs: [
@@ -52,7 +52,7 @@ export const performances: Performance[] = [
   },
   {
     id: 5,
-    clubName: '쇳물결',
+    name: '쇳물결',
     startTime: '14:30',
     endTime: '15:00',
     songs: [
@@ -65,7 +65,7 @@ export const performances: Performance[] = [
   },
   {
     id: 6,
-    clubName: '테크니칼',
+    name: '테크니칼',
     startTime: '15:00',
     endTime: '15:30',
     songs: [
@@ -77,7 +77,7 @@ export const performances: Performance[] = [
   },
   {
     id: 7,
-    clubName: '모비딕스',
+    name: '모비딕스',
     startTime: '15:30',
     endTime: '16:00',
     songs: [
@@ -89,7 +89,7 @@ export const performances: Performance[] = [
   },
   {
     id: 8,
-    clubName: '한누리',
+    name: '한누리',
     startTime: '16:00',
     endTime: '16:30',
     songs: [
@@ -101,7 +101,7 @@ export const performances: Performance[] = [
   },
   {
     id: 9,
-    clubName: '네오쇼크',
+    name: '네오쇼크',
     startTime: '16:30',
     endTime: '17:00',
     songs: [
@@ -118,7 +118,7 @@ export const performances: Performance[] = [
   },
   {
     id: 10,
-    clubName: 'UCDC',
+    name: 'UCDC',
     startTime: '17:00',
     endTime: '17:30',
     songs: [
@@ -138,7 +138,7 @@ export const performances: Performance[] = [
   },
   {
     id: 11,
-    clubName: '보블리스',
+    name: '보블리스',
     startTime: '17:30',
     endTime: '18:00',
     songs: [

--- a/frontend/src/pages/FestivalPage/data/performances.ts
+++ b/frontend/src/pages/FestivalPage/data/performances.ts
@@ -1,6 +1,6 @@
 export interface Performance {
   id: number;
-  clubName: string;
+  name: string;
   startTime: string; // "HH:mm"
   endTime: string; // "HH:mm"
   songs: string[];
@@ -9,14 +9,14 @@ export interface Performance {
 export const performances: Performance[] = [
   {
     id: 1,
-    clubName: '터',
+    name: '터',
     startTime: '13:00',
     endTime: '13:30',
     songs: ['차선농악'],
   },
   {
     id: 2,
-    clubName: '매니아',
+    name: '매니아',
     startTime: '13:30',
     endTime: '14:00',
     songs: [
@@ -28,7 +28,7 @@ export const performances: Performance[] = [
   },
   {
     id: 3,
-    clubName: '씨사운드',
+    name: '씨사운드',
     startTime: '14:00',
     endTime: '14:30',
     songs: [
@@ -40,7 +40,7 @@ export const performances: Performance[] = [
   },
   {
     id: 4,
-    clubName: '송웨이브',
+    name: '송웨이브',
     startTime: '14:30',
     endTime: '15:00',
     songs: [
@@ -52,7 +52,7 @@ export const performances: Performance[] = [
   },
   {
     id: 5,
-    clubName: '쇳물결',
+    name: '쇳물결',
     startTime: '15:00',
     endTime: '15:30',
     songs: [
@@ -65,7 +65,7 @@ export const performances: Performance[] = [
   },
   {
     id: 6,
-    clubName: '테크니칼',
+    name: '테크니칼',
     startTime: '15:30',
     endTime: '16:00',
     songs: [
@@ -77,7 +77,7 @@ export const performances: Performance[] = [
   },
   {
     id: 7,
-    clubName: '모비딕스',
+    name: '모비딕스',
     startTime: '16:00',
     endTime: '16:30',
     songs: [
@@ -89,7 +89,7 @@ export const performances: Performance[] = [
   },
   {
     id: 8,
-    clubName: '한누리',
+    name: '한누리',
     startTime: '16:30',
     endTime: '17:00',
     songs: [
@@ -101,7 +101,7 @@ export const performances: Performance[] = [
   },
   {
     id: 9,
-    clubName: '네오쇼크',
+    name: '네오쇼크',
     startTime: '17:00',
     endTime: '17:30',
     songs: [
@@ -118,7 +118,7 @@ export const performances: Performance[] = [
   },
   {
     id: 10,
-    clubName: 'UCDC',
+    name: 'UCDC',
     startTime: '17:30',
     endTime: '18:00',
     songs: [
@@ -138,7 +138,7 @@ export const performances: Performance[] = [
   },
   {
     id: 11,
-    clubName: '보블리스',
+    name: '보블리스',
     startTime: '18:00',
     endTime: '18:30',
     songs: [

--- a/frontend/src/pages/FestivalPage/data/performances.ts
+++ b/frontend/src/pages/FestivalPage/data/performances.ts
@@ -1,6 +1,6 @@
 export interface Performance {
   id: number;
-  name: string;
+  clubName: string;
   startTime: string; // "HH:mm"
   endTime: string; // "HH:mm"
   songs: string[];
@@ -9,14 +9,14 @@ export interface Performance {
 export const performances: Performance[] = [
   {
     id: 1,
-    name: '터',
+    clubName: '터',
     startTime: '13:00',
     endTime: '13:30',
     songs: ['차선농악'],
   },
   {
     id: 2,
-    name: '매니아',
+    clubName: '매니아',
     startTime: '13:30',
     endTime: '14:00',
     songs: [
@@ -28,7 +28,7 @@ export const performances: Performance[] = [
   },
   {
     id: 3,
-    name: '씨사운드',
+    clubName: '씨사운드',
     startTime: '14:00',
     endTime: '14:30',
     songs: [
@@ -40,7 +40,7 @@ export const performances: Performance[] = [
   },
   {
     id: 4,
-    name: '송웨이브',
+    clubName: '송웨이브',
     startTime: '14:30',
     endTime: '15:00',
     songs: [
@@ -52,7 +52,7 @@ export const performances: Performance[] = [
   },
   {
     id: 5,
-    name: '쇳물결',
+    clubName: '쇳물결',
     startTime: '15:00',
     endTime: '15:30',
     songs: [
@@ -65,7 +65,7 @@ export const performances: Performance[] = [
   },
   {
     id: 6,
-    name: '테크니칼',
+    clubName: '테크니칼',
     startTime: '15:30',
     endTime: '16:00',
     songs: [
@@ -77,7 +77,7 @@ export const performances: Performance[] = [
   },
   {
     id: 7,
-    name: '모비딕스',
+    clubName: '모비딕스',
     startTime: '16:00',
     endTime: '16:30',
     songs: [
@@ -89,7 +89,7 @@ export const performances: Performance[] = [
   },
   {
     id: 8,
-    name: '한누리',
+    clubName: '한누리',
     startTime: '16:30',
     endTime: '17:00',
     songs: [
@@ -101,7 +101,7 @@ export const performances: Performance[] = [
   },
   {
     id: 9,
-    name: '네오쇼크',
+    clubName: '네오쇼크',
     startTime: '17:00',
     endTime: '17:30',
     songs: [
@@ -118,7 +118,7 @@ export const performances: Performance[] = [
   },
   {
     id: 10,
-    name: 'UCDC',
+    clubName: 'UCDC',
     startTime: '17:30',
     endTime: '18:00',
     songs: [
@@ -138,7 +138,7 @@ export const performances: Performance[] = [
   },
   {
     id: 11,
-    name: '보블리스',
+    clubName: '보블리스',
     startTime: '18:00',
     endTime: '18:30',
     songs: [

--- a/frontend/src/pages/MainPage/MainPage.tsx
+++ b/frontend/src/pages/MainPage/MainPage.tsx
@@ -52,6 +52,7 @@ const MainPage = () => {
   return (
     <>
       <Popup configs={[DAEDONG_POPUP]} />
+      {/* <Popup configs={[APP_DOWNLOAD_POPUP]} /> */}
       <Header />
       <Filter hasNotification={hasNotification} />
       <Banner />

--- a/frontend/src/pages/MainPage/MainPage.tsx
+++ b/frontend/src/pages/MainPage/MainPage.tsx
@@ -11,7 +11,7 @@ import Banner from '@/pages/MainPage/components/Banner/Banner';
 import CategoryButtonList from '@/pages/MainPage/components/CategoryButtonList/CategoryButtonList';
 import ClubCard from '@/pages/MainPage/components/ClubCard/ClubCard';
 import Popup from '@/pages/MainPage/components/Popup/Popup';
-import { APP_DOWNLOAD_POPUP } from '@/pages/MainPage/components/Popup/popupConfigs';
+import { DAEDONG_POPUP } from '@/pages/MainPage/components/Popup/popupConfigs';
 import { useSelectedCategory } from '@/store/useCategoryStore';
 import { useSearchIsSearching, useSearchKeyword } from '@/store/useSearchStore';
 import { Club } from '@/types/club';
@@ -51,7 +51,7 @@ const MainPage = () => {
 
   return (
     <>
-      <Popup configs={[APP_DOWNLOAD_POPUP]} />
+      <Popup configs={[DAEDONG_POPUP]} />
       <Header />
       <Filter hasNotification={hasNotification} />
       <Banner />

--- a/frontend/src/pages/MainPage/MainPage.tsx
+++ b/frontend/src/pages/MainPage/MainPage.tsx
@@ -11,6 +11,7 @@ import Banner from '@/pages/MainPage/components/Banner/Banner';
 import CategoryButtonList from '@/pages/MainPage/components/CategoryButtonList/CategoryButtonList';
 import ClubCard from '@/pages/MainPage/components/ClubCard/ClubCard';
 import Popup from '@/pages/MainPage/components/Popup/Popup';
+import { APP_DOWNLOAD_POPUP } from '@/pages/MainPage/components/Popup/popupConfigs';
 import { useSelectedCategory } from '@/store/useCategoryStore';
 import { useSearchIsSearching, useSearchKeyword } from '@/store/useSearchStore';
 import { Club } from '@/types/club';
@@ -50,7 +51,7 @@ const MainPage = () => {
 
   return (
     <>
-      <Popup />
+      <Popup configs={[APP_DOWNLOAD_POPUP]} />
       <Header />
       <Filter hasNotification={hasNotification} />
       <Banner />

--- a/frontend/src/pages/MainPage/components/Popup/Popup.stories.tsx
+++ b/frontend/src/pages/MainPage/components/Popup/Popup.stories.tsx
@@ -1,11 +1,12 @@
 import { MemoryRouter } from 'react-router-dom';
 import type { Meta, StoryObj } from '@storybook/react';
 import { INITIAL_VIEWPORTS } from 'storybook/viewport';
-import Popup, { POPUP_SESSION_KEY, POPUP_STORAGE_KEY } from './Popup';
+import Popup from './Popup';
+import { APP_DOWNLOAD_POPUP } from './popupConfigs';
 
-const setMobilePopupState = () => {
-  sessionStorage.removeItem(POPUP_SESSION_KEY);
-  localStorage.removeItem(POPUP_STORAGE_KEY);
+const clearPopupState = () => {
+  sessionStorage.removeItem(APP_DOWNLOAD_POPUP.sessionKey);
+  localStorage.removeItem(APP_DOWNLOAD_POPUP.storageKey);
 };
 
 const meta = {
@@ -25,7 +26,7 @@ const meta = {
   },
   decorators: [
     (Story) => {
-      setMobilePopupState();
+      clearPopupState();
       return (
         <MemoryRouter>
           <Story />
@@ -39,4 +40,8 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  args: {
+    configs: [APP_DOWNLOAD_POPUP],
+  },
+};

--- a/frontend/src/pages/MainPage/components/Popup/Popup.styles.ts
+++ b/frontend/src/pages/MainPage/components/Popup/Popup.styles.ts
@@ -49,7 +49,8 @@ export const PopupImage = styled.img`
   width: 100%;
   height: auto;
   display: block;
-  object-fit: cover;
+  transform: scale(1.1);
+  transform-origin: center;
 `;
 
 export const ButtonGroup = styled.div`

--- a/frontend/src/pages/MainPage/components/Popup/Popup.test.tsx
+++ b/frontend/src/pages/MainPage/components/Popup/Popup.test.tsx
@@ -1,64 +1,90 @@
-import { DAYS_TO_HIDE, isPopupHidden, POPUP_STORAGE_KEY } from './Popup';
+import { DAYS_TO_HIDE, isPopupHidden, PopupConfig } from '@/utils/popupUtils';
+
+const mockConfig: PopupConfig = {
+  id: 'test_popup',
+  storageKey: 'test_popup_hidden_date',
+  sessionKey: 'test_popup_closed',
+  image: '',
+  imageAlt: '',
+};
 
 describe('Popup 유틸 함수 테스트', () => {
   beforeEach(() => {
     localStorage.clear();
+    sessionStorage.clear();
   });
 
   afterEach(() => {
     localStorage.clear();
+    sessionStorage.clear();
   });
 
   describe('isPopupHidden', () => {
     it('저장된 날짜가 없으면 false를 반환한다', () => {
-      expect(isPopupHidden()).toBe(false);
+      expect(isPopupHidden(mockConfig)).toBe(false);
     });
 
     it('7일 미만이면 true를 반환한다 (1일 전)', () => {
       const oneDayAgo = Date.now() - 1 * 24 * 60 * 60 * 1000;
-      localStorage.setItem(POPUP_STORAGE_KEY, oneDayAgo.toString());
+      localStorage.setItem(mockConfig.storageKey, oneDayAgo.toString());
 
-      expect(isPopupHidden()).toBe(true);
+      expect(isPopupHidden(mockConfig)).toBe(true);
     });
 
     it('7일 미만이면 true를 반환한다 (6일 전)', () => {
       const sixDaysAgo = Date.now() - 6 * 24 * 60 * 60 * 1000;
-      localStorage.setItem(POPUP_STORAGE_KEY, sixDaysAgo.toString());
+      localStorage.setItem(mockConfig.storageKey, sixDaysAgo.toString());
 
-      expect(isPopupHidden()).toBe(true);
+      expect(isPopupHidden(mockConfig)).toBe(true);
     });
 
     it('정확히 7일이면 false를 반환한다', () => {
       const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
-      localStorage.setItem(POPUP_STORAGE_KEY, sevenDaysAgo.toString());
+      localStorage.setItem(mockConfig.storageKey, sevenDaysAgo.toString());
 
-      expect(isPopupHidden()).toBe(false);
+      expect(isPopupHidden(mockConfig)).toBe(false);
     });
 
     it('7일 이상이면 false를 반환한다 (8일 전)', () => {
       const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000;
-      localStorage.setItem(POPUP_STORAGE_KEY, eightDaysAgo.toString());
+      localStorage.setItem(mockConfig.storageKey, eightDaysAgo.toString());
 
-      expect(isPopupHidden()).toBe(false);
+      expect(isPopupHidden(mockConfig)).toBe(false);
     });
 
     it('7일 이상이면 false를 반환한다 (30일 전)', () => {
       const thirtyDaysAgo = Date.now() - 30 * 24 * 60 * 60 * 1000;
-      localStorage.setItem(POPUP_STORAGE_KEY, thirtyDaysAgo.toString());
+      localStorage.setItem(mockConfig.storageKey, thirtyDaysAgo.toString());
 
-      expect(isPopupHidden()).toBe(false);
+      expect(isPopupHidden(mockConfig)).toBe(false);
     });
 
     it('방금 저장한 경우 true를 반환한다', () => {
-      localStorage.setItem(POPUP_STORAGE_KEY, Date.now().toString());
+      localStorage.setItem(mockConfig.storageKey, Date.now().toString());
 
-      expect(isPopupHidden()).toBe(true);
+      expect(isPopupHidden(mockConfig)).toBe(true);
     });
 
     it('잘못된 형식의 날짜는 NaN으로 처리되어 false를 반환한다', () => {
-      localStorage.setItem(POPUP_STORAGE_KEY, 'invalid_date');
+      localStorage.setItem(mockConfig.storageKey, 'invalid_date');
 
-      expect(isPopupHidden()).toBe(false);
+      expect(isPopupHidden(mockConfig)).toBe(false);
+    });
+
+    it('daysToHide가 0이면 "다시 보지 않기" 후에도 항상 표시된다', () => {
+      const alwaysShowConfig: PopupConfig = {
+        ...mockConfig,
+        daysToHide: 0,
+      };
+      localStorage.setItem(alwaysShowConfig.storageKey, Date.now().toString());
+
+      expect(isPopupHidden(alwaysShowConfig)).toBe(false);
+    });
+
+    it('sessionStorage에 닫힘 상태가 있으면 true를 반환한다', () => {
+      sessionStorage.setItem(mockConfig.sessionKey, 'true');
+
+      expect(isPopupHidden(mockConfig)).toBe(true);
     });
   });
 
@@ -68,30 +94,24 @@ describe('Popup 유틸 함수 테스트', () => {
     });
   });
 
-  describe('localStorage 키', () => {
-    it('POPUP_STORAGE_KEY가 올바르게 정의되어 있다', () => {
-      expect(POPUP_STORAGE_KEY).toBe('mainpage_popup_hidden_date');
-    });
-  });
-
   describe('통합 시나리오', () => {
     it('시나리오: 첫 방문 → 다시 보지 않기 → 6일 후 방문 → 7일 후 방문', () => {
       // 1. 첫 방문
-      expect(isPopupHidden()).toBe(false);
+      expect(isPopupHidden(mockConfig)).toBe(false);
 
       // 2. "다시 보지 않기" 클릭
-      localStorage.setItem(POPUP_STORAGE_KEY, Date.now().toString());
-      expect(isPopupHidden()).toBe(true);
+      localStorage.setItem(mockConfig.storageKey, Date.now().toString());
+      expect(isPopupHidden(mockConfig)).toBe(true);
 
       // 3. 6일 후 방문 (아직 숨김)
       const sixDaysAgo = Date.now() - 6 * 24 * 60 * 60 * 1000;
-      localStorage.setItem(POPUP_STORAGE_KEY, sixDaysAgo.toString());
-      expect(isPopupHidden()).toBe(true);
+      localStorage.setItem(mockConfig.storageKey, sixDaysAgo.toString());
+      expect(isPopupHidden(mockConfig)).toBe(true);
 
       // 4. 7일 후 방문 (다시 표시)
       const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
-      localStorage.setItem(POPUP_STORAGE_KEY, sevenDaysAgo.toString());
-      expect(isPopupHidden()).toBe(false);
+      localStorage.setItem(mockConfig.storageKey, sevenDaysAgo.toString());
+      expect(isPopupHidden(mockConfig)).toBe(false);
     });
   });
 });

--- a/frontend/src/pages/MainPage/components/Popup/Popup.tsx
+++ b/frontend/src/pages/MainPage/components/Popup/Popup.tsx
@@ -1,56 +1,43 @@
 import { MouseEvent, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import AppDownloadImage from '@/assets/images/popup/app-download.png';
 import { USER_EVENT } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import useDevice from '@/hooks/useDevice';
-import { detectPlatform, getAppStoreLink } from '@/utils/appStoreLink';
+import { isPopupHidden, PopupConfig } from '@/utils/popupUtils';
 import * as Styled from './Popup.styles';
 
-export const POPUP_STORAGE_KEY = 'mainpage_popup_hidden_date';
-export const POPUP_SESSION_KEY = 'mainpage_popup_closed';
-export const DAYS_TO_HIDE = 7;
+interface PopupProps {
+  configs: PopupConfig[];
+}
 
-export const isPopupHidden = (): boolean => {
-  if (sessionStorage.getItem(POPUP_SESSION_KEY)) return true;
-
-  const hiddenDate = localStorage.getItem(POPUP_STORAGE_KEY);
-  if (!hiddenDate) return false;
-
-  const daysSinceHidden =
-    (Date.now() - parseInt(hiddenDate)) / (1000 * 60 * 60 * 24);
-  return daysSinceHidden < DAYS_TO_HIDE;
-};
-
-const Popup = () => {
+const Popup = ({ configs }: PopupProps) => {
+  const trackEvent = useMixpanelTrack();
+  const { isMobile } = useDevice();
+  const [activeConfig, setActiveConfig] = useState<PopupConfig | null>(null);
   const [isOpen, setIsOpen] = useState(false);
   const [imageLoaded, setImageLoaded] = useState(false);
-  const { isMobile } = useDevice();
-  const trackEvent = useMixpanelTrack();
 
   useEffect(() => {
+    const eligible = configs.find((config) => {
+      if (config.mobileOnly && !isMobile) return false;
+      return !isPopupHidden(config);
+    });
+    setActiveConfig(eligible ?? null);
+  }, [configs, isMobile]);
+
+  useEffect(() => {
+    if (!activeConfig) return;
+    setImageLoaded(false);
     const img = new Image();
-    img.src = AppDownloadImage;
+    img.src = activeConfig.image;
     img.onload = () => setImageLoaded(true);
     img.onerror = () => setImageLoaded(true);
-  }, []);
+  }, [activeConfig]);
 
   useEffect(() => {
-    if (!imageLoaded) return;
-
-    const isHidden = isPopupHidden();
-
-    if (isMobile && !isHidden && imageLoaded) {
-      setIsOpen(true);
-      trackEvent(USER_EVENT.MAIN_POPUP_VIEWED, {
-        popupType: 'app_download',
-      });
-    } else {
-      trackEvent(USER_EVENT.MAIN_POPUP_NOT_SHOWN, {
-        popupType: 'app_download',
-      });
-    }
-  }, [isMobile, trackEvent, imageLoaded]);
+    if (!imageLoaded || !activeConfig) return;
+    setIsOpen(true);
+    trackEvent(USER_EVENT.MAIN_POPUP_VIEWED, { popupType: activeConfig.id });
+  }, [imageLoaded, activeConfig, trackEvent]);
 
   useEffect(() => {
     if (isOpen) {
@@ -64,39 +51,30 @@ const Popup = () => {
   const handleClose = (
     action: 'close_button' | 'backdrop_click' = 'close_button',
   ) => {
+    if (!activeConfig) return;
     trackEvent(USER_EVENT.MAIN_POPUP_CLOSED, {
-      popupType: 'app_download',
-      action: action,
+      popupType: activeConfig.id,
+      action,
     });
-    sessionStorage.setItem(POPUP_SESSION_KEY, 'true');
+    sessionStorage.setItem(activeConfig.sessionKey, 'true');
     setIsOpen(false);
   };
 
   const handleDontShowAgain = () => {
+    if (!activeConfig) return;
     trackEvent(USER_EVENT.MAIN_POPUP_CLOSED, {
-      popupType: 'app_download',
+      popupType: activeConfig.id,
       action: 'dont_show_again',
     });
-    localStorage.setItem(POPUP_STORAGE_KEY, Date.now().toString());
+    localStorage.setItem(activeConfig.storageKey, Date.now().toString());
     setIsOpen(false);
   };
 
-  const handleDownload = () => {
-    const storeLink = getAppStoreLink();
-    trackEvent(USER_EVENT.APP_DOWNLOAD_POPUP_CLICKED, {
-      popupType: 'app_download',
-      platform: detectPlatform(),
-    });
-    window.open(storeLink, '_blank');
-  };
-
   const handleBackdropClick = (e: MouseEvent<HTMLDivElement>) => {
-    if (e.target === e.currentTarget) {
-      handleClose('backdrop_click');
-    }
+    if (e.target === e.currentTarget) handleClose('backdrop_click');
   };
 
-  if (!isOpen) return null;
+  if (!isOpen || !activeConfig) return null;
 
   return (
     <Styled.Overlay
@@ -109,8 +87,13 @@ const Popup = () => {
         onClick={(e: MouseEvent<HTMLDivElement>) => e.stopPropagation()}
       >
         <Styled.Container>
-          <Styled.ImageWrapper onClick={handleDownload}>
-            <Styled.PopupImage src={AppDownloadImage} alt='앱 다운로드' />
+          <Styled.ImageWrapper
+            onClick={() => activeConfig.onImageClick?.(trackEvent)}
+          >
+            <Styled.PopupImage
+              src={activeConfig.image}
+              alt={activeConfig.imageAlt}
+            />
           </Styled.ImageWrapper>
 
           <Styled.ButtonGroup>

--- a/frontend/src/pages/MainPage/components/Popup/Popup.tsx
+++ b/frontend/src/pages/MainPage/components/Popup/Popup.tsx
@@ -24,7 +24,10 @@ const Popup = ({ configs }: PopupProps) => {
       return !isPopupHidden(config);
     });
     setActiveConfig(eligible ?? null);
-  }, [configs, isMobile]);
+    if (!eligible) {
+      trackEvent(USER_EVENT.MAIN_POPUP_NOT_SHOWN);
+    }
+  }, [configs, isMobile, trackEvent]);
 
   useEffect(() => {
     if (!activeConfig) return;

--- a/frontend/src/pages/MainPage/components/Popup/Popup.tsx
+++ b/frontend/src/pages/MainPage/components/Popup/Popup.tsx
@@ -1,4 +1,5 @@
 import { MouseEvent, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { USER_EVENT } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import useDevice from '@/hooks/useDevice';
@@ -10,6 +11,7 @@ interface PopupProps {
 }
 
 const Popup = ({ configs }: PopupProps) => {
+  const navigate = useNavigate();
   const trackEvent = useMixpanelTrack();
   const { isMobile } = useDevice();
   const [activeConfig, setActiveConfig] = useState<PopupConfig | null>(null);
@@ -88,7 +90,10 @@ const Popup = ({ configs }: PopupProps) => {
       >
         <Styled.Container>
           <Styled.ImageWrapper
-            onClick={() => activeConfig.onImageClick?.(trackEvent)}
+            onClick={() => {
+              activeConfig.onImageClick?.(trackEvent);
+              if (activeConfig.to) navigate(activeConfig.to);
+            }}
           >
             <Styled.PopupImage
               src={activeConfig.image}

--- a/frontend/src/pages/MainPage/components/Popup/popupConfigs.ts
+++ b/frontend/src/pages/MainPage/components/Popup/popupConfigs.ts
@@ -1,4 +1,5 @@
 import AppDownloadImage from '@/assets/images/popup/app-download.png';
+import DaedongImage from '@/assets/images/popup/daedong.png';
 import { USER_EVENT } from '@/constants/eventName';
 import { detectPlatform, getAppStoreLink } from '@/utils/appStoreLink';
 import { PopupConfig } from '@/utils/popupUtils';
@@ -18,4 +19,14 @@ export const APP_DOWNLOAD_POPUP: PopupConfig = {
     });
     window.open(getAppStoreLink(), '_blank');
   },
+};
+
+export const DAEDONG_POPUP: PopupConfig = {
+  id: 'daedong_2026',
+  storageKey: 'mainpage_daedong_popup_hidden_date',
+  sessionKey: 'mainpage_daedong_popup_closed',
+  daysToHide: 7,
+  image: DaedongImage,
+  imageAlt: '2026 대동제',
+  to: '/festival-busking',
 };

--- a/frontend/src/pages/MainPage/components/Popup/popupConfigs.ts
+++ b/frontend/src/pages/MainPage/components/Popup/popupConfigs.ts
@@ -1,0 +1,21 @@
+import AppDownloadImage from '@/assets/images/popup/app-download.png';
+import { USER_EVENT } from '@/constants/eventName';
+import { detectPlatform, getAppStoreLink } from '@/utils/appStoreLink';
+import { PopupConfig } from '@/utils/popupUtils';
+
+export const APP_DOWNLOAD_POPUP: PopupConfig = {
+  id: 'app_download',
+  storageKey: 'mainpage_popup_hidden_date',
+  sessionKey: 'mainpage_popup_closed',
+  daysToHide: 7,
+  image: AppDownloadImage,
+  imageAlt: '앱 다운로드',
+  mobileOnly: true,
+  onImageClick: (trackEvent) => {
+    trackEvent(USER_EVENT.APP_DOWNLOAD_POPUP_CLICKED, {
+      popupType: 'app_download',
+      platform: detectPlatform(),
+    });
+    window.open(getAppStoreLink(), '_blank');
+  },
+};

--- a/frontend/src/pages/WebviewMainPage/WebviewMainPage.tsx
+++ b/frontend/src/pages/WebviewMainPage/WebviewMainPage.tsx
@@ -10,6 +10,8 @@ import useWebviewSubscribe from '@/hooks/useWebviewSubscribe';
 import Banner from '@/pages/MainPage/components/Banner/Banner';
 import CategoryButtonList from '@/pages/MainPage/components/CategoryButtonList/CategoryButtonList';
 import ClubCard from '@/pages/MainPage/components/ClubCard/ClubCard';
+import Popup from '@/pages/MainPage/components/Popup/Popup';
+import { DAEDONG_POPUP } from '@/pages/MainPage/components/Popup/popupConfigs';
 import SearchBox from '@/pages/MainPage/components/SearchBox/SearchBox';
 import { useSelectedCategory } from '@/store/useCategoryStore';
 import { useSearchIsSearching, useSearchKeyword } from '@/store/useSearchStore';
@@ -62,6 +64,8 @@ const WebviewMainPage = () => {
 
   return (
     <Styled.PageContainer>
+      {/* TODO: 대동제 종료 후 제거 */}
+      <Popup configs={[DAEDONG_POPUP]} />
       <Styled.SearchBarArea>
         <Styled.LogoImage src={MobileMainIcon} alt='모아동' />
         <SearchBox />

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -11,6 +11,7 @@ import LegacyClubDetailPage from '@/pages/ClubDetailPage/LegacyClubDetailPage';
 import ClubMapPage from '@/pages/ClubMapPage/ClubMapPage';
 import ClubUnionPage from '@/pages/ClubUnionPage/ClubUnionPage';
 import ErrorTestPage from '@/pages/ErrorTestPage/ErrorTestPage';
+import BuskingPage from '@/pages/FestivalPage/BuskingPage/BuskingPage';
 import IntroductionPage from '@/pages/FestivalPage/IntroductionPage/IntroductionPage';
 import GamePage from '@/pages/GamePage/GamePage';
 import IntroducePage from '@/pages/IntroducePage/IntroducePage';
@@ -95,6 +96,14 @@ const AppRoutes = () =>
       element: (
         <ContentErrorBoundary>
           <IntroductionPage />
+        </ContentErrorBoundary>
+      ),
+    },
+    {
+      path: '/festival-busking',
+      element: (
+        <ContentErrorBoundary>
+          <BuskingPage />
         </ContentErrorBoundary>
       ),
     },

--- a/frontend/src/utils/popupUtils.ts
+++ b/frontend/src/utils/popupUtils.ts
@@ -11,6 +11,7 @@ export interface PopupConfig {
   image: string;
   imageAlt: string;
   mobileOnly?: boolean;
+  to?: string;
   onImageClick?: (trackEvent: TrackEventFn) => void;
 }
 

--- a/frontend/src/utils/popupUtils.ts
+++ b/frontend/src/utils/popupUtils.ts
@@ -1,0 +1,30 @@
+type TrackEventFn = (
+  eventName: string,
+  properties?: Record<string, any>,
+) => void;
+
+export interface PopupConfig {
+  id: string;
+  storageKey: string;
+  sessionKey: string;
+  daysToHide?: number;
+  image: string;
+  imageAlt: string;
+  mobileOnly?: boolean;
+  onImageClick?: (trackEvent: TrackEventFn) => void;
+}
+
+export const DAYS_TO_HIDE = 7;
+
+export const isPopupHidden = (config: PopupConfig): boolean => {
+  if (sessionStorage.getItem(config.sessionKey)) return true;
+
+  const hiddenDate = localStorage.getItem(config.storageKey);
+  if (!hiddenDate) return false;
+
+  const daysSinceHidden =
+    (Date.now() - parseInt(hiddenDate)) / (1000 * 60 * 60 * 24);
+  const daysToHide =
+    config.daysToHide !== undefined ? config.daysToHide : DAYS_TO_HIDE;
+  return daysSinceHidden < daysToHide;
+};


### PR DESCRIPTION
## 🚀 릴리즈 PR

### 📦 버전 정보

| 항목          | 내용                                 |
| ------------- | ------------------------------------ |
| **서비스**    | `💾 BE` / `💻 FE`                    |
| **Bump 타입** | `🚨 MAJOR` / `➕ MINOR` / `🔧 PATCH` |
| **예상 버전** | `vX.Y.Z`                             |

> ⚠️ **반드시 라벨을 지정해주세요**: 서비스 라벨(`💾 BE`, `💻 FE`)과 버전 라벨(`🚨 MAJOR`, `➕ MINOR`, `🔧 PATCH`)이 없으면 태그가 생성되지 않습니다.

<details>
<summary>📖 버전 라벨 선택 가이드 (Semantic Versioning)</summary>

| 라벨       | 버전 변화           | 선택 기준                               | 예시                                                                 |
| ---------- | ------------------- | --------------------------------------- | -------------------------------------------------------------------- |
| `🚨 MAJOR` | `v1.0.0` → `v2.0.0` | 기존 API/기능이 **호환되지 않는** 변경  | API 엔드포인트 삭제/변경, 요청/응답 스펙 변경, DB 스키마 대규모 변경 |
| `➕ MINOR` | `v1.0.0` → `v1.1.0` | 기존 기능은 유지하면서 **새 기능 추가** | 새 API 엔드포인트 추가, 새 기능 도입, 기존 API에 선택적 필드 추가    |
| `🔧 PATCH` | `v1.0.0` → `v1.0.1` | 기능 변경 없이 **버그 수정/내부 개선**  | 버그 수정, 성능 개선, 리팩토링, 문서 수정                            |

</details>

---

### 📋 포함된 변경사항

> 이번 릴리즈에 포함된 주요 변경사항을 요약합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 2026 대동제 버스킹 시간표 페이지 추가(일별 공연 일정, 탭/화살표/스와이프 네비게이션).
  * 팝업 시스템 전면 개선: 다중 팝업 구성 및 축제 안내 팝업 추가.
  * 메인 필터에 ‘대동제’ 알림 도트 추가(세션 기반 표시).

* **Documentation**
  * 버스킹 시간표, 필터 알림, 팝업 구성 문서 추가/보강.

* **Chores**
  * 축제 관련 페이지뷰·날짜 전환·체류 시간 이벤트 트래킹 및 공연 시간 데이터 업데이트.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Moadong/moadong/pull/1524)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->