### PR TITLE
[fix] 홍보게시판 이미지 업로드 시에 올바르게 업로드가 간헐적으로 안되는 문제 수정

### DIFF
--- a/backend/src/main/java/moadong/club/entity/PromotionArticle.java
+++ b/backend/src/main/java/moadong/club/entity/PromotionArticle.java
@@ -9,6 +9,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 
 @Document("promotion_articles")
@@ -60,6 +61,17 @@ public class PromotionArticle {
         this.eventEndDate = request.eventEndDate();
         this.description = request.description();
         this.images = request.images();
+    }
+
+    public void addImage(String imageUrl) {
+        if (imageUrl == null || imageUrl.isBlank()) {
+            return;
+        }
+        List<String> nextImages = new ArrayList<>(this.images == null ? List.of() : this.images);
+        if (!nextImages.contains(imageUrl)) {
+            nextImages.add(imageUrl);
+        }
+        this.images = nextImages;
     }
 
     public void softDelete() {

--- a/backend/src/main/java/moadong/media/service/PromotionImageUploadService.java
+++ b/backend/src/main/java/moadong/media/service/PromotionImageUploadService.java
@@ -1,12 +1,14 @@
 package moadong.media.service;
 
 import lombok.RequiredArgsConstructor;
+import moadong.club.entity.PromotionArticle;
 import moadong.club.repository.PromotionArticleRepository;
+import moadong.global.config.properties.AwsProperties;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
-import moadong.global.config.properties.AwsProperties;
 import moadong.media.dto.PromotionImageUploadResponse;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -22,8 +24,9 @@ public class PromotionImageUploadService {
     private final R2ImageUploadService r2ImageUploadService;
     private final AwsProperties awsProperties;
 
+    @Transactional
     public PromotionImageUploadResponse upload(String articleId, MultipartFile file) {
-        ensurePromotionArticleExists(articleId);
+        PromotionArticle article = getActivePromotionArticle(articleId);
         String key = buildPromotionImageKey(articleId, file);
         String imageUrl = r2ImageUploadService.upload(
             file,
@@ -31,13 +34,14 @@ public class PromotionImageUploadService {
             awsProperties.s3().viewEndpoint(),
             key
         );
+        article.addImage(imageUrl);
+        promotionArticleRepository.save(article);
         return new PromotionImageUploadResponse(imageUrl);
     }
 
-    private void ensurePromotionArticleExists(String articleId) {
-        if (!promotionArticleRepository.existsActiveById(articleId)) {
-            throw new RestApiException(ErrorCode.PROMOTION_ARTICLE_NOT_FOUND);
-        }
+    private PromotionArticle getActivePromotionArticle(String articleId) {
+        return promotionArticleRepository.findActiveById(articleId)
+            .orElseThrow(() -> new RestApiException(ErrorCode.PROMOTION_ARTICLE_NOT_FOUND));
     }
 
     private String buildPromotionImageKey(String articleId, MultipartFile file) {

--- a/backend/src/main/resources/static/dev/index.html
+++ b/backend/src/main/resources/static/dev/index.html
@@ -2410,26 +2410,9 @@
         fileInput.value = '';
 
         if (targetArticleId) {
-          const payload = normalizePromotionPayload();
-          const updateResult = await updatePromotionArticleRequest(targetArticleId, payload);
-          const updateRes = updateResult.res;
-          const updateData = updateResult.data;
-          if (updateRes.status === 403) {
-            setPromotionBanner('이미지는 업로드되었지만 게시글 저장 권한이 없습니다.', 'warn');
-            return;
-          }
-          if (updateRes.status === 404) {
-            setPromotionBanner('이미지는 업로드되었지만 게시글 저장 대상이 없어졌습니다. 목록을 새로고침해 확인하세요.', 'warn');
-            return;
-          }
-          if (!updateRes.ok) {
-            setPromotionBanner(updateData.message || '이미지는 업로드되었지만 게시글 반영 저장에 실패했습니다.', 'warn');
-            return;
-          }
-
           const syncResult = await reloadPromotionList({ selectedArticleId: targetArticleId, keepMessage: true });
           if (!syncResult.ok) {
-            setPromotionBanner('이미지 업로드 후 목록 동기화에 실패했습니다. 목록을 새로고침해 확인하세요.', 'warn');
+            setPromotionBanner('이미지 업로드와 게시글 반영은 완료되었지만 목록 동기화에 실패했습니다. 목록을 새로고침해 확인하세요.', 'warn');
             return;
           }
         }

--- a/backend/src/test/java/moadong/media/service/PromotionImageUploadServiceTest.java
+++ b/backend/src/test/java/moadong/media/service/PromotionImageUploadServiceTest.java
@@ -1,5 +1,6 @@
 package moadong.media.service;
 
+import moadong.club.entity.PromotionArticle;
 import moadong.club.repository.PromotionArticleRepository;
 import moadong.global.config.properties.AwsProperties;
 import moadong.global.exception.ErrorCode;
@@ -12,6 +13,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -38,25 +43,33 @@ class PromotionImageUploadServiceTest {
     private PromotionImageUploadService promotionImageUploadService;
 
     @Test
-    void 홍보이미지_업로드시_articleId_prefix로_저장한다() {
+    void 홍보이미지_업로드시_articleId_prefix로_저장하고_게시글_이미지목록에_추가한다() {
         String articleId = "article-1";
         MockMultipartFile file = new MockMultipartFile("file", "poster main.png", "image/png", "img".getBytes());
         AwsProperties.S3 s3 = new AwsProperties.S3("moadong-dev", "https://r2.example.com", "https://cdn.example.com");
+        PromotionArticle article = PromotionArticle.builder()
+            .id(articleId)
+            .images(new ArrayList<>(List.of("https://cdn.example.com/existing.png")))
+            .build();
+        String uploadedUrl = "https://cdn.example.com/promotion/articles/" + articleId + "/2026/03/uuid-poster_main.png";
         when(awsProperties.s3()).thenReturn(s3);
-        when(promotionArticleRepository.existsActiveById(articleId)).thenReturn(true);
+        when(promotionArticleRepository.findActiveById(articleId)).thenReturn(Optional.of(article));
         when(r2ImageUploadService.upload(eq(file), eq("moadong-dev"), eq("https://cdn.example.com"), startsWith("promotion/articles/" + articleId + "/")))
-            .thenReturn("https://cdn.example.com/promotion/articles/" + articleId + "/2026/03/uuid-poster_main.png");
+            .thenReturn(uploadedUrl);
 
         PromotionImageUploadResponse response = promotionImageUploadService.upload(articleId, file);
 
-        verify(promotionArticleRepository).existsActiveById(articleId);
+        verify(promotionArticleRepository).findActiveById(articleId);
         verify(r2ImageUploadService).upload(eq(file), eq("moadong-dev"), eq("https://cdn.example.com"), startsWith("promotion/articles/" + articleId + "/"));
+        verify(promotionArticleRepository).save(article);
+        assertEquals(uploadedUrl, response.imageUrl());
         assertTrue(response.imageUrl().contains("/promotion/articles/" + articleId + "/"));
+        assertEquals(List.of("https://cdn.example.com/existing.png", uploadedUrl), article.getImages());
     }
 
     @Test
     void 존재하지_않는_홍보게시글이면_예외를_던진다() {
-        when(promotionArticleRepository.existsActiveById("missing")).thenReturn(false);
+        when(promotionArticleRepository.findActiveById("missing")).thenReturn(Optional.empty());
         MockMultipartFile file = new MockMultipartFile("file", "poster.png", "image/png", "img".getBytes());
 
         RestApiException exception = assertThrows(RestApiException.class,
@@ -67,13 +80,13 @@ class PromotionImageUploadServiceTest {
 
     @Test
     void 삭제된_홍보게시글이면_이미지_업로드를_막는다() {
-        when(promotionArticleRepository.existsActiveById("deleted-article")).thenReturn(false);
+        when(promotionArticleRepository.findActiveById("deleted-article")).thenReturn(Optional.empty());
         MockMultipartFile file = new MockMultipartFile("file", "poster.png", "image/png", "img".getBytes());
 
         RestApiException exception = assertThrows(RestApiException.class,
             () -> promotionImageUploadService.upload("deleted-article", file));
 
         assertEquals(ErrorCode.PROMOTION_ARTICLE_NOT_FOUND, exception.getErrorCode());
-        verify(promotionArticleRepository).existsActiveById("deleted-article");
+        verify(promotionArticleRepository).findActiveById("deleted-article");
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #1571, MOA-883

## 📝작업 내용

- 홍보 이미지 업로드 API에서 R2 업로드 후 게시글 `images` 목록에 업로드 URL을 바로 저장하도록 변경했습니다.
- 개발자 포털에서 이미지 업로드 후 게시글 전체 `PUT` 저장을 다시 호출하지 않고 목록 동기화만 수행하도록 변경했습니다.
- 좌표 등 기존 게시글 필드 검증 실패로 이미지 반영이 누락되는 케이스를 막았습니다.
- 업로드 서비스 단위 테스트를 이미지 목록 저장까지 검증하도록 보강했습니다.

## 중점적으로 리뷰받고 싶은 부분(선택)

- 이미지 업로드 API가 URL 반환뿐 아니라 게시글 이미지 목록 저장까지 책임지도록 변경한 방향이 적절한지 봐주세요.

## 논의하고 싶은 부분(선택)

- 현재 R2 업로드 성공 후 DB 저장이 실패하면 업로드된 파일이 남을 수 있습니다. 이미지 정리 정책은 별도 후속으로 가져갈지 논의가 필요합니다.

## 🫡 참고사항

- 검증: `backend`에서 `./gradlew.bat test`
- 미추적 파일 `backend/.gradle-user-home/`는 커밋에 포함하지 않았습니다.