### PR TITLE
[fix] 메인 바텀네비 floating 글리치 수정

### DIFF
--- a/frontend/src/components/common/BottomNavigation/BottomNavigation.styles.ts
+++ b/frontend/src/components/common/BottomNavigation/BottomNavigation.styles.ts
@@ -18,7 +18,6 @@ export const Nav = styled.nav`
     z-index: ${Z_INDEX.bottomNav};
     /* iOS/안드로이드 fixed-bottom 글리치 방지: 레이어 승격으로 visual viewport 추적 */
     transform: translateZ(0);
-    will-change: transform;
   }
 `;
 

--- a/frontend/src/components/common/BottomNavigation/BottomNavigation.styles.ts
+++ b/frontend/src/components/common/BottomNavigation/BottomNavigation.styles.ts
@@ -16,6 +16,9 @@ export const Nav = styled.nav`
     border-top: 1px solid #f0f0f0;
     padding-bottom: env(safe-area-inset-bottom);
     z-index: ${Z_INDEX.bottomNav};
+    /* iOS/안드로이드 fixed-bottom 글리치 방지: 레이어 승격으로 visual viewport 추적 */
+    transform: translateZ(0);
+    will-change: transform;
   }
 `;
 

--- a/frontend/src/hooks/Scroll/ScrollToTop.tsx
+++ b/frontend/src/hooks/Scroll/ScrollToTop.tsx
@@ -7,7 +7,9 @@ export const ScrollToTop = () => {
   const { scrollToTop } = useScrollTo();
 
   useEffect(() => {
-    scrollToTop();
+    // 경로 변경 시 즉시 이동(instant). smooth 프로그램 스크롤은
+    // 모바일에서 fixed-bottom 바텀네비가 viewport와 어긋나는 글리치를 유발함
+    scrollToTop('auto');
   }, [pathname, scrollToTop]);
 
   return null;


### PR DESCRIPTION
## 개요
상세 페이지에서 메인으로 복귀한 뒤 스크롤 시 하단 바텀네비가 visual viewport와 어긋나 위로 떠 보이는 모바일 글리치를 수정합니다.

## 원인
- 바텀네비는 `position: fixed; bottom: 0` (viewport 고정). 모바일 브라우저에서 스크롤 중 주소창/툴바 전환 시 fixed-bottom 요소가 viewport를 한 박자 늦게 따라가며 아래에 틈이 생김.
- 상세 → 메인 복귀 시 `ScrollToTop`이 경로 변경마다 `window.scrollTo({ behavior: 'smooth' })`를 호출 → 프로그램적 smooth 스크롤이 어긋남을 트리거.

## 변경 사항
- `BottomNavigation.styles.ts`: Nav에 `transform: translateZ(0)` / `will-change: transform` 추가 → 레이어 승격으로 visual viewport 즉시 추적
- `ScrollToTop.tsx`: 경로 변경 스크롤을 `scrollToTop('auto')`(instant)로 전환. `useScrollTo` 기본값(`'smooth'`)은 유지해 타 호출부 영향 없음
