### PR TITLE
[chore] Vite dev proxy 설정 및 API base URL dev/prod 분기

### DIFF
--- a/frontend/config/vite.config.ts
+++ b/frontend/config/vite.config.ts
@@ -97,8 +97,8 @@ export default defineConfig(({ mode }) => {
     server: {
       port: DEFAULT_PORT,
       proxy: {
-        '/api': { target: 'https://yourun.shop', changeOrigin: true, cookieDomainRewrite: 'localhost' },
-        '/auth': { target: 'https://yourun.shop', changeOrigin: true, cookieDomainRewrite: 'localhost' },
+        '/api': { target: env.VITE_API_BASE_URL || 'https://yourun.shop', changeOrigin: true, cookieDomainRewrite: 'localhost' },
+        '/auth': { target: env.VITE_API_BASE_URL || 'https://yourun.shop', changeOrigin: true, cookieDomainRewrite: 'localhost' },
       },
     },
   };

--- a/frontend/config/vite.config.ts
+++ b/frontend/config/vite.config.ts
@@ -96,6 +96,10 @@ export default defineConfig(({ mode }) => {
     },
     server: {
       port: DEFAULT_PORT,
+      proxy: {
+        '/api': { target: 'https://yourun.shop', changeOrigin: true, cookieDomainRewrite: 'localhost' },
+        '/auth': { target: 'https://yourun.shop', changeOrigin: true, cookieDomainRewrite: 'localhost' },
+      },
     },
   };
 });

--- a/frontend/config/vite.config.ts
+++ b/frontend/config/vite.config.ts
@@ -98,12 +98,12 @@ export default defineConfig(({ mode }) => {
       port: DEFAULT_PORT,
       proxy: {
         '/api': {
-          target: env.VITE_API_BASE_URL || 'https://yourun.shop',
+          target: env.VITE_API_BASE_URL,
           changeOrigin: true,
           cookieDomainRewrite: 'localhost',
         },
         '/auth': {
-          target: env.VITE_API_BASE_URL || 'https://yourun.shop',
+          target: env.VITE_API_BASE_URL,
           changeOrigin: true,
           cookieDomainRewrite: 'localhost',
         },

--- a/frontend/config/vite.config.ts
+++ b/frontend/config/vite.config.ts
@@ -97,8 +97,16 @@ export default defineConfig(({ mode }) => {
     server: {
       port: DEFAULT_PORT,
       proxy: {
-        '/api': { target: env.VITE_API_BASE_URL || 'https://yourun.shop', changeOrigin: true, cookieDomainRewrite: 'localhost' },
-        '/auth': { target: env.VITE_API_BASE_URL || 'https://yourun.shop', changeOrigin: true, cookieDomainRewrite: 'localhost' },
+        '/api': {
+          target: env.VITE_API_BASE_URL || 'https://yourun.shop',
+          changeOrigin: true,
+          cookieDomainRewrite: 'localhost',
+        },
+        '/auth': {
+          target: env.VITE_API_BASE_URL || 'https://yourun.shop',
+          changeOrigin: true,
+          cookieDomainRewrite: 'localhost',
+        },
       },
     },
   };

--- a/frontend/src/constants/api.ts
+++ b/frontend/src/constants/api.ts
@@ -1,2 +1,4 @@
-const API_BASE_URL = import.meta.env.DEV ? window.location.origin : import.meta.env.VITE_API_BASE_URL;
+const API_BASE_URL = import.meta.env.DEV
+  ? window.location.origin
+  : import.meta.env.VITE_API_BASE_URL;
 export default API_BASE_URL;

--- a/frontend/src/constants/api.ts
+++ b/frontend/src/constants/api.ts
@@ -1,2 +1,2 @@
-const API_BASE_URL = import.meta.env.DEV ? '' : import.meta.env.VITE_API_BASE_URL;
+const API_BASE_URL = import.meta.env.DEV ? window.location.origin : import.meta.env.VITE_API_BASE_URL;
 export default API_BASE_URL;

--- a/frontend/src/constants/api.ts
+++ b/frontend/src/constants/api.ts
@@ -1,2 +1,2 @@
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+const API_BASE_URL = import.meta.env.DEV ? '' : import.meta.env.VITE_API_BASE_URL;
 export default API_BASE_URL;


### PR DESCRIPTION
## Summary
- `config/vite.config.ts`: `/api`, `/auth` 경로를 `https://yourun.shop`으로 프록시 추가 (`changeOrigin`, `cookieDomainRewrite: 'localhost'`)
- `src/constants/api.ts`: DEV 환경에서 빈 문자열 반환 → 상대경로로 요청 → Vite 프록시가 가로챔

## 배경
Conductor 워크스페이스는 동적 포트(`$CONDUCTOR_PORT`)를 할당하는데, 인증이 `credentials: 'include'`(쿠키 기반 refresh token)를 사용하므로 CORS 와일드카드 origin이 금지됨. 포트가 바뀔 때마다 백엔드 allowlist 관리가 불가능한 문제를 Vite proxy로 same-origin화하여 해결.

## Test plan
- [ ] dev 서버 실행 후 `/api`, `/auth` 요청이 CORS 없이 정상 응답하는지 확인
- [ ] 로그인(쿠키 기반 refresh token) 정상 동작 확인
- [ ] prod 빌드(`npm run build`) 타입 에러 없이 통과 확인

Closes #1725

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 개발 환경에서의 API 프록시 구성이 개선되었습니다.
  * 환경에 따라 API 기본 URL이 자동으로 구성되도록 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->