### PR TITLE
Jira 스토리 생성 스크립트 개선 (Windows 호환성, 자동 스프린트/담당자/에픽 지정)

### DIFF
--- a/frontend/scripts/jira-story.sh
+++ b/frontend/scripts/jira-story.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Jira 스토리 생성 스크립트
-# 사용법: ./scripts/jira-story.sh "제목" "설명" "인수조건"
+# 사용법: ./scripts/jira-story.sh "제목" "설명" "인수조건" "에픽키(선택)"
 #
 # 필수 환경 변수 (.env 또는 shell에서 설정):
 #   JIRA_HOST         - Atlassian 인스턴스 호스트명 (예: yourcompany.atlassian.net)
@@ -22,6 +22,7 @@ ISSUE_TYPE="Story"
 SUMMARY="${1:-}"
 DESCRIPTION="${2:-}"
 AC="${3:-}"
+EPIC_KEY="${4:-}"
 
 if [ -z "$SUMMARY" ]; then
   echo "오류: 스토리 제목이 필요합니다." >&2
@@ -109,6 +110,7 @@ jq -n \
   --argjson content "$ADF_CONTENT" \
   --argjson sprintId "${SPRINT_ID:-null}" \
   --arg assigneeId "${JIRA_ASSIGNEE_ID:-}" \
+  --arg epicKey "${EPIC_KEY:-}" \
   '{
     fields: {
       project: { key: $project },
@@ -122,7 +124,8 @@ jq -n \
     }
   }
   | if $sprintId != null then .fields.customfield_10020 = $sprintId else . end
-  | if $assigneeId != "" then .fields.assignee = { accountId: $assigneeId } else . end' \
+  | if $assigneeId != "" then .fields.assignee = { accountId: $assigneeId } else . end
+  | if $epicKey != "" then .fields.parent = { key: $epicKey } else . end' \
   > "$PAYLOAD_FILE"
 
 TMPFILE=$(mktemp)

--- a/frontend/scripts/jira-story.sh
+++ b/frontend/scripts/jira-story.sh
@@ -42,6 +42,17 @@ if [ -z "${JIRA_EMAIL:-}" ] || [ -z "${JIRA_API_TOKEN:-}" ]; then
   exit 1
 fi
 
+if ! command -v jq &>/dev/null; then
+  echo "오류: jq가 필요합니다." >&2
+  case "$(uname -s)" in
+    Darwin*) echo "  brew install jq" >&2 ;;
+    MINGW*|MSYS*|CYGWIN*) echo "  winget install jqlang.jq" >&2 ;;
+    Linux*) echo "  sudo apt install jq  또는  sudo yum install jq" >&2 ;;
+    *) echo "  https://jqlang.github.io/jq/download/" >&2 ;;
+  esac
+  exit 1
+fi
+
 # ADF(Atlassian Document Format) 본문 구성
 build_adf_content() {
   local desc="$1"
@@ -65,14 +76,11 @@ build_adf_content() {
   echo "$content"
 }
 
-if ! command -v jq &>/dev/null; then
-  echo "오류: jq가 필요합니다. brew install jq" >&2
-  exit 1
-fi
-
 ADF_CONTENT=$(build_adf_content "$DESCRIPTION" "$AC")
 
-PAYLOAD=$(jq -n \
+# payload를 파일로 저장 (Windows 셸 호환)
+PAYLOAD_FILE=$(mktemp)
+jq -n \
   --arg summary "$SUMMARY" \
   --arg project "$PROJECT_KEY" \
   --arg issuetype "$ISSUE_TYPE" \
@@ -89,7 +97,8 @@ PAYLOAD=$(jq -n \
         content: $content
       }
     }
-  } | if $sprintId != null then .fields.customfield_10020 = $sprintId else . end')
+  } | if $sprintId != null then .fields.customfield_10020 = $sprintId else . end' \
+  > "$PAYLOAD_FILE"
 
 TMPFILE=$(mktemp)
 HTTP_CODE=$(curl -s -o "$TMPFILE" -w "%{http_code}" \
@@ -98,10 +107,10 @@ HTTP_CODE=$(curl -s -o "$TMPFILE" -w "%{http_code}" \
   -X POST \
   -u "${JIRA_EMAIL}:${JIRA_API_TOKEN}" \
   -H "Content-Type: application/json" \
-  -d "$PAYLOAD" \
+  -d @"$PAYLOAD_FILE" \
   "https://${JIRA_HOST}/rest/api/3/issue")
 BODY=$(cat "$TMPFILE")
-rm -f "$TMPFILE"
+rm -f "$TMPFILE" "$PAYLOAD_FILE"
 
 if [ "$HTTP_CODE" = "201" ]; then
   ISSUE_KEY=$(echo "$BODY" | jq -r '.key')

--- a/frontend/scripts/jira-story.sh
+++ b/frontend/scripts/jira-story.sh
@@ -3,10 +3,12 @@
 # 사용법: ./scripts/jira-story.sh "제목" "설명" "인수조건"
 #
 # 필수 환경 변수 (.env 또는 shell에서 설정):
-#   JIRA_HOST       - Atlassian 인스턴스 호스트명 (예: yourcompany.atlassian.net)
-#   PROJECT_KEY     - Jira 프로젝트 키 (예: MOA)
-#   JIRA_EMAIL      - Atlassian 계정 이메일
-#   JIRA_API_TOKEN  - Atlassian API 토큰 (https://id.atlassian.com/manage-profile/security/api-tokens)
+#   JIRA_HOST         - Atlassian 인스턴스 호스트명 (예: yourcompany.atlassian.net)
+#   PROJECT_KEY       - Jira 프로젝트 키 (예: MOA)
+#   JIRA_EMAIL        - Atlassian 계정 이메일
+#   JIRA_API_TOKEN    - Atlassian API 토큰 (https://id.atlassian.com/manage-profile/security/api-tokens)
+#   JIRA_BOARD_ID     - Jira 보드 ID (활성 스프린트 자동 조회용)
+#   JIRA_ASSIGNEE_ID  - 담당자 Jira account ID
 set -euo pipefail
 
 # 프로젝트 루트의 .env 자동 로드
@@ -20,7 +22,6 @@ ISSUE_TYPE="Story"
 SUMMARY="${1:-}"
 DESCRIPTION="${2:-}"
 AC="${3:-}"
-SPRINT_ID="${4:-}"
 
 if [ -z "$SUMMARY" ]; then
   echo "오류: 스토리 제목이 필요합니다." >&2
@@ -51,6 +52,27 @@ if ! command -v jq &>/dev/null; then
     *) echo "  https://jqlang.github.io/jq/download/" >&2 ;;
   esac
   exit 1
+fi
+
+# 활성 스프린트 자동 조회
+SPRINT_ID=""
+if [ -n "${JIRA_BOARD_ID:-}" ]; then
+  SPRINT_RESPONSE=$(curl -s \
+    --connect-timeout 5 \
+    --max-time 10 \
+    -u "${JIRA_EMAIL}:${JIRA_API_TOKEN}" \
+    "https://${JIRA_HOST}/rest/agile/1.0/board/${JIRA_BOARD_ID}/sprint?state=active" 2>/dev/null || true)
+
+  if [ -n "$SPRINT_RESPONSE" ]; then
+    SPRINT_ID=$(echo "$SPRINT_RESPONSE" | jq -r '.values[0].id // empty' 2>/dev/null || true)
+    SPRINT_NAME=$(echo "$SPRINT_RESPONSE" | jq -r '.values[0].name // empty' 2>/dev/null || true)
+  fi
+
+  if [ -n "$SPRINT_ID" ]; then
+    echo "📋 활성 스프린트: ${SPRINT_NAME} (ID: ${SPRINT_ID})"
+  else
+    echo "⚠️  활성 스프린트가 없어 백로그에 추가됩니다."
+  fi
 fi
 
 # ADF(Atlassian Document Format) 본문 구성
@@ -86,6 +108,7 @@ jq -n \
   --arg issuetype "$ISSUE_TYPE" \
   --argjson content "$ADF_CONTENT" \
   --argjson sprintId "${SPRINT_ID:-null}" \
+  --arg assigneeId "${JIRA_ASSIGNEE_ID:-}" \
   '{
     fields: {
       project: { key: $project },
@@ -97,7 +120,9 @@ jq -n \
         content: $content
       }
     }
-  } | if $sprintId != null then .fields.customfield_10020 = $sprintId else . end' \
+  }
+  | if $sprintId != null then .fields.customfield_10020 = $sprintId else . end
+  | if $assigneeId != "" then .fields.assignee = { accountId: $assigneeId } else . end' \
   > "$PAYLOAD_FILE"
 
 TMPFILE=$(mktemp)

--- a/frontend/src/pages/ClubDetailPage/components/ClubProfileCard/ClubProfileCard.styles.ts
+++ b/frontend/src/pages/ClubDetailPage/components/ClubProfileCard/ClubProfileCard.styles.ts
@@ -214,6 +214,8 @@ export const LocationInfo = styled.div`
   gap: 5px;
   cursor: default;
   user-select: none;
+  min-width: 0;
+  overflow: hidden;
 
   img {
     width: 12px;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #1568 

## 📝작업 내용

> jira-story.sh 스크립트를 개선하여 Windows 환경 호환성을 확보하고, 스토리 생성 시 자동화 기능을 추가했습니다.

### Windows 호환성 개선
- jq 미설치 시 OS별(Mac/Windows/Linux) 안내 메시지 출력
- JSON payload를 임시 파일로 저장 후 -d @파일로 전달하여 Windows 셸에서 JSON 파싱 오류 해결

### 활성 스프린트 자동 배치
- JIRA_BOARD_ID 환경변수로 보드의 활성 스프린트를 API로 자동 조회
- 활성 스프린트가 없으면 백로그에 추가

### 담당자 자동 지정
- JIRA_ASSIGNEE_ID 환경변수로 스토리 생성 시 담당자 자동 설정

### 에픽(상위항목) 자동 지정
- 4번째 인자로 에픽 키를 전달하면 parent 필드로 상위항목 자동 지정
- /jira-story 실행 시 내용을 분석하여 기존 에픽 중 적절한 에픽을 추천


## 🫡 참고사항
- .env에 JIRA_BOARD_ID, JIRA_ASSIGNEE_ID 추가가 필요합니다
- [.env](https://www.notion.so/Jira-api-token-1b2aad23209680e88ecfdfeaac33278e)
