### PR TITLE
chore: PR 머지 시 참조 이슈 자동 닫기

### DIFF
--- a/.github/workflows/close-issue-on-pr-merge.yml
+++ b/.github/workflows/close-issue-on-pr-merge.yml
@@ -1,0 +1,32 @@
+name: Close Issue on PR Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [develop-fe, main]
+
+jobs:
+  close-issue:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Close referenced issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const pattern = /(?:closes?|fixes?|resolves?)\s+#(\d+)/gi;
+            const matches = [...body.matchAll(pattern)];
+
+            for (const match of matches) {
+              const issueNumber = parseInt(match[1]);
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                state: 'closed',
+              });
+              console.log(`Closed issue #${issueNumber}`);
+            }


### PR DESCRIPTION
## Summary
- PR body의 `Closes #xxx` / `Fixes #xxx` / `Resolves #xxx` 패턴을 파싱해 머지 시 GitHub 이슈 자동 닫기
- `develop-fe`, `main` 브랜치 대상 PR에 적용

## 배경
GitHub 기본 동작은 default branch(main)로 머지 시에만 이슈 자동 닫힘. develop-fe로 머지 시엔 수동으로 닫아야 했음.

## 보안
PR body는 `actions/github-script` JS context에서 처리, `parseInt()`로 이슈 번호만 추출 → shell injection 없음