### PR TITLE
fix(middleware): 카카오톡 인앱 브라우저 공유 링크가 텍스트만 보이는 문제 수정

### DIFF
--- a/frontend/docs/claude/features.md
+++ b/frontend/docs/claude/features.md
@@ -48,7 +48,9 @@ React SPA는 클라이언트 사이드 렌더링이라 카카오톡/페이스북
 - `/club/@:clubName` — 클럽 상세 (이름)
 - `/clubDetail/@:clubName`
 
-**감지 크롤러:** KakaoTalk, facebookexternalhit, Twitterbot, LINE, WhatsApp, Telegram, Discord, Slack 등
+**감지 크롤러:** 카카오톡 스크랩 봇(`kakaotalk-scrap`), facebookexternalhit, Twitterbot, LINE, WhatsApp, Telegram, Discord, Slack 등
+
+> 카카오는 인앱 브라우저(`KAKAOTALK <버전>`)와 스크랩 봇(`kakaotalk-scrap`)이 UA가 다르다. 봇만 감지해야 실제 사용자가 SPA를 받는다. ([인앱 브라우저 오탐 위험](#현재-구조의-실질적-위험) 참고)
 
 ### 새 라우트에 OG 추가 방법
 
@@ -81,6 +83,7 @@ export const config = {
 1. **API 3초 초과 시 OG 미노출** — 백엔드가 느리면 크롤러에게 빈 HTML 반환
 2. **새 크롤러 미감지** — `CRAWLER_PATTERN` regex에 없는 봇은 SPA를 받아 OG 미노출
 3. **라우트 수동 관리** — 새 페이지에 OG가 필요하면 middleware를 직접 수정해야 함
+4. **인앱 브라우저 오탐 위험** — `CRAWLER_PATTERN` 토큰이 메신저 인앱 브라우저 UA까지 잡으면 실제 사용자가 SPA 대신 OG용 텍스트 HTML(제목+설명만)을 받아 빈 화면처럼 보인다. 과거 `kakao` 토큰이 카카오톡 인앱 브라우저(`KAKAOTALK <버전>`)를 오탐해 공유 링크가 빈 화면+텍스트로 떴고, 봇 전용 식별자 `kakaotalk-scrap`로 좁혀 해결했다. `line` 토큰도 LINE 인앱 브라우저(`Line/<버전>`)를 잡는 동일 위험이 남아 있으나 사용량이 적어 보류 — 손볼 경우 봇 전용 UA로 좁힐 것.
 
 ## 실시간 업데이트
 

--- a/frontend/docs/features/club-detail/og-crawler-inapp-browser.md
+++ b/frontend/docs/features/club-detail/og-crawler-inapp-browser.md
@@ -1,0 +1,20 @@
+# 공유 링크 OG 크롤러 분기 — 인앱 브라우저 오탐 수정
+
+앱 상세페이지 "공유하기"로 받은 링크를 카카오톡에서 열면 빈 화면에 텍스트만 보이던 문제를 수정했다.
+
+## 원인
+
+`middleware.ts`(Vercel Edge Middleware)는 `CRAWLER_PATTERN`으로 크롤러를 감지해 OG 정적 HTML(`<h1>제목</h1><p>설명</p>`)을 반환하고, 일반 요청은 SPA로 통과시킨다. 기존 패턴의 `kakao` 토큰이 카카오톡 **스크랩 봇**뿐 아니라 **인앱 브라우저** UA(`KAKAOTALK <버전>`)까지 잡아, 링크를 연 실제 사용자가 SPA 대신 OG용 텍스트 HTML을 받았다.
+
+## 수정
+
+- `kakao` → `kakaotalk-scrap`로 토큰을 좁혔다. 카카오 스크랩 봇 UA는 `facebookexternalhit/1.1; kakaotalk-scrap/1.0`이라 OG 미리보기는 기존 `facebookexternalhit` + 새 `kakaotalk-scrap` 양쪽으로 유지되고, 인앱 브라우저(`KAKAOTALK`)는 둘 다 안 걸려 SPA로 통과한다.
+- OG fetch의 `API_BASE`가 dev 서버(`yourun.shop`)로 하드코딩돼 있어 `process.env.VITE_API_BASE_URL`로 교체했다. 클라이언트와 동일 소스를 사용해 환경별(prod/preview)로 올바른 백엔드를 조회한다. 미설정 시 가드로 SPA fallback.
+
+`line` 등 다른 메신저 인앱 브라우저도 동일한 잠재 위험이 있으나 사용량이 적어 보류했다 (`docs/claude/features.md`에 캐비엇 기록).
+
+## 관련 코드
+
+- `middleware.ts` — `CRAWLER_PATTERN`, `API_BASE`, OG HTML 빌드/반환
+- `src/pages/ClubDetailPage/components/ShareButton/ShareButton.tsx` — `/clubDetail/@{name}` 공유 링크 생성
+- `src/utils/isKakaoTalkBrowser.ts` — 인앱 브라우저 UA(`KAKAOTALK`) 감지 (UA 문자열 교차검증)

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,7 +1,9 @@
-const CRAWLER_PATTERN =
-  /bot|crawl|facebookexternalhit|twitterbot|kakao|line|whatsapp|telegram|discord|slack/i;
+/// <reference types="node" />
 
-const API_BASE = 'https://yourun.shop';
+const CRAWLER_PATTERN =
+  /bot|crawl|facebookexternalhit|twitterbot|kakaotalk-scrap|line|whatsapp|telegram|discord|slack/i;
+
+const API_BASE = process.env.VITE_API_BASE_URL;
 const SITE_URL = 'https://www.moadong.com';
 const DEFAULT_OG_IMAGE = `${SITE_URL}/og_image.png`;
 
@@ -75,6 +77,8 @@ export default async function middleware(request: Request) {
     redirectUrl.pathname = canonicalPath;
     return Response.redirect(redirectUrl.toString(), 301);
   }
+
+  if (!API_BASE) return;
 
   try {
     const res = await fetch(`${API_BASE}/api/club/${clubId}`, {


### PR DESCRIPTION


## 📝작업 내용

- CRAWLER_PATTERN의 kakao 토큰이 카카오톡 인앱 브라우저(KAKAOTALK)까지 크롤러로 오인해 실제 사용자에게 OG 정적 HTML을 반환하던 문제를 봇 전용 식별자 kakaotalk-scrap로 좁혀 해결 (OG 미리보기는 facebookexternalhit로 유지)
- OG fetch의 API_BASE 하드코딩(dev 서버)을 process.env.VITE_API_BASE_URL로 교체해 프로덕션이 프로덕션 백엔드를 조회하도록 수정, 미설정 시 가드 추가
- middleware.ts에 node 타입 레퍼런스 추가로 process 타입 인식
- docs: OG 크롤러/인앱 브라우저 구분 및 line 토큰 캐비엇 기록


## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항
