### PR TITLE
[hotfix] 버스킹 시간표 페이지에서 데스크탑 레이아웃 문제 수정

### DIFF
--- a/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.styles.ts
+++ b/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.styles.ts
@@ -1,5 +1,5 @@
-import { media } from '@/styles/mediaQuery';
 import styled from 'styled-components';
+import { media } from '@/styles/mediaQuery';
 
 export const PageWrapper = styled.div`
   display: flex;

--- a/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.styles.ts
+++ b/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.styles.ts
@@ -1,7 +1,14 @@
 import { media } from '@/styles/mediaQuery';
 import styled from 'styled-components';
 
+export const PageWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+`;
+
 export const Container = styled.div`
+  flex: 1;
   width: 100%;
   max-width: 550px;
   margin: 0 auto;

--- a/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.styles.ts
+++ b/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.styles.ts
@@ -1,9 +1,15 @@
+import { media } from '@/styles/mediaQuery';
 import styled from 'styled-components';
 
 export const Container = styled.div`
   width: 100%;
   max-width: 550px;
   margin: 0 auto;
+  padding-top: 92px;
+
+  ${media.mobile} {
+    padding-top: 0;
+  }
 `;
 
 export const NavWrapper = styled.div`

--- a/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.tsx
+++ b/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.tsx
@@ -91,7 +91,7 @@ const BuskingPage = () => {
   };
 
   return (
-    <>
+    <Styled.PageWrapper>
       <Header hideOn={['webview']} />
       <Filter hasNotification={hasNotification} />
       <Styled.Container>
@@ -153,7 +153,7 @@ const BuskingPage = () => {
         </motion.div>
       </Styled.Container>
       {!isInAppWebView() && <Footer />}
-    </>
+    </Styled.PageWrapper>
   );
 };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #1527 

## 📝작업 내용

>  버스킹 시간표 페이지에서 데스크탑 레이아웃 문제 2건을 수정합니다.
  - **데스크탑 padding-top 누락 수정**: Filter 컴포넌트가 모바일에서만
  렌더링되어, 데스크탑에서 고정 Header 뒤에 Day 탭/날짜 네비게이션이 가려지는 문제 → Container에 데스크탑용 padding-top: 92px 추가
  - **Footer 레이아웃 수정**: 공연 일정이 적은 날(05.11 등) Footer가 화면 중간에 뜨는 문제 → PageWrapper에 min-height: 100vh + flex 레이아웃 적용하여 Footer를 항상 뷰포트 하단에 위치

## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 페스티벌 페이지의 반응형 디자인을 개선했습니다.
  * 모바일 기기에서 최적화된 여백 조정을 추가했습니다.
  * 페이지 레이아웃 구조를 개선했습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Moadong/moadong/pull/1528)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->