### PR TITLE
fix: 클라이언트 제공 ctAt 기반 속도 검사 제거

### DIFF
--- a/backend/src/main/java/moadong/club/service/ClubClickService.java
+++ b/backend/src/main/java/moadong/club/service/ClubClickService.java
@@ -101,13 +101,10 @@ public class ClubClickService {
         try {
             Instant clickedAt = Instant.parse(ctAt);
             long elapsedMs = Duration.between(clickedAt, Instant.now()).toMillis();
-            // 30초 이상 과거(replay attack) 또는 2초 이상 미래(비정상) 거부
+            // 30초 이상 과거(재전송 방지) 또는 2초 이상 미래(비정상 타임스탬프) 거부
+            // 속도 검사는 클라이언트 제공 타임스탬프로 수행 시 우회 가능하므로 제거
+            // 실제 속도 제한은 IP 기반 쿨다운(50ms)/레이트리밋(10초/20회)으로 처리
             if (elapsedMs > 30_000L || elapsedMs < -2_000L) {
-                throw new RestApiException(ErrorCode.CLICK_TIMESTAMP_INVALID);
-            }
-            // 속도 검사: ctAt는 첫 클릭 시각이므로 (count-1)번의 간격만 경과하면 됨
-            // 클럭 드리프트로 음수인 경우 스킵
-            if (elapsedMs >= 0 && elapsedMs < (long) (count - 1) * 80) {
                 throw new RestApiException(ErrorCode.CLICK_TIMESTAMP_INVALID);
             }
         } catch (RestApiException e) {


### PR DESCRIPTION

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

ctAt는 클라이언트가 조작 가능한 값이므로 속도 검사에 사용 시 미래/과거 시각 전송으로 우회 가능. 
실제 속도 제한은 기존 IP 기반 쿨다운(50ms)/레이트리밋(10초/20회)으로 처리.
ctAt 윈도우 체크(±30초/2초)는 재전송 방지 목적으로 유지.



## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항
