### PR TITLE
[fix] 동아리방 상세 위치가 긴 경우 지도 버튼이 가려지는 현상 수정

### DIFF
--- a/frontend/src/pages/ClubDetailPage/components/ClubProfileCard/ClubProfileCard.styles.ts
+++ b/frontend/src/pages/ClubDetailPage/components/ClubProfileCard/ClubProfileCard.styles.ts
@@ -214,6 +214,8 @@ export const LocationInfo = styled.div`
   gap: 5px;
   cursor: default;
   user-select: none;
+  min-width: 0;
+  overflow: hidden;
 
   img {
     width: 12px;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #1532 

## 📝작업 내용

> 모바일에서 동아리방 위치 텍스트가 길 경우 `LocationInfo`가 flex 컨테이너를 넘어서면서 `· 지도` 버튼이 화면 밖으로 밀려나는 문제를 수정했습니다.

  | 수정 전 | 수정 후 |
  |---------|---------|                                                     
  | <img src="https://github.com/user-attachments/assets/0b36d099-86de-4ea7-9307-cfb56e670550" width="300" /> | <img src="https://github.com/user-attachments/assets/1967394b-6957-4d9c-8091-5650f7d186d0" width="300" /> |

 - `LocationInfo`에 `min-width: 0` 추가 → flex 자식이 콘텐츠 크기 이하로 축소 가능
 - `LocationInfo`에 `overflow: hidden` 추가 → 기존 `text-overflow: ellipsis`와 결합되어 긴 텍스트는 `...`으로 표시
 - `LocationDot`(·)과 `MapLink`(지도)는 `flex-shrink: 0`이므로 항상 표시됨


## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 클럽 프로필 카드의 위치 정보 텍스트 표시 개선으로 더 나은 레이아웃 안정성 제공

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Moadong/moadong/pull/1543)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->