### PR TITLE
[feature] 대동제 종료 — A/B 테스트 정리 및 관련 코드 제거

### DIFF
--- a/frontend/src/components/common/Filter/Filter.tsx
+++ b/frontend/src/components/common/Filter/Filter.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { USER_EVENT } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
@@ -9,7 +8,6 @@ import * as Styled from './Filter.styles';
 const WEB_FILTER_OPTIONS = [
   { label: '동아리', path: '/' },
   { label: '홍보', path: '/promotions' },
-  { label: '대동제', path: '/festival-busking' },
 ] as const;
 
 interface FilterProps {
@@ -23,20 +21,12 @@ const Filter = ({ alwaysVisible = false, hasNotification }: FilterProps) => {
   const { pathname } = useLocation();
   const trackEvent = useMixpanelTrack();
 
-  const [daedongDotSeen, setDaedongDotSeen] = useState(
-    () => sessionStorage.getItem('daedong_filter_seen') === 'true',
-  );
-
   const isWebview = pathname.startsWith('/webview');
   const filterOptions = isWebview ? WEBVIEW_FILTER_CONFIG : WEB_FILTER_OPTIONS;
   const shouldShow = alwaysVisible || isMobile || isWebview;
 
   const handleFilterOptionClick = (path: string) => {
     trackEvent(USER_EVENT.FILTER_OPTION_CLICKED, { path });
-    if (path.includes('festival-busking')) {
-      sessionStorage.setItem('daedong_filter_seen', 'true');
-      setDaedongDotSeen(true);
-    }
     navigate(path);
   };
 
@@ -47,10 +37,7 @@ const Filter = ({ alwaysVisible = false, hasNotification }: FilterProps) => {
           {filterOptions.map((filter) => (
             <Styled.FilterButtonWrapper key={filter.path}>
               <Styled.NotificationDot
-                $isVisible={
-                  (hasNotification && filter.label === '홍보') ||
-                  (filter.label === '대동제' && !daedongDotSeen)
-                }
+                $isVisible={hasNotification && filter.label === '홍보'}
               />
               <Styled.FilterButton
                 $isActive={pathname === filter.path}

--- a/frontend/src/experiments/definitions.ts
+++ b/frontend/src/experiments/definitions.ts
@@ -1,13 +1,1 @@
-import type { ExperimentDefinition } from './types';
-
-export const festivalTimetableNavExperiment = {
-  key: 'festival_timetable_nav_v1',
-  variants: ['tabs', 'arrows'] as const,
-  defaultVariant: 'tabs',
-  weights: {
-    tabs: 50,
-    arrows: 50,
-  },
-} satisfies ExperimentDefinition<'tabs' | 'arrows'>;
-
-export const ALL_EXPERIMENTS = [festivalTimetableNavExperiment] as const;
+export const ALL_EXPERIMENTS = [] as const;

--- a/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.tsx
+++ b/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.tsx
@@ -5,13 +5,10 @@ import Filter from '@/components/common/Filter/Filter';
 import Footer from '@/components/common/Footer/Footer';
 import Header from '@/components/common/Header/Header';
 import { PAGE_VIEW, USER_EVENT } from '@/constants/eventName';
-import { festivalTimetableNavExperiment } from '@/experiments/definitions';
-import { useExperimentVariant } from '@/hooks/Experiment/useExperimentVariant';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import useTrackPageView from '@/hooks/Mixpanel/useTrackPageView';
 import usePromotionNotification from '@/hooks/Queries/usePromotionNotification';
 import isInAppWebView from '@/utils/isInAppWebView';
-import DayArrowsNav from '../components/DayArrowsNav/DayArrowsNav';
 import DayTabsNav from '../components/DayTabsNav/DayTabsNav';
 import PerformanceList from '../components/PerformanceList/PerformanceList';
 import { BUSKING_DAYS } from '../data/buskingDays';
@@ -35,8 +32,6 @@ const getInitialDayId = (): string => {
 const BuskingPage = () => {
   useTrackPageView(PAGE_VIEW.DAEDONG2026_BUSKING_PAGE);
   const trackEvent = useMixpanelTrack();
-  const navVariant = useExperimentVariant(festivalTimetableNavExperiment);
-
   const hasNotification = usePromotionNotification();
   const [activeDayId, setActiveDayId] = useState(getInitialDayId);
   const dayStartTime = useRef(Date.now());
@@ -53,7 +48,6 @@ const BuskingPage = () => {
       const duration = Date.now() - dayStartTime.current;
       trackEvent(USER_EVENT.DAEDONG2026_DAY_DURATION, {
         day: activeDayIdRef.current,
-        nav_variant: navVariant,
         duration,
         duration_seconds: Math.round(duration / 1000),
       });
@@ -67,14 +61,12 @@ const BuskingPage = () => {
     const duration = Date.now() - dayStartTime.current;
     trackEvent(USER_EVENT.DAEDONG2026_DAY_DURATION, {
       day: activeDayId,
-      nav_variant: navVariant,
       duration,
       duration_seconds: Math.round(duration / 1000),
     });
     trackEvent(USER_EVENT.DAEDONG2026_DAY_CHANGED, {
       from_day: activeDayId,
       to_day: dayId,
-      nav_variant: navVariant,
       interaction,
     });
     dayStartTime.current = Date.now();
@@ -104,19 +96,11 @@ const BuskingPage = () => {
       >
         <Styled.Container>
           <Styled.NavWrapper>
-            {navVariant === 'tabs' ? (
-              <DayTabsNav
-                days={availableDays}
-                activeDayId={activeDayId}
-                onChange={handleDayChange}
-              />
-            ) : (
-              <DayArrowsNav
-                days={availableDays}
-                activeDayId={activeDayId}
-                onChange={handleDayChange}
-              />
-            )}
+            <DayTabsNav
+              days={availableDays}
+              activeDayId={activeDayId}
+              onChange={handleDayChange}
+            />
           </Styled.NavWrapper>
           <Styled.TimetableSection>
             <Styled.TimetableHeader>

--- a/frontend/src/pages/MainPage/MainPage.tsx
+++ b/frontend/src/pages/MainPage/MainPage.tsx
@@ -11,7 +11,7 @@ import Banner from '@/pages/MainPage/components/Banner/Banner';
 import CategoryButtonList from '@/pages/MainPage/components/CategoryButtonList/CategoryButtonList';
 import ClubCard from '@/pages/MainPage/components/ClubCard/ClubCard';
 import Popup from '@/pages/MainPage/components/Popup/Popup';
-import { DAEDONG_POPUP } from '@/pages/MainPage/components/Popup/popupConfigs';
+import { APP_DOWNLOAD_POPUP } from '@/pages/MainPage/components/Popup/popupConfigs';
 import { useSelectedCategory } from '@/store/useCategoryStore';
 import { useSearchIsSearching, useSearchKeyword } from '@/store/useSearchStore';
 import { Club } from '@/types/club';
@@ -51,8 +51,7 @@ const MainPage = () => {
 
   return (
     <>
-      <Popup configs={[DAEDONG_POPUP]} />
-      {/* <Popup configs={[APP_DOWNLOAD_POPUP]} /> */}
+      <Popup configs={[APP_DOWNLOAD_POPUP]} />
       <Header />
       <Filter hasNotification={hasNotification} />
       <Banner />

--- a/frontend/src/pages/MainPage/components/Popup/popupConfigs.ts
+++ b/frontend/src/pages/MainPage/components/Popup/popupConfigs.ts
@@ -1,5 +1,4 @@
 import AppDownloadImage from '@/assets/images/popup/app-download.png';
-import DaedongImage from '@/assets/images/popup/daedong.png';
 import { USER_EVENT } from '@/constants/eventName';
 import { detectPlatform, getAppStoreLink } from '@/utils/appStoreLink';
 import { PopupConfig } from '@/utils/popupUtils';
@@ -19,14 +18,4 @@ export const APP_DOWNLOAD_POPUP: PopupConfig = {
     });
     window.open(getAppStoreLink(), '_blank');
   },
-};
-
-export const DAEDONG_POPUP: PopupConfig = {
-  id: 'daedong_2026',
-  storageKey: 'mainpage_daedong_popup_hidden_date',
-  sessionKey: 'mainpage_daedong_popup_closed',
-  daysToHide: 7,
-  image: DaedongImage,
-  imageAlt: '2026 대동제',
-  to: '/festival-busking',
 };

--- a/frontend/src/pages/WebviewMainPage/WebviewMainPage.tsx
+++ b/frontend/src/pages/WebviewMainPage/WebviewMainPage.tsx
@@ -10,8 +10,6 @@ import useWebviewSubscribe from '@/hooks/useWebviewSubscribe';
 import Banner from '@/pages/MainPage/components/Banner/Banner';
 import CategoryButtonList from '@/pages/MainPage/components/CategoryButtonList/CategoryButtonList';
 import ClubCard from '@/pages/MainPage/components/ClubCard/ClubCard';
-import Popup from '@/pages/MainPage/components/Popup/Popup';
-import { DAEDONG_POPUP } from '@/pages/MainPage/components/Popup/popupConfigs';
 import SearchBox from '@/pages/MainPage/components/SearchBox/SearchBox';
 import { useSelectedCategory } from '@/store/useCategoryStore';
 import { useSearchIsSearching, useSearchKeyword } from '@/store/useSearchStore';
@@ -64,8 +62,6 @@ const WebviewMainPage = () => {
 
   return (
     <Styled.PageContainer>
-      {/* TODO: 대동제 종료 후 제거 */}
-      <Popup configs={[DAEDONG_POPUP]} />
       <Styled.SearchBarArea>
         <Styled.LogoImage src={MobileMainIcon} alt='모아동' />
         <SearchBox />

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -11,8 +11,6 @@ import LegacyClubDetailPage from '@/pages/ClubDetailPage/LegacyClubDetailPage';
 import ClubMapPage from '@/pages/ClubMapPage/ClubMapPage';
 import ClubUnionPage from '@/pages/ClubUnionPage/ClubUnionPage';
 import ErrorTestPage from '@/pages/ErrorTestPage/ErrorTestPage';
-import BuskingPage from '@/pages/FestivalPage/BuskingPage/BuskingPage';
-import IntroductionPage from '@/pages/FestivalPage/IntroductionPage/IntroductionPage';
 import GamePage from '@/pages/GamePage/GamePage';
 import IntroducePage from '@/pages/IntroducePage/IntroducePage';
 import MainPage from '@/pages/MainPage/MainPage';
@@ -88,22 +86,6 @@ const AppRoutes = () =>
       element: (
         <ContentErrorBoundary>
           <ClubUnionPage />
-        </ContentErrorBoundary>
-      ),
-    },
-    {
-      path: '/festival-introduction',
-      element: (
-        <ContentErrorBoundary>
-          <IntroductionPage />
-        </ContentErrorBoundary>
-      ),
-    },
-    {
-      path: '/festival-busking',
-      element: (
-        <ContentErrorBoundary>
-          <BuskingPage />
         </ContentErrorBoundary>
       ),
     },

--- a/frontend/src/routes/webviewFilterConfig.ts
+++ b/frontend/src/routes/webviewFilterConfig.ts
@@ -1,7 +1,6 @@
 export const WEBVIEW_FILTER_CONFIG = [
   { label: '동아리', path: '/webview/main' },
   { label: '홍보', path: '/webview/promotions' },
-  { label: '대동제', path: '/webview/festival-busking' },
 ] as const;
 
 export type WebviewFilterPath = (typeof WEBVIEW_FILTER_CONFIG)[number]['path'];

--- a/frontend/src/routes/webviewRoutes.tsx
+++ b/frontend/src/routes/webviewRoutes.tsx
@@ -3,7 +3,6 @@ import { RouteObject } from 'react-router-dom';
 import { ContentErrorBoundary } from '@/components/common/ErrorBoundary';
 import ClubDetailPage from '@/pages/ClubDetailPage/ClubDetailPage';
 import ClubMapPage from '@/pages/ClubMapPage/ClubMapPage';
-import BuskingPage from '@/pages/FestivalPage/BuskingPage/BuskingPage';
 import PromotionListPage from '@/pages/PromotionPage/PromotionListPage';
 import WebviewLayout from '@/pages/WebviewLayout/WebviewLayout';
 import WebviewMainPage from '@/pages/WebviewMainPage/WebviewMainPage';
@@ -15,7 +14,6 @@ import {
 const PAGE_MAP: Record<WebviewFilterPath, ComponentType> = {
   '/webview/main': WebviewMainPage,
   '/webview/promotions': PromotionListPage,
-  '/webview/festival-busking': BuskingPage,
 };
 
 const webviewRoutes: RouteObject[] = [


### PR DESCRIPTION

## #️⃣연관된 이슈

> ex) #1550

## 📝작업 내용

### 배경

  2026 대동제 버스킹 시간표 페이지에서 진행한 festival_timetable_nav_v1  A/B 테스트가 종료됨.
tabs 변형이 인당 날짜 탐색 횟수에서 우위를 보여 tabs UI로 고정하고, 대동제 관련 임시 코드 전체를 제거함.

  ---
  실험 결과 요약
  
```
  ┌─────────┬─────────┬───────────┬───────────┬────────────┐
  │ variant │ 유저 수 │ 총 이벤트 │ 인당 평균 │ swipe 비율 │
  ├─────────┼─────────┼───────────┼───────────┼────────────┤
  │ tabs    │ 73명    │ 514       │ 7.0회     │ 23.3%      │
  ├─────────┼─────────┼───────────┼───────────┼────────────┤
  │ arrows  │ 61명    │ 350       │ 5.7회     │ 20.3%      │
  └─────────┴─────────┴───────────┴───────────┴────────────┘
```

  → tabs 승리 (인당 탐색 23% 우위), tabs UI로 고정

  ---
###  변경 내용

 #### 실험 코드 제거
  - src/experiments/definitions.ts — festivalTimetableNavExperiment
  제거, ALL_EXPERIMENTS = []
  - src/pages/FestivalPage/BuskingPage/BuskingPage.tsx — DayTabsNav로
  고정, DayArrowsNav / useExperimentVariant / nav_variant 프로퍼티 제거
  
####  라우트 및 필터 제거
  - src/routes/AppRoutes.tsx — /festival-busking, /festival-introduction
   라우트 제거
  - src/routes/webviewRoutes.tsx — /webview/festival-busking 라우트 제거
  - src/routes/webviewFilterConfig.ts — 대동제 탭 제거
  - src/components/common/Filter/Filter.tsx — 대동제 칩, daedongDotSeen
  세션스토리지 로직 제거

 #### 팝업 복구
  - src/pages/MainPage/MainPage.tsx — DAEDONG_POPUP → APP_DOWNLOAD_POPUP
   복구
  - src/pages/WebviewMainPage/WebviewMainPage.tsx — 팝업 제거 (원래 없던
   상태로 복원)
  - src/pages/MainPage/components/Popup/popupConfigs.ts — DAEDONG_POPUP
  및 daedong 이미지 제거

## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 앱 다운로드 팝업 추가

* **Refactor**
  * 축제 및 대동제 관련 기능 제거
  * 실험 기반 네비게이션 코드 제거
  * 필터 옵션 및 로직 단순화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Moadong/moadong/pull/1551)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->