### PR TITLE
fix: 속도 검사 기준 수정 및 clubName null 체크 추가

### DIFF
--- a/backend/src/main/java/moadong/club/service/ClubClickService.java
+++ b/backend/src/main/java/moadong/club/service/ClubClickService.java
@@ -88,6 +88,9 @@ public class ClubClickService {
     }
 
     public ClubClickResponse recordClick(String clubName, int count, String clientIp, String ctAt) {
+        if (clubName == null || clubName.isBlank()) {
+            throw new RestApiException(ErrorCode.CLUB_NOT_FOUND);
+        }
         if (count < 1 || count > 5) {
             throw new RestApiException(ErrorCode.CLICK_COUNT_INVALID);
         }
@@ -102,8 +105,9 @@ public class ClubClickService {
             if (elapsedMs > 30_000L || elapsedMs < -2_000L) {
                 throw new RestApiException(ErrorCode.CLICK_TIMESTAMP_INVALID);
             }
-            // 속도 검사: 클럭 드리프트로 음수인 경우 스킵, 그 외 count×80ms보다 짧으면 거부
-            if (elapsedMs >= 0 && elapsedMs < (long) count * 80) {
+            // 속도 검사: ctAt는 첫 클릭 시각이므로 (count-1)번의 간격만 경과하면 됨
+            // 클럭 드리프트로 음수인 경우 스킵
+            if (elapsedMs >= 0 && elapsedMs < (long) (count - 1) * 80) {
                 throw new RestApiException(ErrorCode.CLICK_TIMESTAMP_INVALID);
             }
         } catch (RestApiException e) {


### PR DESCRIPTION


## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

- count×80ms → (count-1)×80ms: ctAt는 첫 클릭 시각이므로 (count-1)번 간격만 경과하면 정상 (False Positive 수정)
- clubName null/blank 시 CLUB_NOT_FOUND로 명시적 거부

## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항
