### PR TITLE
[feature] Mixpanel 이벤트명 하드코딩 방지 ESLint 커스텀 룰 추가

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -3,6 +3,7 @@ import parser from '@typescript-eslint/parser';
 import configPrettier from 'eslint-config-prettier';
 import react from 'eslint-plugin-react';
 import storybook from 'eslint-plugin-storybook';
+import localRules from './scripts/eslint-rules/index.js';
 
 const config = [
   {
@@ -33,8 +34,10 @@ const config = [
       '@typescript-eslint': typescript,
       react,
       storybook,
+      local: localRules,
     },
     rules: {
+      'local/no-hardcoded-event-name': 'error',
       semi: ['error', 'always'],
       quotes: ['error', 'single'],
       'no-console': 'warn',

--- a/frontend/scripts/eslint-rules/index.js
+++ b/frontend/scripts/eslint-rules/index.js
@@ -1,0 +1,9 @@
+/**
+ * 모아동 로컬 ESLint 플러그인.
+ * @type {import('eslint').ESLint.Plugin}
+ */
+module.exports = {
+  rules: {
+    'no-hardcoded-event-name': require('./no-hardcoded-event-name'),
+  },
+};

--- a/frontend/scripts/eslint-rules/no-hardcoded-event-name.js
+++ b/frontend/scripts/eslint-rules/no-hardcoded-event-name.js
@@ -24,8 +24,12 @@ module.exports = {
       if (callee.type === 'Identifier') {
         return callee.name === 'trackEvent';
       }
+      // mixpanel?.track(...) 옵셔널 체이닝도 함께 검사
+      const isMember =
+        callee.type === 'MemberExpression' ||
+        callee.type === 'OptionalMemberExpression';
       return (
-        callee.type === 'MemberExpression' &&
+        isMember &&
         callee.object.type === 'Identifier' &&
         callee.object.name === 'mixpanel' &&
         callee.property.type === 'Identifier' &&

--- a/frontend/scripts/eslint-rules/no-hardcoded-event-name.js
+++ b/frontend/scripts/eslint-rules/no-hardcoded-event-name.js
@@ -1,0 +1,56 @@
+/**
+ * @fileoverview Mixpanel 이벤트명은 USER_EVENT 상수만 사용하도록 강제한다.
+ * 문자열 하드코딩을 막아 이벤트명 오타/중복을 컴파일 전에 잡는다.
+ * (conventions.md: "문자열 하드코딩 금지")
+ * @type {import('eslint').Rule.RuleModule}
+ */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Mixpanel 이벤트명은 src/constants/eventName.ts의 USER_EVENT 상수만 사용 (문자열 하드코딩 금지)',
+    },
+    schema: [],
+    messages: {
+      hardcoded:
+        '이벤트명을 문자열로 하드코딩하지 마세요. USER_EVENT 상수를 사용하세요.',
+    },
+  },
+
+  create(context) {
+    /** trackEvent(...) 또는 mixpanel.track(...) 호출인지 판별 */
+    function isTrackCall(callee) {
+      if (callee.type === 'Identifier') {
+        return callee.name === 'trackEvent';
+      }
+      return (
+        callee.type === 'MemberExpression' &&
+        callee.object.type === 'Identifier' &&
+        callee.object.name === 'mixpanel' &&
+        callee.property.type === 'Identifier' &&
+        callee.property.name === 'track'
+      );
+    }
+
+    /** 첫 인자가 하드코딩된 문자열(리터럴 또는 정적 템플릿)인지 판별 */
+    function isHardcodedString(arg) {
+      if (arg.type === 'Literal') {
+        return typeof arg.value === 'string';
+      }
+      // `${x} Visited` 같은 동적 템플릿은 허용, `foo` 같은 정적 템플릿만 금지
+      return arg.type === 'TemplateLiteral' && arg.expressions.length === 0;
+    }
+
+    return {
+      CallExpression(node) {
+        if (!isTrackCall(node.callee)) return;
+        const firstArg = node.arguments[0];
+        if (!firstArg) return;
+        if (isHardcodedString(firstArg)) {
+          context.report({ node: firstArg, messageId: 'hardcoded' });
+        }
+      },
+    };
+  },
+};

--- a/frontend/scripts/eslint-rules/no-hardcoded-event-name.test.ts
+++ b/frontend/scripts/eslint-rules/no-hardcoded-event-name.test.ts
@@ -1,7 +1,12 @@
 import { RuleTester } from 'eslint';
 import rule from './no-hardcoded-event-name';
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+  },
+});
 
 ruleTester.run('no-hardcoded-event-name', rule, {
   valid: [
@@ -26,6 +31,11 @@ ruleTester.run('no-hardcoded-event-name', rule, {
     {
       // 표현식 없는 정적 템플릿도 하드코딩으로 간주
       code: 'trackEvent(`Banner Clicked`);',
+      errors: [{ messageId: 'hardcoded' }],
+    },
+    {
+      // 옵셔널 체이닝(mixpanel?.track)으로 우회해도 검출
+      code: "mixpanel?.track('Search Executed');",
       errors: [{ messageId: 'hardcoded' }],
     },
   ],

--- a/frontend/scripts/eslint-rules/no-hardcoded-event-name.test.ts
+++ b/frontend/scripts/eslint-rules/no-hardcoded-event-name.test.ts
@@ -1,0 +1,32 @@
+import { RuleTester } from 'eslint';
+import rule from './no-hardcoded-event-name';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-hardcoded-event-name', rule, {
+  valid: [
+    // USER_EVENT 상수 사용 — 정상
+    'trackEvent(USER_EVENT.BANNER_CLICKED, { id: 1 });',
+    'mixpanel.track(USER_EVENT.SEARCH_EXCUTED);',
+    // 동적 템플릿(페이지뷰 패턴)은 허용
+    'mixpanel.track(`${pageName} Visited`);',
+    // 추적 호출이 아니면 무시
+    "track('something');",
+    "logger.track('event');",
+  ],
+  invalid: [
+    {
+      code: "trackEvent('Banner Clicked');",
+      errors: [{ messageId: 'hardcoded' }],
+    },
+    {
+      code: "mixpanel.track('Search Executed', { q: 'a' });",
+      errors: [{ messageId: 'hardcoded' }],
+    },
+    {
+      // 표현식 없는 정적 템플릿도 하드코딩으로 간주
+      code: 'trackEvent(`Banner Clicked`);',
+      errors: [{ messageId: 'hardcoded' }],
+    },
+  ],
+});


### PR DESCRIPTION
## 작업내용

Mixpanel 이벤트명을 문자열로 하드코딩하면 ESLint가 에러를 내는 커스텀 룰 `local/no-hardcoded-event-name`을 추가했습니다.

- `trackEvent(...)` / `mixpanel.track(...)` 호출의 첫 인자가 하드코딩 문자열(또는 표현식 없는 정적 템플릿)이면 위반으로 보고
- `USER_EVENT` 상수 사용을 강제
- `` `${pageName} Visited` `` 같은 동적 템플릿은 허용해 기존 페이지뷰 트래킹에서 오탐 방지

## 도입이유

컨벤션상 이벤트명은 `eventName.ts` 상수로만 관리해야 하는데, 이를 코드리뷰로 사람이 잡는 것이 비효율적이라 린트로 자동 검출하도록 했습니다.

## 변경 사항

- `scripts/eslint-rules/no-hardcoded-event-name.js` — 룰 구현 (AST `CallExpression` 순회)
- `scripts/eslint-rules/index.js` — 로컬 플러그인 묶음
- `scripts/eslint-rules/no-hardcoded-event-name.test.ts` — RuleTester 테스트 (valid 5 / invalid 3)
- `eslint.config.mjs` — 로컬 플러그인 등록 및 룰 `'error'` 활성화


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 이벤트 추적 호출에서 하드코딩된 이름을 감지하는 린트 규칙 추가
  * 정적 문자열 또는 표현식이 없는 템플릿 리터럴 사용 시 오류 보고
  * 동적 템플릿과 상수 사용은 자동으로 허용되며, 해당 규칙에 대한 테스트 포함

<!-- end of auto-generated comment: release notes by coderabbit.ai -->