### PR TITLE
[feature] 실시간 순위 변동 인디케이터 추가

### DIFF
--- a/frontend/src/pages/GamePage/GamePage.tsx
+++ b/frontend/src/pages/GamePage/GamePage.tsx
@@ -66,14 +66,40 @@ const GamePage = () => {
   const initializedRef = useRef(false);
   const burstIdRef = useRef(0);
 
+  // 순위 변동 추적
+  const prevRanksRef = useRef<Map<string, number>>(new Map());
+  const [rankDelta, setRankDelta] = useState<Map<string, number>>(new Map());
+
   useEffect(() => {
     const clubs = rankingData?.clubs;
     if (!clubs) return;
 
     if (!initializedRef.current) {
       clubs.forEach((c) => prevCountsRef.current.set(c.clubName, c.clickCount));
+      clubs.forEach((c) => prevRanksRef.current.set(c.clubName, c.rank));
       initializedRef.current = true;
       return;
+    }
+
+    // 순위 변동 계산 (양수 = 상승, 음수 = 하락), 변동이 있을 때만 갱신
+    let hasRankChange = false;
+    clubs.forEach((c) => {
+      const prevRank = prevRanksRef.current.get(c.clubName);
+      if (prevRank !== undefined && prevRank !== c.rank) {
+        hasRankChange = true;
+      }
+    });
+
+    if (hasRankChange) {
+      const newDelta = new Map<string, number>();
+      clubs.forEach((c) => {
+        const prevRank = prevRanksRef.current.get(c.clubName);
+        if (prevRank !== undefined) {
+          newDelta.set(c.clubName, prevRank - c.rank);
+        }
+      });
+      setRankDelta(newDelta);
+      clubs.forEach((c) => prevRanksRef.current.set(c.clubName, c.rank));
     }
 
     const crossed = clubs.some((c) => {
@@ -161,6 +187,7 @@ const GamePage = () => {
                   ranking={rankingData?.clubs ?? []}
                   myClubName={clubName}
                   isDark={isDark}
+                  rankDelta={rankDelta}
                 />
               </motion.div>
             </S.DesktopOnly>
@@ -218,6 +245,7 @@ const GamePage = () => {
                 ranking={rankingData?.clubs ?? []}
                 myClubName={clubName}
                 isDark={isDark}
+                rankDelta={rankDelta}
               />
             </motion.div>
           </S.MobileOnly>

--- a/frontend/src/pages/GamePage/GamePage.tsx
+++ b/frontend/src/pages/GamePage/GamePage.tsx
@@ -99,8 +99,8 @@ const GamePage = () => {
         }
       });
       setRankDelta(newDelta);
-      clubs.forEach((c) => prevRanksRef.current.set(c.clubName, c.rank));
     }
+    clubs.forEach((c) => prevRanksRef.current.set(c.clubName, c.rank));
 
     const crossed = clubs.some((c) => {
       const prev = prevCountsRef.current.get(c.clubName) ?? 0;

--- a/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.styles.ts
+++ b/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.styles.ts
@@ -78,6 +78,13 @@ export const ClubName = styled.span<{ $dark: boolean }>`
   white-space: nowrap;
 `;
 
+export const RankDelta = styled.span<{ $direction: 'up' | 'down' }>`
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: ${({ $direction }) => ($direction === 'up' ? '#E53935' : '#1E88E5')};
+  white-space: nowrap;
+`;
+
 export const ClickCount = styled.span`
   font-size: 0.875rem;
   font-weight: 700;

--- a/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.tsx
+++ b/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.tsx
@@ -8,6 +8,7 @@ interface RankingBoardProps {
   ranking: GameRankingEntry[];
   myClubName?: string;
   isDark?: boolean;
+  rankDelta?: Map<string, number>;
 }
 
 const MEDAL = ['🥇', '🥈', '🥉'];
@@ -17,6 +18,7 @@ const RankingBoard = ({
   ranking,
   myClubName,
   isDark = false,
+  rankDelta,
 }: RankingBoardProps) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
@@ -61,6 +63,18 @@ const RankingBoard = ({
                       {MEDAL[entry.rank - 1] ?? entry.rank}
                     </S.Rank>
                     <S.ClubName $dark={isDark}>{entry.clubName}</S.ClubName>
+                    {(() => {
+                      const delta = rankDelta?.get(entry.clubName) ?? 0;
+                      if (delta > 0)
+                        return <S.RankDelta $direction="up">▲{delta}</S.RankDelta>;
+                      if (delta < 0)
+                        return (
+                          <S.RankDelta $direction="down">
+                            ▼{Math.abs(delta)}
+                          </S.RankDelta>
+                        );
+                      return null;
+                    })()}
                     <S.ClickCount>
                       {entry.clickCount.toLocaleString()}회
                     </S.ClickCount>

--- a/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.tsx
+++ b/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.tsx
@@ -65,15 +65,12 @@ const RankingBoard = ({
                     <S.ClubName $dark={isDark}>{entry.clubName}</S.ClubName>
                     {(() => {
                       const delta = rankDelta?.get(entry.clubName) ?? 0;
-                      if (delta > 0)
-                        return <S.RankDelta $direction="up">▲{delta}</S.RankDelta>;
-                      if (delta < 0)
-                        return (
-                          <S.RankDelta $direction="down">
-                            ▼{Math.abs(delta)}
-                          </S.RankDelta>
-                        );
-                      return null;
+                      if (delta === 0) return null;
+                      return (
+                        <S.RankDelta $direction={delta > 0 ? 'up' : 'down'}>
+                          {delta > 0 ? '▲' + delta : '▼' + Math.abs(delta)}
+                        </S.RankDelta>
+                      );
                     })()}
                     <S.ClickCount>
                       {entry.clickCount.toLocaleString()}회


### PR DESCRIPTION
## Summary
- 게임 랭킹 보드에서 순위 변동 시 ▲N/▼N 인디케이터 표시
- 상승은 빨강(▲), 하락은 파랑(▼)으로 시각 구분
- 2초 폴링 기준으로 변동 감지, 다음 변동까지 표시 유지

## 변경 파일
- `GamePage.tsx` — 이전 순위 추적 및 delta 계산 로직
- `RankingBoard.tsx` — delta 표시 UI
- `RankingBoard.styles.ts` — RankDelta 스타일 컴포넌트

closes #1754

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  * 순위 변동을 추적하고 시각적으로 표시하는 기능이 추가되었습니다. 순위가 올라가거나 내려갈 때 화살표 아이콘과 변동폭을 함께 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->