### PR TITLE
[fix] iOS 스와이프 백 전환 시 검은 배경 깜빡임 수정

### DIFF
--- a/frontend/src/styles/Global.styles.ts
+++ b/frontend/src/styles/Global.styles.ts
@@ -1,4 +1,5 @@
 import { createGlobalStyle } from 'styled-components';
+import { colors } from './theme/colors';
 
 const GlobalStyles = createGlobalStyle`
   * {
@@ -20,7 +21,7 @@ const GlobalStyles = createGlobalStyle`
     sans-serif;
     color: #121212;
     letter-spacing: -0.02em;
-    background-color: #ffffff;
+    background-color: ${colors.base.white};
   }
 `;
 

--- a/frontend/src/styles/Global.styles.ts
+++ b/frontend/src/styles/Global.styles.ts
@@ -20,6 +20,7 @@ const GlobalStyles = createGlobalStyle`
     sans-serif;
     color: #121212;
     letter-spacing: -0.02em;
+    background-color: #ffffff;
   }
 `;
 


### PR DESCRIPTION

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용
<img width="300" height="500" alt="IMG_8797" src="https://github.com/user-attachments/assets/94567ab3-6435-45b2-b3ac-f3a2be36ebc6" />

body에 background-color: #ffffff 추가하여
iOS WebView 스와이프 백 제스처 시 네이티브 레이어(검정색)가 비쳐 보이는 현상 수정

## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항
