### PR TITLE
[fix] 예약 알림 및 홍보 이미지 업로드 안정성 개선

### DIFF
--- a/backend/src/main/java/moadong/club/repository/PromotionArticleRepository.java
+++ b/backend/src/main/java/moadong/club/repository/PromotionArticleRepository.java
@@ -3,6 +3,7 @@ package moadong.club.repository;
 import moadong.club.entity.PromotionArticle;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
+import org.springframework.data.mongodb.repository.Update;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -22,4 +23,8 @@ public interface PromotionArticleRepository extends MongoRepository<PromotionArt
 
     @Query(value = "{ '_id': ?0, 'deleted': { $ne: true } }", exists = true)
     boolean existsActiveById(String id);
+
+    @Query("{ '_id': ?0, 'deleted': { $ne: true } }")
+    @Update("{ '$addToSet': { 'images': ?1 } }")
+    long addImageToActiveArticle(String id, String imageUrl);
 }

--- a/backend/src/main/java/moadong/fcm/service/FcmScheduledNotificationDispatcher.java
+++ b/backend/src/main/java/moadong/fcm/service/FcmScheduledNotificationDispatcher.java
@@ -14,12 +14,15 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class FcmScheduledNotificationDispatcher {
+
+    private static final int MULTICAST_BATCH_SIZE = 500;
 
     private final FcmScheduledNotificationService scheduleService;
     private final FcmAdminService fcmAdminService;
@@ -73,13 +76,31 @@ public class FcmScheduledNotificationDispatcher {
             return;
         }
 
-        MulticastPushResult result = pushNotificationPort.sendToTokens(new MulticastPushPayload(
-                tokens,
-                schedule.getTitle(),
-                schedule.getBody(),
-                schedule.getData()
-        ));
+        MulticastPushResult result = sendToTokensInBatches(schedule, tokens);
 
         scheduleService.markBatchSent(schedule.getId(), tokens.size(), result, Instant.now());
+    }
+
+    private MulticastPushResult sendToTokensInBatches(FcmScheduledNotification schedule, List<String> tokens) {
+        int batchCount = 0;
+        int successCount = 0;
+        int failureCount = 0;
+        List<String> failedTokens = new ArrayList<>();
+
+        for (int start = 0; start < tokens.size(); start += MULTICAST_BATCH_SIZE) {
+            int end = Math.min(start + MULTICAST_BATCH_SIZE, tokens.size());
+            MulticastPushResult result = pushNotificationPort.sendToTokens(new MulticastPushPayload(
+                    tokens.subList(start, end),
+                    schedule.getTitle(),
+                    schedule.getBody(),
+                    schedule.getData()
+            ));
+            batchCount += result.batchCount();
+            successCount += result.successCount();
+            failureCount += result.failureCount();
+            failedTokens.addAll(result.failedTokens());
+        }
+
+        return new MulticastPushResult(batchCount, successCount, failureCount, List.copyOf(failedTokens));
     }
 }

--- a/backend/src/main/java/moadong/media/service/PromotionImageUploadService.java
+++ b/backend/src/main/java/moadong/media/service/PromotionImageUploadService.java
@@ -1,14 +1,12 @@
 package moadong.media.service;
 
 import lombok.RequiredArgsConstructor;
-import moadong.club.entity.PromotionArticle;
 import moadong.club.repository.PromotionArticleRepository;
 import moadong.global.config.properties.AwsProperties;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
 import moadong.media.dto.PromotionImageUploadResponse;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -24,9 +22,8 @@ public class PromotionImageUploadService {
     private final R2ImageUploadService r2ImageUploadService;
     private final AwsProperties awsProperties;
 
-    @Transactional
     public PromotionImageUploadResponse upload(String articleId, MultipartFile file) {
-        PromotionArticle article = getActivePromotionArticle(articleId);
+        validateActivePromotionArticle(articleId);
         String key = buildPromotionImageKey(articleId, file);
         String imageUrl = r2ImageUploadService.upload(
             file,
@@ -34,14 +31,14 @@ public class PromotionImageUploadService {
             awsProperties.s3().viewEndpoint(),
             key
         );
-        article.addImage(imageUrl);
-        promotionArticleRepository.save(article);
+        promotionArticleRepository.addImageToActiveArticle(articleId, imageUrl);
         return new PromotionImageUploadResponse(imageUrl);
     }
 
-    private PromotionArticle getActivePromotionArticle(String articleId) {
-        return promotionArticleRepository.findActiveById(articleId)
-            .orElseThrow(() -> new RestApiException(ErrorCode.PROMOTION_ARTICLE_NOT_FOUND));
+    private void validateActivePromotionArticle(String articleId) {
+        if (!promotionArticleRepository.existsActiveById(articleId)) {
+            throw new RestApiException(ErrorCode.PROMOTION_ARTICLE_NOT_FOUND);
+        }
     }
 
     private String buildPromotionImageKey(String articleId, MultipartFile file) {

--- a/backend/src/test/java/moadong/fcm/service/FcmScheduledNotificationDispatcherTest.java
+++ b/backend/src/test/java/moadong/fcm/service/FcmScheduledNotificationDispatcherTest.java
@@ -2,21 +2,26 @@ package moadong.fcm.service;
 
 import moadong.fcm.entity.FcmScheduledNotification;
 import moadong.fcm.enums.FcmScheduleTargetType;
+import moadong.fcm.model.MulticastPushPayload;
 import moadong.fcm.model.MulticastPushResult;
 import moadong.fcm.model.TokenPushResult;
 import moadong.fcm.port.PushNotificationPort;
 import moadong.fcm.payload.response.TokenListResponse;
 import moadong.util.annotations.UnitTest;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -96,5 +101,38 @@ class FcmScheduledNotificationDispatcherTest {
 
         verify(pushNotificationPort).sendToTokens(any());
         verify(scheduleService).markBatchSent(any(), org.mockito.ArgumentMatchers.eq(2), any(), any());
+    }
+
+    @Test
+    void 전체_예약은_FCM_멀티캐스트_제한에_맞춰_500개씩_나눠_발송한다() {
+        FcmScheduledNotification schedule = FcmScheduledNotification.create(
+                FcmScheduleTargetType.ALL_TOKENS,
+                null,
+                "title",
+                "body",
+                Map.of("path", "/webview"),
+                Instant.now().minusSeconds(10)
+        );
+        List<String> tokens = new ArrayList<>();
+        for (int index = 0; index < 501; index++) {
+            tokens.add("token-" + index);
+        }
+
+        when(scheduleService.findDueSchedules(any())).thenReturn(List.of(schedule));
+        when(scheduleService.claimForSending(any(), any())).thenReturn(Optional.of(schedule));
+        when(fcmAdminService.getAllAvailableToken()).thenReturn(new TokenListResponse(tokens));
+        when(pushNotificationPort.sendToTokens(any()))
+                .thenReturn(new MulticastPushResult(1, 500, 0, List.of()))
+                .thenReturn(new MulticastPushResult(1, 0, 1, List.of("token-500")));
+
+        dispatcher.dispatchDueNotifications();
+
+        ArgumentCaptor<MulticastPushPayload> payloadCaptor = ArgumentCaptor.forClass(MulticastPushPayload.class);
+        verify(pushNotificationPort, org.mockito.Mockito.times(2)).sendToTokens(payloadCaptor.capture());
+        assertEquals(500, payloadCaptor.getAllValues().get(0).tokens().size());
+        assertEquals(1, payloadCaptor.getAllValues().get(1).tokens().size());
+        verify(scheduleService).markBatchSent(eq(schedule.getId()), eq(501),
+                eq(new MulticastPushResult(2, 500, 1, List.of("token-500"))),
+                any());
     }
 }

--- a/backend/src/test/java/moadong/media/service/PromotionImageUploadServiceTest.java
+++ b/backend/src/test/java/moadong/media/service/PromotionImageUploadServiceTest.java
@@ -1,6 +1,5 @@
 package moadong.media.service;
 
-import moadong.club.entity.PromotionArticle;
 import moadong.club.repository.PromotionArticleRepository;
 import moadong.global.config.properties.AwsProperties;
 import moadong.global.exception.ErrorCode;
@@ -14,15 +13,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -47,29 +44,26 @@ class PromotionImageUploadServiceTest {
         String articleId = "article-1";
         MockMultipartFile file = new MockMultipartFile("file", "poster main.png", "image/png", "img".getBytes());
         AwsProperties.S3 s3 = new AwsProperties.S3("moadong-dev", "https://r2.example.com", "https://cdn.example.com");
-        PromotionArticle article = PromotionArticle.builder()
-            .id(articleId)
-            .images(new ArrayList<>(List.of("https://cdn.example.com/existing.png")))
-            .build();
         String uploadedUrl = "https://cdn.example.com/promotion/articles/" + articleId + "/2026/03/uuid-poster_main.png";
         when(awsProperties.s3()).thenReturn(s3);
-        when(promotionArticleRepository.findActiveById(articleId)).thenReturn(Optional.of(article));
+        when(promotionArticleRepository.existsActiveById(articleId)).thenReturn(true);
         when(r2ImageUploadService.upload(eq(file), eq("moadong-dev"), eq("https://cdn.example.com"), startsWith("promotion/articles/" + articleId + "/")))
             .thenReturn(uploadedUrl);
+        when(promotionArticleRepository.addImageToActiveArticle(articleId, uploadedUrl)).thenReturn(1L);
 
         PromotionImageUploadResponse response = promotionImageUploadService.upload(articleId, file);
 
-        verify(promotionArticleRepository).findActiveById(articleId);
+        verify(promotionArticleRepository).existsActiveById(articleId);
         verify(r2ImageUploadService).upload(eq(file), eq("moadong-dev"), eq("https://cdn.example.com"), startsWith("promotion/articles/" + articleId + "/"));
-        verify(promotionArticleRepository).save(article);
+        verify(promotionArticleRepository).addImageToActiveArticle(articleId, uploadedUrl);
+        verify(promotionArticleRepository, never()).save(any());
         assertEquals(uploadedUrl, response.imageUrl());
         assertTrue(response.imageUrl().contains("/promotion/articles/" + articleId + "/"));
-        assertEquals(List.of("https://cdn.example.com/existing.png", uploadedUrl), article.getImages());
     }
 
     @Test
     void 존재하지_않는_홍보게시글이면_예외를_던진다() {
-        when(promotionArticleRepository.findActiveById("missing")).thenReturn(Optional.empty());
+        when(promotionArticleRepository.existsActiveById("missing")).thenReturn(false);
         MockMultipartFile file = new MockMultipartFile("file", "poster.png", "image/png", "img".getBytes());
 
         RestApiException exception = assertThrows(RestApiException.class,
@@ -80,13 +74,13 @@ class PromotionImageUploadServiceTest {
 
     @Test
     void 삭제된_홍보게시글이면_이미지_업로드를_막는다() {
-        when(promotionArticleRepository.findActiveById("deleted-article")).thenReturn(Optional.empty());
+        when(promotionArticleRepository.existsActiveById("deleted-article")).thenReturn(false);
         MockMultipartFile file = new MockMultipartFile("file", "poster.png", "image/png", "img".getBytes());
 
         RestApiException exception = assertThrows(RestApiException.class,
             () -> promotionImageUploadService.upload("deleted-article", file));
 
         assertEquals(ErrorCode.PROMOTION_ARTICLE_NOT_FOUND, exception.getErrorCode());
-        verify(promotionArticleRepository).findActiveById("deleted-article");
+        verify(promotionArticleRepository).existsActiveById("deleted-article");
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #1684, MOA-978

## 📝작업 내용

- 홍보 이미지 업로드 시 게시글 이미지 목록을 문서 전체 저장 대신 MongoDB `$addToSet` 원자 업데이트로 추가하도록 변경했습니다.
- 이미지 업로드 서비스에서 외부 R2 업로드를 감싸던 불필요한 `@Transactional`을 제거했습니다.
- FCM 예약 전체 발송 시 토큰을 500개 단위로 나눠 발송하고 `MulticastPushResult`를 합산하도록 변경했습니다.
- 홍보 이미지 업로드와 FCM 예약 디스패처 단위 테스트를 보강했습니다.

## 중점적으로 리뷰받고 싶은 부분(선택)

- 다중 이미지 업로드 동시성 대응을 `$addToSet` 원자 업데이트로 처리한 방향이 적절한지 봐주세요.
- FCM 500개 제한을 dispatcher 레벨에서도 방어하도록 한 구조가 충분한지 확인 부탁드립니다.

## 논의하고 싶은 부분(선택)

- R2 업로드 성공 후 DB 업데이트가 실패하거나 대상 게시글이 삭제된 경우 업로드된 파일 정리 정책을 후속으로 둘지 논의가 필요합니다.

## 🫡 참고사항

- 검증: `backend`에서 `.\gradlew.bat test --tests moadong.media.service.PromotionImageUploadServiceTest --tests moadong.fcm.service.FcmScheduledNotificationDispatcherTest`
- 검증: `git diff --check`
- 미추적 파일 `backend/.gradle-user-home/`는 커밋에 포함하지 않았습니다.