### PR TITLE
fix: __VERCEL_PREVIEW__ typeof 체크 및 탭 체류시간 측정 개선

### DIFF
--- a/frontend/src/constants/adminTabs.ts
+++ b/frontend/src/constants/adminTabs.ts
@@ -15,7 +15,8 @@ export const ADMIN_TABS: TabCategory[] = [
       { label: '기본 정보 수정', path: '/admin/club-info' },
       { label: '소개 정보 수정', path: '/admin/club-intro' },
       { label: '활동 사진 수정', path: '/admin/photo-edit' },
-      ...(import.meta.env.DEV || __VERCEL_PREVIEW__
+      ...(import.meta.env.DEV ||
+      (typeof __VERCEL_PREVIEW__ !== 'undefined' && __VERCEL_PREVIEW__)
         ? [{ label: '동아리 일정 관리', path: '/admin/calendar-sync' }]
         : []),
     ],

--- a/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.tsx
+++ b/frontend/src/pages/FestivalPage/BuskingPage/BuskingPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { format } from 'date-fns';
 import { motion } from 'framer-motion';
 import Footer from '@/components/common/Footer/Footer';
@@ -32,43 +32,30 @@ const BuskingPage = () => {
   useTrackPageView(PAGE_VIEW.DAEDONG2026_BUSKING_PAGE);
   const trackEvent = useMixpanelTrack();
   const [activeDayId, setActiveDayId] = useState(getInitialDayId);
-  const dayStartTime = useRef(0);
-  const activeDayIdRef = useRef(activeDayId);
 
   const activeDay = BUSKING_DAYS.find((d) => d.id === activeDayId)!;
 
   useEffect(() => {
-    activeDayIdRef.current = activeDayId;
-  }, [activeDayId]);
-
-  useEffect(() => {
-    dayStartTime.current = Date.now();
+    const startTime = Date.now();
     return () => {
-      const duration = Date.now() - dayStartTime.current;
+      const duration = Date.now() - startTime;
       trackEvent(USER_EVENT.DAEDONG2026_DAY_DURATION, {
-        day: activeDayIdRef.current,
+        day: activeDayId,
         duration,
         duration_seconds: Math.round(duration / 1000),
       });
     };
-  }, []);
+  }, [activeDayId, trackEvent]);
 
   const handleDayChange = (
     dayId: string,
     interaction: 'click' | 'swipe' = 'click',
   ) => {
-    const duration = Date.now() - dayStartTime.current;
-    trackEvent(USER_EVENT.DAEDONG2026_DAY_DURATION, {
-      day: activeDayId,
-      duration,
-      duration_seconds: Math.round(duration / 1000),
-    });
     trackEvent(USER_EVENT.DAEDONG2026_DAY_CHANGED, {
       from_day: activeDayId,
       to_day: dayId,
       interaction,
     });
-    dayStartTime.current = Date.now();
     setActiveDayId(dayId);
   };
 

--- a/frontend/src/pages/FestivalPage/IntroductionPage/IntroductionPage.tsx
+++ b/frontend/src/pages/FestivalPage/IntroductionPage/IntroductionPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import Footer from '@/components/common/Footer/Footer';
 import Header from '@/components/common/Header/Header';
 import UnderlineTabs from '@/components/common/UnderlineTabs/UnderlineTabs';
@@ -25,34 +25,20 @@ const IntroductionPage = () => {
   const [activeTab, setActiveTab] = useState<FestivalTabType>(
     FESTIVAL_TAB_TYPE.BOOTH_MAP,
   );
-  const tabStartTime = useRef(0);
-  const activeTabRef = useRef(activeTab);
-
   useEffect(() => {
-    activeTabRef.current = activeTab;
-  }, [activeTab]);
-
-  useEffect(() => {
-    tabStartTime.current = Date.now();
+    const startTime = Date.now();
     return () => {
-      const duration = Date.now() - tabStartTime.current;
+      const duration = Date.now() - startTime;
       trackEvent(USER_EVENT.FESTIVAL_TAB_DURATION, {
-        tab: activeTabRef.current,
+        tab: activeTab,
         duration,
         duration_seconds: Math.round(duration / 1000),
       });
     };
-  }, []);
+  }, [activeTab, trackEvent]);
 
   const handleTabClick = (tabKey: string) => {
-    const duration = Date.now() - tabStartTime.current;
-    trackEvent(USER_EVENT.FESTIVAL_TAB_DURATION, {
-      tab: activeTab,
-      duration,
-      duration_seconds: Math.round(duration / 1000),
-    });
     trackEvent(USER_EVENT.FESTIVAL_TAB_CLICKED, { tab: tabKey });
-    tabStartTime.current = Date.now();
     setActiveTab(tabKey as FestivalTabType);
   };
 


### PR DESCRIPTION
## Summary
- PR #1733 Gemini Code Assist 리뷰 피드백 반영
- `adminTabs.ts`: `__VERCEL_PREVIEW__`에 `typeof` 체크 추가하여 비-Vite 환경(Jest, Storybook 등) `ReferenceError` 방지
- `BuskingPage.tsx`: `useEffect` 의존성 배열에 `activeDayId` 추가하여 탭 전환 시 개별 체류시간 정확 측정 (불필요한 ref 제거)
- `IntroductionPage.tsx`: `useEffect` 의존성 배열에 `activeTab` 추가하여 탭 전환 시 개별 체류시간 정확 측정 (불필요한 ref 제거)

## Related
- Resolves review comments on #1733

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 관리자 탭 표시 조건 개선
  * 분석 이벤트 추적 로직 최적화 (일정 변경 및 탭 전환 시)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->