### PR TITLE
[docs] CLAUDE.md SDK 초기화 정정 및 Node 버전 명시

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -4,6 +4,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## 빌드 및 개발 명령어
 
+> Node 22.12.0 사용 (`.nvmrc` 기준). `nvm use`로 맞출 것.
+
 ```bash
 # 개발 서버 (Vite - 주로 사용)
 npm run dev              # 포트 3000에서 개발 서버 시작
@@ -63,7 +65,7 @@ npm run generate:sitemap # sitemap.xml 생성
 - **Kakao SDK**: 카카오 공유 기능
 - **Naver Map**: 동아리방 위치 지도 (네이버 클라우드 플랫폼)
 
-모든 SDK는 `src/utils/initSDK.ts`에서 초기화되며, 각각 환경 변수 필요.
+Mixpanel·Sentry·Channel.io는 `src/utils/initSDK.ts`에서 초기화. Naver Map은 `src/utils/loadNaverMapScript.ts`로 동적 로드(SDK init 아님). 각각 환경 변수 필요.
 
 ### 환경 변수
 


### PR DESCRIPTION
## 개요
CLAUDE.md 정확성 점검 중 발견한 두 가지 불일치를 수정합니다.

## 변경 사항
1. **SDK 초기화 위치 정정** — 기존 "모든 SDK는 `initSDK.ts`에서 초기화" 문구는 부정확. 실제로 `initSDK.ts`는 Mixpanel·Sentry·Channel.io만 초기화하며, Naver Map은 `src/utils/loadNaverMapScript.ts`로 동적 로드됨.
2. **Node 버전 명시** — `.nvmrc`가 `22.12.0`을 고정하고 있으나 문서에 안내가 없어 추가.

## 검증
- `src/utils/initSDK.ts`: Mixpanel·Sentry·Channel.io만 init 확인
- `src/utils/loadNaverMapScript.ts`: Naver Map 동적 로드 확인
- `.nvmrc`: 22.12.0 확인

문서 변경만 포함 (코드 영향 없음).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* 개발 환경 설정 가이드 업데이트: Node 22.12.0 권장 버전 명시 및 nvm 사용법 안내 추가
* 외부 SDK 초기화 및 동적 로드 방식 설명 개선: Mixpanel, Sentry, Channel.io 초기화 위치와 Naver Map 동적 로드 방식 명확화
* 필수 환경 변수 설정 가이드 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->