### PR TITLE
[feature] iOS OS 버전을 Mixpanel $os_version으로 트래킹

### DIFF
--- a/frontend/docs/features/utils/getIOSVersion.md
+++ b/frontend/docs/features/utils/getIOSVersion.md
@@ -1,0 +1,18 @@
+# iOS OS 버전 Mixpanel 트래킹
+
+Mixpanel 웹 SDK(`mixpanel-browser`)는 `$os_version`을 수집하지 않는다. 기본 자동 속성에는 OS 이름(`$os`)만 있고 OS 버전 항목 자체가 없으며, `$browser_version`은 브라우저 앱 버전이라 OS 버전 판별에 쓸 수 없다. 이 때문에 iOS 버전별(예: iOS 14 미만) 사용자 필터링이 불가능했다.
+
+이를 보완하기 위해 `navigator.userAgent`에서 iOS OS 버전을 직접 파싱해 `major.minor` 형식 문자열로 추출하고, `mixpanel.init` 직후 `mixpanel.register`로 `$os_version` 슈퍼 프로퍼티에 등록한다. 등록 이후 모든 이벤트에 자동 부착되며, 네이티브 iOS Mixpanel SDK와 동일한 속성명·포맷("17.2")이라 웹/앱 데이터가 같은 속성으로 통합된다.
+
+iOS가 아니거나 UA에서 버전을 못 찾으면 등록하지 않는다. macOS는 최근 브라우저의 UA freeze(`Mac OS X 10_15_7` 고정)로 버전 신뢰성이 없어 대상에서 제외했다.
+
+## 주의
+
+- 슈퍼 프로퍼티는 등록 시점 이후 이벤트에만 부착되고 과거 이벤트엔 소급되지 않는다.
+- `$os_version`은 문자열이므로 "iOS 14 미만" 같은 필터는 숫자 비교(less than)로 걸어야 사전순 비교 오류(`"9" > "14"`)를 피할 수 있다.
+
+## 관련 코드
+
+- `src/utils/getIOSVersion.ts` — UA에서 iOS OS 버전을 `major.minor`로 추출 (iOS 아니면 `null`)
+- `src/utils/initSDK.ts` — `initializeMixpanel`에서 `mixpanel.register({ $os_version })` 등록
+- `src/utils/getIOSVersion.test.ts` — iPhone/iPad/patch/macOS/Android 파싱 테스트

--- a/frontend/src/utils/getIOSVersion.test.ts
+++ b/frontend/src/utils/getIOSVersion.test.ts
@@ -1,0 +1,31 @@
+import getIOSVersion from '@/utils/getIOSVersion';
+
+describe('getIOSVersion', () => {
+  it('iPhone UA에서 major.minor를 추출한다', () => {
+    const ua =
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1';
+    expect(getIOSVersion(ua)).toBe('17.2');
+  });
+
+  it('iPad UA에서 버전을 추출한다', () => {
+    const ua =
+      'Mozilla/5.0 (iPad; CPU OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148';
+    expect(getIOSVersion(ua)).toBe('14.0');
+  });
+
+  it('patch 버전이 있어도 major.minor만 반환한다', () => {
+    const ua = 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_4_1 like Mac OS X)';
+    expect(getIOSVersion(ua)).toBe('13.4');
+  });
+
+  it('iOS가 아니면 null을 반환한다', () => {
+    const ua =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15';
+    expect(getIOSVersion(ua)).toBeNull();
+  });
+
+  it('Android는 null을 반환한다', () => {
+    const ua = 'Mozilla/5.0 (Linux; Android 13; SM-S918N) AppleWebKit/537.36';
+    expect(getIOSVersion(ua)).toBeNull();
+  });
+});

--- a/frontend/src/utils/getIOSVersion.ts
+++ b/frontend/src/utils/getIOSVersion.ts
@@ -1,0 +1,21 @@
+/**
+ * iOS UA에서 OS 버전을 "major.minor" 형식 문자열로 추출
+ * 예) "...iPhone OS 17_2 like Mac OS X..." → "17.2"
+ */
+const getIOSVersion = (
+  userAgent: string = navigator.userAgent,
+): string | null => {
+  if (!/(iPhone|iPad|iPod)/.test(userAgent)) {
+    return null;
+  }
+
+  const match = userAgent.match(/OS (\d+)[._](\d+)(?:[._](\d+))?/);
+  if (!match) {
+    return null;
+  }
+
+  const [, major, minor] = match;
+  return `${major}.${minor}`;
+};
+
+export default getIOSVersion;

--- a/frontend/src/utils/initSDK.ts
+++ b/frontend/src/utils/initSDK.ts
@@ -2,6 +2,7 @@ import * as ChannelService from '@channel.io/channel-web-sdk-loader';
 import Clarity from '@microsoft/clarity';
 import * as Sentry from '@sentry/react';
 import mixpanel from 'mixpanel-browser';
+import getIOSVersion from '@/utils/getIOSVersion';
 
 const LOCALHOST_HOSTNAME = 'localhost';
 
@@ -15,6 +16,11 @@ export function initializeMixpanel() {
     ignore_dnt: true,
     debug: false,
   });
+
+  const iosVersion = getIOSVersion();
+  if (iosVersion) {
+    mixpanel.register({ $os_version: iosVersion });
+  }
 
   if (window.location.hostname === LOCALHOST_HOSTNAME) {
     mixpanel.disable();


### PR DESCRIPTION
## 개요

Mixpanel 웹 SDK(`mixpanel-browser`)는 `$os_version`을 수집하지 않아 iOS 버전별(예: iOS 14 미만) 사용자 필터링이 불가능했습니다. UA에서 iOS 버전을 직접 파싱해 `$os_version` 슈퍼 프로퍼티로 보강합니다.

## 변경 사항

- `getIOSVersion.ts` 신규: `navigator.userAgent`에서 iOS OS 버전을 `major.minor`로 추출 (iOS 아니면 `null`)
- `initSDK.ts`: `mixpanel.init` 직후 iOS면 `mixpanel.register({ $os_version })`
- `getIOSVersion.test.ts`: iPhone/iPad/patch/macOS/Android 5케이스
- `docs/features/utils/getIOSVersion.md`: 기능 문서

## 참고

- 네이티브 iOS SDK와 동일한 `$os_version`("17.2") 포맷이라 웹/앱 데이터가 한 속성으로 통합됩니다.
- 슈퍼 프로퍼티는 등록 이후 이벤트에만 부착되며 과거 이벤트엔 소급되지 않습니다.
- `$os_version`은 문자열이라 "iOS 14 미만" 필터는 숫자 비교(less than)로 걸어야 합니다.
- macOS는 UA freeze(`Mac OS X 10_15_7` 고정)로 신뢰 불가해 이번 범위에서 제외했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * iOS 사용자의 기기 운영 체제 버전을 자동으로 감지하여 분석 데이터 플랫폼에 등록하는 기능 추가

* **Documentation**
  * iOS 버전 정보 수집 및 등록 프로세스에 대한 상세 문서 추가

* **Tests**
  * iOS 기기 버전 감지 기능의 정확성을 검증하는 테스트 케이스 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->