### PR TITLE
fix(club-union): PR #1603 리뷰 대응 및 코드 개선

### DIFF
--- a/frontend/docs/features/club-union/README.md
+++ b/frontend/docs/features/club-union/README.md
@@ -4,7 +4,7 @@
 
 ## 레이아웃
 
-4열 staggered flex grid 구조. 홀수 컬럼(1, 3번째)은 `padding-top: 125px`로 엇갈린 배치.
+4열 staggered flex grid 구조. 짝수 컬럼(2, 4번째)은 `padding-top: 125px`로 엇갈린 배치.
 tablet 이하에서는 2열 CSS grid, mobile에서는 1열로 전환.
 
 컬럼별 멤버 수는 `COLUMN_SIZES = [3, 3, 4, 3]`로 명시적 지정.
@@ -46,7 +46,7 @@ mobile(≤500px)에서는 `CLUB_UNION_MEMBERS_MOBILE`을 단일 컬럼으로 fla
 
 ## 아이콘
 
-임원진은 `inactiveCategoryIcons.representative` 공용 아이콘 사용.
+임원진은 `iconAllNoBg` (club_union 전용 SVG) 아이콘 사용.
 분과 아이콘은 배경 `<rect>` 제거한 별도 SVG 사용 → 기존 카테고리 버튼 아이콘 영향 없음.
 
 ## 관련 코드

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -70,6 +70,12 @@ export default async function middleware(request: Request) {
   // /club/:id 는 레거시 경로 — canonical은 /clubDetail/:id 로 통일
   const canonicalPath = pathname.replace(/^\/club\//, '/clubDetail/');
 
+  if (pathname.startsWith('/club/')) {
+    const redirectUrl = new URL(request.url);
+    redirectUrl.pathname = canonicalPath;
+    return Response.redirect(redirectUrl.toString(), 301);
+  }
+
   try {
     const res = await fetch(`${API_BASE}/api/club/${clubId}`, {
       signal: AbortSignal.timeout(3000), // 5초 Edge 제한 내 여유있게 3초

--- a/frontend/src/constants/clubUnionInfo.ts
+++ b/frontend/src/constants/clubUnionInfo.ts
@@ -166,6 +166,13 @@ export const CLUB_UNION_MEMBERS: ClubUnionMember[] = [
 
 const MOBILE_ORDER = [1, 4, 7, 8, 11, 2, 5, 9, 12, 10, 13, 3, 6];
 
-export const CLUB_UNION_MEMBERS_MOBILE: ClubUnionMember[] = MOBILE_ORDER.map(
-  (id) => CLUB_UNION_MEMBERS.find((m) => m.id === id),
-).filter((m): m is ClubUnionMember => !!m);
+const getMemberById = (id: number): ClubUnionMember => {
+  const member = CLUB_UNION_MEMBERS.find((m) => m.id === id);
+  if (!member) {
+    throw new Error(`Invalid MOBILE_ORDER id: ${id}`);
+  }
+  return member;
+};
+
+export const CLUB_UNION_MEMBERS_MOBILE: ClubUnionMember[] =
+  MOBILE_ORDER.map(getMemberById);

--- a/frontend/src/constants/clubUnionInfo.ts
+++ b/frontend/src/constants/clubUnionInfo.ts
@@ -167,5 +167,5 @@ export const CLUB_UNION_MEMBERS: ClubUnionMember[] = [
 const MOBILE_ORDER = [1, 4, 7, 8, 11, 2, 5, 9, 12, 10, 13, 3, 6];
 
 export const CLUB_UNION_MEMBERS_MOBILE: ClubUnionMember[] = MOBILE_ORDER.map(
-  (id) => CLUB_UNION_MEMBERS.find((m) => m.id === id)!,
-);
+  (id) => CLUB_UNION_MEMBERS.find((m) => m.id === id),
+).filter((m): m is ClubUnionMember => !!m);

--- a/frontend/src/pages/ClubUnionPage/ClubUnionPage.styles.ts
+++ b/frontend/src/pages/ClubUnionPage/ClubUnionPage.styles.ts
@@ -57,7 +57,7 @@ export const SnsLink = styled.a`
   transition: background-color 0.2s ease;
 
   &:hover {
-    background-color: #e8e8e8;
+    background-color: ${colors.gray[300]};
   }
 
   img {

--- a/frontend/src/pages/ClubUnionPage/ClubUnionPage.tsx
+++ b/frontend/src/pages/ClubUnionPage/ClubUnionPage.tsx
@@ -18,6 +18,22 @@ import * as Styled from './ClubUnionPage.styles';
 const COLUMN_SIZES = [3, 3, 4, 3];
 const MOBILE_BREAKPOINT = '(max-width: 500px)';
 
+const { cols, offset } = COLUMN_SIZES.reduce<{
+  cols: (typeof CLUB_UNION_MEMBERS)[];
+  offset: number;
+}>(
+  ({ cols, offset }, size) => ({
+    cols: [...cols, CLUB_UNION_MEMBERS.slice(offset, offset + size)],
+    offset: offset + size,
+  }),
+  { cols: [], offset: 0 },
+);
+
+const COLUMNS =
+  offset < CLUB_UNION_MEMBERS.length
+    ? [...cols, CLUB_UNION_MEMBERS.slice(offset)]
+    : cols;
+
 const ProfileCard = ({ member }: { member: ClubUnionMember }) => (
   <Styled.ProfileCard $bgColor={member.bgColor}>
     <Styled.CardContent>
@@ -50,22 +66,6 @@ const ClubUnionPage = () => {
     mq.addEventListener('change', handler);
     return () => mq.removeEventListener('change', handler);
   }, []);
-
-  const { cols, offset } = COLUMN_SIZES.reduce<{
-    cols: (typeof CLUB_UNION_MEMBERS)[];
-    offset: number;
-  }>(
-    ({ cols, offset }, size) => ({
-      cols: [...cols, CLUB_UNION_MEMBERS.slice(offset, offset + size)],
-      offset: offset + size,
-    }),
-    { cols: [], offset: 0 },
-  );
-
-  const columns =
-    offset < CLUB_UNION_MEMBERS.length
-      ? [...cols, CLUB_UNION_MEMBERS.slice(offset)]
-      : cols;
 
   return (
     <>
@@ -113,7 +113,7 @@ const ClubUnionPage = () => {
               ))}
             </Styled.ProfileColumn>
           ) : (
-            columns.map((columnMembers, colIdx) => (
+            COLUMNS.map((columnMembers, colIdx) => (
               <Styled.ProfileColumn key={colIdx} $staggered={colIdx % 2 === 1}>
                 {columnMembers.map((member) => (
                   <ProfileCard key={member.id} member={member} />

--- a/frontend/src/pages/ClubUnionPage/ClubUnionPage.tsx
+++ b/frontend/src/pages/ClubUnionPage/ClubUnionPage.tsx
@@ -55,13 +55,11 @@ const ProfileCard = ({ member }: { member: ClubUnionMember }) => (
 const ClubUnionPage = () => {
   useTrackPageView(PAGE_VIEW.CLUB_UNION_PAGE);
   const trackEvent = useMixpanelTrack();
-  const [isMobile, setIsMobile] = useState(() => {
-    if (typeof window === 'undefined') return false;
-    return window.matchMedia(MOBILE_BREAKPOINT).matches;
-  });
+  const [isMobile, setIsMobile] = useState(false);
 
   useEffect(() => {
     const mq = window.matchMedia(MOBILE_BREAKPOINT);
+    setIsMobile(mq.matches);
     const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
     mq.addEventListener('change', handler);
     return () => mq.removeEventListener('change', handler);


### PR DESCRIPTION
## Summary

- `find()!` non-null assertion 제거 → `.filter()` 기반 안전한 처리
- 컬럼 분배 로직을 모듈 상수 `COLUMNS`로 이동 (렌더마다 재계산 제거)
- hover 배경색 하드코딩 `#e8e8e8` → `colors.gray[300]` 테마 적용
- `/club/` 크롤러 요청 시 `/clubDetail/`로 301 redirect 추가
- README staggered 컬럼 번호 및 아이콘 명칭 오류 수정

## Test plan

- [ ] 총동연 페이지 데스크탑/태블릿/모바일 카드 렌더링 확인
- [ ] 크롤러 UA로 `/club/:id` 요청 시 301 redirect → `/clubDetail/:id` 확인
- [ ] TypeScript 타입체크 통과 확인 (`npm run typecheck`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 총동아리연합회 페이지가 카드 기반 레이아웃으로 재설계되어 멤버 정보(이름·직책·설명·일러스트)를 기본 노출합니다.
  * 멤버 카드에 개별 배경색과 아이콘 일러스트가 적용됩니다.

* **개선 사항**
  * 반응형 레이아웃 개선: 태블릿 2열, 모바일 1열 전환 및 staggered 열 배치 지원.
  * 모바일에서 멤버 노출 순서가 최적화되고 SNS 링크 아이콘/표시가 개선되었습니다.

* **문서**
  * 총동아리연합회 페이지 구성 및 레이아웃 가이드 문서가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Moadong/moadong/pull/1613?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->