### PR TITLE
[fix] 클릭 버튼 쓰로틀 완화 (200ms → 100ms)

### DIFF
--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
@@ -93,7 +93,7 @@ const ClickButton = ({
 
   const handleClick = () => {
     const now = Date.now();
-    if (now - lastClickRef.current < 200) return;
+    if (now - lastClickRef.current < 100) return;
     lastClickRef.current = now;
 
     setClickCount((prev) => prev + 1);

--- a/frontend/src/pages/GamePage/hooks/useBatchedClick.ts
+++ b/frontend/src/pages/GamePage/hooks/useBatchedClick.ts
@@ -3,7 +3,7 @@ import { useClickGame } from '@/hooks/Queries/useGame';
 
 const FLUSH_THRESHOLD = 5;
 const FLUSH_DELAY = 500;
-// UI 버튼(200ms)보다 짧게 잡아 버튼 핸들러를 우회하는 DOM 레벨 매크로를 차단
+// UI 버튼(100ms)보다 짧게 잡아 버튼 핸들러를 우회하는 DOM 레벨 매크로를 차단
 const MIN_CLICK_INTERVAL = 80;
 
 /**


### PR DESCRIPTION
## Summary
- 게임 페이지 클릭 버튼의 쓰로틀을 200ms(초당 5회)에서 100ms(초당 10회)로 완화
- 매크로 방어는 useBatchedClick의 80ms 가드가 담당하므로 안전
- 사람 손가락 연타 최대치(~10회/초)와 맞춰 매크로 이점 최소화

## Changes
- `ClickButton.tsx`: lastClickRef 쓰로틀 200ms → 100ms
- `useBatchedClick.ts`: 주석 업데이트 (UI 버튼 간격 반영)

Closes #1747

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 게임 페이지의 버튼 클릭 감지 속도를 향상시켰습니다. 더 빠른 연속 클릭이 가능해져 게임 플레이 반응성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->