### PR TITLE
[fix] 홍보 게시판 카드의 제목 가독성을 개선하고 clubTag를 제거한다

### DIFF
--- a/frontend/src/pages/PromotionPage/components/list/PromotionCard/CardMeta/CardMeta.styles.ts
+++ b/frontend/src/pages/PromotionPage/components/list/PromotionCard/CardMeta/CardMeta.styles.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { media } from '@/styles/mediaQuery';
 import { colors } from '@/styles/theme/colors';
+import { setTypography, typography } from '@/styles/theme/typography';
 
 export const Container = styled.div`
   display: flex;
@@ -8,8 +9,9 @@ export const Container = styled.div`
 `;
 
 export const Title = styled.h3`
-  font-size: 16px;
-  font-weight: 600;
+  ${setTypography(typography.paragraph.p2)}
+  line-height: 1.4;
+  height: calc(1.4em * 2);
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -19,7 +21,7 @@ export const Title = styled.h3`
   margin-bottom: 4px;
 
   ${media.mini_mobile} {
-    font-size: 14px;
+    ${setTypography(typography.button.button1)}
     margin-bottom: 2px;
   }
 `;

--- a/frontend/src/pages/PromotionPage/components/list/PromotionCard/CardMeta/CardMeta.styles.ts
+++ b/frontend/src/pages/PromotionPage/components/list/PromotionCard/CardMeta/CardMeta.styles.ts
@@ -13,7 +13,9 @@ export const Title = styled.h3`
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
   margin-bottom: 4px;
 
   ${media.mini_mobile} {

--- a/frontend/src/pages/PromotionPage/components/list/PromotionCard/PromotionCard.styles.ts
+++ b/frontend/src/pages/PromotionPage/components/list/PromotionCard/PromotionCard.styles.ts
@@ -43,10 +43,3 @@ export const Content = styled.div`
   }
 `;
 
-export const TagWrapper = styled.div`
-  margin-top: 8px;
-
-  ${media.mini_mobile} {
-    margin-top: 4px;
-  }
-`;

--- a/frontend/src/pages/PromotionPage/components/list/PromotionCard/PromotionCard.styles.ts
+++ b/frontend/src/pages/PromotionPage/components/list/PromotionCard/PromotionCard.styles.ts
@@ -42,4 +42,3 @@ export const Content = styled.div`
     padding: 10px;
   }
 `;
-

--- a/frontend/src/pages/PromotionPage/components/list/PromotionCard/PromotionCard.tsx
+++ b/frontend/src/pages/PromotionPage/components/list/PromotionCard/PromotionCard.tsx
@@ -4,7 +4,6 @@ import useNavigator from '@/hooks/useNavigator';
 import { getDDay } from '@/pages/PromotionPage/utils/getDday';
 import { PromotionArticle } from '@/types/promotion';
 import CardMeta from './CardMeta/CardMeta';
-import ClubTag from './ClubTag/ClubTag';
 import DdayBadge from './DdayBadge/DdayBadge';
 import * as Styled from './PromotionCard.styles';
 
@@ -42,9 +41,6 @@ const PromotionCard = ({ article }: PromotionCardProps) => {
           location={article.location}
           startDate={article.eventStartDate}
         />
-        <Styled.TagWrapper>
-          <ClubTag clubName={article.clubName} />
-        </Styled.TagWrapper>
       </Styled.Content>
     </Styled.Container>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈
> #1658 

## 📝작업 내용
  - `ClubTag` 컴포넌트 및 `TagWrapper` 스타일 제거 -> 모바일에서 공간을 차지해 제목이 잘리는 문제 해결
  - 홍보 카드 제목 최대 2줄 표시로 변경 (`-webkit-line-clamp: 2`)
  - 제목이 1줄이더라도 2줄 높이 공간 고정 (`height: calc(1.4em * 2)`)
  - 제목 typography 토큰 적용 (`paragraph.p2` / `button.button1`)

  ### 변경 전 / 변경 후

  | 변경 전 | 변경 후 |
  |:---:|:---:|
  | ![before](https://github.com/user-attachments/assets/96528789-799b-4d61-b409-76ba786ff681) | ![after](https://github.com/user-attachments/assets/383d61ac-fee9-407f-a808-be88578cbbac) |



## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 프로모션 카드 제목이 2줄까지 표시되도록 개선되었습니다.
  * 통합 타이포그래피 시스템이 적용되었습니다.

* **기능 제거**
  * 프로모션 카드에서 ClubTag가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->