### PR TITLE
[feature] 동아리 클릭 랭킹 자동 초기화 제거 및 수동 초기화 API 추가

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -47,3 +47,4 @@ moadong.json
 firebase.json
 
 /.cursor
+/dailyNote

--- a/backend/src/main/java/moadong/club/controller/ClubClickAdminController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubClickAdminController.java
@@ -3,13 +3,17 @@ package moadong.club.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import moadong.club.service.ClubClickService;
 import moadong.global.payload.Response;
+import moadong.user.annotation.CurrentUser;
+import moadong.user.payload.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/admin/game")
 @RequiredArgsConstructor
@@ -20,7 +24,8 @@ public class ClubClickAdminController {
 
     @PostMapping("/ranking/reset")
     @Operation(summary = "동아리 클릭 랭킹 초기화", description = "동아리 클릭 수를 전체 삭제하여 랭킹을 초기화합니다.")
-    public ResponseEntity<?> resetRanking() {
+    public ResponseEntity<?> resetRanking(@CurrentUser CustomUserDetails user) {
+        log.info("관리자 [{}]가 동아리 클릭 랭킹 초기화를 수행했습니다.", user.getUserId());
         clubClickService.resetRanking();
         return Response.ok("동아리 클릭 랭킹이 초기화되었습니다");
     }

--- a/backend/src/main/java/moadong/club/controller/ClubClickAdminController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubClickAdminController.java
@@ -1,0 +1,27 @@
+package moadong.club.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import moadong.club.service.ClubClickService;
+import moadong.global.payload.Response;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin/game")
+@RequiredArgsConstructor
+@Tag(name = "Game_Admin", description = "동아리 클릭 게임 관리자 API")
+public class ClubClickAdminController {
+
+    private final ClubClickService clubClickService;
+
+    @PostMapping("/ranking/reset")
+    @Operation(summary = "동아리 클릭 랭킹 초기화", description = "동아리 클릭 수를 전체 삭제하여 랭킹을 초기화합니다.")
+    public ResponseEntity<?> resetRanking() {
+        clubClickService.resetRanking();
+        return Response.ok("동아리 클릭 랭킹이 초기화되었습니다");
+    }
+}

--- a/backend/src/main/java/moadong/club/service/ClubClickScheduler.java
+++ b/backend/src/main/java/moadong/club/service/ClubClickScheduler.java
@@ -15,12 +15,6 @@ public class ClubClickScheduler {
 
     private final ClubClickService clubClickService;
 
-    @Scheduled(cron = "0 0 0 * * MON", zone = "Asia/Seoul")
-    @SchedulerLock(name = "ClubClickWeeklyReset", lockAtMostFor = "1m", lockAtLeastFor = "1s")
-    public void resetWeeklyClicks() {
-        clubClickService.resetWeeklyClicks();
-    }
-
     @Scheduled(cron = "0 0 * * * *")
     @SchedulerLock(name = "ClubClickWhitelistRefresh", lockAtMostFor = "5m", lockAtLeastFor = "1s")
     public void refreshWhitelist() {

--- a/backend/src/main/java/moadong/club/service/ClubClickService.java
+++ b/backend/src/main/java/moadong/club/service/ClubClickService.java
@@ -134,9 +134,9 @@ public class ClubClickService {
         return new ClubClickRankingResponse(ranked, nextMondayMidnightKst());
     }
 
-    public void resetWeeklyClicks() {
+    public void resetRanking() {
         clickCountRepository.deleteAll();
-        log.info("동아리 클릭 수 주간 초기화 완료");
+        log.info("동아리 클릭 수 초기화 완료");
     }
 
     public String nextMondayMidnightKst() {


### PR DESCRIPTION
## 변경 사항

동아리 클릭 게임 랭킹의 **매주 월요일 자동 초기화**를 제거하고, 관리자가 직접 초기화할 수 있는 API로 전환했습니다.

### 상세
- `ClubClickScheduler`: 주간 자동 초기화(`@Scheduled` cron `0 0 0 * * MON`) 제거. 화이트리스트 매시간 갱신은 유지
- `ClubClickService`: `resetWeeklyClicks()` → `resetRanking()`으로 변경 (더 이상 주간 동작이 아님), 로그 메시지 수정
- `ClubClickAdminController`: 신규 수동 초기화 API 추가
  - `POST /api/admin/game/ranking/reset`
  - `/api/admin/**` 경로라 `SecurityConfig`에 의해 **DEVELOPER 권한(JWT) 필수**로 보호됨

### 참고
- 초기화는 MongoDB의 `ClubClickCount`만 삭제. Redis의 `game:cooldown/ratelimit/banned` 키는 TTL로 자동 만료되어 그대로 둠
- `getRanking()` 응답의 `resetAt`(다음 월요일 자정)은 프론트 호환성을 위해 **그대로 유지** (자동 초기화가 사라져 의미상 표시값으로만 남음)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자가 동아리 클릭 랭킹을 수동으로 초기화할 수 있는 관리 기능이 추가되었습니다. 관리자는 전용 엔드포인트를 통해 필요할 때 언제든 랭킹을 초기화할 수 있습니다.

* **기타**
  * 저장소 구성 파일이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->