### PR TITLE
[feature] 웹뷰 바텀 네비게이션 + 셸 레이아웃

### DIFF
--- a/frontend/src/components/common/WebviewBottomNav/WebviewBottomNav.styles.ts
+++ b/frontend/src/components/common/WebviewBottomNav/WebviewBottomNav.styles.ts
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import { theme } from '@/styles/theme';
 
 export const WEBVIEW_BOTTOM_NAV_HEIGHT = 56;
 
@@ -11,8 +10,8 @@ export const BottomNavContainer = styled.nav`
   height: calc(${WEBVIEW_BOTTOM_NAV_HEIGHT}px + env(safe-area-inset-bottom));
   padding-bottom: env(safe-area-inset-bottom);
   display: flex;
-  background-color: ${theme.colors.base.white};
-  border-top: 1px solid ${theme.colors.gray[300]};
+  background-color: ${({ theme }) => theme.colors.base.white};
+  border-top: 1px solid ${({ theme }) => theme.colors.gray[300]};
   z-index: 100;
 `;
 
@@ -26,6 +25,6 @@ export const NavButton = styled.button<{ $isActive: boolean }>`
   cursor: pointer;
   font-size: 12px;
   font-weight: ${({ $isActive }) => ($isActive ? 600 : 400)};
-  color: ${({ $isActive }) =>
+  color: ${({ theme, $isActive }) =>
     $isActive ? theme.colors.primary[900] : theme.colors.gray[600]};
 `;

--- a/frontend/src/components/common/WebviewBottomNav/WebviewBottomNav.styles.ts
+++ b/frontend/src/components/common/WebviewBottomNav/WebviewBottomNav.styles.ts
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+import { theme } from '@/styles/theme';
+
+export const WEBVIEW_BOTTOM_NAV_HEIGHT = 56;
+
+export const BottomNavContainer = styled.nav`
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: calc(${WEBVIEW_BOTTOM_NAV_HEIGHT}px + env(safe-area-inset-bottom));
+  padding-bottom: env(safe-area-inset-bottom);
+  display: flex;
+  background-color: ${theme.colors.base.white};
+  border-top: 1px solid ${theme.colors.gray[300]};
+  z-index: 100;
+`;
+
+export const NavButton = styled.button<{ $isActive: boolean }>`
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: ${({ $isActive }) => ($isActive ? 600 : 400)};
+  color: ${({ $isActive }) =>
+    $isActive ? theme.colors.primary[900] : theme.colors.gray[600]};
+`;

--- a/frontend/src/components/common/WebviewBottomNav/WebviewBottomNav.tsx
+++ b/frontend/src/components/common/WebviewBottomNav/WebviewBottomNav.tsx
@@ -1,15 +1,15 @@
 import { useLocation, useNavigate } from 'react-router-dom';
-import { WEBVIEW_BOTTOM_NAV } from '@/routes/webviewBottomNavConfig';
+import {
+  WEBVIEW_BOTTOM_NAV,
+  WebviewBottomNavPath,
+} from '@/routes/webviewBottomNavConfig';
 import * as Styled from './WebviewBottomNav.styles';
 
 const WebviewBottomNav = () => {
   const navigate = useNavigate();
   const { pathname } = useLocation();
 
-  // 동아리 상세는 풀스크린 — 바텀바를 숨긴다.
-  if (pathname.startsWith('/webview/club')) return null;
-
-  const isActive = (path: string) => {
+  const isActive = (path: WebviewBottomNavPath) => {
     // 홈 탭은 동아리 목록(/webview/main)과 홍보(/webview/promotions)에서 활성.
     if (path === '/webview/main') {
       return pathname === '/webview/main' || pathname === '/webview/promotions';
@@ -19,16 +19,20 @@ const WebviewBottomNav = () => {
 
   return (
     <Styled.BottomNavContainer>
-      {WEBVIEW_BOTTOM_NAV.map((tab) => (
-        <Styled.NavButton
-          key={tab.path}
-          type='button'
-          $isActive={isActive(tab.path)}
-          onClick={() => navigate(tab.path)}
-        >
-          {tab.label}
-        </Styled.NavButton>
-      ))}
+      {WEBVIEW_BOTTOM_NAV.map((tab) => {
+        const active = isActive(tab.path);
+        return (
+          <Styled.NavButton
+            key={tab.path}
+            type='button'
+            $isActive={active}
+            aria-current={active ? 'page' : undefined}
+            onClick={() => navigate(tab.path)}
+          >
+            {tab.label}
+          </Styled.NavButton>
+        );
+      })}
     </Styled.BottomNavContainer>
   );
 };

--- a/frontend/src/components/common/WebviewBottomNav/WebviewBottomNav.tsx
+++ b/frontend/src/components/common/WebviewBottomNav/WebviewBottomNav.tsx
@@ -1,0 +1,36 @@
+import { useLocation, useNavigate } from 'react-router-dom';
+import { WEBVIEW_BOTTOM_NAV } from '@/routes/webviewBottomNavConfig';
+import * as Styled from './WebviewBottomNav.styles';
+
+const WebviewBottomNav = () => {
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+
+  // 동아리 상세는 풀스크린 — 바텀바를 숨긴다.
+  if (pathname.startsWith('/webview/club')) return null;
+
+  const isActive = (path: string) => {
+    // 홈 탭은 동아리 목록(/webview/main)과 홍보(/webview/promotions)에서 활성.
+    if (path === '/webview/main') {
+      return pathname === '/webview/main' || pathname === '/webview/promotions';
+    }
+    return pathname === path;
+  };
+
+  return (
+    <Styled.BottomNavContainer>
+      {WEBVIEW_BOTTOM_NAV.map((tab) => (
+        <Styled.NavButton
+          key={tab.path}
+          type='button'
+          $isActive={isActive(tab.path)}
+          onClick={() => navigate(tab.path)}
+        >
+          {tab.label}
+        </Styled.NavButton>
+      ))}
+    </Styled.BottomNavContainer>
+  );
+};
+
+export default WebviewBottomNav;

--- a/frontend/src/pages/WebviewLayout/WebviewLayout.styles.ts
+++ b/frontend/src/pages/WebviewLayout/WebviewLayout.styles.ts
@@ -1,8 +1,9 @@
 import styled from 'styled-components';
 import { WEBVIEW_BOTTOM_NAV_HEIGHT } from '@/components/common/WebviewBottomNav/WebviewBottomNav.styles';
 
-export const ContentArea = styled.div`
-  padding-bottom: calc(
-    ${WEBVIEW_BOTTOM_NAV_HEIGHT}px + env(safe-area-inset-bottom)
-  );
+export const ContentArea = styled.div<{ $hideBottomNav: boolean }>`
+  padding-bottom: ${({ $hideBottomNav }) =>
+    $hideBottomNav
+      ? '0'
+      : `calc(${WEBVIEW_BOTTOM_NAV_HEIGHT}px + env(safe-area-inset-bottom))`};
 `;

--- a/frontend/src/pages/WebviewLayout/WebviewLayout.styles.ts
+++ b/frontend/src/pages/WebviewLayout/WebviewLayout.styles.ts
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+import { WEBVIEW_BOTTOM_NAV_HEIGHT } from '@/components/common/WebviewBottomNav/WebviewBottomNav.styles';
+
+export const ContentArea = styled.div`
+  padding-bottom: calc(
+    ${WEBVIEW_BOTTOM_NAV_HEIGHT}px + env(safe-area-inset-bottom)
+  );
+`;

--- a/frontend/src/pages/WebviewLayout/WebviewLayout.tsx
+++ b/frontend/src/pages/WebviewLayout/WebviewLayout.tsx
@@ -1,16 +1,20 @@
-import { Outlet } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
 import WebviewBottomNav from '@/components/common/WebviewBottomNav/WebviewBottomNav';
 import WebviewGlobalStyles from '@/styles/WebviewGlobal.styles';
 import * as Styled from './WebviewLayout.styles';
 
 const WebviewLayout = () => {
+  const { pathname } = useLocation();
+  // 동아리 상세는 풀스크린 — 바텀바와 하단 패딩을 함께 숨긴다.
+  const hideBottomNav = pathname.startsWith('/webview/club');
+
   return (
     <>
       <WebviewGlobalStyles />
-      <Styled.ContentArea>
+      <Styled.ContentArea $hideBottomNav={hideBottomNav}>
         <Outlet />
       </Styled.ContentArea>
-      <WebviewBottomNav />
+      {!hideBottomNav && <WebviewBottomNav />}
     </>
   );
 };

--- a/frontend/src/pages/WebviewLayout/WebviewLayout.tsx
+++ b/frontend/src/pages/WebviewLayout/WebviewLayout.tsx
@@ -1,11 +1,16 @@
 import { Outlet } from 'react-router-dom';
+import WebviewBottomNav from '@/components/common/WebviewBottomNav/WebviewBottomNav';
 import WebviewGlobalStyles from '@/styles/WebviewGlobal.styles';
+import * as Styled from './WebviewLayout.styles';
 
 const WebviewLayout = () => {
   return (
     <>
       <WebviewGlobalStyles />
-      <Outlet />
+      <Styled.ContentArea>
+        <Outlet />
+      </Styled.ContentArea>
+      <WebviewBottomNav />
     </>
   );
 };

--- a/frontend/src/pages/WebviewMenuPage/WebviewMenuPage.tsx
+++ b/frontend/src/pages/WebviewMenuPage/WebviewMenuPage.tsx
@@ -1,0 +1,6 @@
+// Placeholder — Sub-task 3(#1624)에서 메뉴 항목 + 앱 버전으로 구현 예정.
+const WebviewMenuPage = () => {
+  return <div>메뉴</div>;
+};
+
+export default WebviewMenuPage;

--- a/frontend/src/pages/WebviewSubscribedPage/WebviewSubscribedPage.tsx
+++ b/frontend/src/pages/WebviewSubscribedPage/WebviewSubscribedPage.tsx
@@ -1,0 +1,6 @@
+// Placeholder — Sub-task 2(#1623)에서 구독 동아리 목록으로 구현 예정.
+const WebviewSubscribedPage = () => {
+  return <div>구독</div>;
+};
+
+export default WebviewSubscribedPage;

--- a/frontend/src/routes/webviewBottomNavConfig.ts
+++ b/frontend/src/routes/webviewBottomNavConfig.ts
@@ -1,0 +1,9 @@
+// 웹뷰 바텀 네비게이션 탭 정의
+// 상단 필터칩(WEBVIEW_FILTER_CONFIG: 동아리/홍보)과는 별개의 리스트다.
+export const WEBVIEW_BOTTOM_NAV = [
+  { label: '홈', path: '/webview/main' },
+  { label: '구독', path: '/webview/subscribed' },
+  { label: '메뉴', path: '/webview/menu' },
+] as const;
+
+export type WebviewBottomNavPath = (typeof WEBVIEW_BOTTOM_NAV)[number]['path'];

--- a/frontend/src/routes/webviewRoutes.tsx
+++ b/frontend/src/routes/webviewRoutes.tsx
@@ -6,6 +6,8 @@ import ClubMapPage from '@/pages/ClubMapPage/ClubMapPage';
 import PromotionListPage from '@/pages/PromotionPage/PromotionListPage';
 import WebviewLayout from '@/pages/WebviewLayout/WebviewLayout';
 import WebviewMainPage from '@/pages/WebviewMainPage/WebviewMainPage';
+import WebviewMenuPage from '@/pages/WebviewMenuPage/WebviewMenuPage';
+import WebviewSubscribedPage from '@/pages/WebviewSubscribedPage/WebviewSubscribedPage';
 import {
   WEBVIEW_FILTER_CONFIG,
   WebviewFilterPath,
@@ -32,6 +34,22 @@ const webviewRoutes: RouteObject[] = [
           ),
         };
       }),
+      {
+        path: 'subscribed',
+        element: (
+          <ContentErrorBoundary>
+            <WebviewSubscribedPage />
+          </ContentErrorBoundary>
+        ),
+      },
+      {
+        path: 'menu',
+        element: (
+          <ContentErrorBoundary>
+            <WebviewMenuPage />
+          </ContentErrorBoundary>
+        ),
+      },
       {
         path: 'club/:clubId',
         element: (


### PR DESCRIPTION
## 요약
홍보·알림 위치 ABCD 실험(MOA-924)의 선행 조건인 **바텀 네비 웹뷰 이관**의 첫 단계. 네이티브 탭바를 대체할 웹 바텀 네비게이션과 셸 레이아웃을 추가합니다.

## 변경
- `WebviewBottomNav`(홈/구독/메뉴) + `webviewBottomNavConfig` 신규 — 상단 필터칩(동아리/홍보)과 **별개 리스트**
- `WebviewLayout`에 영구 바텀바 장착, 콘텐츠 하단 패딩
- `/webview/subscribed`, `/webview/menu` 라우트 추가 (페이지는 후속 #1623/#1624에서 구현, 현재 placeholder)
- 동아리 상세에서는 바텀바 숨김, 홈 탭은 main/promotions에서 활성




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 웹뷰에 하단 탭 네비게이션 추가 (홈, 구독, 메뉴)
  * 구독 및 메뉴 페이지 추가로 기능 확장
  * 탭 선택 시 활성 상태 시각적 표시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->