### PR TITLE
[fix] 좁은 뷰포트에서 sticky 탭 즉시 발동 버그 수정

### DIFF
--- a/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
@@ -91,9 +91,18 @@ const ClubDetailPage = () => {
   useEffect(() => {
     if (!showTopBar || !inlineTabsEl) return;
 
-    // 인라인 탭이 TopBar 아래로 잘리기 시작하는 순간 헤더 탭으로 교체
+    // top < TOP_BAR_RENDERED_HEIGHT: viewport가 좁아 탭이 아래에 있는 경우를 제외하고 sticky 활성화
     const observer = new IntersectionObserver(
-      ([entry]) => setShowStickyTabs(!entry.isIntersecting),
+      ([entry]) => {
+        if (
+          !entry.isIntersecting &&
+          entry.boundingClientRect.top < TOP_BAR_RENDERED_HEIGHT
+        ) {
+          setShowStickyTabs(true);
+        } else {
+          setShowStickyTabs(false);
+        }
+      },
       { rootMargin: `-${TOP_BAR_RENDERED_HEIGHT}px 0px 0px 0px`, threshold: 1 },
     );
     observer.observe(inlineTabsEl);


### PR DESCRIPTION
## #️⃣연관된 이슈

#1741

## 📝작업 내용

### 문제 배경

#1736 에서 탑바와 탭이 겹치는 문제를 수정할 때, `IntersectionObserver`의 rootMargin(`-73px`)과 `threshold: 1` 조합을 도입했습니다.

이 방식은 탭 요소가 감시 영역(viewport - 73px)에 **완전히 포함될 때만** `isIntersecting: true`로 판단합니다. 뷰포트 높이가 충분한 경우에는 정상 동작하지만, 좁은 뷰포트(약 500px 이하)에서는 페이지 로드 시점에 탭이 아직 스크롤 아래쪽에 있음에도 감시 영역 밖으로 판단되어 `isIntersecting: false`가 즉시 발생했습니다.

### 원인

`isIntersecting: false`는 두 가지 상황에서 발생합니다.

| 상황 | `isIntersecting` | 기대 동작 |
|---|---|---|
| 탭이 위로 스크롤되어 TopBar 뒤로 사라짐 | `false` | sticky 활성화 ✅ |
| 뷰포트가 좁아 탭이 아직 화면 아래에 있음 | `false` | sticky 비활성화 ✅ |

기존 코드는 두 경우를 구분하지 않고 `!entry.isIntersecting`만으로 sticky를 활성화했기 때문에, 좁은 뷰포트에서는 스크롤 없이도 탭이 헤더에 붙어버리는 문제가 발생했습니다.

### 해결 방법

`entry.boundingClientRect.top`으로 두 경우를 구분했습니다.

- 탭이 **위로 스크롤되어 사라진 경우**: `top < TOP_BAR_RENDERED_HEIGHT(73px)` → sticky 활성화
- 탭이 **화면 아래에 있는 경우**: `top`이 viewport 높이보다 큰 양수 → sticky 비활성화

```ts
([entry]) => {
  if (!entry.isIntersecting && entry.boundingClientRect.top < TOP_BAR_RENDERED_HEIGHT) {
    setShowStickyTabs(true);
  } else {
    setShowStickyTabs(false);
  }
}
```

### 수정 전 / 수정 후

| 수정 전 | 수정 후 |
|---|---|
| <img width="500" height="auto" alt="image" src="https://github.com/user-attachments/assets/8f54ba38-b5ae-4728-a225-3bbee278dd4a" /> | <img width="500" height="auto" alt="image" src="https://github.com/user-attachments/assets/5d488617-5ada-4bdb-9e13-d0b8b331ab0c" /> |


## 🫡 참고사항

좁은 뷰포트(약 500px 이하 높이)에서 재현 가능합니다. 브라우저 DevTools에서 뷰포트 높이를 줄여 확인할 수 있습니다.