### PR TITLE
[feature] 구독 버튼 브라우저 분기 (앱/스토어) 

### DIFF
--- a/frontend/src/hooks/useOpenApp.ts
+++ b/frontend/src/hooks/useOpenApp.ts
@@ -1,0 +1,76 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+  APP_STORE_LINKS,
+  detectPlatform,
+  getAppStoreLink,
+} from '@/utils/appStoreLink';
+
+const ANDROID_PACKAGE = 'com.moadong.moadong';
+const APP_HOST = 'www.moadong.com';
+const IOS_SCHEME = 'moadongapp';
+const STORE_FALLBACK_DELAY_MS = 2000;
+
+/**
+ * 일반 브라우저에서 앱을 연다. 앱이 설치돼 있으면 딥링크로 진입하고, 없으면 스토어로 보낸다.
+ * (카카오 인앱브라우저 전용인 useOpenAppFromKakao와 달리 iOS 폴백이 스토어로 직접 이동한다.)
+ */
+const useOpenApp = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const openApp = () => {
+    const platform = detectPlatform();
+
+    // 데스크톱 등: 앱이 없으니 스토어로 바로 이동
+    if (platform === 'Other') {
+      window.location.href = getAppStoreLink();
+      return;
+    }
+
+    const url = new URL(window.location.href);
+    const path = `${url.pathname}${url.search}${url.hash}`;
+
+    if (platform === 'Android') {
+      const fallback = encodeURIComponent(APP_STORE_LINKS.android);
+      window.location.href =
+        `intent://${APP_HOST}${path}` +
+        `#Intent;scheme=https;package=${ANDROID_PACKAGE};S.browser_fallback_url=${fallback};end`;
+      return;
+    }
+
+    // iOS: 커스텀 스킴 시도 → 앱이 열리지 않으면(=화면이 그대로면) 스토어로
+    if (timerRef.current !== null) clearTimeout(timerRef.current);
+    setIsLoading(true);
+    window.location.href = `${IOS_SCHEME}://${path}`;
+
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      setIsLoading(false);
+      if (!document.hidden) {
+        window.location.href = APP_STORE_LINKS.iphone;
+      }
+    }, STORE_FALLBACK_DELAY_MS);
+
+    document.addEventListener(
+      'visibilitychange',
+      () => {
+        if (document.hidden && timerRef.current !== null) {
+          clearTimeout(timerRef.current);
+          timerRef.current = null;
+          setIsLoading(false);
+        }
+      },
+      { once: true },
+    );
+  };
+
+  return { openApp, isLoading };
+};
+
+export default useOpenApp;

--- a/frontend/src/hooks/useOpenApp.ts
+++ b/frontend/src/hooks/useOpenApp.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   APP_STORE_LINKS,
   detectPlatform,
@@ -17,14 +17,16 @@ const STORE_FALLBACK_DELAY_MS = 2000;
 const useOpenApp = () => {
   const [isLoading, setIsLoading] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const removeVisibilityListenerRef = useRef<(() => void) | null>(null);
 
   useEffect(() => {
     return () => {
       if (timerRef.current !== null) clearTimeout(timerRef.current);
+      removeVisibilityListenerRef.current?.();
     };
   }, []);
 
-  const openApp = () => {
+  const openApp = useCallback(() => {
     const platform = detectPlatform();
 
     // 데스크톱 등: 앱이 없으니 스토어로 바로 이동
@@ -47,28 +49,32 @@ const useOpenApp = () => {
     // iOS: 커스텀 스킴 시도 → 앱이 열리지 않으면(=화면이 그대로면) 스토어로
     if (timerRef.current !== null) clearTimeout(timerRef.current);
     setIsLoading(true);
-    window.location.href = `${IOS_SCHEME}://${path}`;
+    // pathname은 항상 '/'로 시작 — 스킴 뒤 '///' 중복을 막기 위해 선행 슬래시 제거
+    window.location.href = `${IOS_SCHEME}://${path.replace(/^\//, '')}`;
+
+    const onVisibilityChange = () => {
+      if (document.hidden && timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+        setIsLoading(false);
+        removeVisibilityListenerRef.current?.();
+        removeVisibilityListenerRef.current = null;
+      }
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    removeVisibilityListenerRef.current = () =>
+      document.removeEventListener('visibilitychange', onVisibilityChange);
 
     timerRef.current = setTimeout(() => {
       timerRef.current = null;
+      removeVisibilityListenerRef.current?.();
+      removeVisibilityListenerRef.current = null;
       setIsLoading(false);
       if (!document.hidden) {
         window.location.href = APP_STORE_LINKS.iphone;
       }
     }, STORE_FALLBACK_DELAY_MS);
-
-    document.addEventListener(
-      'visibilitychange',
-      () => {
-        if (document.hidden && timerRef.current !== null) {
-          clearTimeout(timerRef.current);
-          timerRef.current = null;
-          setIsLoading(false);
-        }
-      },
-      { once: true },
-    );
-  };
+  }, []);
 
   return { openApp, isLoading };
 };

--- a/frontend/src/hooks/useWebviewSubscribe.ts
+++ b/frontend/src/hooks/useWebviewSubscribe.ts
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
 import { USER_EVENT } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
+import useOpenApp from '@/hooks/useOpenApp';
+import isInAppWebView from '@/utils/isInAppWebView';
 import {
   AppToWebMessage,
   requestSubscribeState,
@@ -9,6 +11,7 @@ import {
 
 const useWebviewSubscribe = () => {
   const trackEvent = useMixpanelTrack();
+  const { openApp } = useOpenApp();
   const [subscribedClubIds, setSubscribedClubIds] = useState<Set<string>>(
     new Set(),
   );
@@ -58,13 +61,18 @@ const useWebviewSubscribe = () => {
 
   const toggleSubscribe = useCallback(
     (clubId: string, subscribed: boolean) => {
+      // 일반 브라우저: 구독(푸시)은 앱 전용이라 앱 실행→미설치 시 스토어로 유도
+      if (!isInAppWebView()) {
+        openApp();
+        return;
+      }
       requestSubscribeToggle(clubId);
       trackEvent(USER_EVENT.WEBVIEW_SUBSCRIBE_TOGGLED, {
         club_id: clubId,
         subscribed: !subscribed,
       });
     },
-    [trackEvent],
+    [trackEvent, openApp],
   );
 
   return { subscribedClubIds, toggleSubscribe };


### PR DESCRIPTION
## 요약
바텀 네비 웹뷰 이관(MOA-923)의 일부. 일반 브라우저(비인앱)에서 구독 버튼을 누르면 **앱 설치 시 앱으로, 미설치 시 스토어**로 유도한다. (구독=푸시는 앱 전용 기능이므로)

## 변경
- `useOpenApp` 훅 신규 — `appStoreLink` 재사용
  - Android: `intent://...;S.browser_fallback_url=<store>;end` (OS가 설치여부 자동 분기)
  - iOS: `moadongapp://` 스킴 시도 → 2초 내 미실행 시 App Store
  - 데스크톱: 스토어로 바로 이동
- `useWebviewSubscribe.toggleSubscribe` — `isInAppWebView()` 분기: 비인앱이면 `openApp()`, 인앱은 기존 브릿지 토글 유지
- 카카오 인앱브라우저 전용 `useOpenAppFromKakao`는 건드리지 않음(별 훅)
