### PR TITLE
fix: 게임 클릭 ctAt 타임스탬프 검증 추가

### DIFF
--- a/backend/src/main/java/moadong/club/controller/ClubClickController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubClickController.java
@@ -29,7 +29,7 @@ public class ClubClickController {
     @Operation(summary = "동아리 클릭 기록", description = "실제 동아리 이름으로만 클릭 수를 누적합니다. IP당 1초 쿨다운이 적용됩니다.")
     public ResponseEntity<?> recordClick(@RequestBody ClubClickRequest request, HttpServletRequest httpRequest) {
         String clientIp = resolveClientIp(httpRequest);
-        ClubClickResponse result = clubClickService.recordClick(request.clubName(), request.count(), clientIp);
+        ClubClickResponse result = clubClickService.recordClick(request.clubName(), request.count(), clientIp, request.ctAt());
         return Response.ok(result);
     }
 

--- a/backend/src/main/java/moadong/club/service/ClubClickService.java
+++ b/backend/src/main/java/moadong/club/service/ClubClickService.java
@@ -24,6 +24,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.DayOfWeek;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -86,9 +87,22 @@ public class ClubClickService {
         log.info("동아리 화이트리스트 갱신 완료 ({}개)", names.size());
     }
 
-    public ClubClickResponse recordClick(String clubName, int count, String clientIp) {
+    public ClubClickResponse recordClick(String clubName, int count, String clientIp, String ctAt) {
         if (count < 1 || count > 5) {
             throw new RestApiException(ErrorCode.CLICK_COUNT_INVALID);
+        }
+
+        try {
+            Instant clickedAt = Instant.parse(ctAt);
+            long elapsedMs = Duration.between(clickedAt, Instant.now()).toMillis();
+            // 30초 초과(재전송 방지) 또는 count×80ms보다 짧으면(물리적 불가 속도) 거부
+            if (Math.abs(elapsedMs) > 30_000L || elapsedMs < (long) count * 80) {
+                throw new RestApiException(ErrorCode.CLICK_TIMESTAMP_INVALID);
+            }
+        } catch (RestApiException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RestApiException(ErrorCode.CLICK_TIMESTAMP_INVALID);
         }
 
         String banKey = BAN_KEY_PREFIX + clientIp;

--- a/backend/src/main/java/moadong/club/service/ClubClickService.java
+++ b/backend/src/main/java/moadong/club/service/ClubClickService.java
@@ -92,11 +92,18 @@ public class ClubClickService {
             throw new RestApiException(ErrorCode.CLICK_COUNT_INVALID);
         }
 
+        if (ctAt == null || ctAt.isBlank()) {
+            throw new RestApiException(ErrorCode.CLICK_TIMESTAMP_INVALID);
+        }
         try {
             Instant clickedAt = Instant.parse(ctAt);
             long elapsedMs = Duration.between(clickedAt, Instant.now()).toMillis();
-            // 30초 초과(재전송 방지) 또는 count×80ms보다 짧으면(물리적 불가 속도) 거부
-            if (Math.abs(elapsedMs) > 30_000L || elapsedMs < (long) count * 80) {
+            // 30초 이상 과거(replay attack) 또는 2초 이상 미래(비정상) 거부
+            if (elapsedMs > 30_000L || elapsedMs < -2_000L) {
+                throw new RestApiException(ErrorCode.CLICK_TIMESTAMP_INVALID);
+            }
+            // 속도 검사: 클럭 드리프트로 음수인 경우 스킵, 그 외 count×80ms보다 짧으면 거부
+            if (elapsedMs >= 0 && elapsedMs < (long) count * 80) {
                 throw new RestApiException(ErrorCode.CLICK_TIMESTAMP_INVALID);
             }
         } catch (RestApiException e) {

--- a/backend/src/main/java/moadong/global/exception/ErrorCode.java
+++ b/backend/src/main/java/moadong/global/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     CLICK_COOLDOWN(HttpStatus.TOO_MANY_REQUESTS, "600-12", "클릭 요청이 너무 빠릅니다. 잠시 후 다시 시도해주세요."),
     CLICK_COUNT_INVALID(HttpStatus.BAD_REQUEST, "600-13", "클릭 수는 1 이상 5 이하이어야 합니다."),
     CLICK_RATE_LIMITED(HttpStatus.TOO_MANY_REQUESTS, "600-14", "비정상적인 요청이 감지되었습니다. 30초 후 다시 시도해주세요."),
+    CLICK_TIMESTAMP_INVALID(HttpStatus.BAD_REQUEST, "600-15", "클릭 시각이 유효하지 않습니다."),
 
     // 601xx: 파일/미디어 관련 오류
     IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "601-1", "이미지 업로드에 실패하였습니다."),


### PR DESCRIPTION
## Summary

- `CLICK_TIMESTAMP_INVALID(600-15)` 에러코드 추가
- `recordClick`에 `ctAt` 파라미터 추가 및 두 가지 검증 적용

## 검증 로직

| 조건 | 거부 이유 |
|------|-----------|
| `\|now - ctAt\| > 30초` | replay attack — 과거 요청 캡처 후 재전송 |
| `elapsed < count × 80ms` | 물리적으로 불가능한 클릭 속도 (80ms는 인간 최소 클릭 간격) |

## 배경

프론트엔드(`useBatchedClick`)에서 `ctAt`를 **배치 첫 클릭 시각**으로 전송하도록 수정(PR #1710)했으나, 백엔드가 해당 필드를 미사용 상태였음. 이번 PR에서 검증을 활성화하여 API 레벨 봇 차단을 강화함.

기존 방어: IP 레이트리밋(50ms 쿨다운, 10초/20회) + count 1~5 검증  
추가 방어: 타임스탬프 기반 속도/재전송 검증

## Test plan

- [ ] 정상 클릭(ctAt 최근, 속도 정상) → 200 OK
- [ ] ctAt가 31초 이전 → 400 CLICK_TIMESTAMP_INVALID
- [ ] count=5, ctAt가 100ms 전 → 400 CLICK_TIMESTAMP_INVALID
- [ ] ctAt 누락/잘못된 형식 → 400 CLICK_TIMESTAMP_INVALID