### PR TITLE
fix: 캘린더 연동 상태가 항상 false로 반환되는 버그 수정

### DIFF
--- a/backend/src/main/java/moadong/calendar/notion/service/NotionOAuthService.java
+++ b/backend/src/main/java/moadong/calendar/notion/service/NotionOAuthService.java
@@ -491,6 +491,7 @@ public class NotionOAuthService {
         try {
             String encryptedAccessToken = cipher.encrypt(body.accessToken());
             NotionConnection connection = notionConnectionRepository.findById(clubId)
+                    .or(() -> findLegacyNotionConnectionAndMigrate(clubId))
                     .orElse(NotionConnection.builder().clubId(clubId).build());
             connection.updateConnection(encryptedAccessToken, body.workspaceName(), body.workspaceId());
             notionConnectionRepository.save(connection);
@@ -540,8 +541,7 @@ public class NotionOAuthService {
     }
 
     private void saveDatabaseId(String clubId, String databaseId) {
-        NotionConnection connection = notionConnectionRepository.findById(clubId)
-                .orElseThrow(() -> new RestApiException(ErrorCode.NOTION_NOT_CONNECTED));
+        NotionConnection connection = getNotionConnection(clubId);
         connection.updateDatabaseId(databaseId);
         notionConnectionRepository.save(connection);
     }

--- a/backend/src/main/java/moadong/calendar/notion/service/NotionOAuthService.java
+++ b/backend/src/main/java/moadong/calendar/notion/service/NotionOAuthService.java
@@ -24,10 +24,6 @@ import moadong.club.payload.dto.ClubCalendarEventResult;
 import moadong.club.repository.ClubRepository;
 import moadong.user.payload.CustomUserDetails;
 import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.query.Criteria;
-import org.springframework.data.mongodb.core.query.Query;
-import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -46,7 +42,6 @@ public class NotionOAuthService {
 
     private final RestTemplate restTemplate;
     private final NotionConnectionRepository notionConnectionRepository;
-    private final MongoTemplate mongoTemplate;
     private final ClubRepository clubRepository;
     private final AESCipher cipher;
     private final NotionProperties notionProperties;
@@ -495,13 +490,10 @@ public class NotionOAuthService {
     private void saveNotionConnection(String clubId, NotionTokenApiResponse body) {
         try {
             String encryptedAccessToken = cipher.encrypt(body.accessToken());
-            Query query = Query.query(Criteria.where("_id").is(clubId));
-            Update update = new Update()
-                    .set("encryptedAccessToken", encryptedAccessToken)
-                    .set("workspaceName", body.workspaceName())
-                    .set("workspaceId", body.workspaceId())
-                    .set("updatedAt", LocalDateTime.now());
-            mongoTemplate.upsert(query, update, NotionConnection.class);
+            NotionConnection connection = notionConnectionRepository.findById(clubId)
+                    .orElse(NotionConnection.builder().clubId(clubId).build());
+            connection.updateConnection(encryptedAccessToken, body.workspaceName(), body.workspaceId());
+            notionConnectionRepository.save(connection);
         } catch (Exception e) {
             log.error("Notion access token 암호화 저장 실패. clubId={}", clubId, e);
             throw new RestApiException(ErrorCode.NOTION_TOKEN_SAVE_FAILED);
@@ -548,14 +540,10 @@ public class NotionOAuthService {
     }
 
     private void saveDatabaseId(String clubId, String databaseId) {
-        Query query = Query.query(Criteria.where("_id").is(clubId));
-        Update update = new Update()
-                .set("databaseId", databaseId)
-                .set("updatedAt", LocalDateTime.now());
-        com.mongodb.client.result.UpdateResult result = mongoTemplate.updateFirst(query, update, NotionConnection.class);
-        if (result.getMatchedCount() == 0) {
-            throw new RestApiException(ErrorCode.NOTION_NOT_CONNECTED);
-        }
+        NotionConnection connection = notionConnectionRepository.findById(clubId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.NOTION_NOT_CONNECTED));
+        connection.updateDatabaseId(databaseId);
+        notionConnectionRepository.save(connection);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary
- `NotionOAuthService`에서 `mongoTemplate`(raw query)과 `MongoRepository`를 혼용하여 `_id` BSON 타입 불일치(String vs ObjectId) 발생
- `hasCalendarConnection`이 캘린더 연동 후에도 항상 `false`를 반환하던 문제 수정
- `saveNotionConnection`, `saveDatabaseId`를 기존 엔티티 메서드(`updateConnection`, `updateDatabaseId`) + Repository `save()`로 교체하여 일관된 `_id` 타입 보장

## Test plan
- [x] `./gradlew build -x test` 빌드 성공
- [ ] Notion OAuth 연동 후 `/api/club/{id}` 응답에서 `hasCalendarConnection: true` 확인
- [ ] 운영 DB `notion_connections` 컬렉션의 기존 `_id` 타입 확인 (String으로 저장된 문서가 있다면 마이그레이션 필요)
