### PR TITLE
chore: 캘린더 메뉴 개발 환경에서만 노출

### DIFF
--- a/frontend/config/vite.config.ts
+++ b/frontend/config/vite.config.ts
@@ -20,6 +20,9 @@ export default defineConfig(({ mode }) => {
   }
 
   return {
+    define: {
+      __VERCEL_PREVIEW__: process.env.VERCEL_ENV === 'preview',
+    },
     plugins: [
       react({
         babel: {

--- a/frontend/src/constants/adminTabs.ts
+++ b/frontend/src/constants/adminTabs.ts
@@ -15,7 +15,7 @@ export const ADMIN_TABS: TabCategory[] = [
       { label: '기본 정보 수정', path: '/admin/club-info' },
       { label: '소개 정보 수정', path: '/admin/club-intro' },
       { label: '활동 사진 수정', path: '/admin/photo-edit' },
-      ...(import.meta.env.DEV
+      ...(import.meta.env.DEV || __VERCEL_PREVIEW__
         ? [{ label: '동아리 일정 관리', path: '/admin/calendar-sync' }]
         : []),
     ],

--- a/frontend/src/constants/adminTabs.ts
+++ b/frontend/src/constants/adminTabs.ts
@@ -15,8 +15,9 @@ export const ADMIN_TABS: TabCategory[] = [
       { label: '기본 정보 수정', path: '/admin/club-info' },
       { label: '소개 정보 수정', path: '/admin/club-intro' },
       { label: '활동 사진 수정', path: '/admin/photo-edit' },
-      // TODO: 캘린더 기능 재오픈 시 복구
-      // { label: '동아리 일정 관리', path: '/admin/calendar-sync' },
+      ...(import.meta.env.DEV
+        ? [{ label: '동아리 일정 관리', path: '/admin/calendar-sync' }]
+        : []),
     ],
   },
   {

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,2 +1,4 @@
 /// <reference types="vite/client" />
 /// <reference types="vite-plugin-svgr/client" />
+
+declare const __VERCEL_PREVIEW__: boolean;


### PR DESCRIPTION
## Summary
- 관리자 사이드바의 '동아리 일정 관리' 메뉴를 개발 환경(`import.meta.env.DEV`)에서만 노출되도록 변경
- 프로덕션 빌드에서는 캘린더 메뉴가 포함되지 않음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 관리자 기능 업데이트

* **기능 조정**
  * 동아리 일정 관리 메뉴가 개발 환경에서만 관리자 탭에 표시되도록 변경되었습니다. 프로덕션 환경에서는 해당 메뉴에 접근할 수 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->