### PR TITLE
[feature] 클럽카드 impression 트래킹 전면 개편 및 배너 네비게이션 트래킹 추가

### DIFF
--- a/frontend/docs/claude/conventions.md
+++ b/frontend/docs/claude/conventions.md
@@ -16,3 +16,9 @@
 - styled-components 사용, 테마 시스템 활용
 - `any` 금지, 명시적 타입 정의
 - 상수는 `src/constants/`에서 관리
+
+## Mixpanel 이벤트 트래킹
+
+- 이벤트명은 `src/constants/eventName.ts`의 `USER_EVENT`에서 관리
+- 문자열 하드코딩 금지
+- sessionStorage 키는 `page + id` 스코프로 작성

--- a/frontend/docs/features/main/club-card-tracking.md
+++ b/frontend/docs/features/main/club-card-tracking.md
@@ -1,0 +1,40 @@
+# ClubCard 뷰 트래킹
+
+ClubCard 컴포넌트의 Mixpanel 인상(impression) 트래킹 구현.
+
+## 동작 방식
+
+IntersectionObserver(threshold 50%)로 카드 진입/이탈을 감지한다.
+
+- **진입 시**: `intersectStart`, `capturedTop`, `capturedScrollY` 기록. cooldown(2s) 이내 재진입은 무시.
+- **이탈 시**: `fireImpressionEvent()` 호출 → `CLUB_CARD_VIEWED` 이벤트 발화.
+- **탭 전환/종료 시**: `visibilitychange` 이벤트로 동일하게 처리.
+- **언마운트 시**: cleanup에서 `fireImpressionEvent()` 호출.
+
+## sessionStorage 구조
+
+```
+clubcard_last_{page}_{clubId}   → 마지막 이벤트 발화 시각 (cooldown 판단용)
+clubcard_count_{page}_{clubId}  → 탭 세션 내 누적 view_count
+```
+
+키에 `page`를 포함해 같은 카드가 여러 페이지에 렌더링돼도 독립 집계한다.
+
+## CLUB_CARD_VIEWED 이벤트 프로퍼티
+
+| 프로퍼티 | 설명 |
+|----------|------|
+| `club_id` / `club_name` | 카드 식별자 |
+| `recruitment_status` | 모집 상태 |
+| `page` | 렌더링된 페이지 |
+| `scroll_y` | 진입 시점 스크롤 위치 |
+| `card_top_in_viewport` | 진입 시점 카드 상단 좌표(px) |
+| `dwell_ms` | 실제 체류 시간 (진입 → 이탈) |
+| `view_count` | 탭 세션 내 누적 조회 횟수 |
+| `reentry_count` | `view_count - 1` (재방문 횟수) |
+| `device_type` | 디바이스 타입 |
+
+## 관련 코드
+
+- `src/pages/MainPage/components/ClubCard/ClubCard.tsx` — 트래킹 구현
+- `src/constants/eventName.ts` — `CLUB_CARD_VIEWED`, `CLUB_CARD_CLICKED`

--- a/frontend/docs/features/main/club-card-tracking.md
+++ b/frontend/docs/features/main/club-card-tracking.md
@@ -37,4 +37,4 @@ clubcard_count_{page}_{clubId}  → 탭 세션 내 누적 view_count
 ## 관련 코드
 
 - `src/pages/MainPage/components/ClubCard/ClubCard.tsx` — 트래킹 구현
-- `src/constants/eventName.ts` — `CLUB_CARD_VIEWED`, `CLUB_CARD_CLICKED`
+- `src/constants/eventName.ts` — `CLUB_CARD_VIEWED`, `CLUB_CARD_CLICKED`, `BANNER_NAVIGATION_CLICKED`

--- a/frontend/docs/features/main/club-card-tracking.md
+++ b/frontend/docs/features/main/club-card-tracking.md
@@ -13,7 +13,7 @@ IntersectionObserver(threshold 50%)로 카드 진입/이탈을 감지한다.
 
 ## sessionStorage 구조
 
-```
+```text
 clubcard_last_{page}_{clubId}   → 마지막 이벤트 발화 시각 (cooldown 판단용)
 clubcard_count_{page}_{clubId}  → 탭 세션 내 누적 view_count
 ```

--- a/frontend/scripts/cross-review.sh
+++ b/frontend/scripts/cross-review.sh
@@ -39,11 +39,11 @@ esac
 pick_reviewer() {
   local prefer="$1"
   if [ "$prefer" = "codex" ] && command -v codex &>/dev/null; then
-    RUN_REVIEW() { codex -q "$1"; }; CLI_NAME="codex"
+    RUN_REVIEW() { codex review "$1"; }; CLI_NAME="codex"
   elif [ "$prefer" = "claude" ] && command -v claude &>/dev/null; then
     RUN_REVIEW() { claude -p "$1"; }; CLI_NAME="claude"
   elif command -v codex &>/dev/null; then
-    RUN_REVIEW() { codex -q "$1"; }; CLI_NAME="codex"
+    RUN_REVIEW() { codex review "$1"; }; CLI_NAME="codex"
   elif command -v claude &>/dev/null; then
     RUN_REVIEW() { claude -p "$1"; }; CLI_NAME="claude"
   else

--- a/frontend/src/constants/eventName.ts
+++ b/frontend/src/constants/eventName.ts
@@ -17,6 +17,7 @@ export const USER_EVENT = {
   // 배너 클릭
   BANNER_CLICKED: 'Banner Clicked',
   APP_DOWNLOAD_BANNER_CLICKED: 'App Download Banner Clicked',
+  BANNER_NAVIGATION_CLICKED: 'Banner Navigation Clicked',
 
   // 네비게이션
   BACK_BUTTON_CLICKED: 'Back Button Clicked',

--- a/frontend/src/pages/MainPage/components/Banner/Banner.tsx
+++ b/frontend/src/pages/MainPage/components/Banner/Banner.tsx
@@ -46,7 +46,7 @@ const Banner = ({ isWebview = false }: BannerProps) => {
     swiperInstance?.slidePrev();
     trackEvent(USER_EVENT.BANNER_NAVIGATION_CLICKED, {
       direction: 'prev',
-      current_index: currentIndex,
+      from_index: currentIndex,
     });
   };
 
@@ -54,7 +54,7 @@ const Banner = ({ isWebview = false }: BannerProps) => {
     swiperInstance?.slideNext();
     trackEvent(USER_EVENT.BANNER_NAVIGATION_CLICKED, {
       direction: 'next',
-      current_index: currentIndex,
+      from_index: currentIndex,
     });
   };
 

--- a/frontend/src/pages/MainPage/components/Banner/Banner.tsx
+++ b/frontend/src/pages/MainPage/components/Banner/Banner.tsx
@@ -44,10 +44,18 @@ const Banner = ({ isWebview = false }: BannerProps) => {
 
   const handlePrev = () => {
     swiperInstance?.slidePrev();
+    trackEvent(USER_EVENT.BANNER_NAVIGATION_CLICKED, {
+      direction: 'prev',
+      current_index: currentIndex,
+    });
   };
 
   const handleNext = () => {
     swiperInstance?.slideNext();
+    trackEvent(USER_EVENT.BANNER_NAVIGATION_CLICKED, {
+      direction: 'next',
+      current_index: currentIndex,
+    });
   };
 
   const handleImageError = (

--- a/frontend/src/pages/MainPage/components/ClubCard/ClubCard.tsx
+++ b/frontend/src/pages/MainPage/components/ClubCard/ClubCard.tsx
@@ -73,6 +73,7 @@ const ClubCard = ({
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) {
+          if (intersectStart !== null) return;
           const lastTime = parseInt(
             sessionStorage.getItem(SS_LAST_KEY) ?? '0',
             10,

--- a/frontend/src/pages/MainPage/components/ClubCard/ClubCard.tsx
+++ b/frontend/src/pages/MainPage/components/ClubCard/ClubCard.tsx
@@ -18,6 +18,9 @@ interface ClubCardProps {
   onCardClick?: (club: Club) => void;
 }
 
+const COOLDOWN_MS = 2_000; // IntersectionObserver jitter 방지
+const IMPRESSION_THRESHOLD = 0.5; // IAB 뷰어빌리티 기준 (50% in-view)
+
 const ClubCard = ({
   club,
   index,
@@ -29,45 +32,68 @@ const ClubCard = ({
   const trackEvent = useMixpanelTrack();
   const [isClicked, setIsClicked] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
-  const hasTrackedImpression = useRef(false);
+
+  const SS_LAST_KEY = `clubcard_last_${page ?? 'default'}_${club.id}`;
+  const SS_COUNT_KEY = `clubcard_count_${page ?? 'default'}_${club.id}`;
 
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
 
-    let dwellTimer: ReturnType<typeof setTimeout> | null = null;
+    let intersectStart: number | null = null;
+    let capturedTop: number | null = null;
+    let capturedScrollY: number | null = null;
+
+    const fireImpressionEvent = () => {
+      if (intersectStart === null) return;
+      const dwell_ms = Date.now() - intersectStart;
+      const count =
+        parseInt(sessionStorage.getItem(SS_COUNT_KEY) ?? '0', 10) + 1;
+      sessionStorage.setItem(SS_LAST_KEY, String(Date.now()));
+      sessionStorage.setItem(SS_COUNT_KEY, String(count));
+      trackEvent(USER_EVENT.CLUB_CARD_VIEWED, {
+        club_id: club.id,
+        club_name: club.name,
+        recruitment_status: club.recruitmentStatus,
+        page,
+        scroll_y: capturedScrollY,
+        card_top_in_viewport: capturedTop,
+        dwell_ms,
+        view_count: count,
+        reentry_count: Math.max(0, count - 1),
+        device_type: getDeviceType(),
+      });
+      intersectStart = null;
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') fireImpressionEvent();
+    };
 
     const observer = new IntersectionObserver(
       ([entry]) => {
-        if (entry.isIntersecting && !hasTrackedImpression.current) {
-          const intersectTime = Date.now();
-          const capturedTop = Math.round(entry.boundingClientRect.top);
-          dwellTimer = setTimeout(() => {
-            if (hasTrackedImpression.current) return;
-            hasTrackedImpression.current = true;
-            trackEvent(USER_EVENT.CLUB_CARD_VIEWED, {
-              club_id: club.id,
-              club_name: club.name,
-              recruitment_status: club.recruitmentStatus,
-              page,
-              scroll_y: Math.round(window.scrollY),
-              card_top_in_viewport: capturedTop,
-              dwell_ms: Date.now() - intersectTime,
-              device_type: getDeviceType(),
-            });
-          }, 3000);
-        } else if (dwellTimer) {
-          clearTimeout(dwellTimer);
-          dwellTimer = null;
+        if (entry.isIntersecting) {
+          const lastTime = parseInt(
+            sessionStorage.getItem(SS_LAST_KEY) ?? '0',
+            10,
+          );
+          if (Date.now() - lastTime < COOLDOWN_MS) return;
+          intersectStart = Date.now();
+          capturedTop = Math.round(entry.boundingClientRect.top);
+          capturedScrollY = Math.round(window.scrollY);
+        } else {
+          fireImpressionEvent();
         }
       },
-      { threshold: 0.5 },
+      { threshold: IMPRESSION_THRESHOLD },
     );
 
     observer.observe(el);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
     return () => {
       observer.disconnect();
-      if (dwellTimer) clearTimeout(dwellTimer);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      fireImpressionEvent();
     };
   }, [club.id, club.name, club.recruitmentStatus, page]);
 

--- a/frontend/src/pages/MainPage/components/ClubCard/ClubCard.tsx
+++ b/frontend/src/pages/MainPage/components/ClubCard/ClubCard.tsx
@@ -20,6 +20,7 @@ interface ClubCardProps {
 
 const COOLDOWN_MS = 2_000; // IntersectionObserver jitter 방지
 const IMPRESSION_THRESHOLD = 0.5; // IAB 뷰어빌리티 기준 (50% in-view)
+const MIN_DWELL_MS = 300; // 안구 고정 최소 시간 기반, fly-by 스크롤 제외
 
 const ClubCard = ({
   club,
@@ -47,6 +48,8 @@ const ClubCard = ({
     const fireImpressionEvent = () => {
       if (intersectStart === null) return;
       const dwell_ms = Date.now() - intersectStart;
+      intersectStart = null;
+      if (dwell_ms < MIN_DWELL_MS) return;
       const count =
         parseInt(sessionStorage.getItem(SS_COUNT_KEY) ?? '0', 10) + 1;
       sessionStorage.setItem(SS_LAST_KEY, String(Date.now()));
@@ -63,7 +66,6 @@ const ClubCard = ({
         reentry_count: Math.max(0, count - 1),
         device_type: getDeviceType(),
       });
-      intersectStart = null;
     };
 
     const handleVisibilityChange = () => {


### PR DESCRIPTION
## Summary

- ClubCard: 3초 dwell 임계값 제거 → 뷰포트 진입/이탈 기반 실제 체류시간(`dwell_ms`) 측정
- ClubCard: `view_count` · `reentry_count` sessionStorage 세션 집계 (page 스코프로 cross-page 오염 방지)
- ClubCard: `visibilitychange` 이벤트로 탭 종료/전환 시 이벤트 유실 방지, cooldown 15s → 2s
- ClubCard: `MIN_DWELL_MS = 300ms` fly-by 필터 추가 — 안구 고정 최소 지속 시간(~200ms, Rayner 1998) 기반, 300ms 미만 체류는 이벤트 미발생
- Banner: `BANNER_NAVIGATION_CLICKED` 이벤트 추가 (prev/next 슬라이드 버튼, `from_index` 프로퍼티)
- cross-review.sh: `codex exec` → `codex review` (read-only 보장)

## ClubCard Viewed 이벤트 프로퍼티

| 프로퍼티 | 설명 |
|----------|------|
| `dwell_ms` | 실제 체류 시간 (진입 → 이탈까지 ms). 300ms 미만은 이벤트 미발생 |
| `view_count` | 탭 세션 내 누적 조회 횟수 (페이지별) |
| `reentry_count` | `view_count - 1` (재방문 횟수) |
| `scroll_y` | 진입 시점 스크롤 위치 |
| `card_top_in_viewport` | 진입 시점 카드 상단 좌표 |
| `device_type` | 디바이스 타입 |

관련 이슈: #1592