### PR TITLE
[feature] 동아리 랭킹 Top20 제한 및 상세페이지 연결

### DIFF
--- a/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.styles.ts
+++ b/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.styles.ts
@@ -50,6 +50,7 @@ export const Item = styled.div<{
   box-shadow: ${({ $isMe, $dark }) =>
     !$isMe && !$dark ? '0 1px 3px rgba(0, 0, 0, 0.06)' : 'none'};
   transition: background 0.3s;
+  cursor: pointer;
 `;
 
 export const Rank = styled.span<{ $rank: number }>`
@@ -80,6 +81,26 @@ export const ClickCount = styled.span`
   font-size: 0.875rem;
   font-weight: 700;
   color: ${({ theme }) => theme.colors.primary[900]};
+`;
+
+export const MoreButton = styled.button<{ $dark: boolean }>`
+  display: block;
+  width: 100%;
+  margin-top: 12px;
+  padding: 12px 0;
+  border: none;
+  border-radius: 10px;
+  background: ${({ $dark }) => ($dark ? '#2A2A36' : '#F0F0F0')};
+  color: ${({ $dark, theme }) =>
+    $dark ? theme.colors.gray[300] : theme.colors.gray[600]};
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s;
+
+  &:hover {
+    background: ${({ $dark }) => ($dark ? '#33333F' : '#E5E5E5')};
+  }
 `;
 
 export const EmptyMessage = styled.p<{ $dark: boolean }>`

--- a/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.styles.ts
+++ b/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.styles.ts
@@ -51,6 +51,7 @@ export const Item = styled.div<{
     !$isMe && !$dark ? '0 1px 3px rgba(0, 0, 0, 0.06)' : 'none'};
   transition: background 0.3s;
   cursor: pointer;
+  text-decoration: none;
 `;
 
 export const Rank = styled.span<{ $rank: number }>`

--- a/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.tsx
+++ b/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.tsx
@@ -52,7 +52,7 @@ const RankingBoard = ({
                     $rank={entry.rank}
                     $dark={isDark}
                     onClick={() =>
-                      navigate(`/clubDetail/@${entry.clubName}`)
+                      navigate(`/clubDetail/@${encodeURIComponent(entry.clubName)}`)
                     }
                   >
                     <S.Rank $rank={entry.rank}>

--- a/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.tsx
+++ b/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { AnimatePresence, motion } from 'framer-motion';
 import { GameRankingEntry } from '@/types/game';
 import * as S from './RankingBoard.styles';
@@ -18,7 +18,6 @@ const RankingBoard = ({
   myClubName,
   isDark = false,
 }: RankingBoardProps) => {
-  const navigate = useNavigate();
   const [isExpanded, setIsExpanded] = useState(false);
 
   const visibleRanking = isExpanded ? ranking : ranking.slice(0, TOP_COUNT);
@@ -44,16 +43,19 @@ const RankingBoard = ({
                   initial={{ opacity: 0, x: -20 }}
                   animate={{ opacity: 1, x: 0 }}
                   exit={{ opacity: 0, x: 20 }}
-                  transition={{ duration: 0.2, delay: i * 0.02 }}
+                  transition={{
+                    duration: 0.2,
+                    delay:
+                      (isExpanded && i >= TOP_COUNT ? i - TOP_COUNT : i) * 0.02,
+                  }}
                   style={{ listStyle: 'none' }}
                 >
                   <S.Item
+                    as={Link}
+                    to={`/clubDetail/@${encodeURIComponent(entry.clubName)}`}
                     $isMe={entry.clubName === myClubName}
                     $rank={entry.rank}
                     $dark={isDark}
-                    onClick={() =>
-                      navigate(`/clubDetail/@${encodeURIComponent(entry.clubName)}`)
-                    }
                   >
                     <S.Rank $rank={entry.rank}>
                       {MEDAL[entry.rank - 1] ?? entry.rank}

--- a/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.tsx
+++ b/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { AnimatePresence, motion } from 'framer-motion';
 import { GameRankingEntry } from '@/types/game';
 import * as S from './RankingBoard.styles';
@@ -9,12 +11,19 @@ interface RankingBoardProps {
 }
 
 const MEDAL = ['🥇', '🥈', '🥉'];
+const TOP_COUNT = 20;
 
 const RankingBoard = ({
   ranking,
   myClubName,
   isDark = false,
 }: RankingBoardProps) => {
+  const navigate = useNavigate();
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const visibleRanking = isExpanded ? ranking : ranking.slice(0, TOP_COUNT);
+  const hasMore = ranking.length > TOP_COUNT;
+
   return (
     <S.Wrapper>
       <S.Header>
@@ -25,35 +34,50 @@ const RankingBoard = ({
           아직 참여한 동아리가 없어요. 첫 번째로 클릭해보세요!
         </S.EmptyMessage>
       ) : (
-        <S.List>
-          <AnimatePresence initial={false}>
-            {ranking.map((entry, i) => (
-              <motion.li
-                key={entry.clubName}
-                layout
-                initial={{ opacity: 0, x: -20 }}
-                animate={{ opacity: 1, x: 0 }}
-                exit={{ opacity: 0, x: 20 }}
-                transition={{ duration: 0.3, delay: i * 0.04 }}
-                style={{ listStyle: 'none' }}
-              >
-                <S.Item
-                  $isMe={entry.clubName === myClubName}
-                  $rank={entry.rank}
-                  $dark={isDark}
+        <>
+          <S.List>
+            <AnimatePresence initial={false}>
+              {visibleRanking.map((entry, i) => (
+                <motion.li
+                  key={entry.clubName}
+                  layout
+                  initial={{ opacity: 0, x: -20 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={{ opacity: 0, x: 20 }}
+                  transition={{ duration: 0.2, delay: i * 0.02 }}
+                  style={{ listStyle: 'none' }}
                 >
-                  <S.Rank $rank={entry.rank}>
-                    {MEDAL[entry.rank - 1] ?? entry.rank}
-                  </S.Rank>
-                  <S.ClubName $dark={isDark}>{entry.clubName}</S.ClubName>
-                  <S.ClickCount>
-                    {entry.clickCount.toLocaleString()}회
-                  </S.ClickCount>
-                </S.Item>
-              </motion.li>
-            ))}
-          </AnimatePresence>
-        </S.List>
+                  <S.Item
+                    $isMe={entry.clubName === myClubName}
+                    $rank={entry.rank}
+                    $dark={isDark}
+                    onClick={() =>
+                      navigate(`/clubDetail/@${entry.clubName}`)
+                    }
+                  >
+                    <S.Rank $rank={entry.rank}>
+                      {MEDAL[entry.rank - 1] ?? entry.rank}
+                    </S.Rank>
+                    <S.ClubName $dark={isDark}>{entry.clubName}</S.ClubName>
+                    <S.ClickCount>
+                      {entry.clickCount.toLocaleString()}회
+                    </S.ClickCount>
+                  </S.Item>
+                </motion.li>
+              ))}
+            </AnimatePresence>
+          </S.List>
+          {hasMore && (
+            <S.MoreButton
+              $dark={isDark}
+              onClick={() => setIsExpanded((prev) => !prev)}
+            >
+              {isExpanded
+                ? '접기'
+                : `더보기 (${ranking.length - TOP_COUNT}개 동아리)`}
+            </S.MoreButton>
+          )}
+        </>
       )}
     </S.Wrapper>
   );


### PR DESCRIPTION
## Summary
- 게임페이지 동아리 랭킹을 Top 20으로 제한하고, 나머지는 더보기/접기 버튼으로 토글
- 각 동아리 카드 클릭 시 `/clubDetail/@clubName` 상세페이지로 이동
- 랭킹 아이템 등장 애니메이션 속도 개선

## Test plan
- [x] `/game` 페이지에서 랭킹이 20개까지만 표시되는지 확인
- [x] 20개 초과 시 더보기 버튼이 나타나고 클릭하면 전체 목록 표시
- [x] 접기 버튼 클릭 시 다시 20개로 축소
- [x] 동아리 카드 클릭 시 상세페이지로 이동
- [x] 다크모드에서 더보기 버튼 스타일 정상 표시