### PR TITLE
[fix] 관리자 로그아웃 refresh token 쿠키 처리 수정

### DIFF
--- a/backend/src/main/java/moadong/user/controller/UserController.java
+++ b/backend/src/main/java/moadong/user/controller/UserController.java
@@ -17,6 +17,7 @@ import moadong.user.payload.response.LoginResponse;
 import moadong.user.payload.response.RefreshResponse;
 import moadong.user.payload.response.TempPasswordResponse;
 import moadong.user.service.UserCommandService;
+import moadong.user.util.CookieMaker;
 import moadong.user.view.UserSwaggerView;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
@@ -38,6 +39,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final UserCommandService userCommandService;
+    private final CookieMaker cookieMaker;
 
     @PostMapping("/register")
     @Operation(
@@ -66,16 +68,10 @@ public class UserController {
     @GetMapping("/logout")
     @Operation(summary = "로그아웃", description = "클라이언트의 refresh token을 제거합니다.")
     public ResponseEntity<?> logout(
-            @CookieValue(value = "refresh_token", required = false) String refreshToken,
+            @CookieValue(value = CookieMaker.REFRESH_TOKEN_COOKIE_NAME, required = false) String refreshToken,
             HttpServletResponse response) {
         userCommandService.logoutUser(refreshToken);
-        ResponseCookie cookie = ResponseCookie.from("refreshToken", "")
-                .path("/")
-                .maxAge(0)
-                .httpOnly(true)
-                .sameSite("None")
-                .secure(true)
-                .build();
+        ResponseCookie cookie = cookieMaker.makeExpiredRefreshTokenCookie();
         response.addHeader("Set-Cookie", cookie.toString());
         return Response.ok("success logout");
     }
@@ -83,7 +79,7 @@ public class UserController {
     @PostMapping("/refresh")
     @Operation(summary = "토큰 재발급", description = "refresh token을 이용하여 access token을 재발급합니다.")
     public ResponseEntity<?> refresh(
-            @CookieValue(value = "refresh_token", required = false) String refreshToken,
+            @CookieValue(value = CookieMaker.REFRESH_TOKEN_COOKIE_NAME, required = false) String refreshToken,
             HttpServletResponse response) {
         RefreshResponse refreshResponse = userCommandService.refreshAccessToken(
                 refreshToken, response);

--- a/backend/src/main/java/moadong/user/service/UserCommandService.java
+++ b/backend/src/main/java/moadong/user/service/UserCommandService.java
@@ -120,6 +120,10 @@ public class UserCommandService {
     }
 
     public void logoutUser(String refreshToken) {
+        if (refreshToken == null || refreshToken.isBlank()) {
+            throw new RestApiException(ErrorCode.TOKEN_INVALID);
+        }
+
         User user = userRepository.findUserByRefreshTokens_Token(refreshToken)
             .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_EXIST));
 
@@ -129,7 +133,7 @@ public class UserCommandService {
 
     public RefreshResponse refreshAccessToken(String refreshToken,
         HttpServletResponse response) {
-        if (refreshToken.isBlank() ||
+        if (refreshToken == null || refreshToken.isBlank() ||
             !jwtProvider.validateToken(refreshToken, jwtProvider.extractUsername(refreshToken))) {
             throw new RestApiException(ErrorCode.TOKEN_INVALID);
         }

--- a/backend/src/main/java/moadong/user/util/CookieMaker.java
+++ b/backend/src/main/java/moadong/user/util/CookieMaker.java
@@ -9,15 +9,29 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class CookieMaker {
 
+    public static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+    private static final String REFRESH_TOKEN_COOKIE_DOMAIN = ".moadong.com";
+
     private final JwtProperties jwtProperties;
 
     public ResponseCookie makeRefreshTokenCookie(String refreshToken) {
-        return ResponseCookie.from("refreshToken", refreshToken)
+        return ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
                 .httpOnly(true)
                 .path("/")
                 .maxAge(jwtProperties.refreshToken().expiration().hour() * 60 * 60)
                 .secure(true)
-                .domain(".moadong.com")
+                .domain(REFRESH_TOKEN_COOKIE_DOMAIN)
+                .sameSite("None")
+                .build();
+    }
+
+    public ResponseCookie makeExpiredRefreshTokenCookie() {
+        return ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, "")
+                .httpOnly(true)
+                .path("/")
+                .maxAge(0)
+                .secure(true)
+                .domain(REFRESH_TOKEN_COOKIE_DOMAIN)
                 .sameSite("None")
                 .build();
     }

--- a/backend/src/main/resources/static/dev/index.html
+++ b/backend/src/main/resources/static/dev/index.html
@@ -887,7 +887,7 @@
       }
     };
 
-    function doLogout() {
+    function clearLogoutState() {
       clearToken();
       clearUserId();
       promotionMapKey = '';
@@ -900,6 +900,22 @@
       clearPromotionState();
       clearBannerState();
       clearFcmState();
+    }
+
+    async function doLogout() {
+      const btn = document.getElementById('headerLogout');
+      btn.disabled = true;
+      try {
+        await fetch(API_BASE + '/auth/user/logout', {
+          method: 'GET',
+          credentials: 'include'
+        });
+      } catch (e) {
+        console.warn('Logout request failed', e);
+      } finally {
+        btn.disabled = false;
+        clearLogoutState();
+      }
     }
 
     function openEditWindow(clubId) {

--- a/backend/src/test/java/moadong/unit/user/DevPortalLogoutTest.java
+++ b/backend/src/test/java/moadong/unit/user/DevPortalLogoutTest.java
@@ -1,0 +1,20 @@
+package moadong.unit.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+
+class DevPortalLogoutTest {
+
+    @Test
+    void 관리자_포털_로그아웃은_서버_로그아웃_API를_호출한다() throws IOException {
+        String indexHtml = new ClassPathResource("static/dev/index.html")
+                .getContentAsString(StandardCharsets.UTF_8);
+
+        assertThat(indexHtml).contains("fetch(API_BASE + '/auth/user/logout'");
+        assertThat(indexHtml).contains("credentials: 'include'");
+    }
+}

--- a/backend/src/test/java/moadong/unit/user/UserControllerTest.java
+++ b/backend/src/test/java/moadong/unit/user/UserControllerTest.java
@@ -1,0 +1,63 @@
+package moadong.unit.user;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import jakarta.servlet.http.Cookie;
+import moadong.user.controller.UserController;
+import moadong.user.service.UserCommandService;
+import moadong.user.util.CookieMaker;
+import moadong.util.annotations.UnitTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@UnitTest
+class UserControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private UserCommandService userCommandService;
+
+    @Mock
+    private CookieMaker cookieMaker;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new UserController(userCommandService, cookieMaker))
+                .build();
+    }
+
+    @Test
+    void 로그아웃은_refreshToken_쿠키를_읽고_만료시킨다() throws Exception {
+        String refreshToken = "refreshToken123";
+        ResponseCookie expiredCookie = ResponseCookie.from("refreshToken", "")
+                .path("/")
+                .maxAge(0)
+                .httpOnly(true)
+                .secure(true)
+                .domain(".moadong.com")
+                .sameSite("None")
+                .build();
+        when(cookieMaker.makeExpiredRefreshTokenCookie()).thenReturn(expiredCookie);
+
+        mockMvc.perform(get("/auth/user/logout")
+                        .cookie(new Cookie("refreshToken", refreshToken)))
+                .andExpect(status().isOk())
+                .andExpect(cookie().maxAge("refreshToken", 0))
+                .andExpect(header().string(HttpHeaders.SET_COOKIE,
+                        "refreshToken=; Path=/; Domain=.moadong.com; Max-Age=0; Expires=Thu, 1 Jan 1970 00:00:00 GMT; Secure; HttpOnly; SameSite=None"));
+
+        verify(userCommandService).logoutUser(refreshToken);
+        verify(cookieMaker).makeExpiredRefreshTokenCookie();
+    }
+}

--- a/backend/src/test/java/moadong/unit/user/UserLoginTest.java
+++ b/backend/src/test/java/moadong/unit/user/UserLoginTest.java
@@ -16,6 +16,7 @@ import java.util.Date;
 import java.util.Optional;
 import moadong.club.entity.Club;
 import moadong.club.repository.ClubRepository;
+import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
 import moadong.global.util.JwtProvider;
 import moadong.user.entity.RefreshToken;
@@ -110,5 +111,27 @@ public class UserLoginTest {
         assertThrows(RestApiException.class, ()->{
             LoginResponse result = userCommandService.loginUser(request, realHttpServletResponse);
         });
+    }
+
+    @Test
+    void 로그아웃_시에_저장된_리프레시_토큰을_제거한다() {
+        String refreshToken = "refreshToken123";
+        User user = new User();
+        user.addRefreshToken(new RefreshToken(refreshToken, Date.from(Instant.now().plusSeconds(3600))));
+        when(userRepository.findUserByRefreshTokens_Token(refreshToken)).thenReturn(Optional.of(user));
+
+        userCommandService.logoutUser(refreshToken);
+
+        assertTrue(user.getRefreshTokens().isEmpty());
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    void 로그아웃_시에_리프레시_토큰이_없으면_토큰_오류로_실패한다() {
+        RestApiException exception = assertThrows(RestApiException.class, () -> {
+            userCommandService.logoutUser(null);
+        });
+
+        assertEquals(ErrorCode.TOKEN_INVALID, exception.getErrorCode());
     }
 }

--- a/docs/spec/logout-refresh-token-cookie-spec.md
+++ b/docs/spec/logout-refresh-token-cookie-spec.md
@@ -1,0 +1,37 @@
+# 관리자 로그아웃 refresh token 쿠키 스펙
+
+## 목적
+
+관리자가 로그아웃할 때 로그인 시 발급된 refresh token이 서버 저장소와 브라우저 쿠키에서 모두 제거되어야 한다.
+
+## 문제
+
+로그인 응답은 `refreshToken` 이름으로 쿠키를 발급한다.
+로그아웃과 토큰 재발급 요청도 같은 이름의 쿠키를 읽어야 한다.
+
+쿠키 이름이 다르면 서버는 refresh token을 받지 못하고, 빈 토큰으로 계정을 조회해 `700-2 존재하지 않는 계정입니다.`를 반환할 수 있다.
+
+## 대상 범위
+
+- `POST /auth/user/login`
+- `GET /auth/user/logout`
+- `POST /auth/user/refresh`
+- 개발자 포털 관리자 인증 흐름
+
+## 정책
+
+1. refresh token 쿠키 이름은 `refreshToken`으로 통일한다.
+2. 로그아웃은 `refreshToken` 쿠키 값을 사용해 저장된 refresh token을 제거한다.
+3. 로그아웃 성공 시 로그인 쿠키와 같은 `Path=/`, `Domain=.moadong.com`, `Secure`, `HttpOnly`, `SameSite=None` 속성으로 `refreshToken` 쿠키를 만료시킨다.
+4. refresh token 쿠키가 없거나 비어 있으면 계정 조회를 하지 않고 `TOKEN_INVALID(701-1)`로 실패한다.
+5. DB에 저장된 refresh token과 일치하지 않는 유효한 형식의 토큰은 기존 정책대로 `USER_NOT_EXIST(700-2)`를 반환한다.
+6. 개발자 포털 로그아웃 버튼은 `/auth/user/logout`을 호출한 뒤 로컬 access token과 화면 상태를 정리한다.
+7. 서버 로그아웃 요청이 실패하더라도 클라이언트의 로컬 로그인 상태는 정리한다.
+
+## 검증 기준
+
+1. `GET /auth/user/logout` 요청에 `refreshToken` 쿠키가 있으면 서비스에 같은 토큰 값이 전달된다.
+2. 로그아웃 응답은 `refreshToken` 쿠키를 `Domain=.moadong.com`, `Max-Age=0`으로 만료시킨다.
+3. refresh token이 없으면 `USER_NOT_EXIST`가 아니라 `TOKEN_INVALID`가 발생한다.
+4. `POST /auth/user/refresh`도 `refreshToken` 쿠키를 읽는다.
+5. 개발자 포털 로그아웃 함수는 credentials 포함 요청으로 서버 로그아웃 API를 호출한다.


### PR DESCRIPTION
## #️⃣연관된 이슈

> #1723, MOA-988

## 📝작업 내용

- 로그인에서 발급하는 refresh token 쿠키명(`refreshToken`)과 로그아웃/토큰 재발급에서 읽는 쿠키명을 통일했습니다.
- refresh token이 누락된 로그아웃 요청은 계정 조회 전에 `TOKEN_INVALID(701-1)`로 실패하도록 방어했습니다.
- 로그아웃 만료 쿠키가 로그인 쿠키와 같은 `Domain=.moadong.com`, `Path=/`, `Secure`, `HttpOnly`, `SameSite=None` 속성을 사용하도록 공통 CookieMaker로 정리했습니다.
- 개발자 포털 로그아웃 버튼이 서버 로그아웃 API(`/auth/user/logout`)를 호출한 뒤 로컬 로그인 상태를 정리하도록 수정했습니다.
- 로그아웃 쿠키 바인딩, 토큰 누락 방어, 개발자 포털 로그아웃 호출 회귀 테스트와 SDD 스펙 문서를 추가했습니다.

## 중점적으로 리뷰받고 싶은 부분(선택)

- refresh token 쿠키명을 `refreshToken`으로 통일한 방향이 기존 클라이언트/운영 쿠키 정책과 맞는지 확인 부탁드립니다.
- 쿠키 누락 시 `USER_NOT_EXIST` 대신 `TOKEN_INVALID`로 처리하는 에러 정책이 적절한지 봐주세요.
- 로그아웃 만료 쿠키에 `Domain=.moadong.com`을 포함한 것이 운영 쿠키 삭제 조건과 일치하는지 확인 부탁드립니다.

## 논의하고 싶은 부분(선택)

- 로그아웃 API가 실패하더라도 개발자 포털에서는 로컬 세션을 정리하도록 했습니다. 관리자 도구 UX 기준으로 이 동작을 유지할지 확인이 필요합니다.

## 🫡 참고사항

- 검증: `backend`에서 `.\gradlew.bat test --tests moadong.unit.user.UserControllerTest --tests moadong.unit.user.UserLoginTest --tests moadong.unit.user.DevPortalLogoutTest`
- 검증: `backend`에서 `.\gradlew.bat test`
- 검증: `git diff --check`
- 미추적 파일 `backend/.gradle-user-home/`는 커밋에 포함하지 않았습니다.