### PR TITLE
[feature] 클럽 상세 페이지 OG 태그 Edge Middleware 적용

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -29,3 +29,4 @@ AGENTS.md
 
 # Claude Code (personal settings)
 .claude/
+.vercel

--- a/frontend/docs/claude/features.md
+++ b/frontend/docs/claude/features.md
@@ -25,6 +25,63 @@ const { variant } = useExperiment(mainBannerExperiment);
 
 `WEBVIEW_FILTER_CONFIG`을 수정하면 `Filter.tsx`의 탭 UI와 `webviewRoutes.tsx`의 라우트가 자동으로 반영됨.
 
+## OG 태그 (소셜 미디어 공유 미리보기)
+
+### 구조
+
+React SPA는 클라이언트 사이드 렌더링이라 카카오톡/페이스북 크롤러가 JavaScript를 실행하지 않아 OG 태그를 읽지 못한다. 이를 해결하기 위해 `middleware.ts`(프로젝트 루트)에 Vercel Edge Middleware를 적용했다.
+
+**요청 흐름:**
+
+```
+크롤러 요청 → middleware.ts (User-Agent 감지)
+  → 백엔드 API fetch (timeout 3초)
+  → OG 태그 포함 HTML 반환
+
+일반 브라우저 → middleware.ts → 통과 → index.html (SPA)
+```
+
+**커버하는 라우트:**
+
+- `/club/:objectId` — 클럽 상세 (ObjectId)
+- `/clubDetail/:objectId`
+- `/club/@:clubName` — 클럽 상세 (이름)
+- `/clubDetail/@:clubName`
+
+**감지 크롤러:** KakaoTalk, facebookexternalhit, Twitterbot, LINE, WhatsApp, Telegram, Discord, Slack 등
+
+### 새 라우트에 OG 추가 방법
+
+`middleware.ts`의 regex와 matcher를 수정한다.
+
+```ts
+// 라우트 추가
+const match = pathname.match(/^\/club(?:Detail)?\/([a-f0-9]{24}|@[^/]+)/i);
+
+// config matcher에도 추가
+export const config = {
+  matcher: ['/club/:path*', '/clubDetail/:path*', '/새라우트/:path*'],
+};
+```
+
+### Next.js 대비 한계점
+
+| 항목                | Vercel Edge Middleware (현재)        | Next.js                            |
+| ------------------- | ------------------------------------ | ---------------------------------- |
+| **OG 생성 방식**    | 크롤러 감지 후 API fetch             | `generateMetadata()`로 서버 렌더링 |
+| **일반 사용자**     | 영향 없음 (SPA 그대로)               | SSR로 항상 메타태그 포함           |
+| **실행 제한**       | 5초, 메모리 128MiB                   | 제한 없음 (서버 함수)              |
+| **API 의존성**      | API 실패 시 OG 없이 fallback         | 서버에서 직접 DB 조회 가능         |
+| **User-Agent 오탐** | 새 크롤러 추가 시 수동 업데이트 필요 | 해당 없음                          |
+| **캐싱**            | Edge에서 별도 캐시 없음              | ISR로 캐싱 가능                    |
+| **커버 범위**       | 명시적으로 등록한 라우트만           | 모든 페이지 자동                   |
+
+**현재 구조의 실질적 위험:**
+
+1. **API 3초 초과 시 OG 미노출** — 백엔드가 느리면 크롤러에게 빈 HTML 반환
+2. **새 크롤러 미감지** — `CRAWLER_PATTERN` regex에 없는 봇은 SPA를 받아 OG 미노출
+3. **라우트 수동 관리** — 새 페이지에 OG가 필요하면 middleware를 직접 수정해야 함
+
 ## 실시간 업데이트
 
 지원자 상태 업데이트를 위해 SSE(Server-Sent Events) 사용, `AdminClubContext`에서 관리.

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -49,8 +49,8 @@ export default async function middleware(request: Request) {
 
   const { pathname } = new URL(request.url);
 
-  // /club/:clubId 또는 /clubDetail/:clubId 매칭 (MongoDB ObjectId)
-  const match = pathname.match(/^\/club(?:Detail)?\/([a-f0-9]{24})/i);
+  // /club/:clubId, /clubDetail/:clubId, /club/@:clubName, /clubDetail/@:clubName 매칭
+  const match = pathname.match(/^\/club(?:Detail)?\/([a-f0-9]{24}|@[^/]+)/i);
   if (!match) return;
 
   const clubId = match[1];

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,0 +1,86 @@
+const CRAWLER_PATTERN =
+  /bot|crawl|facebookexternalhit|twitterbot|kakao|line|whatsapp|telegram|discord|slack/i;
+
+const API_BASE = 'https://yourun.shop';
+const SITE_URL = 'https://www.moadong.com';
+const DEFAULT_OG_IMAGE = `${SITE_URL}/og_image.png`;
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function buildOgHtml(og: {
+  title: string;
+  description: string;
+  image: string;
+  url: string;
+}): string {
+  const t = escapeHtml(og.title);
+  const d = escapeHtml(og.description);
+  const i = escapeHtml(og.image);
+  const u = escapeHtml(og.url);
+  return `<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+  <title>${t}</title>
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="${t}" />
+  <meta property="og:description" content="${d}" />
+  <meta property="og:image" content="${i}" />
+  <meta property="og:url" content="${u}" />
+  <meta property="og:site_name" content="모아동" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="${t}" />
+  <meta name="twitter:description" content="${d}" />
+  <meta name="twitter:image" content="${i}" />
+</head>
+<body></body>
+</html>`;
+}
+
+export default async function middleware(request: Request) {
+  const ua = request.headers.get('user-agent') ?? '';
+  if (!CRAWLER_PATTERN.test(ua)) return;
+
+  const { pathname } = new URL(request.url);
+
+  // /club/:clubId 또는 /clubDetail/:clubId 매칭 (MongoDB ObjectId)
+  const match = pathname.match(/^\/club(?:Detail)?\/([a-f0-9]{24})/i);
+  if (!match) return;
+
+  const clubId = match[1];
+
+  try {
+    const res = await fetch(`${API_BASE}/api/club/${clubId}`);
+    if (!res.ok) return;
+
+    const json = await res.json();
+    const club = json?.data?.club;
+    if (!club) return;
+
+    return new Response(
+      buildOgHtml({
+        title: `${club.name} - 모아동`,
+        description:
+          club.introduction ||
+          club.description?.introDescription ||
+          '부경대학교 동아리 정보를 확인해보세요.',
+        image: club.cover || club.logo || DEFAULT_OG_IMAGE,
+        url: `${SITE_URL}${pathname}`,
+      }),
+      { headers: { 'content-type': 'text/html; charset=utf-8' } },
+    );
+  } catch {
+    // API 실패 시 SPA로 fallback
+    return;
+  }
+}
+
+export const config = {
+  matcher: ['/club/:path*', '/clubDetail/:path*'],
+};

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -56,7 +56,9 @@ export default async function middleware(request: Request) {
   const clubId = match[1];
 
   try {
-    const res = await fetch(`${API_BASE}/api/club/${clubId}`);
+    const res = await fetch(`${API_BASE}/api/club/${clubId}`, {
+      signal: AbortSignal.timeout(3000), // 5초 Edge 제한 내 여유있게 3초
+    });
     if (!res.ok) return;
 
     const json = await res.json();


### PR DESCRIPTION

## #️⃣연관된 이슈

> ex) #1549

## 배경

  카카오톡, 페이스북 등 SNS에 클럽 페이지 링크를 공유하면 제목/이미지가 나오지 않는 문제가 있었습니다.

  **원인**: 우리 서비스는 React SPA(클라이언트 사이드 렌더링)입니다.
  소셜 미디어 크롤러는 JavaScript를 실행하지 않기 때문에, React가 동적으로 삽입하는 OG 태그를 읽지 못합니다.
  크롤러 눈에는 `<div id="root"></div>` 만 보이는 빈 HTML입니다.


## 해결 방법: Vercel Edge Middleware

  `middleware.ts` 파일 하나를 프로젝트 루트에 추가했습니다.


### 동작방식

일반 사용자 요청
```
    → middleware (크롤러 아님을 감지)
    → 그대로 통과
    → index.html → React 앱 실행 (기존과 동일)
```

  카카오/페이스북 크롤러 요청
```
    → middleware (User-Agent로 크롤러 감지)
    → 백엔드 API에서 클럽 정보 fetch
    → OG 태그가 포함된 HTML 즉시 반환 ✓
```

  Vercel Edge Middleware는 CDN 단에서 실행되어 요청을 가로채고, 응답을 바꿀 수 있습니다.

### 감지하는 크롤러 목록

  `KakaoTalk`, `facebookexternalhit`, `Twitterbot`, `LINE`, `WhatsApp`, `Telegram`, `Discord`, `Slack` 등

  ### 커버하는 라우트

  | 라우트 형식 | 예시 |
  |---|---|
  | `/club/:objectId` | `/club/67e54ae51cfd27718dd40bea` |
  | `/clubDetail/:objectId` | `/clubDetail/67e54ae51cfd27718dd40bea` |
  | `/club/@:clubName` | `/club/@매니아` |
  | `/clubDetail/@:clubName` | `/clubDetail/@매니아` |


### 크롤러에게 반환되는 HTML 예시

  ```html
  <head>
    <title>매니아 - 모아동</title>
    <meta property="og:title" content="매니아 - 모아동" />
    <meta property="og:description" content="부경대 락밴드 동아리" />
    <meta property="og:image" content="https://cdn.moadong.com/.../LOGO/..." />
    <meta property="og:url" content="https://www.moadong.com/clubDetail/@매니아" />
  </head>
```

  **API 실패 시**

  클럽 정보를 가져오지 못하면 middleware가 그냥 통과시킵니다. 서비스 장애로 이어지지 않습니다.


## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 클럽 페이지를 소셜 미디어에서 공유할 때 클럽의 제목, 설명, 이미지 정보가 포함된 미리보기가 자동으로 생성됩니다.

* **유지보수**
  * Vercel 관련 로컬 파일이 버전 관리에서 제외되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Moadong/moadong/pull/1549)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->