### PR TITLE
[fix] 종료된 A/B 실험 Mixpanel super property 자동 정리

### DIFF
--- a/frontend/src/experiments/ExperimentRepository.ts
+++ b/frontend/src/experiments/ExperimentRepository.ts
@@ -63,9 +63,16 @@ const pickWeightedVariant = <V extends ExperimentVariant>(
 
 class ExperimentRepository {
   fetchAndAssignExperiments(experiments: readonly ExperimentDefinition<any>[]) {
-    if (experiments.length === 0) return;
-
     const assignments = safeReadAssignments();
+    const definedKeys = new Set(experiments.map((e) => e.key));
+
+    // 정의에서 사라진 실험은 Mixpanel super property 및 로컬 배정 정리.
+    // 누락 시 종료된 실험 key가 모든 이벤트에 계속 따라붙어 데이터가 오염됨.
+    Object.keys(assignments).forEach((key) => {
+      if (definedKeys.has(key)) return;
+      mixpanel.unregister(key);
+      delete assignments[key];
+    });
 
     experiments.forEach((experiment) => {
       const existing = assignments[experiment.key];


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #1600, MOA-907

## 📝 작업 내용

`ExperimentRepository.fetchAndAssignExperiments` 에 종료된 실험 자동 정리 로직 추가.

### 발견된 문제

`festival_timetable_nav_v1: arrows` 같은 종료된 실험 key가 모든 Mixpanel 이벤트에 좀비처럼 따라붙어 데이터 오염 발생.

**원인 흐름:**
1. 과거: \`ALL_EXPERIMENTS\` 에 \`festival_timetable_nav_v1\` 정의
2. \`mixpanel.register({festival_timetable_nav_v1: 'arrows'})\` 호출 → Mixpanel이 \`mp_super_properties\` localStorage에 영구 저장
3. 실험 종료 후 \`definitions.ts\` 에서 제거 (커밋 \`0582ed30\`)
4. 그러나 register된 super property는 자동 해제되지 않음 → 이후 발생하는 **모든 이벤트에 죽은 key가 계속 첨부**

### 수정 내용

- \`ALL_EXPERIMENTS\`에 없는 key는 \`mixpanel.unregister\` 호출 + \`moadong_experiments\` localStorage에서 동기 삭제
- \`experiments.length === 0\` early return 제거 → 빈 정의 상태에서도 정리 로직 동작
- 앞으로 실험을 정의에서 제거하기만 하면 다음 방문 시 자동 정리됨

## 🔧 검증 방법

브라우저 콘솔에서 정리 동작 확인:

```js
// 정리 전
localStorage.getItem('moadong_experiments')
// → festival_timetable_nav_v1 key 포함된 JSON

// 페이지 새로고침 후
localStorage.getItem('moadong_experiments')
// → festival_timetable_nav_v1 사라짐

// Mixpanel super properties도 정리됨
mixpanel.persistence.properties()
// → festival_timetable_nav_v1 없음
```

이후 새 이벤트(\`Club Card Viewed\`, \`Club Prefetch Triggered\` 등)에는 좀비 key가 더 이상 첨부되지 않음.

## 🫡 참고사항

- **현재 활성 실험에는 영향 없음** — \`ALL_EXPERIMENTS\`에 정의된 key는 그대로 유지
- variant rename 케이스도 안전 — 기존 \`isValidExisting\` 체크 로직이 처리