### PR TITLE
[fix] PhotoModal 이미지 잘림 수정

### DIFF
--- a/frontend/src/pages/ClubDetailPage/components/PhotoModal/PhotoModal.styles.ts
+++ b/frontend/src/pages/ClubDetailPage/components/PhotoModal/PhotoModal.styles.ts
@@ -92,11 +92,24 @@ export const ImageContainer = styled.div`
   justify-content: center;
   align-items: center;
   margin-top: 60px;
+  overflow: hidden;
+
+  ${media.mobile} {
+    margin-top: calc(60px + var(--rn-safe-top, 0px));
+  }
+`;
+
+export const SlideInner = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   padding: 0 60px;
+  box-sizing: border-box;
 
   ${media.mobile} {
     padding: 0 16px;
-    margin-top: calc(60px + var(--rn-safe-top, 0px));
   }
 `;
 

--- a/frontend/src/pages/ClubDetailPage/components/PhotoModal/PhotoModal.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/PhotoModal/PhotoModal.tsx
@@ -68,25 +68,13 @@ const PhotoModal = ({ isOpen, onClose, clubName, photos }: PhotoModalProps) => {
               loop={urls.length > 1}
               spaceBetween={0}
               slidesPerView={1}
-              style={{
-                width: '100%',
-                height: '100%',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-              }}
+              style={{ width: '100%', height: '100%' }}
             >
               {urls.map((url, idx) => (
-                <SwiperSlide
-                  key={url}
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    height: '100%',
-                  }}
-                >
-                  <Styled.Image src={url} alt={`활동 사진 ${idx + 1}`} />
+                <SwiperSlide key={url}>
+                  <Styled.SlideInner>
+                    <Styled.Image src={url} alt={`활동 사진 ${idx + 1}`} />
+                  </Styled.SlideInner>
                 </SwiperSlide>
               ))}
             </Swiper>


### PR DESCRIPTION
## 문제
활동사진 모달에서 특정 가로 너비 또는 스와이프 시, 이미지가 좌우로 잘려서 인접한 이미지의 일부가 살짝 보이는 현상이 있었습니다. 특히 가로가 넓은 이미지일수록 잘 보였고, 아래 이미지를 자세히 보면 오른쪽에 약간 다음 이미지가 미리 보이는 것을 확인할 수 있습니다.

| 수정 전 | 수정 후 |
|---|---|
| <img width="300" src="https://github.com/user-attachments/assets/aa4aa67f-c713-4222-9435-3ec8fe179ae1" /> | <img width="300" src="https://github.com/user-attachments/assets/eb970c21-7b99-412d-8104-92729bb04bfa" /> |

## 원인
`ImageContainer`의 `padding: 0 60px`이 Swiper 뷰포트를 컨텐츠 영역 안쪽으로 제한하면서, loop 모드의 `translate3d` 슬라이드 위치 계산에 오차가 발생했기 때문입니다.

| 수정 전 | 수정 후 |
|---|---|
| <img width="300" src="https://github.com/user-attachments/assets/a823645f-935a-416c-9341-b2b2be656e47" /> | <img width="300" src="https://github.com/user-attachments/assets/9a22c24d-575c-4cea-ab5d-6189c0f98fc8" /> |


```
[수정 전]                                  [수정 후]
ImageContainer (padding: 0 60px)          ImageContainer (padding 없음)
  └─ Swiper (width: 컨텐츠 영역만)          └─ Swiper (width: 전체)
      └─ slide                                  └─ slide
          └─ image                                  └─ SlideInner (padding: 0 60px)
                                                        └─ image
```

Swiper 뷰포트 ≠ 컨테이너 너비                Swiper 뷰포트 = 컨테이너 너비
→ translate3d 오차로 잘림                   → 오차 없음

## 수정

ImageContainer에 있던 `padding`을 SlideInner 래퍼로 이동하여 Swiper 뷰포트가 컨테이너 전체와 일치하도록 했습니다.

| 파일 | 변경 내용 |
|---|---|
| `PhotoModal.styles.ts` | ImageContainer에서 padding 제거, SlideInner 스타일 컴포넌트 추가 |
| `PhotoModal.tsx` | SwiperSlide 내부에 SlideInner 래퍼 적용 |