### PR TITLE
[fix] 웹뷰 구독 상태 동기화 버그수정

### DIFF
--- a/frontend/src/components/common/BottomNavigation/BottomNavigation.tsx
+++ b/frontend/src/components/common/BottomNavigation/BottomNavigation.tsx
@@ -53,12 +53,13 @@ const isTabActive = (pathname: string, path: string) => {
   // 메뉴 탭: 메뉴 페이지에서 진입하는 소개/연합회 하위 페이지까지 활성
   if (path === '/menu') {
     return (
-      pathname.startsWith('/menu') ||
+      pathname === '/menu' ||
+      pathname.startsWith('/menu/') ||
       pathname === '/introduce' ||
       pathname === '/club-union'
     );
   }
-  return pathname.startsWith(path);
+  return pathname === path || pathname.startsWith(path + '/');
 };
 
 const renderIcon = (icon: TabIcon, active: boolean) => {

--- a/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
@@ -132,7 +132,7 @@ const ClubDetailPage = () => {
       <Header hideOn={['mobile', 'tablet']} />
       {showTopBar && (
         <ClubDetailTopBar
-          clubId={clubId || ''}
+          clubId={clubDetail.id}
           clubName={clubDetail.name}
           tabs={topBarTabs}
           activeTab={activeTab}

--- a/frontend/src/pages/ClubDetailPage/components/ClubDetailTopBar/ClubDetailTopBar.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubDetailTopBar/ClubDetailTopBar.tsx
@@ -11,9 +11,9 @@ import useOpenAppFromKakao from '@/hooks/useOpenAppFromKakao';
 import isInAppWebView from '@/utils/isInAppWebView';
 import isKakaoTalkBrowser from '@/utils/isKakaoTalkBrowser';
 import {
-  type AppToWebMessage,
   requestNavigateBack,
   requestSubscribeToggle,
+  type AppToWebMessage,
 } from '@/utils/webviewBridge';
 import * as Styled from './ClubDetailTopBar.styles';
 

--- a/frontend/src/pages/ClubDetailPage/components/ClubDetailTopBar/ClubDetailTopBar.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubDetailTopBar/ClubDetailTopBar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTheme } from 'styled-components';
 import NotificationIcon from '@/assets/images/icons/notification_icon.svg?react';
@@ -11,6 +11,7 @@ import useOpenAppFromKakao from '@/hooks/useOpenAppFromKakao';
 import isInAppWebView from '@/utils/isInAppWebView';
 import isKakaoTalkBrowser from '@/utils/isKakaoTalkBrowser';
 import {
+  type AppToWebMessage,
   requestNavigateBack,
   requestSubscribeToggle,
 } from '@/utils/webviewBridge';
@@ -53,6 +54,30 @@ const ClubDetailTopBar = ({
   const [isNotificationActive, setIsNotificationActive] =
     useState(initialIsSubscribed);
 
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      let data: AppToWebMessage;
+      try {
+        data =
+          typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
+      } catch {
+        return;
+      }
+      if (data.type === 'SUBSCRIBE_STATE') {
+        setIsNotificationActive(
+          data.payload.subscribedClubIds.includes(clubId),
+        );
+      } else if (
+        data.type === 'SUBSCRIBE_RESULT' &&
+        data.payload.clubId === clubId
+      ) {
+        setIsNotificationActive(data.payload.subscribed);
+      }
+    };
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, [clubId]);
+
   // 스크롤 위치에 따른 상태 관리
   const { isTriggered: isHeaderVisible } = useScrollTrigger({
     threshold: SCROLL_THRESHOLD.HEADER_VISIBLE,
@@ -78,8 +103,7 @@ const ClubDetailTopBar = ({
   };
 
   const handleNotificationClick = () => {
-    const success = requestSubscribeToggle(clubId);
-    if (success) setIsNotificationActive(!isNotificationActive);
+    requestSubscribeToggle(clubId);
   };
 
   return (

--- a/frontend/src/pages/ClubDetailPage/components/ClubDetailTopBar/ClubDetailTopBar.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubDetailTopBar/ClubDetailTopBar.tsx
@@ -12,8 +12,7 @@ import isInAppWebView from '@/utils/isInAppWebView';
 import isKakaoTalkBrowser from '@/utils/isKakaoTalkBrowser';
 import {
   requestNavigateBack,
-  requestNotificationSubscribe,
-  requestNotificationUnsubscribe,
+  requestSubscribeToggle,
 } from '@/utils/webviewBridge';
 import * as Styled from './ClubDetailTopBar.styles';
 
@@ -79,17 +78,8 @@ const ClubDetailTopBar = ({
   };
 
   const handleNotificationClick = () => {
-    if (isNotificationActive) {
-      const success = requestNotificationUnsubscribe(clubId);
-      if (success) {
-        setIsNotificationActive(false);
-      }
-    } else {
-      const success = requestNotificationSubscribe(clubId, clubName);
-      if (success) {
-        setIsNotificationActive(true);
-      }
-    }
+    const success = requestSubscribeToggle(clubId);
+    if (success) setIsNotificationActive(!isNotificationActive);
   };
 
   return (

--- a/frontend/src/pages/SubscriptionsPage/SubscriptionsPage.tsx
+++ b/frontend/src/pages/SubscriptionsPage/SubscriptionsPage.tsx
@@ -56,6 +56,11 @@ const SubscribedClubs = () => {
               club={club}
               index={index}
               page={PAGE_NAME.SUBSCRIPTIONS}
+              onCardClick={(c) =>
+                navigate(
+                  `/clubDetail/@${encodeURIComponent(c.name)}?is_subscribed=true`,
+                )
+              }
             >
               <SubscribeButton
                 subscribed={subscribedClubIds.has(club.id)}


### PR DESCRIPTION
## Summary
- 구독 목록에서 동아리 상세 진입 시 알림 벨 초기값 항상 OFF 버그 수정
- 동아리 상세에서 구독 토글 후 메인 목록에 반영 안 되는 버그 수정
- 홍보 상세에서 동아리 상세 이동 후 구독 토글이 전체에 반영 안 되는 버그 수정
- `@clubName` 경로 진입 시 `SUBSCRIBE_TOGGLE`에 빈 문자열 전달로 앱 API 404 버그 수정

## Changes

### `SubscriptionsPage` — 동아리 상세 이동 시 `is_subscribed=true` 전달
구독 목록은 항상 구독된 클럽만 표시되므로 `onCardClick`에서 `?is_subscribed=true` 포함해 이동.

### `ClubDetailTopBar` — 알림 토글을 `SUBSCRIBE_TOGGLE`로 변경
기존 `NOTIFICATION_SUBSCRIBE`/`NOTIFICATION_UNSUBSCRIBE`는 앱 미구현 상태로 구독 상태가 변경되지 않았음.
`SUBSCRIBE_TOGGLE`로 변경해 앱이 `SUBSCRIBE_RESULT`로 응답 → `useWebviewSubscribe`가 업데이트 → 메인/구독 목록 동기화.

### `ClubDetailPage` — `SUBSCRIBE_TOGGLE`에 실제 `clubId` 전달
`/clubDetail/@clubName` 경로 진입 시 URL params의 `clubId`가 `undefined` → `''`로 전송되어 앱 API 404 발생.
`clubDetail.id`(API 응답의 실제 ObjectId)를 사용하도록 수정.

Closes #1664