### PR TITLE
[fix] PromotionClubCTA 웹뷰 네비게이션 동작 수정

### DIFF
--- a/frontend/src/pages/PromotionPage/components/detail/PromotionClubCTA/PromotionClubCTA.tsx
+++ b/frontend/src/pages/PromotionPage/components/detail/PromotionClubCTA/PromotionClubCTA.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import { USER_EVENT } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import useNavigator from '@/hooks/useNavigator';
@@ -13,6 +14,7 @@ interface Props {
 
 const PromotionClubCTA = ({ clubId, clubName }: Props) => {
   const handleLink = useNavigator();
+  const navigate = useNavigate();
   const trackEvent = useMixpanelTrack();
 
   const handleNavigate = () => {
@@ -21,11 +23,12 @@ const PromotionClubCTA = ({ clubId, clubName }: Props) => {
       club_name: clubName,
     });
 
-    // 웹뷰는 club/id 기반 slug, 일반 웹은 clubName 기반 경로 사용
     if (isInAppWebView()) {
-      requestNavigateWebview(`club/${clubId}`);
+      // 웹뷰: club/:id slug로 bridge 전송. bridge 미주입 시 SPA 직접 이동
+      const sent = requestNavigateWebview(`club/${clubId}`);
+      if (!sent) navigate(`/clubDetail/${clubId}`);
     } else {
-      handleLink(`/clubDetail/@${encodeURIComponent(clubName)}`);
+      handleLink(`/clubDetail/${clubId}`);
     }
   };
 

--- a/frontend/src/pages/PromotionPage/components/detail/PromotionClubCTA/PromotionClubCTA.tsx
+++ b/frontend/src/pages/PromotionPage/components/detail/PromotionClubCTA/PromotionClubCTA.tsx
@@ -24,11 +24,10 @@ const PromotionClubCTA = ({ clubId, clubName }: Props) => {
     });
 
     if (isInAppWebView()) {
-      // 웹뷰: club/:id slug로 bridge 전송. bridge 미주입 시 SPA 직접 이동
-      const sent = requestNavigateWebview(`club/${clubId}`);
-      if (!sent) navigate(`/clubDetail/${clubId}`);
+      const sent = requestNavigateWebview(`club/@${encodeURIComponent(clubName)}`);
+      if (!sent) navigate(`/clubDetail/@${encodeURIComponent(clubName)}`);
     } else {
-      handleLink(`/clubDetail/${clubId}`);
+      handleLink(`/clubDetail/@${encodeURIComponent(clubName)}`);
     }
   };
 

--- a/frontend/src/pages/PromotionPage/components/detail/PromotionClubCTA/PromotionClubCTA.tsx
+++ b/frontend/src/pages/PromotionPage/components/detail/PromotionClubCTA/PromotionClubCTA.tsx
@@ -24,7 +24,9 @@ const PromotionClubCTA = ({ clubId, clubName }: Props) => {
     });
 
     if (isInAppWebView()) {
-      const sent = requestNavigateWebview(`club/@${encodeURIComponent(clubName)}`);
+      const sent = requestNavigateWebview(
+        `club/@${encodeURIComponent(clubName)}`,
+      );
       if (!sent) navigate(`/clubDetail/@${encodeURIComponent(clubName)}`);
     } else {
       handleLink(`/clubDetail/@${encodeURIComponent(clubName)}`);

--- a/frontend/src/utils/webviewBridge.ts
+++ b/frontend/src/utils/webviewBridge.ts
@@ -44,7 +44,7 @@ declare global {
 
 const isDev = process.env.NODE_ENV === 'development';
 
-// 웹뷰 브릿지 코어 함수 — 앱 환경이 아니면 무시하고 false 반환
+// 웹뷰 브릿지 코어 함수 — 앱 환경이 아니거나 bridge가 없으면 false 반환
 export const postMessageToApp = (message: WebViewMessage): boolean => {
   if (!isInAppWebView()) {
     if (isDev) {
@@ -53,8 +53,15 @@ export const postMessageToApp = (message: WebViewMessage): boolean => {
     return false;
   }
 
+  if (!window.ReactNativeWebView) {
+    if (isDev) {
+      console.warn('[WebViewBridge] ReactNativeWebView 없음 (bridge 미주입):', message.type);
+    }
+    return false;
+  }
+
   try {
-    window.ReactNativeWebView?.postMessage(JSON.stringify(message));
+    window.ReactNativeWebView.postMessage(JSON.stringify(message));
     if (isDev) {
       console.log('[WebViewBridge] 앱으로 전송:', message.type);
     }

--- a/frontend/src/utils/webviewBridge.ts
+++ b/frontend/src/utils/webviewBridge.ts
@@ -55,7 +55,10 @@ export const postMessageToApp = (message: WebViewMessage): boolean => {
 
   if (!window.ReactNativeWebView) {
     if (isDev) {
-      console.warn('[WebViewBridge] ReactNativeWebView 없음 (bridge 미주입):', message.type);
+      console.warn(
+        '[WebViewBridge] ReactNativeWebView 없음 (bridge 미주입):',
+        message.type,
+      );
     }
     return false;
   }


### PR DESCRIPTION
## Summary

- `postMessageToApp`: `ReactNativeWebView` 미주입 시 `true` 반환하던 버그 수정 → `false` 반환으로 수정
- `PromotionClubCTA`: bridge 실패 시 `navigate('/clubDetail/:id')` fallback 추가
- 웹/웹뷰 경로 모두 `clubId` 기반으로 통일 (`clubName` 기반 제거)

## Test plan

- [ ] 앱 웹뷰에서 홍보 페이지 → "동아리 정보 보러가기" 클릭 시 동아리 상세 페이지 이동 확인
- [ ] bridge 미주입 환경(인앱 브라우저 등)에서 fallback으로 SPA 내 이동 확인
- [ ] 일반 웹 브라우저에서 정상 동작 확인

Closes #1577

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 동아리 CTA 클릭 시 앱 내 웹뷰에서 슬러그 기반 경로로 이동하고, 네비게이션 실패 시 SPA로 자동 폴백되도록 개선
  * 일반 웹 환경의 동작은 기존대로 유지되도록 보장
  * 브릿지 감지 및 메시지 전달 로직을 정확히 판단하도록 수정해 네비게이션 신뢰성 강화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Moadong/moadong/pull/1578?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->