### PR TITLE
[fix] 동아리 상세 페이지 크롤러 응답 메타태그 개선

### DIFF
--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -68,10 +68,7 @@ export default async function middleware(request: Request) {
 
   const clubId = safeDecode(match[1]);
   // /club/:id 는 레거시 경로 — canonical은 /clubDetail/:id 로 통일
-  const canonicalPath = safeDecode(pathname).replace(
-    /^\/club\//,
-    '/clubDetail/',
-  );
+  const canonicalPath = pathname.replace(/^\/club\//, '/clubDetail/');
 
   try {
     const res = await fetch(`${API_BASE}/api/club/${clubId}`, {

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -25,13 +25,11 @@ function buildOgHtml(og: {
   title: string;
   description: string;
   image: string;
-  url: string;
   canonical: string;
 }): string {
   const t = escapeHtml(og.title);
   const d = escapeHtml(og.description);
   const i = escapeHtml(og.image);
-  const u = escapeHtml(og.url);
   const c = escapeHtml(og.canonical);
   return `<!DOCTYPE html>
 <html lang="ko">
@@ -93,7 +91,6 @@ export default async function middleware(request: Request) {
           club.description?.introDescription ||
           '부경대학교 동아리 정보를 확인해보세요.',
         image: club.cover || club.logo || DEFAULT_OG_IMAGE,
-        url: `${SITE_URL}${safeDecode(pathname)}`,
         canonical: `${SITE_URL}${canonicalPath}`,
       }),
       {

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -26,28 +26,35 @@ function buildOgHtml(og: {
   description: string;
   image: string;
   url: string;
+  canonical: string;
 }): string {
   const t = escapeHtml(og.title);
   const d = escapeHtml(og.description);
   const i = escapeHtml(og.image);
   const u = escapeHtml(og.url);
+  const c = escapeHtml(og.canonical);
   return `<!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="utf-8" />
   <title>${t}</title>
+  <meta name="description" content="${d}" />
+  <link rel="canonical" href="${c}" />
   <meta property="og:type" content="website" />
   <meta property="og:title" content="${t}" />
   <meta property="og:description" content="${d}" />
   <meta property="og:image" content="${i}" />
-  <meta property="og:url" content="${u}" />
+  <meta property="og:url" content="${c}" />
   <meta property="og:site_name" content="모아동" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="${t}" />
   <meta name="twitter:description" content="${d}" />
   <meta name="twitter:image" content="${i}" />
 </head>
-<body></body>
+<body>
+  <h1>${t}</h1>
+  <p>${d}</p>
+</body>
 </html>`;
 }
 
@@ -62,6 +69,11 @@ export default async function middleware(request: Request) {
   if (!match) return;
 
   const clubId = safeDecode(match[1]);
+  // /club/:id 는 레거시 경로 — canonical은 /clubDetail/:id 로 통일
+  const canonicalPath = safeDecode(pathname).replace(
+    /^\/club\//,
+    '/clubDetail/',
+  );
 
   try {
     const res = await fetch(`${API_BASE}/api/club/${clubId}`, {
@@ -82,6 +94,7 @@ export default async function middleware(request: Request) {
           '부경대학교 동아리 정보를 확인해보세요.',
         image: club.cover || club.logo || DEFAULT_OG_IMAGE,
         url: `${SITE_URL}${safeDecode(pathname)}`,
+        canonical: `${SITE_URL}${canonicalPath}`,
       }),
       {
         headers: {


### PR DESCRIPTION
## Summary
- 크롤러에게 내려주는 HTML에 `<meta name="description">` 누락 문제 수정 → 구글 검색 스니펫 CTR 개선
- `/club/:id` 레거시 경로의 `canonical`을 `/clubDetail/:id`로 통일 → SEO 점수 분산 방지
- `<body>`에 `<h1>`, `<p>` 텍스트 추가 → 크롤러 색인 가능 콘텐츠 제공

## Test plan
- [ ] `curl -A "Googlebot" https://www.moadong.com/clubDetail/@{clubName}` 응답에 `meta name="description"` 포함 확인
- [ ] `/club/@{clubName}` 요청 시 canonical이 `/clubDetail/@{clubName}`을 가리키는지 확인
- [ ] 구글 서치 콘솔 URL 검사 도구로 크롤 결과 확인

## 관련 이슈
- Jira: [MOA-909](https://seongwon0903-1741515192605.atlassian.net/browse/MOA-909)
- GitHub: #1604


[MOA-909]: https://seongwon0903-1741515192605.atlassian.net/browse/MOA-909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ