### PR TITLE
chore(tracking): 미사용 USER_EVENT 키 6개 제거

### DIFF
--- a/frontend/src/components/common/Header/Header.styles.ts
+++ b/frontend/src/components/common/Header/Header.styles.ts
@@ -2,6 +2,12 @@ import styled from 'styled-components';
 import { media } from '@/styles/mediaQuery';
 import { Z_INDEX } from '@/styles/zIndex';
 
+export const HEADER_HEIGHT = {
+  desktop: 92,
+  tablet: 76,
+  mobile: 56,
+} as const;
+
 export const Header = styled.header<{ isScrolled: boolean }>`
   position: fixed;
   top: 0;
@@ -10,6 +16,7 @@ export const Header = styled.header<{ isScrolled: boolean }>`
   display: flex;
   justify-content: center;
   width: 100%;
+  height: ${HEADER_HEIGHT.desktop}px;
   padding: 18px 0;
   background-color: white;
   z-index: ${Z_INDEX.header};
@@ -22,12 +29,12 @@ export const Header = styled.header<{ isScrolled: boolean }>`
     padding: 18px 20px;
   }
   ${media.tablet} {
-    height: 76px;
+    height: ${HEADER_HEIGHT.tablet}px;
     padding: 10px 20px;
   }
 
   ${media.mobile} {
-    height: 56px;
+    height: ${HEADER_HEIGHT.mobile}px;
     padding: 8px 20px;
   }
 `;

--- a/frontend/src/constants/eventName.ts
+++ b/frontend/src/constants/eventName.ts
@@ -8,9 +8,6 @@ export const USER_EVENT = {
   MAIN_POPUP_CLOSED: 'Main Popup Closed',
   APP_DOWNLOAD_POPUP_CLICKED: 'App Download Popup Clicked',
 
-  // 동소한 팝업
-  FESTIVAL_POPUP_CLICKED: 'Festival Popup Clicked',
-
   // 동소한 부스
   FESTIVAL_BOOTH_CLICKED: 'Festival Booth Clicked',
 
@@ -22,14 +19,11 @@ export const USER_EVENT = {
   // 네비게이션
   BACK_BUTTON_CLICKED: 'Back Button Clicked',
   HOME_BUTTON_CLICKED: 'Home Button Clicked',
-  MOBILE_HOME_BUTTON_CLICKED: 'Mobile Home Button Clicked',
   MOBILE_MENU_BUTTON_CLICKED: 'Mobile Menu Button Clicked',
   MOBILE_MENU_DELETE_BUTTON_CLICKED: 'Mobile Menubar delete Button Clicked',
   ADMIN_BUTTON_CLICKED: 'Admin Button Clicked',
 
   // 탭 & 섹션
-  TAB_CLICKED: 'Tab Clicked',
-  PHOTO_NAVIGATION_CLICKED: 'Photo Navigation',
   CLUB_CARD_CLICKED: 'ClubCard Clicked',
   CLUB_CARD_VIEWED: 'ClubCard Viewed',
   SCROLL_DEPTH_REACHED: 'Scroll Depth Reached',
@@ -42,7 +36,6 @@ export const USER_EVENT = {
 
   // 동아리 지원
   CLUB_APPLY_BUTTON_CLICKED: 'Club Apply Button Clicked',
-  RECOMMENDED_CLUB_CLICKED: 'Recommended Club Clicked',
   CLUB_UNION_BUTTON_CLICKED: 'Club Union Button Clicked',
 
   // 총동연 페이지
@@ -55,7 +48,6 @@ export const USER_EVENT = {
   STATUS_RADIO_BUTTON_CLICKED: 'StatusRadioButton Clicked',
   INTRODUCE_BUTTON_CLICKED: 'Introduce Button Clicked',
   APPLICATION_FORM_SUBMITTED: 'Application Form Submitted',
-  PATCH_NOTE_BUTTON_CLICKED: 'Patch Note Button Clicked',
   FAQ_TOGGLE_CLICKED: 'FAQ Toggle Clicked',
 
   // 필터칩

--- a/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.styles.ts
+++ b/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.styles.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { HEADER_HEIGHT } from '@/components/common/Header/Header.styles';
 import { media } from '@/styles/mediaQuery';
 
 export const PageWrapper = styled.div`
@@ -12,18 +13,22 @@ export const Container = styled.div`
   width: 100%;
   max-width: 550px;
   margin: 0 auto;
-  padding-top: 92px;
+  padding-top: ${HEADER_HEIGHT.desktop}px;
 `;
 
 export const NavWrapper = styled.div`
   position: sticky;
-  top: 76px;
+  top: ${HEADER_HEIGHT.desktop}px;
   z-index: 10;
   background: white;
   margin-bottom: 16px;
 
+  ${media.tablet} {
+    top: ${HEADER_HEIGHT.tablet}px;
+  }
+
   ${media.mobile} {
-    top: 56px;
+    top: ${HEADER_HEIGHT.mobile}px;
   }
 `;
 

--- a/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.styles.ts
+++ b/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.styles.ts
@@ -13,14 +13,18 @@ export const Container = styled.div`
   max-width: 550px;
   margin: 0 auto;
   padding-top: 92px;
-
-  ${media.mobile} {
-    padding-top: 0;
-  }
 `;
 
 export const NavWrapper = styled.div`
+  position: sticky;
+  top: 76px;
+  z-index: 10;
+  background: white;
   margin-bottom: 16px;
+
+  ${media.mobile} {
+    top: 56px;
+  }
 `;
 
 export const TimetableSection = styled.section`

--- a/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.tsx
+++ b/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.tsx
@@ -1,13 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
 import { format } from 'date-fns';
 import { motion } from 'framer-motion';
-import Filter from '@/components/common/Filter/Filter';
 import Footer from '@/components/common/Footer/Footer';
 import Header from '@/components/common/Header/Header';
 import { PAGE_VIEW, USER_EVENT } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import useTrackPageView from '@/hooks/Mixpanel/useTrackPageView';
-import usePromotionNotification from '@/hooks/Queries/usePromotionNotification';
 import isInAppWebView from '@/utils/isInAppWebView';
 import DayTabsNav from '../components/DayTabsNav/DayTabsNav';
 import PerformanceList from '../components/PerformanceList/PerformanceList';
@@ -32,7 +30,6 @@ const getInitialDayId = (): string => {
 const BuskingPage = () => {
   useTrackPageView(PAGE_VIEW.DAEDONG2026_BUSKING_PAGE);
   const trackEvent = useMixpanelTrack();
-  const hasNotification = usePromotionNotification();
   const [activeDayId, setActiveDayId] = useState(getInitialDayId);
   const dayStartTime = useRef(Date.now());
   const activeDayIdRef = useRef(activeDayId);
@@ -85,7 +82,6 @@ const BuskingPage = () => {
   return (
     <Styled.PageWrapper>
       <Header hideOn={['webview']} />
-      <Filter hasNotification={hasNotification} />
       <motion.div
         style={{ touchAction: 'pan-y' }}
         onPanEnd={(_, info) => {


### PR DESCRIPTION
## Summary

- 코드 어디서도 `trackEvent`로 호출되지 않는 USER_EVENT 상수 6개 제거
  - `FESTIVAL_POPUP_CLICKED` — 미구현
  - `MOBILE_HOME_BUTTON_CLICKED` — `HOME_BUTTON_CLICKED`으로 통합됨
  - `TAB_CLICKED` — 호출 없음
  - `PHOTO_NAVIGATION_CLICKED` — 미구현
  - `RECOMMENDED_CLUB_CLICKED` — 미구현
  - `PATCH_NOTE_BUTTON_CLICKED` — 미구현

## Test plan

- [ ] `npm run typecheck` 통과 확인