### PR TITLE
[feature] Clarity 연동 및 지원서 PII 마스킹

### DIFF
--- a/frontend/docs/features/analytics/clarity.md
+++ b/frontend/docs/features/analytics/clarity.md
@@ -1,0 +1,42 @@
+# Microsoft Clarity (정성 분석)
+
+Mixpanel(정량 이벤트) 외에 세션 리플레이·히트맵 등 정성 분석을 위해 Microsoft Clarity를 도입했다. 다른 SDK와 동일하게 `src/utils/initSDK.ts`에서 초기화하고 `src/index.tsx`에서 앱 부팅 시 호출한다.
+
+## 패키지 선택 — `@microsoft/clarity` (중요)
+
+반드시 공식 래퍼 **`@microsoft/clarity`**를 사용한다. 저수준 OSS 패키지 `clarity-js`는 기본 업로드 엔드포인트가 없어(`config.upload`를 직접 문자열로 주지 않으면 전송 안 함) **데이터가 Clarity 대시보드에 잡히지 않는다**. `@microsoft/clarity`의 `Clarity.init(projectId)`는 `https://www.clarity.ms/tag/<projectId>` 호스팅 태그를 주입해 업로드까지 자동 처리한다.
+
+## 초기화
+
+```ts
+// src/utils/initSDK.ts
+import Clarity from '@microsoft/clarity';
+
+export function initializeClarity() {
+  if (!import.meta.env.VITE_CLARITY_PROJECT_ID) return; // env 가드
+  if (window.location.hostname === LOCALHOST_HOSTNAME) return; // localhost 제외
+  Clarity.init(import.meta.env.VITE_CLARITY_PROJECT_ID);
+}
+```
+
+- 환경변수: `VITE_CLARITY_PROJECT_ID` (Clarity 프로젝트 Settings > Overview의 ID). 배포 환경에도 등록 필요.
+- Mixpanel과 동일하게 localhost에서는 init하지 않는다.
+
+## PII 마스킹
+
+지원서 답변에는 이름·연락처 등 PII가 들어가므로, 정성 분석은 전역으로 유지하되 **답변 영역만 마스킹**한다. 공식 속성 `data-clarity-mask="true"`를 답변 컨테이너에 부여하면 해당 영역의 내용만 가려지고, 스크롤·클릭·이탈 등 상호작용 데이터는 유지된다.
+
+```tsx
+// ApplicationFormPage.tsx
+<Styled.QuestionsWrapper data-clarity-mask='true'>
+```
+
+## 한계
+
+추적 차단기(uBlock 등)나 강화된 추적 보호(Firefox/Zen ETP, Brave Shields)를 쓰는 사용자는 `clarity.ms`가 차단돼 잡히지 않는다. Clarity뿐 아니라 모든 분석 툴의 공통 한계이며, 정성 분석은 전수가 아닌 표본 기준으로 본다.
+
+## 관련 코드
+
+- `src/utils/initSDK.ts` — `initializeClarity()` (init, env·localhost 가드)
+- `src/index.tsx` — 앱 부팅 시 호출
+- `src/pages/ApplicationFormPage/ApplicationFormPage.tsx` — 답변 영역 `data-clarity-mask` 마스킹

--- a/frontend/docs/features/analytics/clarity.md
+++ b/frontend/docs/features/analytics/clarity.md
@@ -13,14 +13,17 @@ Mixpanel(정량 이벤트) 외에 세션 리플레이·히트맵 등 정성 분�
 import Clarity from '@microsoft/clarity';
 
 export function initializeClarity() {
-  if (!import.meta.env.VITE_CLARITY_PROJECT_ID) return; // env 가드
-  if (window.location.hostname === LOCALHOST_HOSTNAME) return; // localhost 제외
+  if (!import.meta.env.VITE_CLARITY_PROJECT_ID) {
+    console.warn('Clarity 환경변수 설정이 안 되어 있습니다.');
+    return; // env 가드
+  }
+  if (import.meta.env.DEV) return; // 개발 환경(localhost·127.0.0.1 등) 제외
   Clarity.init(import.meta.env.VITE_CLARITY_PROJECT_ID);
 }
 ```
 
 - 환경변수: `VITE_CLARITY_PROJECT_ID` (Clarity 프로젝트 Settings > Overview의 ID). 배포 환경에도 등록 필요.
-- Mixpanel과 동일하게 localhost에서는 init하지 않는다.
+- `import.meta.env.DEV` 가드로 개발 환경에서는 init하지 않는다 (localhost뿐 아니라 `127.0.0.1` 등 모든 dev 주소 포함).
 
 ## PII 마스킹
 
@@ -37,6 +40,6 @@ export function initializeClarity() {
 
 ## 관련 코드
 
-- `src/utils/initSDK.ts` — `initializeClarity()` (init, env·localhost 가드)
+- `src/utils/initSDK.ts` — `initializeClarity()` (init, env·dev 가드)
 - `src/index.tsx` — 앱 부팅 시 호출
 - `src/pages/ApplicationFormPage/ApplicationFormPage.tsx` — 답변 영역 `data-clarity-mask` 마스킹

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@channel.io/channel-web-sdk-loader": "^2.0.0",
+        "@microsoft/clarity": "^1.0.2",
         "@sentry/react": "^9.18.0",
         "@tanstack/react-query": "^5.66.0",
         "date-fns": "^4.1.0",
@@ -2257,6 +2258,12 @@
         "@types/react": ">=16",
         "react": ">=16"
       }
+    },
+    "node_modules/@microsoft/clarity": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/clarity/-/clarity-1.0.2.tgz",
+      "integrity": "sha512-9EZYROFpJxEGmQpHvUFqvD3ZJ7QQSqnibYSWmS+1xusoZfG1QQ1/Al9yVBBc11DWMbJrs1pe1hLT273it/skJg==",
+      "license": "MIT"
     },
     "node_modules/@mixpanel/rrdom": {
       "version": "2.0.0-alpha.18.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
   "description": "",
   "dependencies": {
     "@channel.io/channel-web-sdk-loader": "^2.0.0",
+    "@microsoft/clarity": "^1.0.2",
     "@sentry/react": "^9.18.0",
     "@tanstack/react-query": "^5.66.0",
     "date-fns": "^4.1.0",

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,10 +1,15 @@
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import { initializeExperiments } from './experiments/initializeExperiments';
-import { initializeMixpanel, initializeSentry } from './utils/initSDK';
+import {
+  initializeClarity,
+  initializeMixpanel,
+  initializeSentry,
+} from './utils/initSDK';
 
 initializeMixpanel();
 initializeSentry();
+initializeClarity();
 initializeExperiments();
 
 if (import.meta.env.DEV) {

--- a/frontend/src/pages/ApplicationFormPage/ApplicationFormPage.tsx
+++ b/frontend/src/pages/ApplicationFormPage/ApplicationFormPage.tsx
@@ -135,7 +135,7 @@ const ApplicationFormPage = () => {
             {linkifyText(formData.description)}
           </Styled.FormDescription>
         )}
-        <Styled.QuestionsWrapper>
+        <Styled.QuestionsWrapper data-clarity-mask='true'>
           {formData.questions.map((q: Question, i: number) => (
             <QuestionContainer
               key={q.id}

--- a/frontend/src/utils/initSDK.ts
+++ b/frontend/src/utils/initSDK.ts
@@ -1,4 +1,5 @@
 import * as ChannelService from '@channel.io/channel-web-sdk-loader';
+import Clarity from '@microsoft/clarity';
 import * as Sentry from '@sentry/react';
 import mixpanel from 'mixpanel-browser';
 
@@ -30,6 +31,19 @@ export function initializeMixpanel() {
       window.history.replaceState({}, document.title, newUrl);
     }
   }
+}
+
+export function initializeClarity() {
+  if (!import.meta.env.VITE_CLARITY_PROJECT_ID) {
+    console.warn('Clarity 환경변수 설정이 안 되어 있습니다.');
+    return;
+  }
+
+  if (window.location.hostname === LOCALHOST_HOSTNAME) {
+    return;
+  }
+
+  Clarity.init(import.meta.env.VITE_CLARITY_PROJECT_ID);
 }
 
 export function initializeChannelService() {

--- a/frontend/src/utils/initSDK.ts
+++ b/frontend/src/utils/initSDK.ts
@@ -39,7 +39,7 @@ export function initializeClarity() {
     return;
   }
 
-  if (window.location.hostname === LOCALHOST_HOSTNAME) {
+  if (import.meta.env.DEV) {
     return;
   }
 


### PR DESCRIPTION
## 작업 내용
- `@microsoft/clarity` 도입, 앱 부팅 시 localhost 제외하고 `initializeClarity` 호출
- 지원서 답변 영역 `QuestionsWrapper`에 `data-clarity-mask` 적용해 지원자의 답변은 로깅되지 않도록 했습니다.

## 검증
- Chrome에서 Live recordings 수집 확인 (Mixpanel 정량 외 정성 분석 확보)
- 추적 차단기/ETP 사용 환경(예: Zen)은 `clarity.ms` 차단으로 수집되지 않습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 사용자 행동 분석(세션 리플레이·히트맵 등) 통합이 추가되었습니다.
* **Privacy**
  * 민감정보 노출을 막기 위한 DOM 기반 마스킹이 적용되었습니다.
* **Documentation**
  * 분석 도구 설정 및 사용 가이드 문서가 추가/보완되었습니다.
* **Chores**
  * 프런트엔드에 분석 도구 의존성이 추가되어 초기화가 도입되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->