### PR TITLE
[fix] 버스킹 시간표 페이지에서 데스크탑 레이아웃 문제 수정

### DIFF
--- a/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.styles.ts
+++ b/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.styles.ts
@@ -1,5 +1,5 @@
-import { media } from '@/styles/mediaQuery';
 import styled from 'styled-components';
+import { media } from '@/styles/mediaQuery';
 
 export const PageWrapper = styled.div`
   display: flex;

--- a/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.styles.ts
+++ b/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.styles.ts
@@ -1,7 +1,14 @@
 import { media } from '@/styles/mediaQuery';
 import styled from 'styled-components';
 
+export const PageWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+`;
+
 export const Container = styled.div`
+  flex: 1;
   width: 100%;
   max-width: 550px;
   margin: 0 auto;

--- a/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.styles.ts
+++ b/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.styles.ts
@@ -1,9 +1,15 @@
+import { media } from '@/styles/mediaQuery';
 import styled from 'styled-components';
 
 export const Container = styled.div`
   width: 100%;
   max-width: 550px;
   margin: 0 auto;
+  padding-top: 92px;
+
+  ${media.mobile} {
+    padding-top: 0;
+  }
 `;
 
 export const NavWrapper = styled.div`

--- a/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.tsx
+++ b/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.tsx
@@ -91,7 +91,7 @@ const BuskingPage = () => {
   };
 
   return (
-    <>
+    <Styled.PageWrapper>
       <Header hideOn={['webview']} />
       <Filter hasNotification={hasNotification} />
       <Styled.Container>
@@ -153,7 +153,7 @@ const BuskingPage = () => {
         </motion.div>
       </Styled.Container>
       {!isInAppWebView() && <Footer />}
-    </>
+    </Styled.PageWrapper>
   );
 };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #1527 #1528

## 📝작업 내용

> main에 hotfix PR(#1528)로 이미 반영된 커밋들을 develop-fe에 동기화하기 위한 cherry-pick PR입니다.
  - fix(festival): 버스킹 페이지 데스크탑 padding-top 누락 수정
  - fix(festival): 버스킹 페이지 콘텐츠 부족 시 Footer가 화면 중간에 뜨는 문제
  수정
  - refactor: Prettier 코드 포맷 정리

## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 축제 페이지의 반응형 레이아웃과 스타일이 개선되었습니다. 데스크톱 환경에서는 상단에 92px의 여백이 적용되어 콘텐츠가 적절한 위치에 배치되고 시각적 계층이 강화되며, 모바일 환경에서는 여백이 제거되어 제한된 화면 공간을 최대한 효율적으로 활용합니다. 이제 모든 디바이스에서 최적화된 사용자 경험을 제공합니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Moadong/moadong/pull/1531)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->