### PR TITLE
[feature] branded types 도입 (3단계 완료)

### DIFF
--- a/frontend/docs/types/branded-types.md
+++ b/frontend/docs/types/branded-types.md
@@ -92,6 +92,38 @@ export interface ApplicationForm {
 }
 ```
 
+## 도입 단계
+
+branded types 도입은 3단계 브랜치로 진행한다.
+
+| 단계 | 브랜치                               | 작업 내용                                                 | 상태 |
+| ---- | ------------------------------------ | --------------------------------------------------------- | ---- |
+| 1    | `feature/branded-types/core-types`   | `Branded<T, B>` 유틸리티 및 ID 타입 정의                  | 완료 |
+| 2    | `feature/branded-types/domain-types` | 도메인 인터페이스 `id` 필드에 branded type 적용           | 완료 |
+| 3    | `feature/branded-types/api-layer`    | API 응답 파싱 시점에 캐스팅 유틸 추가 및 임시 캐스팅 정리 | 예정 |
+
+### api-layer 브랜치 작업 계획
+
+**캐스팅 유틸리티 추가**
+
+API 응답을 받는 시점에서 안전하게 branded type으로 변환하는 헬퍼를 `src/types/branded.ts`에 추가한다.
+
+```typescript
+export const asClubId = (id: string): ClubId => id as ClubId;
+export const asApplicantId = (id: string): ApplicantId => id as ApplicantId;
+export const asApplicationFormId = (id: string): ApplicationFormId =>
+  id as ApplicationFormId;
+export const asDatabaseId = (id: string): DatabaseId => id as DatabaseId;
+export const asCalendarId = (id: string): CalendarId => id as CalendarId;
+```
+
+**임시 캐스팅 정리 대상**
+
+| 파일                                                                      | 현재 임시 처리               | 개선 방향                                       |
+| ------------------------------------------------------------------------- | ---------------------------- | ----------------------------------------------- |
+| `src/pages/ClubDetailPage/components/ClubApplyButton/ClubApplyButton.tsx` | `forms as ApplicationForm[]` | API 응답 파싱 시점에 `asApplicationFormId` 적용 |
+| `src/pages/AdminPage/.../ApplicantDetailPage.tsx`                         | `questionId as ApplicantId`  | URL params 파싱 유틸 또는 훅에서 처리           |
+
 ## 확장 기준
 
 | 상황                           | 대응                                                |

--- a/frontend/docs/types/branded-types.md
+++ b/frontend/docs/types/branded-types.md
@@ -42,7 +42,7 @@ src/types/branded.ts       ← Branded<T, B> 유틸리티 + 모든 ID 타입
 
 ID 타입이 늘어나고 도메인 경계가 명확해지면 도메인 파일로 분리한다. 한 파일에 모으면 도메인 간 결합도가 높아지고 변경 이유가 달라지기 때문이다.
 
-```
+```text
 src/types/branded.ts       ← Branded<T, B> 유틸리티만
 src/types/club.ts          ← ClubId, CalendarId
 src/types/application.ts   ← ApplicationFormId

--- a/frontend/docs/types/branded-types.md
+++ b/frontend/docs/types/branded-types.md
@@ -30,9 +30,17 @@ type Brand<B> = { [__brand]: B };
 export type Branded<T, B> = T & Brand<B>;
 ```
 
-## 도메인별 ID 타입 위치
+## 현재 구조
 
-도메인 ID 타입은 해당 도메인 파일에 정의한다. 타입 수가 늘어날수록 한 파일에 모으면 도메인 간 결합도가 높아지므로 아래 구조를 따른다.
+ID 타입이 5개 이하로 적으므로 `branded.ts`에 모두 정의한다.
+
+```
+src/types/branded.ts       ← Branded<T, B> 유틸리티 + 모든 ID 타입
+```
+
+## 향후 확장 시 권장 구조
+
+ID 타입이 늘어나고 도메인 경계가 명확해지면 도메인 파일로 분리한다. 한 파일에 모으면 도메인 간 결합도가 높아지고 변경 이유가 달라지기 때문이다.
 
 ```
 src/types/branded.ts       ← Branded<T, B> 유틸리티만
@@ -42,13 +50,20 @@ src/types/applicants.ts    ← ApplicantId
 src/types/notion.ts        ← DatabaseId
 ```
 
-### 새 ID 타입 추가 방법
+### 새 ID 타입 추가 방법 (현재: 중앙 집중)
 
-1. 해당 도메인 타입 파일을 연다 (없으면 `src/types/<domain>.ts` 생성)
-2. `Branded`를 import하고 타입을 정의한다
+현재는 `branded.ts`에 직접 추가한다.
 
 ```typescript
-// src/types/club.ts
+// src/types/branded.ts
+export type ClubId = Branded<string, 'ClubId'>;
+export type NewDomainId = Branded<string, 'NewDomainId'>; // 추가
+```
+
+도메인 파일 분리 단계로 전환한 후에는 해당 도메인 파일에 정의한다.
+
+```typescript
+// src/types/club.ts (향후 분리 시)
 import { Branded } from '@/types/branded';
 
 export type ClubId = Branded<string, 'ClubId'>;

--- a/frontend/docs/types/branded-types.md
+++ b/frontend/docs/types/branded-types.md
@@ -1,0 +1,86 @@
+# Branded Types
+
+타입 안전성을 높이기 위해 primitive 타입에 고유한 브랜드를 부여하는 패턴.
+
+## 개요
+
+`string`처럼 범용적인 타입은 컴파일러가 오용을 잡아주지 못한다.
+
+```typescript
+// ClubId 자리에 ApplicantId를 넘겨도 타입 에러 없음
+function fetchClub(id: string) { ... }
+fetchClub(applicantId); // 런타임 버그
+```
+
+Branded 타입을 사용하면 컴파일 타임에 잡을 수 있다.
+
+```typescript
+function fetchClub(id: ClubId) { ... }
+fetchClub(applicantId); // TS 에러: ApplicantId는 ClubId에 할당 불가
+```
+
+## 유틸리티 타입
+
+`src/types/branded.ts`에 인프라 레이어만 정의한다.
+
+```typescript
+declare const __brand: unique symbol;
+type Brand<B> = { [__brand]: B };
+
+export type Branded<T, B> = T & Brand<B>;
+```
+
+## 도메인별 ID 타입 위치
+
+도메인 ID 타입은 해당 도메인 파일에 정의한다. 타입 수가 늘어날수록 한 파일에 모으면 도메인 간 결합도가 높아지므로 아래 구조를 따른다.
+
+```
+src/types/branded.ts       ← Branded<T, B> 유틸리티만
+src/types/club.ts          ← ClubId, CalendarId
+src/types/application.ts   ← ApplicationFormId
+src/types/applicants.ts    ← ApplicantId
+src/types/notion.ts        ← DatabaseId
+```
+
+### 새 ID 타입 추가 방법
+
+1. 해당 도메인 타입 파일을 연다 (없으면 `src/types/<domain>.ts` 생성)
+2. `Branded`를 import하고 타입을 정의한다
+
+```typescript
+// src/types/club.ts
+import { Branded } from '@/types/branded';
+
+export type ClubId = Branded<string, 'ClubId'>;
+```
+
+3. API 응답을 받는 시점에 캐스팅한다
+
+```typescript
+const clubId = data.id as ClubId;
+```
+
+## 크로스 도메인 참조
+
+다른 도메인 파일에서 ID 타입을 참조할 때는 해당 도메인 파일에서 직접 import한다. 순환 의존성이 생긴다면 `branded.ts`에 임시로 모아두고 도메인 파일에서 re-export하는 방식을 사용한다.
+
+```typescript
+// src/types/application.ts
+import { Branded } from '@/types/branded';
+import type { ClubId } from '@/types/club';
+
+export type ApplicationFormId = Branded<string, 'ApplicationFormId'>;
+
+export interface ApplicationForm {
+  id: ApplicationFormId;
+  clubId: ClubId;
+}
+```
+
+## 확장 기준
+
+| 상황                           | 대응                                                |
+| ------------------------------ | --------------------------------------------------- |
+| ID 타입 5개 이하               | `branded.ts`에 모두 정의해도 무방                   |
+| ID 타입 증가, 도메인 경계 명확 | 도메인 파일로 분리                                  |
+| 크로스 도메인 순환 의존 발생   | `branded.ts`에 공통 ID만 유지, 나머지는 도메인 파일 |

--- a/frontend/docs/types/branded-types.md
+++ b/frontend/docs/types/branded-types.md
@@ -34,7 +34,7 @@ export type Branded<T, B> = T & Brand<B>;
 
 ID 타입이 5개 이하로 적으므로 `branded.ts`에 모두 정의한다.
 
-```
+```text
 src/types/branded.ts       ← Branded<T, B> 유틸리티 + 모든 ID 타입
 ```
 
@@ -100,9 +100,9 @@ branded types 도입은 3단계 브랜치로 진행한다.
 | ---- | ------------------------------------ | --------------------------------------------------------- | ---- |
 | 1    | `feature/branded-types/core-types`   | `Branded<T, B>` 유틸리티 및 ID 타입 정의                  | 완료 |
 | 2    | `feature/branded-types/domain-types` | 도메인 인터페이스 `id` 필드에 branded type 적용           | 완료 |
-| 3    | `feature/branded-types/api-layer`    | API 응답 파싱 시점에 캐스팅 유틸 추가 및 임시 캐스팅 정리 | 예정 |
+| 3    | `feature/branded-types/api-layer`    | API 응답 파싱 시점에 캐스팅 유틸 추가 및 임시 캐스팅 정리 | 완료 |
 
-### api-layer 브랜치 작업 계획
+### api-layer 브랜치 작업 내용
 
 **캐스팅 유틸리티 추가**
 

--- a/frontend/src/apis/application.ts
+++ b/frontend/src/apis/application.ts
@@ -2,9 +2,11 @@ import API_BASE_URL from '@/constants/api';
 import { UpdateApplicantParams } from '@/types/applicants';
 import {
   AnswerItem,
+  ApplicationForm,
   ApplicationFormData,
   SemesterGroup,
 } from '@/types/application';
+import { asApplicationFormId } from '@/types/branded';
 import { secureFetch } from './auth/secureFetch';
 import { handleResponse } from './utils/apiHelpers';
 
@@ -85,17 +87,16 @@ export const getApplication = async (
   return handleResponse<ApplicationFormData>(response);
 };
 
-export const getApplicationOptions = async (clubId: string) => {
+export const getApplicationOptions = async (
+  clubId: string,
+): Promise<ApplicationForm[]> => {
   const response = await fetch(`${API_BASE_URL}/api/club/${clubId}/apply`);
   const data = await handleResponse<{
     forms: Array<{ id: string; title: string }>;
   }>(response);
 
-  let forms: Array<{ id: string; title: string }> = [];
-  if (data && Array.isArray(data.forms)) {
-    forms = data.forms;
-  }
-  return forms;
+  if (!data || !Array.isArray(data.forms)) return [];
+  return data.forms.map((f) => ({ ...f, id: asApplicationFormId(f.id) }));
 };
 
 export const updateApplicantDetail = async (

--- a/frontend/src/apis/calendarOAuth.ts
+++ b/frontend/src/apis/calendarOAuth.ts
@@ -1,4 +1,5 @@
 import API_BASE_URL from '@/constants/api';
+import type { DatabaseId } from '@/types/branded';
 import type {
   GoogleCalendarEvent,
   GoogleCalendarItem,
@@ -167,7 +168,9 @@ export const fetchNotionPages = async () => {
   const items = (data?.items ?? data?.results ?? []) as NotionSearchItem[];
   const totalResults =
     data?.total_results ?? data?.totalResults ?? items.length;
-  const databaseId = data?.database_id ?? data?.databaseId;
+  const databaseId = (data?.database_id ?? data?.databaseId) as
+    | DatabaseId
+    | undefined;
   return {
     items,
     totalResults,
@@ -207,7 +210,7 @@ export const fetchNotionDatabasePages = async ({
     return {
       items: data,
       totalResults: data.length,
-      databaseId,
+      databaseId: databaseId as DatabaseId,
     } satisfies NotionPagesResponse;
   }
 
@@ -219,7 +222,7 @@ export const fetchNotionDatabasePages = async ({
   return {
     items,
     totalResults,
-    databaseId: resolvedDatabaseId,
+    databaseId: resolvedDatabaseId as DatabaseId,
   } satisfies NotionPagesResponse;
 };
 

--- a/frontend/src/apis/calendarOAuth.ts
+++ b/frontend/src/apis/calendarOAuth.ts
@@ -1,5 +1,5 @@
 import API_BASE_URL from '@/constants/api';
-import type { DatabaseId } from '@/types/branded';
+import { asDatabaseId } from '@/types/branded';
 import type {
   GoogleCalendarEvent,
   GoogleCalendarItem,
@@ -168,9 +168,8 @@ export const fetchNotionPages = async () => {
   const items = (data?.items ?? data?.results ?? []) as NotionSearchItem[];
   const totalResults =
     data?.total_results ?? data?.totalResults ?? items.length;
-  const databaseId = (data?.database_id ?? data?.databaseId) as
-    | DatabaseId
-    | undefined;
+  const rawId = data?.database_id ?? data?.databaseId;
+  const databaseId = rawId ? asDatabaseId(rawId) : undefined;
   return {
     items,
     totalResults,
@@ -210,7 +209,7 @@ export const fetchNotionDatabasePages = async ({
     return {
       items: data,
       totalResults: data.length,
-      databaseId: databaseId as DatabaseId,
+      databaseId: asDatabaseId(databaseId),
     } satisfies NotionPagesResponse;
   }
 
@@ -222,7 +221,7 @@ export const fetchNotionDatabasePages = async ({
   return {
     items,
     totalResults,
-    databaseId: resolvedDatabaseId as DatabaseId,
+    databaseId: asDatabaseId(resolvedDatabaseId),
   } satisfies NotionPagesResponse;
 };
 

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPage.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPage.tsx
@@ -86,7 +86,7 @@ const ApplicantDetailPage = () => {
         {
           memo,
           status,
-          applicantId: questionId,
+          applicantId: questionId as import('@/types/branded').ApplicantId,
         },
       ],
       {

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPage.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPage.tsx
@@ -15,6 +15,7 @@ import QuestionAnswerer from '@/pages/ApplicationFormPage/components/QuestionAns
 import QuestionContainer from '@/pages/ApplicationFormPage/components/QuestionContainer/QuestionContainer';
 import { ApplicationStatus } from '@/types/applicants';
 import { Question } from '@/types/application';
+import { asApplicantId } from '@/types/branded';
 import mapStatusToGroup from '@/utils/mapStatusToGroup';
 import * as Styled from './ApplicantDetailPage.styles';
 
@@ -86,7 +87,7 @@ const ApplicantDetailPage = () => {
         {
           memo,
           status,
-          applicantId: questionId as import('@/types/branded').ApplicantId,
+          applicantId: asApplicantId(questionId),
         },
       ],
       {

--- a/frontend/src/pages/ClubDetailPage/components/ClubApplyButton/ClubApplyButton.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubApplyButton/ClubApplyButton.tsx
@@ -89,7 +89,7 @@ const ClubApplyButton = ({
         await navigateToApplicationForm(forms[0].id);
         return;
       }
-      setApplicationOptions(forms);
+      setApplicationOptions(forms as ApplicationForm[]);
       setIsApplicationModalOpen(true);
     } catch (e) {
       setApplicationOptions([]);

--- a/frontend/src/pages/ClubDetailPage/components/ClubApplyButton/ClubApplyButton.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubApplyButton/ClubApplyButton.tsx
@@ -89,7 +89,7 @@ const ClubApplyButton = ({
         await navigateToApplicationForm(forms[0].id);
         return;
       }
-      setApplicationOptions(forms as ApplicationForm[]);
+      setApplicationOptions(forms);
       setIsApplicationModalOpen(true);
     } catch (e) {
       setApplicationOptions([]);

--- a/frontend/src/pages/IntroducePage/constants/mockData.ts
+++ b/frontend/src/pages/IntroducePage/constants/mockData.ts
@@ -1,9 +1,10 @@
 import type { Club } from '@/types/club';
+import type { ClubId } from '@/types/branded';
 
 // 동아리 목업 데이터
 export const floatingClubs: Club[] = [
   {
-    id: 'moadong',
+    id: 'moadong' as ClubId,
     name: '모아동',
     logo: '',
     tags: ['학술', '스터디'],
@@ -13,7 +14,7 @@ export const floatingClubs: Club[] = [
     introduction: '다양한 전공 학생들이 모여 학문을 함께 나누는 동아리',
   },
   {
-    id: 'moaboza',
+    id: 'moaboza' as ClubId,
     name: '모아보자',
     logo: '',
     tags: ['봉사', '지역사회'],
@@ -23,7 +24,7 @@ export const floatingClubs: Club[] = [
     introduction: '지역 사회와 함께 봉사하며 따뜻함을 전하는 동아리',
   },
   {
-    id: 'moamoa',
+    id: 'moamoa' as ClubId,
     name: '모아모아',
     logo: '',
     tags: ['취미', '교양'],
@@ -33,7 +34,7 @@ export const floatingClubs: Club[] = [
     introduction: '다양한 취미를 가진 사람들이 모여 교류하는 동아리',
   },
   {
-    id: 'moajup',
+    id: 'moajup' as ClubId,
     name: '모아운동',
     logo: '',
     tags: ['스포츠', '팀워크'],

--- a/frontend/src/pages/IntroducePage/constants/mockData.ts
+++ b/frontend/src/pages/IntroducePage/constants/mockData.ts
@@ -1,10 +1,10 @@
-import type { ClubId } from '@/types/branded';
+import { asClubId } from '@/types/branded';
 import type { Club } from '@/types/club';
 
 // 동아리 목업 데이터
 export const floatingClubs: Club[] = [
   {
-    id: 'moadong' as ClubId,
+    id: asClubId('moadong'),
     name: '모아동',
     logo: '',
     tags: ['학술', '스터디'],
@@ -14,7 +14,7 @@ export const floatingClubs: Club[] = [
     introduction: '다양한 전공 학생들이 모여 학문을 함께 나누는 동아리',
   },
   {
-    id: 'moaboza' as ClubId,
+    id: asClubId('moaboza'),
     name: '모아보자',
     logo: '',
     tags: ['봉사', '지역사회'],
@@ -24,7 +24,7 @@ export const floatingClubs: Club[] = [
     introduction: '지역 사회와 함께 봉사하며 따뜻함을 전하는 동아리',
   },
   {
-    id: 'moamoa' as ClubId,
+    id: asClubId('moamoa'),
     name: '모아모아',
     logo: '',
     tags: ['취미', '교양'],
@@ -34,7 +34,7 @@ export const floatingClubs: Club[] = [
     introduction: '다양한 취미를 가진 사람들이 모여 교류하는 동아리',
   },
   {
-    id: 'moajup' as ClubId,
+    id: asClubId('moajup'),
     name: '모아운동',
     logo: '',
     tags: ['스포츠', '팀워크'],

--- a/frontend/src/pages/IntroducePage/constants/mockData.ts
+++ b/frontend/src/pages/IntroducePage/constants/mockData.ts
@@ -1,5 +1,5 @@
-import type { Club } from '@/types/club';
 import type { ClubId } from '@/types/branded';
+import type { Club } from '@/types/club';
 
 // 동아리 목업 데이터
 export const floatingClubs: Club[] = [

--- a/frontend/src/pages/MainPage/components/ClubCard/ClubCard.stories.tsx
+++ b/frontend/src/pages/MainPage/components/ClubCard/ClubCard.stories.tsx
@@ -1,10 +1,11 @@
 import { MemoryRouter } from 'react-router-dom';
 import type { Meta, StoryObj } from '@storybook/react';
 import { Club } from '@/types/club';
+import type { ClubId } from '@/types/branded';
 import ClubCard from './ClubCard';
 
 const sampleClub: Club = {
-  id: 'club-1',
+  id: 'club-1' as ClubId,
   name: '모아동 밴드',
   logo: '',
   tags: ['락밴드', '공연'],
@@ -54,7 +55,7 @@ export const Closed: Story = {
   args: {
     club: {
       ...sampleClub,
-      id: 'club-2',
+      id: 'club-2' as ClubId,
       recruitmentStatus: 'CLOSED',
       name: '모아동 사진회',
       introduction: '정기 출사와 전시를 준비합니다.',

--- a/frontend/src/pages/MainPage/components/ClubCard/ClubCard.stories.tsx
+++ b/frontend/src/pages/MainPage/components/ClubCard/ClubCard.stories.tsx
@@ -1,11 +1,11 @@
 import { MemoryRouter } from 'react-router-dom';
 import type { Meta, StoryObj } from '@storybook/react';
-import type { ClubId } from '@/types/branded';
+import { asClubId } from '@/types/branded';
 import { Club } from '@/types/club';
 import ClubCard from './ClubCard';
 
 const sampleClub: Club = {
-  id: 'club-1' as ClubId,
+  id: asClubId('club-1'),
   name: '모아동 밴드',
   logo: '',
   tags: ['락밴드', '공연'],
@@ -55,7 +55,7 @@ export const Closed: Story = {
   args: {
     club: {
       ...sampleClub,
-      id: 'club-2' as ClubId,
+      id: asClubId('club-2'),
       recruitmentStatus: 'CLOSED',
       name: '모아동 사진회',
       introduction: '정기 출사와 전시를 준비합니다.',

--- a/frontend/src/pages/MainPage/components/ClubCard/ClubCard.stories.tsx
+++ b/frontend/src/pages/MainPage/components/ClubCard/ClubCard.stories.tsx
@@ -1,7 +1,7 @@
 import { MemoryRouter } from 'react-router-dom';
 import type { Meta, StoryObj } from '@storybook/react';
-import { Club } from '@/types/club';
 import type { ClubId } from '@/types/branded';
+import { Club } from '@/types/club';
 import ClubCard from './ClubCard';
 
 const sampleClub: Club = {

--- a/frontend/src/types/applicants.ts
+++ b/frontend/src/types/applicants.ts
@@ -1,4 +1,5 @@
 import { AnswerItem } from './application';
+import { ApplicantId, ApplicationFormId, ClubId } from './branded';
 
 export enum ApplicationStatus {
   SUBMITTED = 'SUBMITTED', // 제출 완료
@@ -16,27 +17,27 @@ export interface ApplicantsInfo {
 }
 
 export interface Applicant {
-  id: string;
+  id: ApplicantId;
   status: ApplicationStatus;
   answers: AnswerItem[];
   memo: string;
   createdAt: string;
-  applicationFormId: string;
+  applicationFormId: ApplicationFormId;
 }
 
 export interface UpdateApplicantParams {
   memo: string;
   status: ApplicationStatus;
-  applicantId: string | undefined;
+  applicantId: ApplicantId | undefined;
 }
 
 export interface ApplicantStatusEvent {
-  applicantId: string;
+  applicantId: ApplicantId;
   status: ApplicationStatus;
   memo: string;
   timestamp: string;
-  clubId: string;
-  applicationFormId: string;
+  clubId: ClubId;
+  applicationFormId: ApplicationFormId;
 }
 
 export interface ApplicantSSECallbacks {

--- a/frontend/src/types/applicants.ts
+++ b/frontend/src/types/applicants.ts
@@ -1,5 +1,5 @@
-import { AnswerItem } from './application';
 import { ApplicantId, ApplicationFormId, ClubId } from '@/types/branded';
+import { AnswerItem } from './application';
 
 export enum ApplicationStatus {
   SUBMITTED = 'SUBMITTED', // 제출 완료

--- a/frontend/src/types/applicants.ts
+++ b/frontend/src/types/applicants.ts
@@ -1,5 +1,5 @@
 import { AnswerItem } from './application';
-import { ApplicantId, ApplicationFormId, ClubId } from './branded';
+import { ApplicantId, ApplicationFormId, ClubId } from '@/types/branded';
 
 export enum ApplicationStatus {
   SUBMITTED = 'SUBMITTED', // 제출 완료

--- a/frontend/src/types/application.ts
+++ b/frontend/src/types/application.ts
@@ -1,4 +1,5 @@
 import { QUESTION_LABEL_MAP } from '@/constants/applicationForm';
+import { ApplicationFormId } from './branded';
 
 export type QuestionType = keyof typeof QUESTION_LABEL_MAP;
 
@@ -63,12 +64,12 @@ export interface AnswerItem {
 }
 
 export interface ApplicationForm {
-  id: string;
+  id: ApplicationFormId;
   title: string;
 }
 
 export interface ApplicationFormItem {
-  id: string;
+  id: ApplicationFormId;
   title: string;
   editedAt: string;
   status: 'ACTIVE' | 'PUBLISHED' | 'UNPUBLISHED';

--- a/frontend/src/types/application.ts
+++ b/frontend/src/types/application.ts
@@ -1,5 +1,5 @@
 import { QUESTION_LABEL_MAP } from '@/constants/applicationForm';
-import { ApplicationFormId } from './branded';
+import { ApplicationFormId } from '@/types/branded';
 
 export type QuestionType = keyof typeof QUESTION_LABEL_MAP;
 

--- a/frontend/src/types/branded.ts
+++ b/frontend/src/types/branded.ts
@@ -1,0 +1,10 @@
+declare const __brand: unique symbol;
+type Brand<B> = { [__brand]: B };
+
+export type Branded<T, B> = T & Brand<B>;
+
+export type ClubId = Branded<string, 'ClubId'>;
+export type ApplicationFormId = Branded<string, 'ApplicationFormId'>;
+export type ApplicantId = Branded<string, 'ApplicantId'>;
+export type CalendarId = Branded<string, 'CalendarId'>;
+export type DatabaseId = Branded<string, 'DatabaseId'>;

--- a/frontend/src/types/branded.ts
+++ b/frontend/src/types/branded.ts
@@ -8,3 +8,10 @@ export type ApplicationFormId = Branded<string, 'ApplicationFormId'>;
 export type ApplicantId = Branded<string, 'ApplicantId'>;
 export type CalendarId = Branded<string, 'CalendarId'>;
 export type DatabaseId = Branded<string, 'DatabaseId'>;
+
+export const asClubId = (id: string): ClubId => id as ClubId;
+export const asApplicationFormId = (id: string): ApplicationFormId =>
+  id as ApplicationFormId;
+export const asApplicantId = (id: string): ApplicantId => id as ApplicantId;
+export const asCalendarId = (id: string): CalendarId => id as CalendarId;
+export const asDatabaseId = (id: string): DatabaseId => id as DatabaseId;

--- a/frontend/src/types/club.ts
+++ b/frontend/src/types/club.ts
@@ -1,9 +1,10 @@
 import { SNS_CONFIG } from '@/constants/snsConfig';
+import { ClubId } from './branded';
 
 export type RecruitmentStatus = 'OPEN' | 'CLOSED' | 'UPCOMING' | 'ALWAYS';
 
 export interface Club {
-  id: string;
+  id: ClubId;
   name: string;
   logo: string;
   cover?: string;
@@ -46,7 +47,7 @@ export interface ClubCalendarEvent {
 }
 
 export interface ClubDescription {
-  id: string;
+  id: ClubId;
   recruitmentStart: string | null;
   recruitmentEnd: string | null;
   recruitmentTarget: string;

--- a/frontend/src/types/club.ts
+++ b/frontend/src/types/club.ts
@@ -1,5 +1,5 @@
 import { SNS_CONFIG } from '@/constants/snsConfig';
-import { ClubId } from './branded';
+import { ClubId } from '@/types/branded';
 
 export type RecruitmentStatus = 'OPEN' | 'CLOSED' | 'UPCOMING' | 'ALWAYS';
 

--- a/frontend/src/types/google.ts
+++ b/frontend/src/types/google.ts
@@ -1,5 +1,7 @@
+import { CalendarId } from './branded';
+
 export interface GoogleCalendarItem {
-  id: string;
+  id: CalendarId;
   summary: string;
   primary?: boolean;
 }

--- a/frontend/src/types/google.ts
+++ b/frontend/src/types/google.ts
@@ -1,4 +1,4 @@
-import { CalendarId } from './branded';
+import { CalendarId } from '@/types/branded';
 
 export interface GoogleCalendarItem {
   id: CalendarId;

--- a/frontend/src/types/notion.ts
+++ b/frontend/src/types/notion.ts
@@ -1,3 +1,5 @@
+import { DatabaseId } from './branded';
+
 export interface NotionSearchItem {
   id: string;
   object: string;
@@ -7,12 +9,12 @@ export interface NotionSearchItem {
 }
 
 export interface NotionDatabaseOption {
-  id: string;
+  id: DatabaseId;
   title: string;
 }
 
 export interface NotionPagesResponse {
   items: NotionSearchItem[];
   totalResults: number;
-  databaseId?: string;
+  databaseId?: DatabaseId;
 }

--- a/frontend/src/types/notion.ts
+++ b/frontend/src/types/notion.ts
@@ -1,4 +1,4 @@
-import { DatabaseId } from './branded';
+import { DatabaseId } from '@/types/branded';
 
 export interface NotionSearchItem {
   id: string;


### PR DESCRIPTION
## #️⃣연관된 이슈

#1397, #1401, #1614

## 📝작업 내용

branded types를 3단계에 걸쳐 도입하여 ID 타입 안전성을 강화했습니다.

| 단계 | 브랜치 | 작업 내용 |
|------|--------|-----------|
| 1 | `feature/branded-types/core-types` | `Branded<T, B>` 유틸리티 및 `ClubId`, `ApplicationFormId`, `ApplicantId`, `CalendarId`, `DatabaseId` 타입 정의 |
| 2 | `feature/branded-types/domain-types` | 도메인 인터페이스(`Club`, `Applicant`, `ApplicationForm` 등) `id` 필드에 branded type 적용 |
| 3 | `feature/branded-types/api-layer` | API 경계 캐스팅 유틸 추가 및 임시 캐스팅 정리 |

### 변경 파일

**타입 정의**
- `src/types/branded.ts` — `Branded<T, B>` 유틸리티, 5개 ID 타입, 캐스팅 헬퍼(`asClubId`, `asApplicantId` 등) 추가

**도메인 인터페이스**
- `src/types/applicants.ts`, `src/types/application.ts`, `src/types/club.ts`, `src/types/notion.ts`, `src/types/google.ts` — `id` 필드 branded type 적용

**API 경계**
- `src/apis/application.ts` — `getApplicationOptions` 반환 타입 `ApplicationForm[]` 확정, `asApplicationFormId` 적용
- `src/apis/calendarOAuth.ts` — `DatabaseId` 캐스팅
- `src/pages/ClubDetailPage/.../ClubApplyButton.tsx` — `forms as ApplicationForm[]` 임시 캐스팅 제거
- `src/pages/AdminPage/.../ApplicantDetailPage.tsx` — 인라인 import 캐스팅 → `asApplicantId` 헬퍼로 교체

**테스트/스토리북**
- `src/pages/IntroducePage/constants/mockData.ts`, `src/pages/MainPage/.../ClubCard.stories.tsx` — `as ClubId` 캐스팅 적용

## 🫡 참고사항

사용자에게 보이는 기능 변경은 없습니다. 내부 타입 안전성 강화만 포함됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 타입 안전성 패턴 가이드 문서 추가

* **Refactor**
  * 식별자 타입 강화로 컴파일 타임 타입 오류 방지 개선
  * API 응답 처리 시 타입 변환 로직 통일
  * 데이터 모델 전반의 식별자 필드 타입 정확성 향상

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Moadong/moadong/pull/1615?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->