### PR TITLE
[fix] 웹뷰 대동제 필터칩 클릭 시 페이지 이동 안 되는 버그 수정

### DIFF
--- a/frontend/src/routes/webviewRoutes.tsx
+++ b/frontend/src/routes/webviewRoutes.tsx
@@ -2,6 +2,7 @@ import { RouteObject } from 'react-router-dom';
 import { ContentErrorBoundary } from '@/components/common/ErrorBoundary';
 import ClubDetailPage from '@/pages/ClubDetailPage/ClubDetailPage';
 import ClubMapPage from '@/pages/ClubMapPage/ClubMapPage';
+import BuskingPage from '@/pages/FestivalPage/BuskingPage/BuskingPage';
 import PromotionListPage from '@/pages/PromotionPage/PromotionListPage';
 import WebviewLayout from '@/pages/WebviewLayout/WebviewLayout';
 import WebviewMainPage from '@/pages/WebviewMainPage/WebviewMainPage';
@@ -24,6 +25,14 @@ const webviewRoutes: RouteObject[] = [
         element: (
           <ContentErrorBoundary>
             <PromotionListPage />
+          </ContentErrorBoundary>
+        ),
+      },
+      {
+        path: 'festival-busking',
+        element: (
+          <ContentErrorBoundary>
+            <BuskingPage />
           </ContentErrorBoundary>
         ),
       },


### PR DESCRIPTION

## #️⃣연관된 이슈

> ex) #1529

## 📝작업 내용

- webviewRoutes에 festival-busking 라우트가 누락되어
/webview/festival-busking으로 navigate 시 매칭 실패 후 복귀하던 문제 수정

## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 웹뷰에 버스킹 페스티벌 페이지가 추가되었습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Moadong/moadong/pull/1530)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->