### PR TITLE
[feature] 동아리명 localStorage 전환 및 변경 기능 추가 

### DIFF
--- a/frontend/config/vite.config.ts
+++ b/frontend/config/vite.config.ts
@@ -104,11 +104,21 @@ export default defineConfig(({ mode }) => {
           target: env.VITE_API_BASE_URL,
           changeOrigin: true,
           cookieDomainRewrite: 'localhost',
+          configure: (proxy) => {
+            proxy.on('proxyReq', (proxyReq) => {
+              proxyReq.removeHeader('origin');
+            });
+          },
         },
         '/auth': {
           target: env.VITE_API_BASE_URL,
           changeOrigin: true,
           cookieDomainRewrite: 'localhost',
+          configure: (proxy) => {
+            proxy.on('proxyReq', (proxyReq) => {
+              proxyReq.removeHeader('origin');
+            });
+          },
         },
       },
     },

--- a/frontend/src/pages/GamePage/GamePage.tsx
+++ b/frontend/src/pages/GamePage/GamePage.tsx
@@ -171,6 +171,7 @@ const GamePage = () => {
                   ranking={rankingData?.clubs ?? []}
                   myClubName={clubName}
                   isDark={isDark}
+                  onSelectClub={handleStart}
                 />
               </motion.div>
             </S.DesktopOnly>
@@ -233,6 +234,7 @@ const GamePage = () => {
                 ranking={rankingData?.clubs ?? []}
                 myClubName={clubName}
                 isDark={isDark}
+                onSelectClub={handleStart}
               />
             </motion.div>
           </S.MobileOnly>

--- a/frontend/src/pages/GamePage/GamePage.tsx
+++ b/frontend/src/pages/GamePage/GamePage.tsx
@@ -47,8 +47,9 @@ const MoonIcon = () => (
 
 const GamePage = () => {
   const [clubName, setClubName] = useState<string>(
-    () => sessionStorage.getItem(STORAGE_KEY) ?? '',
+    () => localStorage.getItem(STORAGE_KEY) ?? '',
   );
+  const [isEditing, setIsEditing] = useState(false);
   const [bgBursts, setBgBursts] = useState<number[]>([]);
   const [isDark, setIsDark] = useState<boolean>(
     () => sessionStorage.getItem(DARK_KEY) === 'true',
@@ -104,8 +105,17 @@ const GamePage = () => {
   }, [isDark]);
 
   const handleStart = (name: string) => {
-    sessionStorage.setItem(STORAGE_KEY, name);
+    localStorage.setItem(STORAGE_KEY, name);
     setClubName(name);
+    setIsEditing(false);
+  };
+
+  const handleChangeClub = () => {
+    setIsEditing(true);
+  };
+
+  const handleCancelChange = () => {
+    setIsEditing(false);
   };
 
   const toggleDark = () => {
@@ -196,12 +206,17 @@ const GamePage = () => {
             transition={{ duration: 0.4, delay: 0.25 }}
             style={{ marginTop: '40px' }}
           >
-            {!clubName ? (
-              <ClubNameInput onStart={handleStart} isDark={isDark} />
+            {!clubName || isEditing ? (
+              <ClubNameInput
+                onStart={handleStart}
+                onCancel={isEditing ? handleCancelChange : undefined}
+                isDark={isDark}
+              />
             ) : (
               <ClickButton
                 clubName={clubName}
                 onClickGame={handleClick}
+                onChangeClub={handleChangeClub}
                 isDark={isDark}
               />
             )}

--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.styles.ts
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.styles.ts
@@ -20,6 +20,34 @@ export const ButtonArea = styled.div`
   justify-content: center;
 `;
 
+export const ClubRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+`;
+
+export const ChangeButton = styled.button<{ $dark: boolean }>`
+  background: none;
+  border: none;
+  padding: 2px 6px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: ${({ $dark, theme }) =>
+    $dark ? theme.colors.gray[500] : theme.colors.gray[500]};
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  flex-shrink: 0;
+
+  &:hover {
+    color: ${({ theme }) => theme.colors.primary[900]};
+  }
+
+  @media (max-width: 500px) {
+    font-size: 0.7rem;
+  }
+`;
+
 export const ClubLabel = styled.p<{ $dark: boolean }>`
   font-size: 1rem;
   font-weight: 600;

--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
@@ -6,6 +6,7 @@ import * as S from './ClickButton.styles';
 interface ClickButtonProps {
   clubName: string;
   onClickGame: () => void;
+  onChangeClub: () => void;
   isDark?: boolean;
 }
 
@@ -77,6 +78,7 @@ const Firework = () => {
 const ClickButton = ({
   clubName,
   onClickGame,
+  onChangeClub,
   isDark = false,
 }: ClickButtonProps) => {
   const [clickCount, setClickCount] = useState(0);
@@ -112,7 +114,12 @@ const ClickButton = ({
 
   return (
     <S.Wrapper>
-      <S.ClubLabel $dark={isDark}>{clubName}</S.ClubLabel>
+      <S.ClubRow>
+        <S.ClubLabel $dark={isDark}>{clubName}</S.ClubLabel>
+        <S.ChangeButton $dark={isDark} onClick={onChangeClub}>
+          변경
+        </S.ChangeButton>
+      </S.ClubRow>
       <S.ButtonArea>
         {bursts.map((id) => (
           <Firework key={id} />

--- a/frontend/src/pages/GamePage/components/ClubNameInput/ClubNameInput.styles.ts
+++ b/frontend/src/pages/GamePage/components/ClubNameInput/ClubNameInput.styles.ts
@@ -131,3 +131,21 @@ export const ErrorMessage = styled.p`
   color: ${({ theme }) => theme.colors.primary[900]};
   font-weight: 500;
 `;
+
+export const CancelButton = styled.button<{ $dark: boolean }>`
+  background: none;
+  border: none;
+  padding: 4px 8px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: ${({ $dark, theme }) =>
+    $dark ? theme.colors.gray[500] : theme.colors.gray[500]};
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+
+  &:hover {
+    color: ${({ $dark, theme }) =>
+      $dark ? theme.colors.gray[300] : theme.colors.gray[700]};
+  }
+`;

--- a/frontend/src/pages/GamePage/components/ClubNameInput/ClubNameInput.tsx
+++ b/frontend/src/pages/GamePage/components/ClubNameInput/ClubNameInput.tsx
@@ -13,7 +13,11 @@ interface ClubNameInputProps {
   isDark?: boolean;
 }
 
-const ClubNameInput = ({ onStart, onCancel, isDark = false }: ClubNameInputProps) => {
+const ClubNameInput = ({
+  onStart,
+  onCancel,
+  isDark = false,
+}: ClubNameInputProps) => {
   const validateClubName = useValidateClubName();
   const trackEvent = useMixpanelTrack();
   const [value, setValue] = useState('');

--- a/frontend/src/pages/GamePage/components/ClubNameInput/ClubNameInput.tsx
+++ b/frontend/src/pages/GamePage/components/ClubNameInput/ClubNameInput.tsx
@@ -9,10 +9,11 @@ import * as S from './ClubNameInput.styles';
 
 interface ClubNameInputProps {
   onStart: (clubName: string) => void;
+  onCancel?: () => void;
   isDark?: boolean;
 }
 
-const ClubNameInput = ({ onStart, isDark = false }: ClubNameInputProps) => {
+const ClubNameInput = ({ onStart, onCancel, isDark = false }: ClubNameInputProps) => {
   const validateClubName = useValidateClubName();
   const trackEvent = useMixpanelTrack();
   const [value, setValue] = useState('');
@@ -150,6 +151,11 @@ const ClubNameInput = ({ onStart, isDark = false }: ClubNameInputProps) => {
       </S.InputContainer>
 
       {error && <S.ErrorMessage>{error}</S.ErrorMessage>}
+      {onCancel && (
+        <S.CancelButton $dark={isDark} onClick={onCancel}>
+          취소
+        </S.CancelButton>
+      )}
     </S.Wrapper>
   );
 };

--- a/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.styles.ts
+++ b/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.styles.ts
@@ -84,6 +84,23 @@ export const ClickCount = styled.span`
   color: ${({ theme }) => theme.colors.primary[900]};
 `;
 
+export const DetailLink = styled.span<{ $dark: boolean }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  font-size: 0.875rem;
+  color: ${({ $dark, theme }) =>
+    $dark ? theme.colors.gray[500] : theme.colors.gray[400]};
+  text-decoration: none;
+  flex-shrink: 0;
+
+  &:hover {
+    color: ${({ theme }) => theme.colors.primary[900]};
+  }
+`;
+
 export const MoreButton = styled.button<{ $dark: boolean }>`
   display: block;
   width: 100%;

--- a/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.tsx
+++ b/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.tsx
@@ -8,6 +8,7 @@ interface RankingBoardProps {
   ranking: GameRankingEntry[];
   myClubName?: string;
   isDark?: boolean;
+  onSelectClub?: (clubName: string) => void;
 }
 
 const MEDAL = ['🥇', '🥈', '🥉'];
@@ -17,6 +18,7 @@ const RankingBoard = ({
   ranking,
   myClubName,
   isDark = false,
+  onSelectClub,
 }: RankingBoardProps) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
@@ -51,8 +53,14 @@ const RankingBoard = ({
                   style={{ listStyle: 'none' }}
                 >
                   <S.Item
-                    as={Link}
-                    to={`/clubDetail/@${encodeURIComponent(entry.clubName)}`}
+                    {...(onSelectClub
+                      ? {
+                          onClick: () => onSelectClub(entry.clubName),
+                        }
+                      : {
+                          as: Link,
+                          to: `/clubDetail/@${encodeURIComponent(entry.clubName)}`,
+                        })}
                     $isMe={entry.clubName === myClubName}
                     $rank={entry.rank}
                     $dark={isDark}
@@ -64,6 +72,17 @@ const RankingBoard = ({
                     <S.ClickCount>
                       {entry.clickCount.toLocaleString()}회
                     </S.ClickCount>
+                    {onSelectClub && (
+                      <S.DetailLink
+                        as={Link}
+                        to={`/clubDetail/@${encodeURIComponent(entry.clubName)}`}
+                        onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                        $dark={isDark}
+                        aria-label={`${entry.clubName} 상세페이지`}
+                      >
+                        →
+                      </S.DetailLink>
+                    )}
                   </S.Item>
                 </motion.li>
               ))}


### PR DESCRIPTION
## Summary
- 게임페이지 동아리명 저장을 sessionStorage → localStorage로 전환하여 브라우저 재방문 시에도 유지
- 클릭 화면에 "변경" 버튼 추가, 취소 시 기존 동아리명 유지
- Vite 프록시에서 Origin 헤더 제거로 로컬 개발 CORS 해결

## Test plan
- [x] 동아리명 입력 후 브라우저 탭 닫고 재방문 시 동아리명 유지 확인
- [x] "변경" 버튼 클릭 → 새 동아리명 입력 → 정상 전환 확인
- [x] "변경" 버튼 클릭 → "취소" 클릭 → 기존 동아리명 유지 확인
- [x] 로컬 개발 서버에서 클릭 API 403 CORS 에러 해소 확인

closes #1751

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 선택한 동아리를 변경할 수 있는 '변경' 버튼 추가
  * 동아리 선택 중 '취소' 버튼으로 작업 취소 가능

* **개선 사항**
  * 동아리 선택 정보 저장 방식 개선으로 더 오래 유지
  * 랭킹 보드에서 동아리 선택 흐름 최적화
  * API 요청 헤더 처리 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->