### PR TITLE
[refactor] 클릭 쓰로틀 값을 CLICK_THROTTLE_MS 상수로 통합

### DIFF
--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
@@ -1,5 +1,6 @@
 import { memo, useEffect, useRef, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
+import { CLICK_THROTTLE_MS } from '../../hooks/useBatchedClick';
 import * as S from './ClickButton.styles';
 
 interface ClickButtonProps {
@@ -93,7 +94,7 @@ const ClickButton = ({
 
   const handleClick = () => {
     const now = Date.now();
-    if (now - lastClickRef.current < 100) return;
+    if (now - lastClickRef.current < CLICK_THROTTLE_MS) return;
     lastClickRef.current = now;
 
     setClickCount((prev) => prev + 1);

--- a/frontend/src/pages/GamePage/hooks/useBatchedClick.ts
+++ b/frontend/src/pages/GamePage/hooks/useBatchedClick.ts
@@ -3,7 +3,8 @@ import { useClickGame } from '@/hooks/Queries/useGame';
 
 const FLUSH_THRESHOLD = 5;
 const FLUSH_DELAY = 500;
-// UI 버튼(100ms)보다 짧게 잡아 버튼 핸들러를 우회하는 DOM 레벨 매크로를 차단
+export const CLICK_THROTTLE_MS = 100;
+// UI 버튼 쓰로틀(CLICK_THROTTLE_MS)보다 짧게 잡아 버튼 핸들러를 우회하는 DOM 레벨 매크로를 차단
 const MIN_CLICK_INTERVAL = 80;
 
 /**

--- a/frontend/src/pages/GamePage/hooks/useBatchedClick.ts
+++ b/frontend/src/pages/GamePage/hooks/useBatchedClick.ts
@@ -5,7 +5,7 @@ const FLUSH_THRESHOLD = 5;
 const FLUSH_DELAY = 500;
 export const CLICK_THROTTLE_MS = 100;
 // UI 버튼 쓰로틀(CLICK_THROTTLE_MS)보다 짧게 잡아 버튼 핸들러를 우회하는 DOM 레벨 매크로를 차단
-const MIN_CLICK_INTERVAL = 80;
+const MIN_CLICK_INTERVAL = Math.floor(CLICK_THROTTLE_MS * 0.8);
 
 /**
  * 클릭을 모아 일정 개수(5)나 디바운스(500ms) 시점에 한 번에 전송한다.


### PR DESCRIPTION
## Summary
- `useBatchedClick.ts`에서 `CLICK_THROTTLE_MS = 100` 상수를 export
- `ClickButton.tsx`에서 하드코딩된 `100` 대신 해당 상수를 import하여 사용
- 두 파일 간 쓰로틀 설정 동기화 보장 (#1748 리뷰 반영)

## Test plan
- [x] TypeScript 타입 체크 통과
- [ ] 게임 페이지 클릭 버튼 연타 동작 확인