### PR TITLE
[feature] 게임 랭킹 조회 1초 인메모리 캐시 추가

### DIFF
--- a/backend/src/main/java/moadong/club/service/ClubClickService.java
+++ b/backend/src/main/java/moadong/club/service/ClubClickService.java
@@ -45,6 +45,7 @@ public class ClubClickService {
     private static final long RATE_LIMIT_MAX_REQUESTS = 20L;
     private static final long BAN_DURATION_SECONDS = 30L;
     static final long MAX_CLICK_COUNT = 9_999_999_999L;
+    private static final long RANKING_CACHE_MILLIS = 1_000L;
 
     private static final RedisScript<Long> WHITELIST_SWAP_SCRIPT = RedisScript.of(
             "redis.call('DEL', KEYS[1])\n" +
@@ -65,6 +66,9 @@ public class ClubClickService {
     private final ClubRepository clubRepository;
     private final ClubClickCountRepository clickCountRepository;
     private final MongoTemplate mongoTemplate;
+
+    private volatile ClubClickRankingResponse cachedRanking;
+    private volatile long cachedRankingAt;
 
     @EventListener(ApplicationReadyEvent.class)
     public void initWhitelist() {
@@ -126,16 +130,26 @@ public class ClubClickService {
     }
 
     public ClubClickRankingResponse getRanking() {
+        ClubClickRankingResponse cached = cachedRanking;
+        if (cached != null && System.currentTimeMillis() - cachedRankingAt < RANKING_CACHE_MILLIS) {
+            return cached;
+        }
+
         List<ClubClickCount> all = clickCountRepository.findAllByOrderByClickCountDesc();
         AtomicInteger rank = new AtomicInteger(1);
         List<ClubRankItem> ranked = all.stream()
                 .map(c -> new ClubRankItem(rank.getAndIncrement(), c.getClubName(), c.getClickCount()))
                 .toList();
-        return new ClubClickRankingResponse(ranked, nextMondayMidnightKst());
+        ClubClickRankingResponse response = new ClubClickRankingResponse(ranked, nextMondayMidnightKst());
+
+        cachedRanking = response;
+        cachedRankingAt = System.currentTimeMillis();
+        return response;
     }
 
     public void resetRanking() {
         clickCountRepository.deleteAll();
+        cachedRanking = null;
         log.info("동아리 클릭 수 초기화 완료");
     }
 

--- a/backend/src/main/java/moadong/club/service/ClubClickService.java
+++ b/backend/src/main/java/moadong/club/service/ClubClickService.java
@@ -45,7 +45,9 @@ public class ClubClickService {
     private static final long RATE_LIMIT_MAX_REQUESTS = 20L;
     private static final long BAN_DURATION_SECONDS = 30L;
     static final long MAX_CLICK_COUNT = 9_999_999_999L;
-    private static final long RANKING_CACHE_MILLIS = 1_000L;
+    private static final long RANKING_CACHE_NANOS = 1_000_000_000L;
+
+    private record RankingCache(ClubClickRankingResponse response, long nanos) {}
 
     private static final RedisScript<Long> WHITELIST_SWAP_SCRIPT = RedisScript.of(
             "redis.call('DEL', KEYS[1])\n" +
@@ -67,8 +69,7 @@ public class ClubClickService {
     private final ClubClickCountRepository clickCountRepository;
     private final MongoTemplate mongoTemplate;
 
-    private volatile ClubClickRankingResponse cachedRanking;
-    private volatile long cachedRankingAt;
+    private volatile RankingCache rankingCache;
 
     @EventListener(ApplicationReadyEvent.class)
     public void initWhitelist() {
@@ -130,9 +131,9 @@ public class ClubClickService {
     }
 
     public ClubClickRankingResponse getRanking() {
-        ClubClickRankingResponse cached = cachedRanking;
-        if (cached != null && System.currentTimeMillis() - cachedRankingAt < RANKING_CACHE_MILLIS) {
-            return cached;
+        RankingCache cache = rankingCache;
+        if (cache != null && System.nanoTime() - cache.nanos() < RANKING_CACHE_NANOS) {
+            return cache.response();
         }
 
         List<ClubClickCount> all = clickCountRepository.findAllByOrderByClickCountDesc();
@@ -142,14 +143,13 @@ public class ClubClickService {
                 .toList();
         ClubClickRankingResponse response = new ClubClickRankingResponse(ranked, nextMondayMidnightKst());
 
-        cachedRanking = response;
-        cachedRankingAt = System.currentTimeMillis();
+        rankingCache = new RankingCache(response, System.nanoTime());
         return response;
     }
 
     public void resetRanking() {
         clickCountRepository.deleteAll();
-        cachedRanking = null;
+        rankingCache = null;
         log.info("동아리 클릭 수 초기화 완료");
     }
 


### PR DESCRIPTION
## 배경

프론트가 2초마다 `GET /api/game/ranking`을 폴링한다. 매 호출마다 `findAllByOrderByClickCountDesc()`가 MongoDB를 전체 정렬 조회하므로, 동시 접속자 N명이면 초당 약 N/2회의 동일 쿼리가 Mongo를 때리는 읽기 증폭이 발생한다. 매크로로 엔드포인트를 두들기면 그대로 DB 부하로 이어진다.

## 변경

- `ClubClickService.getRanking()`에 **1초 TTL 인메모리 캐시** 적용
  - 1초 내 재호출은 Mongo 조회 없이 캐시 반환 → 조회 쿼리를 **인스턴스당 초당 1회로 수렴**
- `resetRanking()`에서 캐시 무효화 → 어드민 랭킹 초기화가 즉시 반영
- 두 `volatile` 필드를 `RankingCache` record 하나로 원자화 (리뷰 반영)
- `System.currentTimeMillis()` → `System.nanoTime()` 교체 — NTP/수동 시계 보정에 의한 만료 판정 오류 방지 (리뷰 반영)

## 트레이드오프

- 리더보드에 최대 1초 staleness가 생기지만, 프론트 갱신 주기(2초)보다 짧아 체감 차이 없음
- 외부 의존성·직렬화 없이 인메모리로 처리 (Redis 캐시 대비 단순)

## 검증

- `./gradlew compileJava` 통과