### PR TITLE
fix: 상세페이지 카드가 푸터 위로 겹치는 z-index 문제 수정

### DIFF
--- a/frontend/src/pages/ClubDetailPage/components/ClubDetailFooter/ClubDetailFooter.styles.ts
+++ b/frontend/src/pages/ClubDetailPage/components/ClubDetailFooter/ClubDetailFooter.styles.ts
@@ -4,6 +4,7 @@ import { media } from '@/styles/mediaQuery';
 export const ClubDetailFooterContainer = styled.div`
   position: sticky;
   bottom: 0;
+  z-index: 10;
   width: 100%;
   padding: 10px 0px 24px 0px;
 

--- a/frontend/src/pages/ClubDetailPage/components/ClubDetailFooter/ClubDetailFooter.styles.ts
+++ b/frontend/src/pages/ClubDetailPage/components/ClubDetailFooter/ClubDetailFooter.styles.ts
@@ -1,10 +1,11 @@
 import styled from 'styled-components';
 import { media } from '@/styles/mediaQuery';
+import { Z_INDEX } from '@/styles/zIndex';
 
 export const ClubDetailFooterContainer = styled.div`
   position: sticky;
   bottom: 0;
-  z-index: 10;
+  z-index: ${Z_INDEX.clubDetailFooter};
   width: 100%;
   padding: 10px 0px 24px 0px;
 

--- a/frontend/src/styles/zIndex.ts
+++ b/frontend/src/styles/zIndex.ts
@@ -1,4 +1,5 @@
 export const Z_INDEX = {
+  clubDetailFooter: 10, // 상세페이지 하단 푸터
   header: 1000, // 전역 헤더
   bottomNav: 1000, // 하단 네비게이션
   floatingButton: 1050, // 플로팅 버튼


### PR DESCRIPTION
## Summary
- ClubDetailFooter에 `z-index: 10` 추가
- ClubProfileCard의 Content(z-index: 2), LogoWrapper(z-index: 3)보다 높게 설정하여 푸터가 카드 위에 렌더링되도록 수정

## Test plan
- [x] 상세페이지에서 스크롤 시 하단 "지원하기" 푸터가 카드 콘텐츠 위에 정상 표시되는지 확인
- [x] 모달, 헤더 등 다른 z-index 요소와 충돌 없는지 확인