### PR TITLE
[fix] 상세 페이지 탭 이중 노출 해결

### DIFF
--- a/frontend/docs/features/club-detail/sticky-tab-dedup.md
+++ b/frontend/docs/features/club-detail/sticky-tab-dedup.md
@@ -1,0 +1,59 @@
+# 상세 페이지 탭 이중 노출 해결
+
+상세 페이지 스크롤 시 인라인 탭과 헤더 sticky 탭이 동시에 보이는 문제를 수정한다.
+
+## 문제
+
+`ClubDetailPage`에는 탭 UI가 두 곳에 있다.
+
+- **인라인 탭** (`RightSection` 내 `UnderlineTabs`): 콘텐츠 흐름 속에 위치
+- **헤더 sticky 탭** (`ClubDetailTopBar` 내 `TabBar`): 스크롤 후 상단 고정
+
+기존에는 `ClubDetailTopBar`가 내부적으로 `useScrollTrigger(360px)`로 sticky 탭 표시를 결정했다. 360px은 임의의 고정값이라 화면이 큰 기기에서 두 탭이 동시에 노출되는 구간이 생겼다.
+
+## 해결
+
+`IntersectionObserver`로 인라인 탭 요소가 TopBar 뒤로 잘리는 시점을 감지해 두 탭을 정확히 교체한다.
+
+```
+인라인 탭 요소 상단이 TopBar(73px) 아래로 잘리기 시작
+  → showStickyTabs = true
+  → ClubDetailTopBar: showTabs prop으로 헤더 탭 표시
+  → InlineTabsWrapper: visibility: hidden으로 인라인 탭 숨김
+```
+
+`visibility: hidden`을 사용해 인라인 탭의 레이아웃 공간을 유지하며 숨긴다. (`display: none`이면 레이아웃이 밀림)
+
+## 구조 변경
+
+탭 표시 타이밍 결정 책임이 `ClubDetailTopBar` → `ClubDetailPage`로 이동했다.
+
+- `ClubDetailTopBar`: `showTabs` prop을 받아 렌더링만 담당
+- `ClubDetailPage`: `IntersectionObserver`로 타이밍 결정 후 prop으로 전달
+
+### DOM 마운트 타이밍 문제
+
+`clubDetail` 로드 전엔 컴포넌트가 `null`을 반환해 인라인 탭 DOM이 없다. `useRef`는 ref가 채워져도 effect를 재실행하지 않으므로 관찰자가 등록되지 않는 경우가 생긴다. DOM 요소를 `useState`로 관리(callback ref 패턴)하면 마운트 시 state 변경으로 effect가 정확히 재실행된다.
+
+```ts
+const [inlineTabsEl, setInlineTabsEl] = useState<HTMLDivElement | null>(null);
+
+useEffect(() => {
+  if (!showTopBar || !inlineTabsEl) return;
+  const observer = new IntersectionObserver(
+    ([entry]) => setShowStickyTabs(!entry.isIntersecting),
+    { rootMargin: '-73px 0px 0px 0px', threshold: 1 },
+  );
+  observer.observe(inlineTabsEl);
+  return () => observer.disconnect();
+}, [showTopBar, inlineTabsEl]);
+
+// JSX
+<Styled.InlineTabsWrapper ref={setInlineTabsEl} $hidden={showTopBar && showStickyTabs}>
+```
+
+## 관련 코드
+
+- `src/pages/ClubDetailPage/ClubDetailPage.tsx` — IntersectionObserver 로직, showStickyTabs 상태
+- `src/pages/ClubDetailPage/ClubDetailPage.styles.ts` — `InlineTabsWrapper` (visibility 제어)
+- `src/pages/ClubDetailPage/components/ClubDetailTopBar/ClubDetailTopBar.tsx` — `showTabs` prop 수신

--- a/frontend/docs/features/club-detail/sticky-tab-dedup.md
+++ b/frontend/docs/features/club-detail/sticky-tab-dedup.md
@@ -42,7 +42,7 @@ useEffect(() => {
   if (!showTopBar || !inlineTabsEl) return;
   const observer = new IntersectionObserver(
     ([entry]) => setShowStickyTabs(!entry.isIntersecting),
-    { rootMargin: '-73px 0px 0px 0px', threshold: 1 },
+    { rootMargin: `-${TOP_BAR_RENDERED_HEIGHT}px 0px 0px 0px`, threshold: 1 },
   );
   observer.observe(inlineTabsEl);
   return () => observer.disconnect();

--- a/frontend/src/pages/ClubDetailPage/ClubDetailPage.styles.ts
+++ b/frontend/src/pages/ClubDetailPage/ClubDetailPage.styles.ts
@@ -111,6 +111,10 @@ export const RightSection = styled.div`
   }
 `;
 
+export const InlineTabsWrapper = styled.div<{ $hidden: boolean }>`
+  visibility: ${({ $hidden }) => ($hidden ? 'hidden' : 'visible')};
+`;
+
 export const TabContent = styled.div`
   animation: fadeIn ${transitions.duration.normal}
     ${transitions.easing.easeInOut};

--- a/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
@@ -35,6 +35,8 @@ type TabType = (typeof TAB_TYPE)[keyof typeof TAB_TYPE];
 
 // 탭 클릭 시 스크롤이 탑바 하단에 정확히 위치하도록 하는 높이 값
 const TOP_BAR_HEIGHT = 50;
+// 인라인 탭이 TopBar 뒤로 가려지는 시점을 감지하는 IntersectionObserver rootMargin 값 (TopBarContent 60px + 하단 여백)
+const TOP_BAR_RENDERED_HEIGHT = 73;
 
 const ClubDetailPage = () => {
   const trackEvent = useMixpanelTrack();
@@ -92,7 +94,7 @@ const ClubDetailPage = () => {
     // 인라인 탭이 TopBar 아래로 잘리기 시작하는 순간 헤더 탭으로 교체
     const observer = new IntersectionObserver(
       ([entry]) => setShowStickyTabs(!entry.isIntersecting),
-      { rootMargin: '-73px 0px 0px 0px', threshold: 1 },
+      { rootMargin: `-${TOP_BAR_RENDERED_HEIGHT}px 0px 0px 0px`, threshold: 1 },
     );
     observer.observe(inlineTabsEl);
     return () => observer.disconnect();

--- a/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import LocationIcon from '@/assets/images/icons/location_icon.svg?react';
 import Footer from '@/components/common/Footer/Footer';
@@ -76,21 +76,27 @@ const ClubDetailPage = () => {
     [],
   );
 
-  const topBarTabs = useMemo(
-    () => [
-      { key: TAB_TYPE.INTRO, label: '소개내용' },
-      { key: TAB_TYPE.PHOTOS, label: '활동사진' },
-      { key: TAB_TYPE.SCHEDULE, label: '행사일정' },
-    ],
-    [],
-  );
-
   useTrackPageView(
     PAGE_VIEW.CLUB_DETAIL_PAGE,
     clubDetail?.name,
     !clubDetail,
     clubDetail?.recruitmentStatus,
   );
+
+  const [showStickyTabs, setShowStickyTabs] = useState(false);
+  const [inlineTabsEl, setInlineTabsEl] = useState<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!showTopBar || !inlineTabsEl) return;
+
+    // 인라인 탭이 TopBar 아래로 잘리기 시작하는 순간 헤더 탭으로 교체
+    const observer = new IntersectionObserver(
+      ([entry]) => setShowStickyTabs(!entry.isIntersecting),
+      { rootMargin: '-73px 0px 0px 0px', threshold: 1 },
+    );
+    observer.observe(inlineTabsEl);
+    return () => observer.disconnect();
+  }, [showTopBar, inlineTabsEl]);
 
   const contentRef = useRef<HTMLDivElement>(null);
   const { scrollToElement } = useScrollTo();
@@ -134,13 +140,14 @@ const ClubDetailPage = () => {
         <ClubDetailTopBar
           clubId={clubDetail.id}
           clubName={clubDetail.name}
-          tabs={topBarTabs}
+          tabs={tabs}
           activeTab={activeTab}
           onTabClick={(tabKey) => {
             handleTabClick(tabKey as TabType);
             scrollToContent();
           }}
           initialIsSubscribed={searchParams.get('is_subscribed') === 'true'}
+          showTabs={showStickyTabs}
         />
       )}
       <Styled.Container>
@@ -181,12 +188,17 @@ const ClubDetailPage = () => {
           </Styled.LeftSection>
 
           <Styled.RightSection ref={contentRef}>
-            <UnderlineTabs
-              tabs={tabs}
-              activeKey={activeTab}
-              onTabClick={(tabKey) => handleTabClick(tabKey as TabType)}
-              centerOnMobile
-            />
+            <Styled.InlineTabsWrapper
+              ref={setInlineTabsEl}
+              $hidden={showTopBar && showStickyTabs}
+            >
+              <UnderlineTabs
+                tabs={tabs}
+                activeKey={activeTab}
+                onTabClick={(tabKey) => handleTabClick(tabKey as TabType)}
+                centerOnMobile
+              />
+            </Styled.InlineTabsWrapper>
 
             <Styled.TabContent>
               <div

--- a/frontend/src/pages/ClubDetailPage/components/ClubDetailTopBar/ClubDetailTopBar.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubDetailTopBar/ClubDetailTopBar.tsx
@@ -17,12 +17,6 @@ import {
 } from '@/utils/webviewBridge';
 import * as Styled from './ClubDetailTopBar.styles';
 
-// 스크롤 임계값 상수
-const SCROLL_THRESHOLD = {
-  HEADER_VISIBLE: 0, // 헤더 배경/타이틀 표시
-  TAB_STICKY: 360, // 탭바 고정
-} as const;
-
 interface TabItem {
   key: string;
   label: string;
@@ -35,6 +29,7 @@ interface ClubDetailTopBarProps {
   activeTab?: string;
   onTabClick?: (tabKey: string) => void;
   initialIsSubscribed?: boolean;
+  showTabs?: boolean;
 }
 
 const ClubDetailTopBar = ({
@@ -44,6 +39,7 @@ const ClubDetailTopBar = ({
   activeTab,
   onTabClick,
   initialIsSubscribed = false,
+  showTabs = false,
 }: ClubDetailTopBarProps) => {
   const navigate = useNavigate();
   const theme = useTheme();
@@ -78,14 +74,8 @@ const ClubDetailTopBar = ({
     return () => window.removeEventListener('message', handleMessage);
   }, [clubId]);
 
-  // 스크롤 위치에 따른 상태 관리
   const { isTriggered: isHeaderVisible } = useScrollTrigger({
-    threshold: SCROLL_THRESHOLD.HEADER_VISIBLE,
-    direction: 'down',
-  });
-
-  const { isTriggered: showTabs } = useScrollTrigger({
-    threshold: SCROLL_THRESHOLD.TAB_STICKY,
+    threshold: 0,
     direction: 'down',
   });
 


### PR DESCRIPTION
## #️⃣연관된 이슈
#1735, #1675, #1676

## 📝작업 내용
| 수정 전 | 수정 후 |                                           
  |---|---|                                                       
  | <video src="https://github.com/user-attachments/assets/4b311634-350a-4a6e-9c95-dcdf51127d68" width="300"/> | <video src="https://github.com/user-attachments/assets/99a78b6b-c10a-4416-9b4d-b07a29d928ac" width="300"/> | 

### 배경
베이스 브랜치(`fix/#1675-bottom-safe-area-MOA-972`)는 앱 웹뷰 환경에서 safe-area를 대응하는 작업입니다. 앱 웹뷰에서는 하단 푸터가 노출되지 않기 때문에, 상세 페이지의 스크롤 가능 높이가 부족해 인라인 탭과 헤더 sticky 탭이 겹쳐 보이는 구간에서 스크롤이 멈추는 현상이 있었습니다. 이를 해결하기 위해 베이스 브랜치에서 본문 하단에 여백(`AppSpacer`)을 추가했습니다.

그런데 **safe-area가 없는 아이폰**(홈버튼 기기)처럼 뷰포트 높이가 상대적으로 넓은 환경에서는, 추가한 여백만으로는 스크롤이 여전히 부족해 두 탭이 겹쳐 보이는 구간에서 멈추는 문제가 드러났습니다.

### 원인

상세 페이지에는 동일한 탭 UI가 두 곳에 존재합니다.

| 위치 | 설명 |
|---|---|
| `RightSection` 내 `UnderlineTabs` | 콘텐츠 흐름 속 인라인 탭 |
| `ClubDetailTopBar` 내 `TabBar` | 스크롤 후 상단 고정 sticky 탭 |

기존 코드에서는 `ClubDetailTopBar`가 내부적으로 `useScrollTrigger(360px)`를 사용해 sticky 탭 표시를 결정했습니다. **360px은 실제 인라인 탭 위치와 무관한 임의의 고정값**이었기 때문에 기기마다 두 탭이 동시에 노출되는 구간이 달라졌고, 뷰포트가 넓은 기기일수록 이 구간에서 스크롤이 멈출 가능성이 높았습니다.

### 해결 방안 검토
| 방법 | 설명 | 판단 |
|---|---|---|
| 여백 추가 | `AppSpacer`를 더 늘려 스크롤 공간 확보 | 임시방편. 기기마다 결과가 달라 근본 해결이 아님 |
| 탭 이중 노출 자체를 제거 | 두 탭이 동시에 보이지 않도록 정확한 시점에 교체 | 근본 해결. 여백 크기 및 기기와 무관하게 동작 |

여백을 늘리는 방식은 증상을 일시적으로 완화할 뿐입니다. 또한 이 문제는 앱 웹뷰만의 문제가 아니라 **웹에서도 동일하게 존재하던 구조적 결함**이었기 때문에, 이번 기회에 근본 원인을 수정하는 방향을 선택했습니다.

### 해결 방법
`IntersectionObserver`로 인라인 탭 요소가 TopBar 뒤로 잘리기 시작하는 정확한 시점을 감지해, 인라인 탭을 숨기고 헤더 탭을 표시합니다.

```
인라인 탭 상단이 TopBar(73px) 아래로 잘리는 순간
  → showStickyTabs = true
  → 인라인 탭: visibility: hidden  (레이아웃 유지하며 숨김)
  → 헤더 sticky 탭: 표시
```

> `display: none` 대신 `visibility: hidden`을 사용해 인라인 탭의 레이아웃 공간을 유지합니다. `display: none`으로 처리할 경우 탭이 사라지는 순간 콘텐츠가 위로 밀리는 레이아웃 점프가 발생합니다.

**Before**
```
ClubDetailTopBar (내부)
  └─ useScrollTrigger(360px) → sticky 탭 표시 여부 자체 결정
```

**After**
```
ClubDetailPage
  └─ IntersectionObserver(인라인 탭 DOM) → showStickyTabs 결정
       ├─ ClubDetailTopBar에 showTabs prop으로 전달
       └─ InlineTabsWrapper visibility 제어
```

탭 표시 타이밍 결정 책임을 `ClubDetailTopBar` 내부에서 `ClubDetailPage`로 분리했습니다. `ClubDetailTopBar`는 `showTabs` prop을 받아 렌더링만 담당합니다.

#### DOM 마운트 타이밍 처리

`clubDetail` 로드 전에는 컴포넌트가 `null`을 반환해 인라인 탭 DOM이 존재하지 않습니다. `useRef`를 사용하면 ref가 나중에 채워지더라도 effect가 재실행되지 않아 관찰자가 등록되지 않는 경우가 생깁니다.

DOM 요소를 `useState`로 관리(callback ref 패턴)하면, 마운트 시 state 변경으로 effect가 정확히 재실행되어 데이터 로딩 타이밍과 무관하게 항상 동작합니다.

```ts
const [inlineTabsEl, setInlineTabsEl] = useState<HTMLDivElement | null>(null);

useEffect(() => {
  if (!showTopBar || !inlineTabsEl) return;
  const observer = new IntersectionObserver(
    ([entry]) => setShowStickyTabs(!entry.isIntersecting),
    { rootMargin: '-73px 0px 0px 0px', threshold: 1 },
  );
  observer.observe(inlineTabsEl);
  return () => observer.disconnect();
}, [showTopBar, inlineTabsEl]);

// JSX — ref 대신 setState를 callback ref로 전달
<Styled.InlineTabsWrapper ref={setInlineTabsEl} $hidden={showTopBar && showStickyTabs}>
```

## 중점적으로 리뷰받고 싶은 부분(선택)
- `IntersectionObserver`의 `rootMargin: '-73px'` 값이 TopBar 실제 높이와 일치하는지 확인 부탁드립니다.

## 🫡 참고사항

- 베이스 브랜치: `fix/#1675-bottom-safe-area-MOA-972` (safe-area 대응 작업)
- 변경 파일
  - `src/pages/ClubDetailPage/ClubDetailPage.tsx`
  - `src/pages/ClubDetailPage/ClubDetailPage.styles.ts`
  - `src/pages/ClubDetailPage/components/ClubDetailTopBar/ClubDetailTopBar.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 클럽 상세 페이지에서 스크롤 시 인라인 탭과 고정 탭이 동시에 표시되는 문제 해결
  * 탭 가시성 제어 로직 개선으로 레이아웃 안정성 강화

* **Documentation**
  * 스티키 탭 중복 표시 문제 해결 방식 관련 문서 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->