### PR TITLE
[fix] 게임 페이지 세로 스크롤 및 이중 스크롤바 수정

### DIFF
--- a/frontend/src/pages/GamePage/GamePage.styles.ts
+++ b/frontend/src/pages/GamePage/GamePage.styles.ts
@@ -3,7 +3,7 @@ import { media } from '@/styles/mediaQuery';
 
 export const PageContainer = styled.div<{ $dark: boolean }>`
   position: relative;
-  overflow-x: hidden;
+  overflow-x: clip;
   min-height: 100vh;
   background: ${({ $dark, theme }) =>
     $dark ? '#111111' : theme.colors.gray[100]};

--- a/frontend/src/pages/GamePage/GamePage.tsx
+++ b/frontend/src/pages/GamePage/GamePage.tsx
@@ -95,6 +95,14 @@ const GamePage = () => {
     }
   }, [rankingData]);
 
+  useEffect(() => {
+    const bg = isDark ? '#111111' : '#F5F5F5';
+    document.body.style.background = bg;
+    return () => {
+      document.body.style.background = '';
+    };
+  }, [isDark]);
+
   const handleStart = (name: string) => {
     sessionStorage.setItem(STORAGE_KEY, name);
     setClubName(name);

--- a/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.styles.ts
+++ b/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.styles.ts
@@ -4,6 +4,7 @@ export const Wrapper = styled.div`
   width: 100%;
   max-width: 480px;
   margin: 0 auto;
+  padding-bottom: 32px;
 `;
 
 export const Header = styled.div`


### PR DESCRIPTION
## #️⃣연관된 이슈

> #1721 

## 📝작업 내용

> 특정 화면에서 스크롤이 이중으로 적용되는 문제를 해결했습니다.

<img width="960" height="431" alt="image" src="https://github.com/user-attachments/assets/a84b6480-5ecb-4bbb-a200-a0db5d24d516" />


## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항
