### PR TITLE
[fix] 오토클리커 방지 및 ctAt 첫 클릭 시각으로 개선

### DIFF
--- a/frontend/src/apis/game.ts
+++ b/frontend/src/apis/game.ts
@@ -5,11 +5,12 @@ import { handleResponse } from './utils/apiHelpers';
 export const postGameClick = async (
   clubName: string,
   count: number,
+  ctAt: string,
 ): Promise<void> => {
   const response = await fetch(`${API_BASE_URL}/api/game/click`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ clubName, count, ctAt: new Date().toISOString() }),
+    body: JSON.stringify({ clubName, count, ctAt }),
   });
   if (!response.ok) throw new Error('클릭 요청에 실패했습니다.');
 };

--- a/frontend/src/hooks/Queries/useGame.ts
+++ b/frontend/src/hooks/Queries/useGame.ts
@@ -13,8 +13,8 @@ export const useGameRanking = () => {
 
 export const useClickGame = () => {
   return useMutation({
-    mutationFn: ({ clubName, count }: { clubName: string; count: number }) =>
-      postGameClick(clubName, count),
+    mutationFn: ({ clubName, count, ctAt }: { clubName: string; count: number; ctAt: string }) =>
+      postGameClick(clubName, count, ctAt),
     onError: (error) => {
       console.error('Error clicking game:', error);
     },

--- a/frontend/src/hooks/Queries/useGame.ts
+++ b/frontend/src/hooks/Queries/useGame.ts
@@ -13,8 +13,15 @@ export const useGameRanking = () => {
 
 export const useClickGame = () => {
   return useMutation({
-    mutationFn: ({ clubName, count, ctAt }: { clubName: string; count: number; ctAt: string }) =>
-      postGameClick(clubName, count, ctAt),
+    mutationFn: ({
+      clubName,
+      count,
+      ctAt,
+    }: {
+      clubName: string;
+      count: number;
+      ctAt: string;
+    }) => postGameClick(clubName, count, ctAt),
     onError: (error) => {
       console.error('Error clicking game:', error);
     },

--- a/frontend/src/pages/GamePage/hooks/useBatchedClick.ts
+++ b/frontend/src/pages/GamePage/hooks/useBatchedClick.ts
@@ -3,6 +3,7 @@ import { useClickGame } from '@/hooks/Queries/useGame';
 
 const FLUSH_THRESHOLD = 5;
 const FLUSH_DELAY = 500;
+// UI 버튼(200ms)보다 짧게 잡아 버튼 핸들러를 우회하는 DOM 레벨 매크로를 차단
 const MIN_CLICK_INTERVAL = 80;
 
 /**
@@ -14,6 +15,7 @@ export const useBatchedClick = (clubName: string) => {
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastClickTimeRef = useRef(0);
   const firstClickTimeRef = useRef<string | null>(null);
+  const isMountedRef = useRef(true);
   const { mutate: clickGame } = useClickGame();
 
   const flush = useCallback(
@@ -29,8 +31,12 @@ export const useBatchedClick = (clubName: string) => {
         { clubName: name, count, ctAt },
         {
           onError: () => {
+            if (!isMountedRef.current) return;
             pendingRef.current += count;
-            if (firstClickTimeRef.current === null)
+            if (
+              firstClickTimeRef.current === null ||
+              ctAt < firstClickTimeRef.current
+            )
               firstClickTimeRef.current = ctAt;
             if (!timerRef.current) {
               timerRef.current = setTimeout(() => flush(name), FLUSH_DELAY);
@@ -51,6 +57,12 @@ export const useBatchedClick = (clubName: string) => {
   useEffect(() => {
     clubNameRef.current = clubName;
   }, [clubName]);
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   useEffect(() => {
     return () => {

--- a/frontend/src/pages/GamePage/hooks/useBatchedClick.ts
+++ b/frontend/src/pages/GamePage/hooks/useBatchedClick.ts
@@ -3,6 +3,7 @@ import { useClickGame } from '@/hooks/Queries/useGame';
 
 const FLUSH_THRESHOLD = 5;
 const FLUSH_DELAY = 500;
+const MIN_CLICK_INTERVAL = 80;
 
 /**
  * 클릭을 모아 일정 개수(5)나 디바운스(500ms) 시점에 한 번에 전송한다.
@@ -11,6 +12,8 @@ const FLUSH_DELAY = 500;
 export const useBatchedClick = (clubName: string) => {
   const pendingRef = useRef(0);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastClickTimeRef = useRef(0);
+  const firstClickTimeRef = useRef<string | null>(null);
   const { mutate: clickGame } = useClickGame();
 
   const flush = useCallback(
@@ -19,12 +22,16 @@ export const useBatchedClick = (clubName: string) => {
       timerRef.current = null;
       const count = pendingRef.current;
       if (count === 0) return;
+      const ctAt = firstClickTimeRef.current ?? new Date().toISOString();
       pendingRef.current = 0;
+      firstClickTimeRef.current = null;
       clickGame(
-        { clubName: name, count },
+        { clubName: name, count, ctAt },
         {
           onError: () => {
             pendingRef.current += count;
+            if (firstClickTimeRef.current === null)
+              firstClickTimeRef.current = ctAt;
             if (!timerRef.current) {
               timerRef.current = setTimeout(() => flush(name), FLUSH_DELAY);
             }
@@ -52,6 +59,14 @@ export const useBatchedClick = (clubName: string) => {
   }, []);
 
   const handleClick = useCallback(() => {
+    const now = Date.now();
+    if (now - lastClickTimeRef.current < MIN_CLICK_INTERVAL) return;
+    lastClickTimeRef.current = now;
+
+    if (firstClickTimeRef.current === null) {
+      firstClickTimeRef.current = new Date().toISOString();
+    }
+
     pendingRef.current += 1;
 
     if (pendingRef.current >= FLUSH_THRESHOLD) {


### PR DESCRIPTION
## Summary

- 80ms 미만 간격 클릭을 드롭하여 DOM 레벨 오토클리커(매크로) 차단
- `ctAt`를 flush 시점이 아닌 배치 내 **첫 클릭 시각**으로 전송 — 백엔드가 향후 클릭 속도 검증 가능
- 에러 재시도 시 원본 `ctAt` 보존

## 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `useBatchedClick.ts` | `MIN_CLICK_INTERVAL(80ms)` 간격 검사, `firstClickTimeRef` 추적 |
| `useGame.ts` | `ctAt` 파라미터 타입 추가 |
| `game.ts` | `ctAt`를 파라미터로 받도록 변경 (기존: 호출 시점 `new Date()`) |

## 배경

백엔드는 IP 기준 50ms 쿨다운 + 10초/20회 레이트리밋으로 API 레벨 봇을 막고 있으나, 프론트엔드에는 DOM 레벨 오토클리커 방지와 의미 있는 타임스탬프 전송이 없었음.

## Test plan

- [ ] 정상 클릭 시 카운트 증가 정상 동작 확인
- [ ] 빠른 연속 클릭(80ms 미만) 시 일부 클릭 드롭 확인
- [ ] 언마운트 시 미전송 클릭 flush 정상 동작 확인