### PR TITLE
[feature] 메뉴 페이지

### DIFF
--- a/frontend/src/components/common/WebviewBottomNav/WebviewBottomNav.styles.ts
+++ b/frontend/src/components/common/WebviewBottomNav/WebviewBottomNav.styles.ts
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import { theme } from '@/styles/theme';
 
 export const WEBVIEW_BOTTOM_NAV_HEIGHT = 56;
 
@@ -11,8 +10,8 @@ export const BottomNavContainer = styled.nav`
   height: calc(${WEBVIEW_BOTTOM_NAV_HEIGHT}px + env(safe-area-inset-bottom));
   padding-bottom: env(safe-area-inset-bottom);
   display: flex;
-  background-color: ${theme.colors.base.white};
-  border-top: 1px solid ${theme.colors.gray[300]};
+  background-color: ${({ theme }) => theme.colors.base.white};
+  border-top: 1px solid ${({ theme }) => theme.colors.gray[300]};
   z-index: 100;
 `;
 
@@ -26,6 +25,6 @@ export const NavButton = styled.button<{ $isActive: boolean }>`
   cursor: pointer;
   font-size: 12px;
   font-weight: ${({ $isActive }) => ($isActive ? 600 : 400)};
-  color: ${({ $isActive }) =>
+  color: ${({ theme, $isActive }) =>
     $isActive ? theme.colors.primary[900] : theme.colors.gray[600]};
 `;

--- a/frontend/src/components/common/WebviewBottomNav/WebviewBottomNav.styles.ts
+++ b/frontend/src/components/common/WebviewBottomNav/WebviewBottomNav.styles.ts
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+import { theme } from '@/styles/theme';
+
+export const WEBVIEW_BOTTOM_NAV_HEIGHT = 56;
+
+export const BottomNavContainer = styled.nav`
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: calc(${WEBVIEW_BOTTOM_NAV_HEIGHT}px + env(safe-area-inset-bottom));
+  padding-bottom: env(safe-area-inset-bottom);
+  display: flex;
+  background-color: ${theme.colors.base.white};
+  border-top: 1px solid ${theme.colors.gray[300]};
+  z-index: 100;
+`;
+
+export const NavButton = styled.button<{ $isActive: boolean }>`
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: ${({ $isActive }) => ($isActive ? 600 : 400)};
+  color: ${({ $isActive }) =>
+    $isActive ? theme.colors.primary[900] : theme.colors.gray[600]};
+`;

--- a/frontend/src/components/common/WebviewBottomNav/WebviewBottomNav.tsx
+++ b/frontend/src/components/common/WebviewBottomNav/WebviewBottomNav.tsx
@@ -1,15 +1,15 @@
 import { useLocation, useNavigate } from 'react-router-dom';
-import { WEBVIEW_BOTTOM_NAV } from '@/routes/webviewBottomNavConfig';
+import {
+  WEBVIEW_BOTTOM_NAV,
+  WebviewBottomNavPath,
+} from '@/routes/webviewBottomNavConfig';
 import * as Styled from './WebviewBottomNav.styles';
 
 const WebviewBottomNav = () => {
   const navigate = useNavigate();
   const { pathname } = useLocation();
 
-  // 동아리 상세는 풀스크린 — 바텀바를 숨긴다.
-  if (pathname.startsWith('/webview/club')) return null;
-
-  const isActive = (path: string) => {
+  const isActive = (path: WebviewBottomNavPath) => {
     // 홈 탭은 동아리 목록(/webview/main)과 홍보(/webview/promotions)에서 활성.
     if (path === '/webview/main') {
       return pathname === '/webview/main' || pathname === '/webview/promotions';
@@ -19,16 +19,20 @@ const WebviewBottomNav = () => {
 
   return (
     <Styled.BottomNavContainer>
-      {WEBVIEW_BOTTOM_NAV.map((tab) => (
-        <Styled.NavButton
-          key={tab.path}
-          type='button'
-          $isActive={isActive(tab.path)}
-          onClick={() => navigate(tab.path)}
-        >
-          {tab.label}
-        </Styled.NavButton>
-      ))}
+      {WEBVIEW_BOTTOM_NAV.map((tab) => {
+        const active = isActive(tab.path);
+        return (
+          <Styled.NavButton
+            key={tab.path}
+            type='button'
+            $isActive={active}
+            aria-current={active ? 'page' : undefined}
+            onClick={() => navigate(tab.path)}
+          >
+            {tab.label}
+          </Styled.NavButton>
+        );
+      })}
     </Styled.BottomNavContainer>
   );
 };

--- a/frontend/src/components/common/WebviewBottomNav/WebviewBottomNav.tsx
+++ b/frontend/src/components/common/WebviewBottomNav/WebviewBottomNav.tsx
@@ -1,0 +1,36 @@
+import { useLocation, useNavigate } from 'react-router-dom';
+import { WEBVIEW_BOTTOM_NAV } from '@/routes/webviewBottomNavConfig';
+import * as Styled from './WebviewBottomNav.styles';
+
+const WebviewBottomNav = () => {
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+
+  // 동아리 상세는 풀스크린 — 바텀바를 숨긴다.
+  if (pathname.startsWith('/webview/club')) return null;
+
+  const isActive = (path: string) => {
+    // 홈 탭은 동아리 목록(/webview/main)과 홍보(/webview/promotions)에서 활성.
+    if (path === '/webview/main') {
+      return pathname === '/webview/main' || pathname === '/webview/promotions';
+    }
+    return pathname === path;
+  };
+
+  return (
+    <Styled.BottomNavContainer>
+      {WEBVIEW_BOTTOM_NAV.map((tab) => (
+        <Styled.NavButton
+          key={tab.path}
+          type='button'
+          $isActive={isActive(tab.path)}
+          onClick={() => navigate(tab.path)}
+        >
+          {tab.label}
+        </Styled.NavButton>
+      ))}
+    </Styled.BottomNavContainer>
+  );
+};
+
+export default WebviewBottomNav;

--- a/frontend/src/constants/eventName.ts
+++ b/frontend/src/constants/eventName.ts
@@ -77,6 +77,7 @@ export const USER_EVENT = {
   PROMOTION_CLUB_CTA_CLICKED: 'Promotion Club CTA Clicked',
 
   WEBVIEW_SUBSCRIBE_TOGGLED: 'Webview Subscribe Toggled',
+  WEBVIEW_MENU_CLICKED: 'Webview Menu Clicked',
 } as const;
 
 export const WEBVIEW_LINK_TARGET = {
@@ -140,6 +141,7 @@ export const PAGE_VIEW = {
   PROMOTION_DETAIL_PAGE: '홍보 상세 페이지',
 
   WEBVIEW_MAIN_PAGE: 'WebviewMainPage',
+  WEBVIEW_MENU_PAGE: 'WebviewMenuPage',
 
   // 관리자
   LOGIN_PAGE: '로그인페이지',

--- a/frontend/src/hooks/useAppVersion.ts
+++ b/frontend/src/hooks/useAppVersion.ts
@@ -7,15 +7,15 @@ const useAppVersion = () => {
 
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
-      let data: AppToWebMessage;
       try {
-        data =
-          typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
+        const data = (
+          typeof event.data === 'string' ? JSON.parse(event.data) : event.data
+        ) as AppToWebMessage | null;
+        if (data && typeof data === 'object' && data.type === 'APP_VERSION') {
+          setVersion(data.payload.version);
+        }
       } catch {
         return;
-      }
-      if (data.type === 'APP_VERSION') {
-        setVersion(data.payload.version);
       }
     };
 

--- a/frontend/src/hooks/useAppVersion.ts
+++ b/frontend/src/hooks/useAppVersion.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+import { AppToWebMessage, requestAppVersion } from '@/utils/webviewBridge';
+
+// 앱(웹뷰)에서 앱 버전을 받아온다. 일반 브라우저에서는 응답이 없어 빈 문자열로 유지된다.
+const useAppVersion = () => {
+  const [version, setVersion] = useState('');
+
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      let data: AppToWebMessage;
+      try {
+        data =
+          typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
+      } catch {
+        return;
+      }
+      if (data.type === 'APP_VERSION') {
+        setVersion(data.payload.version);
+      }
+    };
+
+    window.addEventListener('message', handleMessage);
+    requestAppVersion();
+
+    return () => {
+      window.removeEventListener('message', handleMessage);
+    };
+  }, []);
+
+  return version;
+};
+
+export default useAppVersion;

--- a/frontend/src/pages/WebviewLayout/WebviewLayout.styles.ts
+++ b/frontend/src/pages/WebviewLayout/WebviewLayout.styles.ts
@@ -1,8 +1,9 @@
 import styled from 'styled-components';
 import { WEBVIEW_BOTTOM_NAV_HEIGHT } from '@/components/common/WebviewBottomNav/WebviewBottomNav.styles';
 
-export const ContentArea = styled.div`
-  padding-bottom: calc(
-    ${WEBVIEW_BOTTOM_NAV_HEIGHT}px + env(safe-area-inset-bottom)
-  );
+export const ContentArea = styled.div<{ $hideBottomNav: boolean }>`
+  padding-bottom: ${({ $hideBottomNav }) =>
+    $hideBottomNav
+      ? '0'
+      : `calc(${WEBVIEW_BOTTOM_NAV_HEIGHT}px + env(safe-area-inset-bottom))`};
 `;

--- a/frontend/src/pages/WebviewLayout/WebviewLayout.styles.ts
+++ b/frontend/src/pages/WebviewLayout/WebviewLayout.styles.ts
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+import { WEBVIEW_BOTTOM_NAV_HEIGHT } from '@/components/common/WebviewBottomNav/WebviewBottomNav.styles';
+
+export const ContentArea = styled.div`
+  padding-bottom: calc(
+    ${WEBVIEW_BOTTOM_NAV_HEIGHT}px + env(safe-area-inset-bottom)
+  );
+`;

--- a/frontend/src/pages/WebviewLayout/WebviewLayout.tsx
+++ b/frontend/src/pages/WebviewLayout/WebviewLayout.tsx
@@ -1,16 +1,20 @@
-import { Outlet } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
 import WebviewBottomNav from '@/components/common/WebviewBottomNav/WebviewBottomNav';
 import WebviewGlobalStyles from '@/styles/WebviewGlobal.styles';
 import * as Styled from './WebviewLayout.styles';
 
 const WebviewLayout = () => {
+  const { pathname } = useLocation();
+  // 동아리 상세는 풀스크린 — 바텀바와 하단 패딩을 함께 숨긴다.
+  const hideBottomNav = pathname.startsWith('/webview/club');
+
   return (
     <>
       <WebviewGlobalStyles />
-      <Styled.ContentArea>
+      <Styled.ContentArea $hideBottomNav={hideBottomNav}>
         <Outlet />
       </Styled.ContentArea>
-      <WebviewBottomNav />
+      {!hideBottomNav && <WebviewBottomNav />}
     </>
   );
 };

--- a/frontend/src/pages/WebviewLayout/WebviewLayout.tsx
+++ b/frontend/src/pages/WebviewLayout/WebviewLayout.tsx
@@ -1,11 +1,16 @@
 import { Outlet } from 'react-router-dom';
+import WebviewBottomNav from '@/components/common/WebviewBottomNav/WebviewBottomNav';
 import WebviewGlobalStyles from '@/styles/WebviewGlobal.styles';
+import * as Styled from './WebviewLayout.styles';
 
 const WebviewLayout = () => {
   return (
     <>
       <WebviewGlobalStyles />
-      <Outlet />
+      <Styled.ContentArea>
+        <Outlet />
+      </Styled.ContentArea>
+      <WebviewBottomNav />
     </>
   );
 };

--- a/frontend/src/pages/WebviewMenuPage/WebviewMenuPage.styles.ts
+++ b/frontend/src/pages/WebviewMenuPage/WebviewMenuPage.styles.ts
@@ -1,0 +1,35 @@
+import styled from 'styled-components';
+
+export const PageContainer = styled.div`
+  width: 100%;
+`;
+
+export const MenuList = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const MenuItem = styled.button`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  height: 56px;
+  padding: 0 20px;
+  border: none;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.gray[300]};
+  background: none;
+  cursor: pointer;
+  font-size: 15px;
+  color: ${({ theme }) => theme.colors.gray[900]};
+  text-align: left;
+
+  &:active {
+    background-color: ${({ theme }) => theme.colors.gray[100]};
+  }
+`;
+
+export const Version = styled.p`
+  margin: 24px 20px;
+  font-size: 12px;
+  color: ${({ theme }) => theme.colors.gray[500]};
+`;

--- a/frontend/src/pages/WebviewMenuPage/WebviewMenuPage.tsx
+++ b/frontend/src/pages/WebviewMenuPage/WebviewMenuPage.tsx
@@ -1,0 +1,6 @@
+// Placeholder — Sub-task 3(#1624)에서 메뉴 항목 + 앱 버전으로 구현 예정.
+const WebviewMenuPage = () => {
+  return <div>메뉴</div>;
+};
+
+export default WebviewMenuPage;

--- a/frontend/src/pages/WebviewMenuPage/WebviewMenuPage.tsx
+++ b/frontend/src/pages/WebviewMenuPage/WebviewMenuPage.tsx
@@ -1,6 +1,46 @@
-// Placeholder — Sub-task 3(#1624)에서 메뉴 항목 + 앱 버전으로 구현 예정.
+import { PAGE_VIEW, USER_EVENT } from '@/constants/eventName';
+import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
+import useTrackPageView from '@/hooks/Mixpanel/useTrackPageView';
+import useAppVersion from '@/hooks/useAppVersion';
+import useNavigator from '@/hooks/useNavigator';
+import * as Styled from './WebviewMenuPage.styles';
+
+const PRIVACY_POLICY_URL =
+  'https://honorable-cough-8f9.notion.site/232aad23209680f2a2cadb146eff81cd?pvs=74';
+
+const MENU_ITEMS = [
+  { label: '서비스 소개', to: '/introduce' },
+  { label: '총 동아리 연합회', to: '/club-union' },
+  { label: '개인정보 처리방침', to: PRIVACY_POLICY_URL },
+] as const;
+
 const WebviewMenuPage = () => {
-  return <div>메뉴</div>;
+  useTrackPageView(PAGE_VIEW.WEBVIEW_MENU_PAGE);
+  const handleLink = useNavigator();
+  const trackEvent = useMixpanelTrack();
+  const appVersion = useAppVersion();
+
+  const handleClick = (label: string, to: string) => {
+    trackEvent(USER_EVENT.WEBVIEW_MENU_CLICKED, { menu: label });
+    handleLink(to);
+  };
+
+  return (
+    <Styled.PageContainer>
+      <Styled.MenuList>
+        {MENU_ITEMS.map((item) => (
+          <Styled.MenuItem
+            key={item.label}
+            type='button'
+            onClick={() => handleClick(item.label, item.to)}
+          >
+            {item.label}
+          </Styled.MenuItem>
+        ))}
+      </Styled.MenuList>
+      {appVersion && <Styled.Version>앱 버전 {appVersion}</Styled.Version>}
+    </Styled.PageContainer>
+  );
 };
 
 export default WebviewMenuPage;

--- a/frontend/src/pages/WebviewSubscribedPage/WebviewSubscribedPage.tsx
+++ b/frontend/src/pages/WebviewSubscribedPage/WebviewSubscribedPage.tsx
@@ -1,0 +1,6 @@
+// Placeholder — Sub-task 2(#1623)에서 구독 동아리 목록으로 구현 예정.
+const WebviewSubscribedPage = () => {
+  return <div>구독</div>;
+};
+
+export default WebviewSubscribedPage;

--- a/frontend/src/routes/webviewBottomNavConfig.ts
+++ b/frontend/src/routes/webviewBottomNavConfig.ts
@@ -1,0 +1,9 @@
+// 웹뷰 바텀 네비게이션 탭 정의
+// 상단 필터칩(WEBVIEW_FILTER_CONFIG: 동아리/홍보)과는 별개의 리스트다.
+export const WEBVIEW_BOTTOM_NAV = [
+  { label: '홈', path: '/webview/main' },
+  { label: '구독', path: '/webview/subscribed' },
+  { label: '메뉴', path: '/webview/menu' },
+] as const;
+
+export type WebviewBottomNavPath = (typeof WEBVIEW_BOTTOM_NAV)[number]['path'];

--- a/frontend/src/routes/webviewRoutes.tsx
+++ b/frontend/src/routes/webviewRoutes.tsx
@@ -6,6 +6,8 @@ import ClubMapPage from '@/pages/ClubMapPage/ClubMapPage';
 import PromotionListPage from '@/pages/PromotionPage/PromotionListPage';
 import WebviewLayout from '@/pages/WebviewLayout/WebviewLayout';
 import WebviewMainPage from '@/pages/WebviewMainPage/WebviewMainPage';
+import WebviewMenuPage from '@/pages/WebviewMenuPage/WebviewMenuPage';
+import WebviewSubscribedPage from '@/pages/WebviewSubscribedPage/WebviewSubscribedPage';
 import {
   WEBVIEW_FILTER_CONFIG,
   WebviewFilterPath,
@@ -32,6 +34,22 @@ const webviewRoutes: RouteObject[] = [
           ),
         };
       }),
+      {
+        path: 'subscribed',
+        element: (
+          <ContentErrorBoundary>
+            <WebviewSubscribedPage />
+          </ContentErrorBoundary>
+        ),
+      },
+      {
+        path: 'menu',
+        element: (
+          <ContentErrorBoundary>
+            <WebviewMenuPage />
+          </ContentErrorBoundary>
+        ),
+      },
       {
         path: 'club/:clubId',
         element: (

--- a/frontend/src/utils/webviewBridge.ts
+++ b/frontend/src/utils/webviewBridge.ts
@@ -16,7 +16,8 @@ export type WebViewMessage =
   | { type: 'SUBSCRIBE_TOGGLE'; payload: { clubId: string } }
   | { type: 'REQUEST_SUBSCRIBE_STATE' }
   | { type: 'NAVIGATE_WEBVIEW'; payload: { slug: string } }
-  | { type: 'OPEN_EXTERNAL_URL'; payload: { url: string } };
+  | { type: 'OPEN_EXTERNAL_URL'; payload: { url: string } }
+  | { type: 'REQUEST_APP_VERSION' };
 
 // 앱 → 웹 방향 메시지 타입
 // 앱이 window.postMessage()로 전송하며, 웹이 message 이벤트로 수신
@@ -29,7 +30,8 @@ export type AppToWebMessage =
         subscribed: boolean;
         needsPermission: boolean;
       };
-    };
+    }
+  | { type: 'APP_VERSION'; payload: { version: string } };
 
 // WebViewMessage의 type 문자열 유니온 (앱 측 타입 공유용)
 export type WebViewMessageType = WebViewMessage['type'];
@@ -146,4 +148,10 @@ export const requestOpenExternalUrl = (url: string): boolean => {
     return false;
   }
   return postMessageToApp({ type: 'OPEN_EXTERNAL_URL', payload: { url } });
+};
+
+// 앱 버전 요청 — 결과는 APP_VERSION 메시지로 수신
+// 언제: 메뉴 페이지에서 앱 버전 표시. 웹 환경에서는 응답이 없어 표시를 생략한다.
+export const requestAppVersion = (): boolean => {
+  return postMessageToApp({ type: 'REQUEST_APP_VERSION' });
 };


### PR DESCRIPTION
## 요약
바텀 네비 웹뷰 이관(MOA-923)의 **메뉴 탭** 구현. `/webview/menu`에서 서비스 소개·총동아리연합회·개인정보 처리방침과 앱 버전을 보여준다.

## 변경
- `WebviewMenuPage` — 메뉴 항목 3개 + 앱 버전
- `useNavigator`(handleLink)로 인앱(`requestNavigateWebview`)/웹(`navigate`)/외부 URL 분기 재사용
- `webviewBridge`에 `REQUEST_APP_VERSION`/`APP_VERSION` 메시지 + `requestAppVersion()` 추가
- `useAppVersion` 훅 신규 (브릿지로 앱 버전 수신, 웹에서는 미표시)
- `PAGE_VIEW.WEBVIEW_MENU_PAGE`, `USER_EVENT.WEBVIEW_MENU_CLICKED` 추가

## 의존성
- #1622(바텀 네비) 위에 쌓음 (#1631 먼저 머지 시 diff 정리됨)
- 인앱 앱 버전 표시는 RN 측 `REQUEST_APP_VERSION` 핸들러(#1626, 별도 레포) 필요 — 미구현 시 버전 표시만 생략(그 외 정상)
