### PR TITLE
[fix] 랭킹 캐시 Cache Stampede·Race Condition 방지

### DIFF
--- a/backend/src/main/java/moadong/club/service/ClubClickService.java
+++ b/backend/src/main/java/moadong/club/service/ClubClickService.java
@@ -136,18 +136,25 @@ public class ClubClickService {
             return cache.response();
         }
 
-        List<ClubClickCount> all = clickCountRepository.findAllByOrderByClickCountDesc();
-        AtomicInteger rank = new AtomicInteger(1);
-        List<ClubRankItem> ranked = all.stream()
-                .map(c -> new ClubRankItem(rank.getAndIncrement(), c.getClubName(), c.getClickCount()))
-                .toList();
-        ClubClickRankingResponse response = new ClubClickRankingResponse(ranked, nextMondayMidnightKst());
+        synchronized (this) {
+            cache = rankingCache;
+            if (cache != null && System.nanoTime() - cache.nanos() < RANKING_CACHE_NANOS) {
+                return cache.response();
+            }
 
-        rankingCache = new RankingCache(response, System.nanoTime());
-        return response;
+            List<ClubClickCount> all = clickCountRepository.findAllByOrderByClickCountDesc();
+            AtomicInteger rank = new AtomicInteger(1);
+            List<ClubRankItem> ranked = all.stream()
+                    .map(c -> new ClubRankItem(rank.getAndIncrement(), c.getClubName(), c.getClickCount()))
+                    .toList();
+            ClubClickRankingResponse response = new ClubClickRankingResponse(ranked, nextMondayMidnightKst());
+
+            rankingCache = new RankingCache(response, System.nanoTime());
+            return response;
+        }
     }
 
-    public void resetRanking() {
+    public synchronized void resetRanking() {
         clickCountRepository.deleteAll();
         rankingCache = null;
         log.info("동아리 클릭 수 초기화 완료");


### PR DESCRIPTION
## 배경

PR #1702 머지 후 리뷰 피드백 반영 추가 커밋.

## 변경

`getRanking()` / `resetRanking()` 동시성 이슈 두 가지 수정:

- **Cache Stampede** — 캐시 만료 시 여러 스레드가 동시에 DB를 조회하는 문제. `synchronized` 블록 + Double-Checked Locking 패턴으로 DB 조회를 직렬화. 캐시 히트 경로는 락 없이 통과해 성능 저하 없음.
- **Race Condition** — `resetRanking()`의 `deleteAll()` 도중 `getRanking()`이 구버전 데이터를 캐시에 덮어쓰는 문제. `resetRanking()`에 `synchronized` 추가해 두 메서드를 동일 락으로 직렬화.

## 검증

- `./gradlew compileJava` 통과