### PR TITLE
fix: frontend CI lint errors 수정

### DIFF
--- a/frontend/src/pages/GamePage/components/BackgroundFirework/BackgroundFirework.tsx
+++ b/frontend/src/pages/GamePage/components/BackgroundFirework/BackgroundFirework.tsx
@@ -30,7 +30,7 @@ const BackgroundFirework = () => {
         spin: (Math.random() - 0.5) * 1080,
         duration: 1.3 + Math.random() * 0.6,
       };
-    })
+    }),
   );
 
   return (

--- a/frontend/src/pages/GamePage/components/BackgroundFirework/BackgroundFirework.tsx
+++ b/frontend/src/pages/GamePage/components/BackgroundFirework/BackgroundFirework.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from 'react';
+import { memo, useState } from 'react';
 import { motion } from 'framer-motion';
 
 const PARTICLE_COUNT = 70;
@@ -13,26 +13,24 @@ const PARTICLE_COLORS = [
 ];
 
 const BackgroundFirework = () => {
-  const particles = useMemo(
-    () =>
-      Array.from({ length: PARTICLE_COUNT }, (_, i) => {
-        const angle =
-          (i / PARTICLE_COUNT) * Math.PI * 2 + (Math.random() - 0.5) * 0.3;
-        const distance = 280 + Math.random() * 380;
-        const size = 8 + Math.random() * 16;
-        const isConfetti = Math.random() > 0.45;
-        return {
-          x: Math.cos(angle) * distance,
-          y: Math.sin(angle) * distance,
-          color:
-            PARTICLE_COLORS[Math.floor(Math.random() * PARTICLE_COLORS.length)],
-          size,
-          isConfetti,
-          spin: (Math.random() - 0.5) * 1080,
-          duration: 1.3 + Math.random() * 0.6,
-        };
-      }),
-    [],
+  const [particles] = useState(() =>
+    Array.from({ length: PARTICLE_COUNT }, (_, i) => {
+      const angle =
+        (i / PARTICLE_COUNT) * Math.PI * 2 + (Math.random() - 0.5) * 0.3;
+      const distance = 280 + Math.random() * 380;
+      const size = 8 + Math.random() * 16;
+      const isConfetti = Math.random() > 0.45;
+      return {
+        x: Math.cos(angle) * distance,
+        y: Math.sin(angle) * distance,
+        color:
+          PARTICLE_COLORS[Math.floor(Math.random() * PARTICLE_COLORS.length)],
+        size,
+        isConfetti,
+        spin: (Math.random() - 0.5) * 1080,
+        duration: 1.3 + Math.random() * 0.6,
+      };
+    })
   );
 
   return (

--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
@@ -37,7 +37,7 @@ const Firework = () => {
         spin: (Math.random() - 0.5) * 720,
         duration: 0.7 + Math.random() * 0.4,
       };
-    })
+    }),
   );
 
   return (

--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useEffect, useRef, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import * as S from './ClickButton.styles';
 
@@ -20,26 +20,24 @@ const PARTICLE_COLORS = [
 ];
 
 const Firework = () => {
-  const particles = useMemo(
-    () =>
-      Array.from({ length: PARTICLE_COUNT }, (_, i) => {
-        const angle =
-          (i / PARTICLE_COUNT) * Math.PI * 2 + (Math.random() - 0.5) * 0.4;
-        const distance = 160 + Math.random() * 130;
-        const size = 6 + Math.random() * 11;
-        const isConfetti = Math.random() > 0.5;
-        return {
-          x: Math.cos(angle) * distance,
-          y: Math.sin(angle) * distance,
-          color:
-            PARTICLE_COLORS[Math.floor(Math.random() * PARTICLE_COLORS.length)],
-          size,
-          isConfetti,
-          spin: (Math.random() - 0.5) * 720,
-          duration: 0.7 + Math.random() * 0.4,
-        };
-      }),
-    [],
+  const [particles] = useState(() =>
+    Array.from({ length: PARTICLE_COUNT }, (_, i) => {
+      const angle =
+        (i / PARTICLE_COUNT) * Math.PI * 2 + (Math.random() - 0.5) * 0.4;
+      const distance = 160 + Math.random() * 130;
+      const size = 6 + Math.random() * 11;
+      const isConfetti = Math.random() > 0.5;
+      return {
+        x: Math.cos(angle) * distance,
+        y: Math.sin(angle) * distance,
+        color:
+          PARTICLE_COLORS[Math.floor(Math.random() * PARTICLE_COLORS.length)],
+        size,
+        isConfetti,
+        spin: (Math.random() - 0.5) * 720,
+        duration: 0.7 + Math.random() * 0.4,
+      };
+    })
   );
 
   return (

--- a/frontend/src/pages/GamePage/hooks/useBatchedClick.ts
+++ b/frontend/src/pages/GamePage/hooks/useBatchedClick.ts
@@ -40,7 +40,10 @@ export const useBatchedClick = (clubName: string) => {
             )
               firstClickTimeRef.current = ctAt;
             if (!timerRef.current) {
-              timerRef.current = setTimeout(() => flushRef.current(name), FLUSH_DELAY);
+              timerRef.current = setTimeout(
+                () => flushRef.current(name),
+                FLUSH_DELAY,
+              );
             }
           },
         },

--- a/frontend/src/pages/GamePage/hooks/useBatchedClick.ts
+++ b/frontend/src/pages/GamePage/hooks/useBatchedClick.ts
@@ -17,6 +17,7 @@ export const useBatchedClick = (clubName: string) => {
   const firstClickTimeRef = useRef<string | null>(null);
   const isMountedRef = useRef(true);
   const { mutate: clickGame } = useClickGame();
+  const flushRef = useRef<(name: string) => void>(() => {});
 
   const flush = useCallback(
     (name: string) => {
@@ -39,7 +40,7 @@ export const useBatchedClick = (clubName: string) => {
             )
               firstClickTimeRef.current = ctAt;
             if (!timerRef.current) {
-              timerRef.current = setTimeout(() => flush(name), FLUSH_DELAY);
+              timerRef.current = setTimeout(() => flushRef.current(name), FLUSH_DELAY);
             }
           },
         },
@@ -49,7 +50,6 @@ export const useBatchedClick = (clubName: string) => {
   );
 
   // 언마운트 시 최신 flush/clubName으로 미전송분을 보내기 위한 ref 미러
-  const flushRef = useRef(flush);
   const clubNameRef = useRef(clubName);
   useEffect(() => {
     flushRef.current = flush;


### PR DESCRIPTION
## Summary
- `BackgroundFirework.tsx`, `ClickButton.tsx`: `useMemo` 안에서 `Math.random()` 호출이 `react-hooks/purity` error 발생 → `useState` 초기화 함수로 변경
- `useBatchedClick.ts`: `useCallback` 내부에서 자기 자신(`flush`)을 재귀 호출 시 선언 전 접근으로 `react-hooks/immutability` error 발생 → `flushRef`를 선언 앞으로 이동, `flushRef.current(name)` 으로 변경

## Test plan
- [ ] `npm run lint` exit code 0 확인 (0 errors, 90 warnings)
- [ ] GamePage 불꽃 애니메이션 동작 확인