### PR TITLE
[fix] 웹뷰 내부 라우팅 React Router 통일 및 구독 상태 전달

### DIFF
--- a/frontend/src/hooks/useNavigator.ts
+++ b/frontend/src/hooks/useNavigator.ts
@@ -1,12 +1,7 @@
 import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import isInAppWebView from '@/utils/isInAppWebView';
-import {
-  requestNavigateWebview,
-  requestOpenExternalUrl,
-} from '@/utils/webviewBridge';
-
-const toSlug = (path: string) => path.replace(/^\//, '');
+import { requestOpenExternalUrl } from '@/utils/webviewBridge';
 
 const useNavigator = () => {
   const navigate = useNavigate();
@@ -27,8 +22,7 @@ const useNavigator = () => {
         return;
       }
 
-      if (inWebview) requestNavigateWebview(toSlug(trimmedUrl));
-      else navigate(trimmedUrl);
+      navigate(trimmedUrl);
     },
     [navigate],
   );

--- a/frontend/src/pages/MainPage/MainPage.tsx
+++ b/frontend/src/pages/MainPage/MainPage.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import Filter from '@/components/common/Filter/Filter';
 import Footer from '@/components/common/Footer/Footer';
 import Header from '@/components/common/Header/Header';
@@ -45,6 +46,7 @@ const MainPage = () => {
     division,
   });
   const hasNotification = usePromotionNotification();
+  const navigate = useNavigate();
   const { subscribedClubIds, toggleSubscribe } = useWebviewSubscribe();
 
   const clubs = data?.clubs || [];
@@ -61,6 +63,14 @@ const MainPage = () => {
         club={club}
         index={i}
         page={inWebview ? PAGE_NAME.WEBVIEW_MAIN : PAGE_NAME.MAIN}
+        onCardClick={
+          inWebview
+            ? (c) =>
+                navigate(
+                  `/clubDetail/@${encodeURIComponent(c.name)}?is_subscribed=${subscribedClubIds.has(c.id)}`,
+                )
+            : undefined
+        }
       >
         {inWebview && (
           <SubscribeButton

--- a/frontend/src/pages/PromotionPage/components/detail/PromotionClubCTA/PromotionClubCTA.tsx
+++ b/frontend/src/pages/PromotionPage/components/detail/PromotionClubCTA/PromotionClubCTA.tsx
@@ -1,6 +1,8 @@
 import { USER_EVENT } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import useNavigator from '@/hooks/useNavigator';
+import useWebviewSubscribe from '@/hooks/useWebviewSubscribe';
+import isInAppWebView from '@/utils/isInAppWebView';
 import ArrowButton from '../PromotionArrowButton/PromotionArrowButton';
 import * as Styled from './PromotionClubCTA.styles';
 
@@ -12,6 +14,7 @@ interface Props {
 const PromotionClubCTA = ({ clubId, clubName }: Props) => {
   const handleLink = useNavigator();
   const trackEvent = useMixpanelTrack();
+  const { subscribedClubIds } = useWebviewSubscribe();
 
   const handleNavigate = () => {
     trackEvent(USER_EVENT.PROMOTION_CLUB_CTA_CLICKED, {
@@ -19,7 +22,11 @@ const PromotionClubCTA = ({ clubId, clubName }: Props) => {
       club_name: clubName,
     });
 
-    handleLink(`/clubDetail/@${encodeURIComponent(clubName)}`);
+    const isSubscribed = isInAppWebView() && subscribedClubIds.has(clubId);
+    const url = isSubscribed
+      ? `/clubDetail/@${encodeURIComponent(clubName)}?is_subscribed=true`
+      : `/clubDetail/@${encodeURIComponent(clubName)}`;
+    handleLink(url);
   };
 
   return (

--- a/frontend/src/pages/PromotionPage/components/detail/PromotionClubCTA/PromotionClubCTA.tsx
+++ b/frontend/src/pages/PromotionPage/components/detail/PromotionClubCTA/PromotionClubCTA.tsx
@@ -26,6 +26,7 @@ const PromotionClubCTA = ({ clubId, clubName }: Props) => {
     if (isInAppWebView()) {
       const sent = requestNavigateWebview(
         `club/@${encodeURIComponent(clubName)}`,
+        clubId,
       );
       if (!sent) navigate(`/clubDetail/@${encodeURIComponent(clubName)}`);
     } else {

--- a/frontend/src/pages/PromotionPage/components/detail/PromotionClubCTA/PromotionClubCTA.tsx
+++ b/frontend/src/pages/PromotionPage/components/detail/PromotionClubCTA/PromotionClubCTA.tsx
@@ -1,9 +1,6 @@
-import { useNavigate } from 'react-router-dom';
 import { USER_EVENT } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import useNavigator from '@/hooks/useNavigator';
-import isInAppWebView from '@/utils/isInAppWebView';
-import { requestNavigateWebview } from '@/utils/webviewBridge';
 import ArrowButton from '../PromotionArrowButton/PromotionArrowButton';
 import * as Styled from './PromotionClubCTA.styles';
 
@@ -14,7 +11,6 @@ interface Props {
 
 const PromotionClubCTA = ({ clubId, clubName }: Props) => {
   const handleLink = useNavigator();
-  const navigate = useNavigate();
   const trackEvent = useMixpanelTrack();
 
   const handleNavigate = () => {
@@ -23,15 +19,7 @@ const PromotionClubCTA = ({ clubId, clubName }: Props) => {
       club_name: clubName,
     });
 
-    if (isInAppWebView()) {
-      const sent = requestNavigateWebview(
-        `club/@${encodeURIComponent(clubName)}`,
-        clubId,
-      );
-      if (!sent) navigate(`/clubDetail/@${encodeURIComponent(clubName)}`);
-    } else {
-      handleLink(`/clubDetail/@${encodeURIComponent(clubName)}`);
-    }
+    handleLink(`/clubDetail/@${encodeURIComponent(clubName)}`);
   };
 
   return (

--- a/frontend/src/utils/webviewBridge.ts
+++ b/frontend/src/utils/webviewBridge.ts
@@ -131,8 +131,14 @@ export const requestSubscribeState = (): boolean => {
 // 앱 내 다른 웹뷰 화면으로 이동 요청 (slug로 앱이 라우팅 결정)
 // 언제: 배너 등에서 앱 내부 특정 화면(예: 'promotions/club-fest-2026')으로 이동할 때.
 //       외부 URL이면 requestOpenExternalUrl 사용
-export const requestNavigateWebview = (slug: string, clubId?: string): boolean => {
-  return postMessageToApp({ type: 'NAVIGATE_WEBVIEW', payload: { slug, clubId } });
+export const requestNavigateWebview = (
+  slug: string,
+  clubId?: string,
+): boolean => {
+  return postMessageToApp({
+    type: 'NAVIGATE_WEBVIEW',
+    payload: { slug, clubId },
+  });
 };
 
 // 외부 URL을 앱 브라우저로 열기 요청 — http/https만 허용, 그 외 프로토콜은 차단

--- a/frontend/src/utils/webviewBridge.ts
+++ b/frontend/src/utils/webviewBridge.ts
@@ -15,7 +15,7 @@ export type WebViewMessage =
     }
   | { type: 'SUBSCRIBE_TOGGLE'; payload: { clubId: string } }
   | { type: 'REQUEST_SUBSCRIBE_STATE' }
-  | { type: 'NAVIGATE_WEBVIEW'; payload: { slug: string } }
+  | { type: 'NAVIGATE_WEBVIEW'; payload: { slug: string; clubId?: string } }
   | { type: 'OPEN_EXTERNAL_URL'; payload: { url: string } };
 
 // 앱 → 웹 방향 메시지 타입
@@ -131,8 +131,8 @@ export const requestSubscribeState = (): boolean => {
 // 앱 내 다른 웹뷰 화면으로 이동 요청 (slug로 앱이 라우팅 결정)
 // 언제: 배너 등에서 앱 내부 특정 화면(예: 'promotions/club-fest-2026')으로 이동할 때.
 //       외부 URL이면 requestOpenExternalUrl 사용
-export const requestNavigateWebview = (slug: string): boolean => {
-  return postMessageToApp({ type: 'NAVIGATE_WEBVIEW', payload: { slug } });
+export const requestNavigateWebview = (slug: string, clubId?: string): boolean => {
+  return postMessageToApp({ type: 'NAVIGATE_WEBVIEW', payload: { slug, clubId } });
 };
 
 // 외부 URL을 앱 브라우저로 열기 요청 — http/https만 허용, 그 외 프로토콜은 차단


### PR DESCRIPTION
## Summary
- 웹뷰 내부 라우팅을 앱 브릿지(`NAVIGATE_WEBVIEW`) 대신 React Router로 통일 (웹 마이그레이션 방향)
- 동아리 상세 이동 시 `?is_subscribed` URL 파라미터 전달 — 알림 벨 초기값 정상화

## Changes

### `useNavigator` — 내부 라우팅 React Router 통일
웹뷰에서 내부 경로 이동 시 `requestNavigateWebview` 브릿지 대신 `navigate()` 사용.
외부 URL(`https://...`)은 기존대로 브릿지 → `window.open` 폴백 유지.

### `MainPage` — 클럽 카드 클릭 시 구독 상태 전달
웹뷰에서 클럽 카드 클릭 시 `onCardClick`으로 `?is_subscribed=true|false` 포함해 이동.

### `PromotionClubCTA` — 브릿지 제거 + 구독 상태 전달
- 웹뷰 분기 제거, `handleLink`로 통일
- `useWebviewSubscribe`로 구독 상태 조회 후 구독 중이면 `?is_subscribed=true` 포함해 이동

### `webviewBridge.ts` — `NAVIGATE_WEBVIEW` payload에 `clubId` 추가
앱이 `NAVIGATE_WEBVIEW` 핸들러 구현 시 `payload.clubId`로 구독 조회 가능하도록 준비.

## 배경
웹뷰에서 홍보 상세 → 홍보 카드 클릭, 동아리 정보 보러가기 등 내부 이동이 앱 브릿지 핸들러 미구현으로 동작하지 않던 문제 수정.
웹 마이그레이션 방향에 따라 내부 라우팅 주도권을 웹(React Router)으로 이전.

Closes #1661