### PR TITLE
[feature] ErrorBoundary에 Sentry 에러 리포팅 연동

### DIFF
--- a/frontend/docs/features/components/error-boundary.md
+++ b/frontend/docs/features/components/error-boundary.md
@@ -1,0 +1,35 @@
+# ErrorBoundary — 3계층 에러 경계 및 Sentry 연동
+
+React 에러 경계를 3계층으로 구성해 에러 범위를 격리하고, 각 계층별로 Sentry 리포팅 정책을 다르게 적용한다.
+
+## 계층 구조
+
+| 계층 | 컴포넌트 | 기반 | Sentry 전송 |
+|---|---|---|---|
+| 최상위 | `GlobalBoundary` | `Sentry.ErrorBoundary` | 자동 전송 (모든 에러) |
+| 라우트 단위 | `ContentErrorBoundary` | `BaseErrorBoundary` | 전체 전송 (`boundary: content`) |
+| 데이터 페칭 단위 | `ApiErrorBoundary` | `BaseErrorBoundary` | 5xx·예상 외만 전송, 4xx 제외 (`boundary: api`) |
+
+## 설계 원칙
+
+- `BaseErrorBoundary`는 Sentry에 비의존(순수). Sentry 보고 정책은 각 경계의 `onError` prop으로 주입한다.
+- React 에러 경계는 잡은 에러를 상위로 재전파하지 않으므로, 하위 경계가 별도로 Sentry를 호출해야 한다.
+
+## ApiErrorBoundary 필터 로직
+
+```ts
+// 예상된 4xx(HttpError.isClientError())는 사용자에게 UI로 안내되는 에러 → Sentry 제외
+// 5xx와 HttpError가 아닌 예상 외 에러만 전송
+if (error instanceof HttpError && error.isClientError()) return;
+Sentry.captureException(error, { extra: { boundary: 'api' } });
+```
+
+4xx를 제외하는 이유: 404·403 등은 예상된 상황으로 폴백 UI가 사용자에게 안내한다. 이를 Sentry로 모두 전송하면 노이즈가 과다해 실제 장애 감지가 어려워진다.
+
+## 관련 코드
+
+- `src/components/common/ErrorBoundary/BaseErrorBoundary.tsx` — 순수 에러 경계 기반 클래스. `onError` prop으로 외부에서 에러 처리 주입 가능
+- `src/components/common/ErrorBoundary/GlobalError/GlobalBoundary.tsx` — Sentry.ErrorBoundary 래핑, 앱 최상위 안전망
+- `src/components/common/ErrorBoundary/ContentError/ContentErrorBoundary.tsx` — 라우트 단위, pathname 기반 자동 리셋, Sentry 전송
+- `src/components/common/ErrorBoundary/ApiError/ApiErrorBoundary.tsx` — 데이터 페칭 단위, 5xx·예상 외만 Sentry 전송
+- `src/errors/HttpError.ts` — `isClientError()`, `isServerError()` 헬퍼 제공

--- a/frontend/src/components/common/ErrorBoundary/ApiError/ApiErrorBoundary.tsx
+++ b/frontend/src/components/common/ErrorBoundary/ApiError/ApiErrorBoundary.tsx
@@ -20,11 +20,13 @@ const ApiErrorBoundary = ({
       fallback={ApiErrorFallback}
       onReset={onReset}
       resetKeys={resetKeys}
-      onError={(error) => {
+      onError={(error, errorInfo) => {
         // 예상된 4xx(404 등 사용자에게 메시지로 안내되는 에러)는 노이즈라 제외하고,
         // 5xx 및 HttpError가 아닌 예상 외 에러만 Sentry로 보낸다.
         if (error instanceof HttpError && error.isClientError()) return;
-        Sentry.captureException(error, { extra: { boundary: 'api' } });
+        Sentry.captureException(error, {
+          extra: { boundary: 'api', componentStack: errorInfo.componentStack },
+        });
       }}
     >
       {children}

--- a/frontend/src/components/common/ErrorBoundary/ApiError/ApiErrorBoundary.tsx
+++ b/frontend/src/components/common/ErrorBoundary/ApiError/ApiErrorBoundary.tsx
@@ -1,4 +1,6 @@
 import { ReactNode } from 'react';
+import * as Sentry from '@sentry/react';
+import { HttpError } from '@/errors';
 import BaseErrorBoundary from '../BaseErrorBoundary';
 import ApiErrorFallback from './ApiErrorFallback';
 
@@ -18,6 +20,12 @@ const ApiErrorBoundary = ({
       fallback={ApiErrorFallback}
       onReset={onReset}
       resetKeys={resetKeys}
+      onError={(error) => {
+        // 예상된 4xx(404 등 사용자에게 메시지로 안내되는 에러)는 노이즈라 제외하고,
+        // 5xx 및 HttpError가 아닌 예상 외 에러만 Sentry로 보낸다.
+        if (error instanceof HttpError && error.isClientError()) return;
+        Sentry.captureException(error, { extra: { boundary: 'api' } });
+      }}
     >
       {children}
     </BaseErrorBoundary>

--- a/frontend/src/components/common/ErrorBoundary/ContentError/ContentErrorBoundary.tsx
+++ b/frontend/src/components/common/ErrorBoundary/ContentError/ContentErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react';
 import { useLocation } from 'react-router-dom';
+import * as Sentry from '@sentry/react';
 import BaseErrorBoundary from '../BaseErrorBoundary';
 import ContentErrorFallback from '../ContentError/ContentErrorFallback';
 
@@ -18,6 +19,15 @@ const ContentErrorBoundary = ({
     <BaseErrorBoundary
       fallback={ContentErrorFallback}
       resetKeys={[pathname, ...resetKeys]}
+      onError={(error, errorInfo) =>
+        Sentry.captureException(error, {
+          extra: {
+            boundary: 'content',
+            pathname,
+            componentStack: errorInfo.componentStack,
+          },
+        })
+      }
     >
       {children}
     </BaseErrorBoundary>


### PR DESCRIPTION
## 변경 내용

기존에 `ContentErrorBoundary`와 `ApiErrorBoundary`가 잡은 에러는 Sentry로 전송되지 않는 사각지대가 있었습니다. (`GlobalBoundary`는 자동 전송되지만, 하위 경계가 에러를 먼저 잡으면 상위로 전파되지 않음)

이번 PR에서 두 경계에 Sentry 리포팅을 추가했습니다.

### ContentErrorBoundary (라우트 단위)
- 모든 렌더링 에러를 Sentry로 전송
- `boundary: content`, `pathname`, `componentStack` 포함

### ApiErrorBoundary (데이터 페칭 단위)
- **4xx는 전송하지 않습니다** — 404, 403 같은 예상된 에러는 사용자에게 UI로 안내되므로 Sentry 노이즈만 늘립니다
- **5xx 및 예상 외 에러만 전송** — `boundary: api`, `componentStack` 포함

### BaseErrorBoundary
- Sentry 코드 없음 유지 — 각 경계가 `onError` prop으로 직접 주입하는 방식

## 검증

`/error-test` 페이지에서 직접 확인:
- [x] ApiErrorBoundary 5xx 에러 → Sentry에 `boundary: api` 이벤트 도착
- [x] ApiErrorBoundary 4xx 에러 → Sentry에 올라오지 않음
- [x] ContentErrorBoundary 에러 → Sentry에 `boundary: content` 이벤트 도착

Closes #1650