### PR TITLE
[fix] OG 미들웨어 정규식 끝 앵커 누락 수정

### DIFF
--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -53,7 +53,7 @@ export default async function middleware(request: Request) {
   const match = pathname.match(/^\/club(?:Detail)?\/([a-f0-9]{24}|@[^/]+)$/i);
   if (!match) return;
 
-  const clubId = match[1];
+  const clubId = decodeURIComponent(match[1]);
 
   try {
     const res = await fetch(`${API_BASE}/api/club/${clubId}`, {
@@ -73,7 +73,7 @@ export default async function middleware(request: Request) {
           club.description?.introDescription ||
           '부경대학교 동아리 정보를 확인해보세요.',
         image: club.cover || club.logo || DEFAULT_OG_IMAGE,
-        url: `${SITE_URL}${pathname}`,
+        url: `${SITE_URL}${decodeURIComponent(pathname)}`,
       }),
       { headers: { 'content-type': 'text/html; charset=utf-8' } },
     );

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -5,6 +5,14 @@ const API_BASE = 'https://yourun.shop';
 const SITE_URL = 'https://www.moadong.com';
 const DEFAULT_OG_IMAGE = `${SITE_URL}/og_image.png`;
 
+function safeDecode(s: string): string {
+  try {
+    return decodeURIComponent(s);
+  } catch {
+    return s;
+  }
+}
+
 function escapeHtml(str: string): string {
   return str
     .replace(/&/g, '&amp;')
@@ -53,7 +61,7 @@ export default async function middleware(request: Request) {
   const match = pathname.match(/^\/club(?:Detail)?\/([a-f0-9]{24}|@[^/]+)$/i);
   if (!match) return;
 
-  const clubId = decodeURIComponent(match[1]);
+  const clubId = safeDecode(match[1]);
 
   try {
     const res = await fetch(`${API_BASE}/api/club/${clubId}`, {
@@ -73,7 +81,7 @@ export default async function middleware(request: Request) {
           club.description?.introDescription ||
           '부경대학교 동아리 정보를 확인해보세요.',
         image: club.cover || club.logo || DEFAULT_OG_IMAGE,
-        url: `${SITE_URL}${decodeURIComponent(pathname)}`,
+        url: `${SITE_URL}${safeDecode(pathname)}`,
       }),
       { headers: { 'content-type': 'text/html; charset=utf-8' } },
     );

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -50,7 +50,7 @@ export default async function middleware(request: Request) {
   const { pathname } = new URL(request.url);
 
   // /club/:clubId, /clubDetail/:clubId, /club/@:clubName, /clubDetail/@:clubName 매칭
-  const match = pathname.match(/^\/club(?:Detail)?\/([a-f0-9]{24}|@[^/]+)/i);
+  const match = pathname.match(/^\/club(?:Detail)?\/([a-f0-9]{24}|@[^/]+)$/i);
   if (!match) return;
 
   const clubId = match[1];


### PR DESCRIPTION
## #️⃣연관된 이슈

MOA-859

## 📝작업 내용

### 문제 1: 정규식 끝 앵커 누락
정규식에 `$` 앵커가 없어 `/club/:clubId` 하위 경로(`/club/:clubId/apply` 등)에도 OG HTML이 반환되던 버그 수정

```ts
// Before
const match = pathname.match(/^\/club(?:Detail)?\/([a-f0-9]{24}|@[^/]+)/i);

// After
const match = pathname.match(/^\/club(?:Detail)?\/([a-f0-9]{24}|@[^/]+)$/i);
```

### 문제 2: 한글 클럽명 URL 디코딩 누락
브라우저/크롤러가 한글 URL을 percent-encode(`@바구니` → `@%EB%B0%94%EA%B5%AC%EB%8B%88`)하여 요청하는데, 이를 디코딩하지 않아 백엔드 API 호출 실패 및 OG 태그 미노출 발생

### 문제 3: `decodeURIComponent` 예외 처리 누락
`decodeURIComponent`가 `try` 블록 밖에 위치하여, 잘못된 percent-encoding 입력 시 `URIError`가 발생해 Edge Function 전체가 500 에러로 터지는 구조적 문제 존재

`safeDecode` 헬퍼를 도입하여 잘못된 인코딩이어도 원본 문자열로 API를 시도하고, 최후에만 SPA fallback하도록 수정

```ts
function safeDecode(s: string): string {
  try {
    return decodeURIComponent(s);
  } catch {
    return s;
  }
}
```

## 🫡 참고사항

- 카카오톡 공유 시 OG 캐시가 남아있을 수 있어 [카카오 OG 캐시 삭제 도구](https://developers.kakao.com/tool/clear/og)로 초기화 필요