### PR TITLE
[fix] RN WebView 홍보 탭 헤더 누락 및 검색바 너비 수정

### DIFF
--- a/frontend/src/pages/PromotionPage/PromotionListPage.styles.ts
+++ b/frontend/src/pages/PromotionPage/PromotionListPage.styles.ts
@@ -2,11 +2,11 @@ import styled from 'styled-components';
 import { media } from '@/styles/mediaQuery';
 import { colors } from '@/styles/theme/colors';
 
-export const Container = styled.div`
+export const Container = styled.div<{ $isWebview?: boolean }>`
   width: 100%;
   max-width: 1280px;
   margin: 0 auto;
-  padding-top: 92px;
+  padding-top: ${({ $isWebview }) => ($isWebview ? '0' : '92px')};
 
   ${media.mobile} {
     padding-top: 0;
@@ -28,6 +28,28 @@ export const Wrapper = styled.div`
   ${media.mobile} {
     padding: 0px 20px 90px;
   }
+`;
+
+export const SearchBarArea = styled.div`
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background-color: #fff;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px 8px;
+
+  & > div:last-child {
+    flex: 1;
+    max-width: none;
+  }
+`;
+
+export const LogoImage = styled.img`
+  flex-shrink: 0;
+  height: 24px;
+  width: auto;
 `;
 
 export const EmptyText = styled.p`

--- a/frontend/src/pages/PromotionPage/PromotionListPage.tsx
+++ b/frontend/src/pages/PromotionPage/PromotionListPage.tsx
@@ -1,9 +1,11 @@
+import MobileMainIcon from '@/assets/images/logos/moadong_mobile_logo.svg';
 import Footer from '@/components/common/Footer/Footer';
 import Header from '@/components/common/Header/Header';
 import { PAGE_VIEW } from '@/constants/eventName';
 import useTrackPageView from '@/hooks/Mixpanel/useTrackPageView';
 import { useGetPromotionArticles } from '@/hooks/Queries/usePromotion';
 import usePromotionNotification from '@/hooks/Queries/usePromotionNotification';
+import SearchBox from '@/pages/MainPage/components/SearchBox/SearchBox';
 import isInAppWebView from '@/utils/isInAppWebView';
 import Filter from '../../components/common/Filter/Filter';
 import PromottionGrid from './components/list/PromotionGrid/PromotionGrid';
@@ -31,7 +33,11 @@ const PromotionListPage = () => {
 
   if (inAppWebView) {
     return (
-      <Styled.Container>
+      <Styled.Container $isWebview>
+        <Styled.SearchBarArea>
+          <Styled.LogoImage src={MobileMainIcon} alt='모아동' />
+          <SearchBox />
+        </Styled.SearchBarArea>
         <Filter hasNotification={hasNotification} />
         {content}
       </Styled.Container>

--- a/frontend/src/pages/WebviewMainPage/WebviewMainPage.styles.ts
+++ b/frontend/src/pages/WebviewMainPage/WebviewMainPage.styles.ts
@@ -15,7 +15,8 @@ export const SearchBarArea = styled.div`
   gap: 10px;
   padding: 12px 16px 8px;
 
-  form {
+  & > div:last-child {
+    flex: 1;
     max-width: none;
   }
 `;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #1611

## 📝작업 내용

RN WebView에서 발생하던 헤더 누락 및 검색바 레이아웃 문제 2가지를 수정했습니다.

### 1. 홍보 탭 (`/webview/promotions`) — 헤더 누락

| Before | After |
|--------|-------|
| Filter 탭만 렌더, 로고·검색바 없음 | 동아리 탭과 동일하게 로고 + 검색바 표시 |

- `PromotionListPage`의 webview 브랜치에 `SearchBarArea` (로고 + 검색바) 추가
- `Container`의 `padding-top: 92px`이 webview에서도 적용되던 문제 → `$isWebview` prop으로 분기해 제거

### 2. 검색바 너비 (`/webview/main`, `/webview/promotions`) — 끝까지 안 늘어나는 문제

| Before | After |
|--------|-------|
| `SearchBoxWrapper`의 `max-width: 345px`에 막혀 중간에서 끊김 | 로고 옆 남은 공간 전체를 검색바가 채움 |

- `SearchBarArea`에서 `& > div:last-child { flex: 1; max-width: none }` 적용

### 변경 파일

- `PromotionListPage.tsx` — webview 브랜치에 헤더 추가
- `PromotionListPage.styles.ts` — `SearchBarArea`, `LogoImage`, `Container $isWebview` 추가
- `WebviewMainPage.styles.ts` — `SearchBarArea` 검색바 너비 수정

## 중점적으로 리뷰받고 싶은 부분(선택)

`SearchBarArea`에서 `& > div:last-child`로 `SearchBoxWrapper`를 타겟하는 방식이 괜찮은지 봐주세요. `SearchBox`에 prop을 추가하는 방법도 있지만 영향 범위를 최소화하려고 이 방법을 선택했습니다.

## 논의하고 싶은 부분(선택)

현재 webview 진입 판별이 `isInAppWebView()` (UA 기반)와 `pathname.startsWith('/webview')` (경로 기반) 두 가지가 혼재되어 있습니다. 추후 기준을 통일하면 좋을 것 같습니다.

## 🫡 참고사항

`isInAppWebView()`는 UA의 `MoadongApp` 포함 여부로 판별합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 모바일 앱 프로모션 페이지에 검색 기능이 추가되었습니다.

* **개선 사항**
  * 모바일 웹뷰 환경의 검색 영역 레이아웃이 개선되어 더 나은 사용자 경험을 제공합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Moadong/moadong/pull/1612?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->