### PR TITLE
[feature] 배너 로딩 중 shimmer 스켈레톤 UI 추가

### DIFF
--- a/frontend/docs/features/main/banner.md
+++ b/frontend/docs/features/main/banner.md
@@ -5,9 +5,17 @@
 
 ## 동작 방식
 
-- `useGetBanners`의 `isPending`이 `true`인 동안 `SkeletonBannerWrapper`를 렌더링
-- 데이터 로드 완료(`isPending === false`) 후 실제 Swiper 배너로 교체
-- TanStack Query 캐시 hit 시에는 `isPending`이 false이므로 스켈레톤이 노출되지 않음
+스켈레톤은 두 단계로 나뉘어 노출된다.
+
+| 단계 | 조건                                | 렌더링                               |
+| ---- | ----------------------------------- | ------------------------------------ |
+| 1    | `isPending`                         | `SkeletonBannerWrapper` (단독)       |
+| 2    | 데이터 로드 완료 + `!isImageLoaded` | `SkeletonOverlay` (BannerWrapper 위) |
+| 3    | 첫 이미지 `onLoad` 발화             | 스켈레톤 제거, 배너 노출             |
+
+- TanStack Query 캐시 hit 시 `isPending`이 false이므로 1단계 스켈레톤은 노출되지 않음
+- `SkeletonOverlay`는 `BannerWrapper` 내부에 `position: absolute; inset: 0`으로 위치 — Swiper가 뒤에서 정상 초기화되고 이미지를 로드할 수 있음
+- `onLoad`는 `index === 0`인 첫 슬라이드에만 부착 — Swiper `loop` 모드의 슬라이드 복제로 인한 중복 발화 방지
 
 ## 반응형
 
@@ -18,5 +26,5 @@
 
 ## 관련 코드
 
-- `src/pages/MainPage/components/Banner/Banner.tsx` — `isPending` 분기 처리
-- `src/pages/MainPage/components/Banner/Banner.styles.ts` — `SkeletonBannerWrapper`, `shimmer` keyframes
+- `src/pages/MainPage/components/Banner/Banner.tsx` — `isPending`, `isImageLoaded` 분기 처리
+- `src/pages/MainPage/components/Banner/Banner.styles.ts` — `SkeletonBannerWrapper`, `SkeletonOverlay`, `shimmer` keyframes

--- a/frontend/docs/features/main/banner.md
+++ b/frontend/docs/features/main/banner.md
@@ -1,0 +1,22 @@
+# Banner — 스켈레톤 UI
+
+배너 데이터 로딩 중 `null` 대신 shimmer 애니메이션이 적용된 스켈레톤 UI를 표시한다.
+모바일/데스크탑/랩탑 전 해상도에서 동일하게 동작하며 웹뷰 여부와 무관하게 적용된다.
+
+## 동작 방식
+
+- `useGetBanners`의 `isPending`이 `true`인 동안 `SkeletonBannerWrapper`를 렌더링
+- 데이터 로드 완료(`isPending === false`) 후 실제 Swiper 배너로 교체
+- TanStack Query 캐시 hit 시에는 `isPending`이 false이므로 스켈레톤이 노출되지 않음
+
+## 반응형
+
+| 환경          | aspect-ratio | border-radius |
+| ------------- | ------------ | ------------- |
+| 데스크탑/랩탑 | `1180 / 316` | `26px`        |
+| 모바일        | `1.8`        | `0`           |
+
+## 관련 코드
+
+- `src/pages/MainPage/components/Banner/Banner.tsx` — `isPending` 분기 처리
+- `src/pages/MainPage/components/Banner/Banner.styles.ts` — `SkeletonBannerWrapper`, `shimmer` keyframes

--- a/frontend/src/pages/MainPage/components/Banner/Banner.styles.ts
+++ b/frontend/src/pages/MainPage/components/Banner/Banner.styles.ts
@@ -21,6 +21,15 @@ export const SkeletonBannerWrapper = styled.div`
   }
 `;
 
+export const SkeletonOverlay = styled.div`
+  position: absolute;
+  inset: 0;
+  z-index: 10;
+  background: linear-gradient(90deg, #f0f0f0 25%, #e4e4e4 50%, #f0f0f0 75%);
+  background-size: 800px 100%;
+  animation: ${shimmer} 1.5s infinite linear;
+`;
+
 export const BannerContainer = styled.div`
   max-width: 1180px;
   margin: 0 auto;

--- a/frontend/src/pages/MainPage/components/Banner/Banner.styles.ts
+++ b/frontend/src/pages/MainPage/components/Banner/Banner.styles.ts
@@ -1,5 +1,25 @@
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 import { media } from '@/styles/mediaQuery';
+
+const shimmer = keyframes`
+  0% { background-position: -800px 0; }
+  100% { background-position: 800px 0; }
+`;
+
+export const SkeletonBannerWrapper = styled.div`
+  width: 100%;
+  max-width: 1180px;
+  aspect-ratio: 1180 / 316;
+  border-radius: 26px;
+  background: linear-gradient(90deg, #f0f0f0 25%, #e4e4e4 50%, #f0f0f0 75%);
+  background-size: 800px 100%;
+  animation: ${shimmer} 1.5s infinite linear;
+
+  ${media.mobile} {
+    aspect-ratio: 1.8;
+    border-radius: 0;
+  }
+`;
 
 export const BannerContainer = styled.div`
   max-width: 1180px;

--- a/frontend/src/pages/MainPage/components/Banner/Banner.tsx
+++ b/frontend/src/pages/MainPage/components/Banner/Banner.tsx
@@ -23,6 +23,7 @@ const Banner = ({ isWebview = false }: BannerProps) => {
   const trackEvent = useMixpanelTrack();
   const [swiperInstance, setSwiperInstance] = useState<SwiperType | null>(null);
   const [currentIndex, setCurrentIndex] = useState(0);
+  const [isImageLoaded, setIsImageLoaded] = useState(false);
   const bannerType = isWebview ? 'APP_HOME' : isMobile ? 'WEB_MOBILE' : 'WEB';
   const { data: banners, isPending, isFetched } = useGetBanners(bannerType);
 
@@ -96,6 +97,7 @@ const Banner = ({ isWebview = false }: BannerProps) => {
   return (
     <Styled.BannerContainer>
       <Styled.BannerWrapper>
+        {!isImageLoaded && <Styled.SkeletonOverlay />}
         <Styled.ButtonContainer>
           <Styled.SlideButton onClick={handlePrev} aria-label='이전 배너'>
             <img src={PrevButton} alt='' />
@@ -116,7 +118,7 @@ const Banner = ({ isWebview = false }: BannerProps) => {
           }}
           speed={500}
         >
-          {displayBanners?.map((banner) => (
+          {displayBanners?.map((banner, index) => (
             <SwiperSlide key={banner.id}>
               <Styled.BannerItem
                 isClickable={!!banner.linkTo}
@@ -128,7 +130,13 @@ const Banner = ({ isWebview = false }: BannerProps) => {
                   )
                 }
               >
-                <img src={banner.imageUrl} alt={banner.alt} />
+                <img
+                  src={banner.imageUrl}
+                  alt={banner.alt}
+                  onLoad={
+                    index === 0 ? () => setIsImageLoaded(true) : undefined
+                  }
+                />
               </Styled.BannerItem>
             </SwiperSlide>
           ))}

--- a/frontend/src/pages/MainPage/components/Banner/Banner.tsx
+++ b/frontend/src/pages/MainPage/components/Banner/Banner.tsx
@@ -24,7 +24,7 @@ const Banner = ({ isWebview = false }: BannerProps) => {
   const [swiperInstance, setSwiperInstance] = useState<SwiperType | null>(null);
   const [currentIndex, setCurrentIndex] = useState(0);
   const bannerType = isWebview ? 'APP_HOME' : isMobile ? 'WEB_MOBILE' : 'WEB';
-  const { data: banners, isLoading, isFetched } = useGetBanners(bannerType);
+  const { data: banners, isPending, isFetched } = useGetBanners(bannerType);
 
   const fallbackBanners = BANNERS.map((banner) => ({
     id: banner.id,
@@ -81,8 +81,12 @@ const Banner = ({ isWebview = false }: BannerProps) => {
     handleLink(url);
   };
 
-  if (isLoading) {
-    return null;
+  if (isPending) {
+    return (
+      <Styled.BannerContainer>
+        <Styled.SkeletonBannerWrapper />
+      </Styled.BannerContainer>
+    );
   }
 
   if (displayBanners?.length === 0) {


### PR DESCRIPTION
## Summary

- `isPending` 상태일 때 `null` 대신 shimmer 애니메이션 스켈레톤 UI 표시
- 모바일/데스크탑/랩탑 전 해상도 및 웹뷰 여부 무관하게 적용
- `isLoading` → `isPending` 교체 (TanStack Query v5 권장 방식)
- API 응답 후 이미지 로딩 중에도 `SkeletonOverlay`로 스켈레톤 유지

## 스켈레톤 노출 흐름

| 단계 | 조건 | 렌더링 |
|------|------|--------|
| 1 | `isPending` | `SkeletonBannerWrapper` (단독) |
| 2 | 데이터 로드 완료 + 이미지 미로드 | `SkeletonOverlay` (BannerWrapper 위 절대 위치) |
| 3 | 첫 이미지 `onLoad` 발화 | 스켈레톤 제거, 배너 노출 |

## Test plan

- [x] 데스크탑: 배너 로딩 중 shimmer 스켈레톤이 올바른 비율(1180/316)로 표시되는지 확인
- [x] 모바일: 배너 로딩 중 shimmer 스켈레톤이 올바른 비율(1.8)로 표시되는지 확인
- [ ] 느린 네트워크 환경에서 API 응답 후 이미지 로딩 중에도 스켈레톤이 유지되는지 확인
- [ ] 데이터 로드 + 이미지 로드 완료 후 스켈레톤이 실제 배너로 교체되는지 확인
- [ ] 캐시 hit 시 스켈레톤 없이 바로 배너가 표시되는지 확인

## Jira

[MOA-861](https://seongwon0903-1741515192605.atlassian.net/browse/MOA-861)

[MOA-861]: https://seongwon0903-1741515192605.atlassian.net/browse/MOA-861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ