### PR TITLE
[feature] 동아리 분과별 테마 색상을 커버 이미지 폴백으로 적용한다

### DIFF
--- a/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
@@ -150,6 +150,7 @@ const ClubDetailPage = () => {
               name={clubDetail.name}
               logo={clubDetail.logo}
               cover={clubDetail.cover}
+              category={clubDetail.category}
               recruitmentStatus={clubDetail.recruitmentStatus}
               socialLinks={clubDetail.socialLinks}
               introDescription={clubDetail.description.introDescription}

--- a/frontend/src/pages/ClubDetailPage/components/ClubProfileCard/ClubProfileCard.styles.ts
+++ b/frontend/src/pages/ClubDetailPage/components/ClubProfileCard/ClubProfileCard.styles.ts
@@ -21,11 +21,20 @@ export const CoverImageWrapper = styled.div`
 `;
 
 export const CoverImage = styled.img`
+  display: block;
   width: 100%;
-  height: 213px;
+  height: 220px;
   position: relative;
   z-index: 1;
   object-fit: cover;
+`;
+
+export const CoverFallback = styled.div<{ $color?: string }>`
+  width: 100%;
+  height: 220px;
+  position: relative;
+  z-index: 1;
+  background-color: ${({ $color }) => $color || colors.gray[400]};
 `;
 
 export const LogoWrapper = styled.div`

--- a/frontend/src/pages/ClubDetailPage/components/ClubProfileCard/ClubProfileCard.styles.ts
+++ b/frontend/src/pages/ClubDetailPage/components/ClubProfileCard/ClubProfileCard.styles.ts
@@ -44,9 +44,13 @@ export const LogoWrapper = styled.div`
   width: 64px;
   height: 64px;
   border-radius: 16px;
-  background-color: ${colors.base.white};
-  padding: 2px;
+  background-color: ${colors.gray[100]};
+  padding: 3.5px;
   z-index: 3;
+
+  ${media.tablet} {
+    background-color: ${colors.base.white};
+  }
 `;
 
 export const Logo = styled.img`

--- a/frontend/src/pages/ClubDetailPage/components/ClubProfileCard/ClubProfileCard.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubProfileCard/ClubProfileCard.tsx
@@ -66,7 +66,7 @@ const ClubProfileCard = ({
       <Styled.CoverImageWrapper>
         {cover ? (
           <Styled.CoverImage src={cover} alt='클럽 커버' />
-        ) : category ? (
+        ) : category && TAG_COLORS[category] ? (
           <Styled.CoverFallback $color={TAG_COLORS[category]} />
         ) : (
           <Styled.CoverImage src={defaultCover} alt='기본 커버' />

--- a/frontend/src/pages/ClubDetailPage/components/ClubProfileCard/ClubProfileCard.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubProfileCard/ClubProfileCard.tsx
@@ -1,13 +1,13 @@
 import locationIcon from '@/assets/images/icons/location_icon.svg';
 import InstagramIcon from '@/assets/images/icons/sns/instagram_icon.svg';
 import YoutubeIcon from '@/assets/images/icons/sns/youtube_icon.svg';
-import DefaultCover from '@/assets/images/logos/default_cover_image.png';
 import DefaultLogo from '@/assets/images/logos/default_profile_image.svg';
 import ClubStateBox from '@/components/ClubStateBox/ClubStateBox';
 import { ClubLocation } from '@/constants/clubLocation';
 import { USER_EVENT } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import useNavigator from '@/hooks/useNavigator';
+import { TAG_COLORS } from '@/styles/clubTags';
 import { SNSPlatform } from '@/types/club';
 import * as Styled from './ClubProfileCard.styles';
 
@@ -15,6 +15,7 @@ interface ClubProfileCardProps {
   name: string;
   logo?: string;
   cover?: string;
+  category?: string;
   recruitmentStatus: string;
   socialLinks: Record<SNSPlatform, string>;
   introDescription: string;
@@ -26,6 +27,7 @@ const ClubProfileCard = ({
   name,
   logo,
   cover,
+  category,
   recruitmentStatus,
   socialLinks,
   introDescription,
@@ -61,7 +63,13 @@ const ClubProfileCard = ({
   return (
     <Styled.Container>
       <Styled.CoverImageWrapper>
-        <Styled.CoverImage src={cover || DefaultCover} alt='클럽 커버' />
+        {cover ? (
+          <Styled.CoverImage src={cover} alt='클럽 커버' />
+        ) : (
+          <Styled.CoverFallback
+            $color={category ? TAG_COLORS[category] : undefined}
+          />
+        )}
       </Styled.CoverImageWrapper>
 
       <Styled.LogoWrapper>

--- a/frontend/src/pages/ClubDetailPage/components/ClubProfileCard/ClubProfileCard.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubProfileCard/ClubProfileCard.tsx
@@ -1,6 +1,7 @@
 import locationIcon from '@/assets/images/icons/location_icon.svg';
 import InstagramIcon from '@/assets/images/icons/sns/instagram_icon.svg';
 import YoutubeIcon from '@/assets/images/icons/sns/youtube_icon.svg';
+import defaultCover from '@/assets/images/logos/default_cover_image.png';
 import DefaultLogo from '@/assets/images/logos/default_profile_image.svg';
 import ClubStateBox from '@/components/ClubStateBox/ClubStateBox';
 import { ClubLocation } from '@/constants/clubLocation';
@@ -65,10 +66,10 @@ const ClubProfileCard = ({
       <Styled.CoverImageWrapper>
         {cover ? (
           <Styled.CoverImage src={cover} alt='클럽 커버' />
+        ) : category ? (
+          <Styled.CoverFallback $color={TAG_COLORS[category]} />
         ) : (
-          <Styled.CoverFallback
-            $color={category ? TAG_COLORS[category] : undefined}
-          />
+          <Styled.CoverImage src={defaultCover} alt='기본 커버' />
         )}
       </Styled.CoverImageWrapper>
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #1544 
## 📝작업 내용

### 1. 커버 이미지 없을 때 분과별 태그 색상 폴백 적용
 - 커버 이미지가 없는 동아리의 경우 기존 기본 이미지 대신 분과별 태그 색상을 배경으로 표시
 - 분과 정보가 없는 경우 기본 커버 이미지 폴백 유지
 - `CoverImage`에 `display: block` 추가하여 img 하단 여백 제거

### 2. 동아리 프로필 로고 테두리 데스크탑/모바일 분리 적용
- 모바일~태블릿: 0.5px gray400 테두리 + 4px 흰색 외곽
- 노트북~데스크탑: 0.5px gray400 테두리 + 4px gray100 외곽 (소개
  배경과 통일)

  | 수정 전 | 수정 후 |
  |---------|---------|
  | <img src="https://github.com/user-attachments/assets/2ff69fde-3a0e-43c9-bee2-ccadf510ff4c" width="300" /> | <img src="https://github.com/user-attachments/assets/52762f98-edbe-4067-8b22-58edc9d7343b" width="300" /> |


## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **새로운 기능**
  * 클럽 상세에서 프로필 카드에 카테고리 정보를 전달해 카테고리 기반 배경색을 표시하도록 지원 추가

* **개선 사항**
  * 커버 영역 높이 조정(220px)으로 시각적 일관성 향상
  * 로고 영역 기본 배경색 및 패딩 조정으로 표시 개선
  * 커버 이미지 미노출 시 카테고리 색상 기반 대체 배경 표시 지원

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Moadong/moadong/pull/1547?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->