### PR TITLE
[fix] IOS safearea 패딩 적용안되는 문제 수정

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,7 +10,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
     />
     <title>모아동 - 부경대학교 모든 동아리를 한눈에</title>
     <meta


### PR DESCRIPTION
> 🚀 릴리즈 PR인 경우 [**릴리즈 템플릿으로 전환**](?template=release.md)해 주세요. _(Preview 탭에서 클릭)_

## #️⃣연관된 이슈

> #1737

## 📝작업 내용

바텀내비에 env(safe-area..) 가적용 되었음에도 정상적으로 패딩이 생기지 않음.
viewport-fit 속성을 cover로 줌으로써 정상적으로 세이프영역값이 주입됨

<img width="859" height="243" alt="image" src="https://github.com/user-attachments/assets/b6a5ace3-89e1-4443-b65c-7b7776583aaa" />

반영된 모습

## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * iOS 기기에서 노치, 동적 아일랜드 등의 안전영역에 대한 화면 표시 호환성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->