### PR TITLE
[refactor] 대동제 버스킹 페이지 필터칩 제거 및 네비 sticky 적용

### DIFF
--- a/frontend/src/components/common/Header/Header.styles.ts
+++ b/frontend/src/components/common/Header/Header.styles.ts
@@ -2,6 +2,12 @@ import styled from 'styled-components';
 import { media } from '@/styles/mediaQuery';
 import { Z_INDEX } from '@/styles/zIndex';
 
+export const HEADER_HEIGHT = {
+  desktop: 92,
+  tablet: 76,
+  mobile: 56,
+} as const;
+
 export const Header = styled.header<{ isScrolled: boolean }>`
   position: fixed;
   top: 0;
@@ -10,6 +16,7 @@ export const Header = styled.header<{ isScrolled: boolean }>`
   display: flex;
   justify-content: center;
   width: 100%;
+  height: ${HEADER_HEIGHT.desktop}px;
   padding: 18px 0;
   background-color: white;
   z-index: ${Z_INDEX.header};
@@ -22,12 +29,12 @@ export const Header = styled.header<{ isScrolled: boolean }>`
     padding: 18px 20px;
   }
   ${media.tablet} {
-    height: 76px;
+    height: ${HEADER_HEIGHT.tablet}px;
     padding: 10px 20px;
   }
 
   ${media.mobile} {
-    height: 56px;
+    height: ${HEADER_HEIGHT.mobile}px;
     padding: 8px 20px;
   }
 `;

--- a/frontend/src/constants/eventName.ts
+++ b/frontend/src/constants/eventName.ts
@@ -8,9 +8,6 @@ export const USER_EVENT = {
   MAIN_POPUP_CLOSED: 'Main Popup Closed',
   APP_DOWNLOAD_POPUP_CLICKED: 'App Download Popup Clicked',
 
-  // 동소한 팝업
-  FESTIVAL_POPUP_CLICKED: 'Festival Popup Clicked',
-
   // 동소한 부스
   FESTIVAL_BOOTH_CLICKED: 'Festival Booth Clicked',
 
@@ -22,14 +19,11 @@ export const USER_EVENT = {
   // 네비게이션
   BACK_BUTTON_CLICKED: 'Back Button Clicked',
   HOME_BUTTON_CLICKED: 'Home Button Clicked',
-  MOBILE_HOME_BUTTON_CLICKED: 'Mobile Home Button Clicked',
   MOBILE_MENU_BUTTON_CLICKED: 'Mobile Menu Button Clicked',
   MOBILE_MENU_DELETE_BUTTON_CLICKED: 'Mobile Menubar delete Button Clicked',
   ADMIN_BUTTON_CLICKED: 'Admin Button Clicked',
 
   // 탭 & 섹션
-  TAB_CLICKED: 'Tab Clicked',
-  PHOTO_NAVIGATION_CLICKED: 'Photo Navigation',
   CLUB_CARD_CLICKED: 'ClubCard Clicked',
   CLUB_CARD_VIEWED: 'ClubCard Viewed',
   SCROLL_DEPTH_REACHED: 'Scroll Depth Reached',
@@ -42,7 +36,6 @@ export const USER_EVENT = {
 
   // 동아리 지원
   CLUB_APPLY_BUTTON_CLICKED: 'Club Apply Button Clicked',
-  RECOMMENDED_CLUB_CLICKED: 'Recommended Club Clicked',
   CLUB_UNION_BUTTON_CLICKED: 'Club Union Button Clicked',
 
   // 총동연 페이지
@@ -55,7 +48,6 @@ export const USER_EVENT = {
   STATUS_RADIO_BUTTON_CLICKED: 'StatusRadioButton Clicked',
   INTRODUCE_BUTTON_CLICKED: 'Introduce Button Clicked',
   APPLICATION_FORM_SUBMITTED: 'Application Form Submitted',
-  PATCH_NOTE_BUTTON_CLICKED: 'Patch Note Button Clicked',
   FAQ_TOGGLE_CLICKED: 'FAQ Toggle Clicked',
 
   // 필터칩

--- a/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.styles.ts
+++ b/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.styles.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { HEADER_HEIGHT } from '@/components/common/Header/Header.styles';
 import { media } from '@/styles/mediaQuery';
 
 export const PageWrapper = styled.div`
@@ -12,18 +13,22 @@ export const Container = styled.div`
   width: 100%;
   max-width: 550px;
   margin: 0 auto;
-  padding-top: 92px;
+  padding-top: ${HEADER_HEIGHT.desktop}px;
 `;
 
 export const NavWrapper = styled.div`
   position: sticky;
-  top: 76px;
+  top: ${HEADER_HEIGHT.desktop}px;
   z-index: 10;
   background: white;
   margin-bottom: 16px;
 
+  ${media.tablet} {
+    top: ${HEADER_HEIGHT.tablet}px;
+  }
+
   ${media.mobile} {
-    top: 56px;
+    top: ${HEADER_HEIGHT.mobile}px;
   }
 `;
 

--- a/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.styles.ts
+++ b/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.styles.ts
@@ -13,14 +13,18 @@ export const Container = styled.div`
   max-width: 550px;
   margin: 0 auto;
   padding-top: 92px;
-
-  ${media.mobile} {
-    padding-top: 0;
-  }
 `;
 
 export const NavWrapper = styled.div`
+  position: sticky;
+  top: 76px;
+  z-index: 10;
+  background: white;
   margin-bottom: 16px;
+
+  ${media.mobile} {
+    top: 56px;
+  }
 `;
 
 export const TimetableSection = styled.section`

--- a/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.tsx
+++ b/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.tsx
@@ -1,13 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
 import { format } from 'date-fns';
 import { motion } from 'framer-motion';
-import Filter from '@/components/common/Filter/Filter';
 import Footer from '@/components/common/Footer/Footer';
 import Header from '@/components/common/Header/Header';
 import { PAGE_VIEW, USER_EVENT } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import useTrackPageView from '@/hooks/Mixpanel/useTrackPageView';
-import usePromotionNotification from '@/hooks/Queries/usePromotionNotification';
 import isInAppWebView from '@/utils/isInAppWebView';
 import DayTabsNav from '../components/DayTabsNav/DayTabsNav';
 import PerformanceList from '../components/PerformanceList/PerformanceList';
@@ -32,7 +30,6 @@ const getInitialDayId = (): string => {
 const BuskingPage = () => {
   useTrackPageView(PAGE_VIEW.DAEDONG2026_BUSKING_PAGE);
   const trackEvent = useMixpanelTrack();
-  const hasNotification = usePromotionNotification();
   const [activeDayId, setActiveDayId] = useState(getInitialDayId);
   const dayStartTime = useRef(Date.now());
   const activeDayIdRef = useRef(activeDayId);
@@ -85,7 +82,6 @@ const BuskingPage = () => {
   return (
     <Styled.PageWrapper>
       <Header hideOn={['webview']} />
-      <Filter hasNotification={hasNotification} />
       <motion.div
         style={{ touchAction: 'pan-y' }}
         onPanEnd={(_, info) => {


### PR DESCRIPTION
## Summary
- `BuskingPage`에서 `<Filter>` 컴포넌트 제거 (동아리/홍보 필터칩이 대동제 페이지에 불필요)
- `Container` 모바일 `padding-top: 0` 오버라이드 제거 → 전 브레이크포인트 `HEADER_HEIGHT.desktop`으로 통일
- `NavWrapper`에 `position: sticky` 적용하여 스크롤 시 헤더 아래 고정
- `Header.styles.ts`에 `HEADER_HEIGHT` 공유 상수 추가 (desktop: 92, tablet: 76, mobile: 56)
  - Header에 데스크탑 명시적 height 추가
  - NavWrapper sticky top을 브레이크포인트별 상수로 관리

## Test plan
- [x] 모바일: 스크롤 시 DayTabsNav가 헤더 바로 아래 고정되는지 확인
- [x] 태블릿(500~700px): sticky top이 76px 기준으로 동작하는지 확인
- [x] 데스크탑: sticky 동작 및 헤더 높이 92px 기준 확인
- [x] 필터칩(동아리/홍보)이 대동제 버스킹 페이지에서 노출되지 않는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 헤더 높이를 반응형 상수로 통일하여 모든 디바이스에서 일관성 강화
  * 네비게이션 바 sticky 처리로 스크롤 시에도 항상 상단에 표시

* **Refactor**
  * 프로모션 알림 기반 필터 UI 제거로 인터페이스 간결화
  * 페이지 분석 추적 이벤트 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->