### PR TITLE
feat: 게임 클릭 버튼 모바일 진동 피드백 추가

### DIFF
--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
@@ -99,7 +99,7 @@ const ClickButton = ({
     lastClickRef.current = now;
 
     try {
-      navigator.vibrate?.(30);
+      navigator.vibrate?.(50);
     } catch {}
     setClickCount((prev) => prev + 1);
     onClickGame();

--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
@@ -98,7 +98,7 @@ const ClickButton = ({
     if (now - lastClickRef.current < 200) return;
     lastClickRef.current = now;
 
-    navigator.vibrate?.(30);
+    try { navigator.vibrate?.(30); } catch {}
     setClickCount((prev) => prev + 1);
     onClickGame();
 

--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
@@ -98,7 +98,9 @@ const ClickButton = ({
     if (now - lastClickRef.current < 200) return;
     lastClickRef.current = now;
 
-    try { navigator.vibrate?.(30); } catch {}
+    try {
+      navigator.vibrate?.(30);
+    } catch {}
     setClickCount((prev) => prev + 1);
     onClickGame();
 

--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
@@ -98,6 +98,7 @@ const ClickButton = ({
     if (now - lastClickRef.current < 200) return;
     lastClickRef.current = now;
 
+    navigator.vibrate?.(30);
     setClickCount((prev) => prev + 1);
     onClickGame();
 


### PR DESCRIPTION
## Summary

- 게임 클릭 버튼 터치 시 30ms 진동 피드백 추가
- Android Chrome/Firefox 지원, iOS Safari는 API 미지원으로 무시됨

## 변경 파일

- ClickButton.tsx: handleClick에 navigator.vibrate?.(30) 추가

## 비고

- 30ms: 빠른 연속 클릭 시 진동이 겹치지 않는 최적 길이
- iOS 지원은 RN WebView 브릿지 HAPTIC 메시지 추가 시 별도 작업 필요