### PR TITLE
[feature] 구독 동아리 목록 페이지

### DIFF
--- a/frontend/src/components/common/WebviewBottomNav/WebviewBottomNav.styles.ts
+++ b/frontend/src/components/common/WebviewBottomNav/WebviewBottomNav.styles.ts
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import { theme } from '@/styles/theme';
 
 export const WEBVIEW_BOTTOM_NAV_HEIGHT = 56;
 
@@ -11,8 +10,8 @@ export const BottomNavContainer = styled.nav`
   height: calc(${WEBVIEW_BOTTOM_NAV_HEIGHT}px + env(safe-area-inset-bottom));
   padding-bottom: env(safe-area-inset-bottom);
   display: flex;
-  background-color: ${theme.colors.base.white};
-  border-top: 1px solid ${theme.colors.gray[300]};
+  background-color: ${({ theme }) => theme.colors.base.white};
+  border-top: 1px solid ${({ theme }) => theme.colors.gray[300]};
   z-index: 100;
 `;
 
@@ -26,6 +25,6 @@ export const NavButton = styled.button<{ $isActive: boolean }>`
   cursor: pointer;
   font-size: 12px;
   font-weight: ${({ $isActive }) => ($isActive ? 600 : 400)};
-  color: ${({ $isActive }) =>
+  color: ${({ theme, $isActive }) =>
     $isActive ? theme.colors.primary[900] : theme.colors.gray[600]};
 `;

--- a/frontend/src/components/common/WebviewBottomNav/WebviewBottomNav.styles.ts
+++ b/frontend/src/components/common/WebviewBottomNav/WebviewBottomNav.styles.ts
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+import { theme } from '@/styles/theme';
+
+export const WEBVIEW_BOTTOM_NAV_HEIGHT = 56;
+
+export const BottomNavContainer = styled.nav`
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: calc(${WEBVIEW_BOTTOM_NAV_HEIGHT}px + env(safe-area-inset-bottom));
+  padding-bottom: env(safe-area-inset-bottom);
+  display: flex;
+  background-color: ${theme.colors.base.white};
+  border-top: 1px solid ${theme.colors.gray[300]};
+  z-index: 100;
+`;
+
+export const NavButton = styled.button<{ $isActive: boolean }>`
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: ${({ $isActive }) => ($isActive ? 600 : 400)};
+  color: ${({ $isActive }) =>
+    $isActive ? theme.colors.primary[900] : theme.colors.gray[600]};
+`;

--- a/frontend/src/components/common/WebviewBottomNav/WebviewBottomNav.tsx
+++ b/frontend/src/components/common/WebviewBottomNav/WebviewBottomNav.tsx
@@ -1,15 +1,15 @@
 import { useLocation, useNavigate } from 'react-router-dom';
-import { WEBVIEW_BOTTOM_NAV } from '@/routes/webviewBottomNavConfig';
+import {
+  WEBVIEW_BOTTOM_NAV,
+  WebviewBottomNavPath,
+} from '@/routes/webviewBottomNavConfig';
 import * as Styled from './WebviewBottomNav.styles';
 
 const WebviewBottomNav = () => {
   const navigate = useNavigate();
   const { pathname } = useLocation();
 
-  // 동아리 상세는 풀스크린 — 바텀바를 숨긴다.
-  if (pathname.startsWith('/webview/club')) return null;
-
-  const isActive = (path: string) => {
+  const isActive = (path: WebviewBottomNavPath) => {
     // 홈 탭은 동아리 목록(/webview/main)과 홍보(/webview/promotions)에서 활성.
     if (path === '/webview/main') {
       return pathname === '/webview/main' || pathname === '/webview/promotions';
@@ -19,16 +19,20 @@ const WebviewBottomNav = () => {
 
   return (
     <Styled.BottomNavContainer>
-      {WEBVIEW_BOTTOM_NAV.map((tab) => (
-        <Styled.NavButton
-          key={tab.path}
-          type='button'
-          $isActive={isActive(tab.path)}
-          onClick={() => navigate(tab.path)}
-        >
-          {tab.label}
-        </Styled.NavButton>
-      ))}
+      {WEBVIEW_BOTTOM_NAV.map((tab) => {
+        const active = isActive(tab.path);
+        return (
+          <Styled.NavButton
+            key={tab.path}
+            type='button'
+            $isActive={active}
+            aria-current={active ? 'page' : undefined}
+            onClick={() => navigate(tab.path)}
+          >
+            {tab.label}
+          </Styled.NavButton>
+        );
+      })}
     </Styled.BottomNavContainer>
   );
 };

--- a/frontend/src/components/common/WebviewBottomNav/WebviewBottomNav.tsx
+++ b/frontend/src/components/common/WebviewBottomNav/WebviewBottomNav.tsx
@@ -1,0 +1,36 @@
+import { useLocation, useNavigate } from 'react-router-dom';
+import { WEBVIEW_BOTTOM_NAV } from '@/routes/webviewBottomNavConfig';
+import * as Styled from './WebviewBottomNav.styles';
+
+const WebviewBottomNav = () => {
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+
+  // 동아리 상세는 풀스크린 — 바텀바를 숨긴다.
+  if (pathname.startsWith('/webview/club')) return null;
+
+  const isActive = (path: string) => {
+    // 홈 탭은 동아리 목록(/webview/main)과 홍보(/webview/promotions)에서 활성.
+    if (path === '/webview/main') {
+      return pathname === '/webview/main' || pathname === '/webview/promotions';
+    }
+    return pathname === path;
+  };
+
+  return (
+    <Styled.BottomNavContainer>
+      {WEBVIEW_BOTTOM_NAV.map((tab) => (
+        <Styled.NavButton
+          key={tab.path}
+          type='button'
+          $isActive={isActive(tab.path)}
+          onClick={() => navigate(tab.path)}
+        >
+          {tab.label}
+        </Styled.NavButton>
+      ))}
+    </Styled.BottomNavContainer>
+  );
+};
+
+export default WebviewBottomNav;

--- a/frontend/src/constants/eventName.ts
+++ b/frontend/src/constants/eventName.ts
@@ -140,6 +140,7 @@ export const PAGE_VIEW = {
   PROMOTION_DETAIL_PAGE: '홍보 상세 페이지',
 
   WEBVIEW_MAIN_PAGE: 'WebviewMainPage',
+  WEBVIEW_SUBSCRIBED_PAGE: 'WebviewSubscribedPage',
 
   // 관리자
   LOGIN_PAGE: '로그인페이지',
@@ -153,5 +154,6 @@ export const PAGE_VIEW = {
 export const PAGE_NAME = {
   MAIN: 'main',
   WEBVIEW_MAIN: 'webview-main',
+  WEBVIEW_SUBSCRIBED: 'webview-subscribed',
   INTRODUCE: 'introduce',
 } as const;

--- a/frontend/src/pages/WebviewLayout/WebviewLayout.styles.ts
+++ b/frontend/src/pages/WebviewLayout/WebviewLayout.styles.ts
@@ -1,8 +1,9 @@
 import styled from 'styled-components';
 import { WEBVIEW_BOTTOM_NAV_HEIGHT } from '@/components/common/WebviewBottomNav/WebviewBottomNav.styles';
 
-export const ContentArea = styled.div`
-  padding-bottom: calc(
-    ${WEBVIEW_BOTTOM_NAV_HEIGHT}px + env(safe-area-inset-bottom)
-  );
+export const ContentArea = styled.div<{ $hideBottomNav: boolean }>`
+  padding-bottom: ${({ $hideBottomNav }) =>
+    $hideBottomNav
+      ? '0'
+      : `calc(${WEBVIEW_BOTTOM_NAV_HEIGHT}px + env(safe-area-inset-bottom))`};
 `;

--- a/frontend/src/pages/WebviewLayout/WebviewLayout.styles.ts
+++ b/frontend/src/pages/WebviewLayout/WebviewLayout.styles.ts
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+import { WEBVIEW_BOTTOM_NAV_HEIGHT } from '@/components/common/WebviewBottomNav/WebviewBottomNav.styles';
+
+export const ContentArea = styled.div`
+  padding-bottom: calc(
+    ${WEBVIEW_BOTTOM_NAV_HEIGHT}px + env(safe-area-inset-bottom)
+  );
+`;

--- a/frontend/src/pages/WebviewLayout/WebviewLayout.tsx
+++ b/frontend/src/pages/WebviewLayout/WebviewLayout.tsx
@@ -1,16 +1,20 @@
-import { Outlet } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
 import WebviewBottomNav from '@/components/common/WebviewBottomNav/WebviewBottomNav';
 import WebviewGlobalStyles from '@/styles/WebviewGlobal.styles';
 import * as Styled from './WebviewLayout.styles';
 
 const WebviewLayout = () => {
+  const { pathname } = useLocation();
+  // 동아리 상세는 풀스크린 — 바텀바와 하단 패딩을 함께 숨긴다.
+  const hideBottomNav = pathname.startsWith('/webview/club');
+
   return (
     <>
       <WebviewGlobalStyles />
-      <Styled.ContentArea>
+      <Styled.ContentArea $hideBottomNav={hideBottomNav}>
         <Outlet />
       </Styled.ContentArea>
-      <WebviewBottomNav />
+      {!hideBottomNav && <WebviewBottomNav />}
     </>
   );
 };

--- a/frontend/src/pages/WebviewLayout/WebviewLayout.tsx
+++ b/frontend/src/pages/WebviewLayout/WebviewLayout.tsx
@@ -1,11 +1,16 @@
 import { Outlet } from 'react-router-dom';
+import WebviewBottomNav from '@/components/common/WebviewBottomNav/WebviewBottomNav';
 import WebviewGlobalStyles from '@/styles/WebviewGlobal.styles';
+import * as Styled from './WebviewLayout.styles';
 
 const WebviewLayout = () => {
   return (
     <>
       <WebviewGlobalStyles />
-      <Outlet />
+      <Styled.ContentArea>
+        <Outlet />
+      </Styled.ContentArea>
+      <WebviewBottomNav />
     </>
   );
 };

--- a/frontend/src/pages/WebviewMenuPage/WebviewMenuPage.tsx
+++ b/frontend/src/pages/WebviewMenuPage/WebviewMenuPage.tsx
@@ -1,0 +1,6 @@
+// Placeholder — Sub-task 3(#1624)에서 메뉴 항목 + 앱 버전으로 구현 예정.
+const WebviewMenuPage = () => {
+  return <div>메뉴</div>;
+};
+
+export default WebviewMenuPage;

--- a/frontend/src/pages/WebviewSubscribedPage/WebviewSubscribedPage.styles.ts
+++ b/frontend/src/pages/WebviewSubscribedPage/WebviewSubscribedPage.styles.ts
@@ -1,0 +1,63 @@
+import styled from 'styled-components';
+
+export const PageContainer = styled.div`
+  width: 100%;
+  padding: 0 16px;
+`;
+
+export const SectionBar = styled.div`
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  margin: 16px 4px 12px;
+`;
+
+export const SectionTitle = styled.span`
+  font-size: 14px;
+  font-weight: 700;
+  color: #787878;
+`;
+
+export const TotalCount = styled.span`
+  font-size: 12px;
+  font-weight: bold;
+  color: #787878;
+`;
+
+export const CardListWrapper = styled.div`
+  width: 100%;
+`;
+
+export const CardList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 4px;
+`;
+
+export const EmptyResult = styled.div`
+  padding: 80px 20px;
+  text-align: center;
+  color: #555;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  white-space: pre-line;
+`;
+
+export const ActionButton = styled.button`
+  display: inline-block;
+  margin-top: 24px;
+  padding: 10px 24px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #fff;
+  background: ${({ theme }) => theme.colors.primary[900]};
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:active {
+    transform: scale(0.98);
+  }
+`;

--- a/frontend/src/pages/WebviewSubscribedPage/WebviewSubscribedPage.tsx
+++ b/frontend/src/pages/WebviewSubscribedPage/WebviewSubscribedPage.tsx
@@ -1,6 +1,96 @@
-// Placeholder — Sub-task 2(#1623)에서 구독 동아리 목록으로 구현 예정.
+import { memo, useCallback, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Spinner from '@/components/common/Spinner/Spinner';
+import { PAGE_NAME, PAGE_VIEW } from '@/constants/eventName';
+import useTrackPageView from '@/hooks/Mixpanel/useTrackPageView';
+import { useGetCardList } from '@/hooks/Queries/useClub';
+import useWebviewSubscribe from '@/hooks/useWebviewSubscribe';
+import ClubCard from '@/pages/MainPage/components/ClubCard/ClubCard';
+import SubscribeButton from '@/pages/WebviewMainPage/components/SubscribeButton/SubscribeButton';
+import { Club } from '@/types/club';
+import { requestNavigateWebview } from '@/utils/webviewBridge';
+import * as Styled from './WebviewSubscribedPage.styles';
+
+const MemoClubCard = memo(ClubCard);
+
 const WebviewSubscribedPage = () => {
-  return <div>구독</div>;
+  useTrackPageView(PAGE_VIEW.WEBVIEW_SUBSCRIBED_PAGE);
+
+  const navigate = useNavigate();
+  const { data, error, isLoading, refetch } = useGetCardList({
+    keyword: '',
+    recruitmentStatus: 'all',
+    category: 'all',
+    division: 'all',
+  });
+  const { toggleSubscribe, subscribedClubIds } = useWebviewSubscribe();
+
+  const handleCardClick = useCallback((club: Club) => {
+    requestNavigateWebview(`club/${club.id}`);
+  }, []);
+
+  const subscribedClubs = useMemo(
+    () => (data?.clubs ?? []).filter((club) => subscribedClubIds.has(club.id)),
+    [data, subscribedClubIds],
+  );
+
+  const clubList = useMemo(
+    () =>
+      subscribedClubs.map((club: Club, i: number) => (
+        <MemoClubCard
+          key={club.id}
+          club={club}
+          index={i}
+          page={PAGE_NAME.WEBVIEW_SUBSCRIBED}
+          onCardClick={handleCardClick}
+        >
+          <SubscribeButton
+            subscribed={subscribedClubIds.has(club.id)}
+            onToggle={() =>
+              toggleSubscribe(club.id, subscribedClubIds.has(club.id))
+            }
+          />
+        </MemoClubCard>
+      )),
+    [subscribedClubs, subscribedClubIds, toggleSubscribe, handleCardClick],
+  );
+
+  return (
+    <Styled.PageContainer>
+      <Styled.SectionBar>
+        <Styled.SectionTitle>구독한 동아리</Styled.SectionTitle>
+        <Styled.TotalCount role='status'>
+          {`전체 ${isLoading ? 0 : subscribedClubs.length}개`}
+        </Styled.TotalCount>
+      </Styled.SectionBar>
+
+      <Styled.CardListWrapper>
+        {isLoading ? (
+          <Spinner />
+        ) : error ? (
+          <Styled.EmptyResult>
+            동아리 목록을 불러오는 중 문제가 발생했습니다.
+            <br />
+            <Styled.ActionButton onClick={() => refetch()}>
+              다시 시도
+            </Styled.ActionButton>
+          </Styled.EmptyResult>
+        ) : subscribedClubs.length === 0 ? (
+          <Styled.EmptyResult>
+            아직 구독한 동아리가 없어요.
+            <br />
+            관심 있는 동아리를 구독해보세요!
+            <br />
+            <Styled.ActionButton onClick={() => navigate('/webview/main')}>
+              동아리 보러 가기
+            </Styled.ActionButton>
+          </Styled.EmptyResult>
+        ) : (
+          <Styled.CardList>{clubList}</Styled.CardList>
+        )}
+      </Styled.CardListWrapper>
+    </Styled.PageContainer>
+  );
 };
 
 export default WebviewSubscribedPage;

--- a/frontend/src/pages/WebviewSubscribedPage/WebviewSubscribedPage.tsx
+++ b/frontend/src/pages/WebviewSubscribedPage/WebviewSubscribedPage.tsx
@@ -1,0 +1,6 @@
+// Placeholder — Sub-task 2(#1623)에서 구독 동아리 목록으로 구현 예정.
+const WebviewSubscribedPage = () => {
+  return <div>구독</div>;
+};
+
+export default WebviewSubscribedPage;

--- a/frontend/src/routes/webviewBottomNavConfig.ts
+++ b/frontend/src/routes/webviewBottomNavConfig.ts
@@ -1,0 +1,9 @@
+// 웹뷰 바텀 네비게이션 탭 정의
+// 상단 필터칩(WEBVIEW_FILTER_CONFIG: 동아리/홍보)과는 별개의 리스트다.
+export const WEBVIEW_BOTTOM_NAV = [
+  { label: '홈', path: '/webview/main' },
+  { label: '구독', path: '/webview/subscribed' },
+  { label: '메뉴', path: '/webview/menu' },
+] as const;
+
+export type WebviewBottomNavPath = (typeof WEBVIEW_BOTTOM_NAV)[number]['path'];

--- a/frontend/src/routes/webviewRoutes.tsx
+++ b/frontend/src/routes/webviewRoutes.tsx
@@ -6,6 +6,8 @@ import ClubMapPage from '@/pages/ClubMapPage/ClubMapPage';
 import PromotionListPage from '@/pages/PromotionPage/PromotionListPage';
 import WebviewLayout from '@/pages/WebviewLayout/WebviewLayout';
 import WebviewMainPage from '@/pages/WebviewMainPage/WebviewMainPage';
+import WebviewMenuPage from '@/pages/WebviewMenuPage/WebviewMenuPage';
+import WebviewSubscribedPage from '@/pages/WebviewSubscribedPage/WebviewSubscribedPage';
 import {
   WEBVIEW_FILTER_CONFIG,
   WebviewFilterPath,
@@ -32,6 +34,22 @@ const webviewRoutes: RouteObject[] = [
           ),
         };
       }),
+      {
+        path: 'subscribed',
+        element: (
+          <ContentErrorBoundary>
+            <WebviewSubscribedPage />
+          </ContentErrorBoundary>
+        ),
+      },
+      {
+        path: 'menu',
+        element: (
+          <ContentErrorBoundary>
+            <WebviewMenuPage />
+          </ContentErrorBoundary>
+        ),
+      },
       {
         path: 'club/:clubId',
         element: (


### PR DESCRIPTION
## 요약
바텀 네비 웹뷰 이관(MOA-923)의 **구독 탭** 구현. `/webview/subscribed`에서 구독한 동아리 목록을 보여준다.

## 변경
- `WebviewSubscribedPage` — 구독한 동아리 목록 + 빈/로딩/에러 상태
- `useWebviewSubscribe`의 `subscribedClubIds`로 `useGetCardList` 결과를 메모리 필터
- `ClubCard`/`SubscribeButton` 재사용, 빈 상태에서 "동아리 보러 가기" → `/webview/main`
- `PAGE_VIEW.WEBVIEW_SUBSCRIBED_PAGE`, `PAGE_NAME.WEBVIEW_SUBSCRIBED` 추가

## 의존성
- #1622(바텀 네비) 위에 쌓임. 충돌 방지를 위해 이 브랜치에 #1622를 머지해 포함했다.
- **#1631 먼저 머지** 후 이 PR의 diff는 본 작업분만 남는다.

## 검증
- `npm run typecheck`, eslint 통과

Refs #1623
