### PR TITLE
[fix] 게임 페이지 모바일 클릭 영역 확대

### DIFF
--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.styles.ts
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.styles.ts
@@ -97,7 +97,7 @@ export const Button = styled.button<{ $clicking: boolean }>`
     &::after {
       content: '';
       position: absolute;
-      inset: -15px;
+      inset: -24px;
     }
   }
 `;

--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.styles.ts
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.styles.ts
@@ -89,8 +89,8 @@ export const Button = styled.button<{ $clicking: boolean }>`
   }
 
   @media (max-width: 500px) {
-    width: 140px;
-    height: 140px;
+    width: 160px;
+    height: 160px;
     font-size: 1.2rem;
   }
 `;

--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.styles.ts
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.styles.ts
@@ -97,7 +97,7 @@ export const Button = styled.button<{ $clicking: boolean }>`
     &::after {
       content: '';
       position: absolute;
-      inset: -40px;
+      inset: -50px;
     }
   }
 `;

--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.styles.ts
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.styles.ts
@@ -26,8 +26,8 @@ export const TouchTarget = styled.div`
   @media (max-width: 500px) {
     display: block;
     position: absolute;
-    width: 260px;
-    height: 260px;
+    width: 360px;
+    height: 360px;
     border-radius: 50%;
     z-index: 0;
     cursor: pointer;
@@ -35,6 +35,8 @@ export const TouchTarget = styled.div`
 `;
 
 export const ClubRow = styled.div`
+  position: relative;
+  z-index: 2;
   display: flex;
   align-items: center;
   gap: 6px;

--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.styles.ts
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.styles.ts
@@ -18,14 +18,11 @@ export const ButtonArea = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-
-  @media (max-width: 500px) {
-    width: 360px;
-    height: 360px;
-    margin: -100px 0;
-    cursor: pointer;
-    z-index: 2;
-  }
+  width: 360px;
+  height: 360px;
+  margin: -100px 0;
+  cursor: pointer;
+  z-index: 2;
 `;
 
 export const ClubRow = styled.div`

--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.styles.ts
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.styles.ts
@@ -97,7 +97,7 @@ export const Button = styled.button<{ $clicking: boolean }>`
     &::after {
       content: '';
       position: absolute;
-      inset: -20px;
+      inset: -15px;
     }
   }
 `;

--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.styles.ts
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.styles.ts
@@ -31,6 +31,7 @@ export const TouchTarget = styled.div`
     border-radius: 50%;
     z-index: 0;
     cursor: pointer;
+    background: rgba(255, 0, 0, 0.1);
   }
 `;
 

--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.styles.ts
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.styles.ts
@@ -18,6 +18,12 @@ export const ButtonArea = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
+  cursor: pointer;
+
+  @media (max-width: 500px) {
+    padding: 30px;
+    margin: -30px;
+  }
 `;
 
 export const ClubRow = styled.div`
@@ -93,12 +99,6 @@ export const Button = styled.button<{ $clicking: boolean }>`
     width: 160px;
     height: 160px;
     font-size: 1.2rem;
-
-    &::after {
-      content: '';
-      position: absolute;
-      inset: -50px;
-    }
   }
 `;
 

--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.styles.ts
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.styles.ts
@@ -74,6 +74,7 @@ export const Button = styled.button<{ $clicking: boolean }>`
   color: #fff;
   font-size: 1.5rem;
   font-weight: 700;
+  position: relative;
   cursor: pointer;
   box-shadow: 0 8px 24px rgba(255, 84, 20, 0.35);
   animation: ${({ $clicking }) => ($clicking ? pop : 'none')} 0.15s ease;
@@ -89,9 +90,15 @@ export const Button = styled.button<{ $clicking: boolean }>`
   }
 
   @media (max-width: 500px) {
-    width: 160px;
-    height: 160px;
+    width: 140px;
+    height: 140px;
     font-size: 1.2rem;
+
+    &::after {
+      content: '';
+      position: absolute;
+      inset: -20px;
+    }
   }
 `;
 

--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.styles.ts
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.styles.ts
@@ -90,8 +90,8 @@ export const Button = styled.button<{ $clicking: boolean }>`
   }
 
   @media (max-width: 500px) {
-    width: 140px;
-    height: 140px;
+    width: 160px;
+    height: 160px;
     font-size: 1.2rem;
 
     &::after {

--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.styles.ts
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.styles.ts
@@ -18,8 +18,15 @@ export const ButtonArea = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-`;
 
+  @media (max-width: 500px) {
+    width: 360px;
+    height: 360px;
+    margin: -100px 0;
+    cursor: pointer;
+    z-index: 2;
+  }
+`;
 
 export const ClubRow = styled.div`
   position: relative;
@@ -96,10 +103,7 @@ export const Button = styled.button<{ $clicking: boolean }>`
     width: 160px;
     height: 160px;
     font-size: 1.2rem;
-    padding: 50px;
-    margin: -50px;
-    box-sizing: content-box;
-    background-clip: content-box;
+    box-shadow: none;
   }
 `;
 

--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.styles.ts
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.styles.ts
@@ -97,7 +97,7 @@ export const Button = styled.button<{ $clicking: boolean }>`
     &::after {
       content: '';
       position: absolute;
-      inset: -24px;
+      inset: -40px;
     }
   }
 `;

--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.styles.ts
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.styles.ts
@@ -20,20 +20,6 @@ export const ButtonArea = styled.div`
   justify-content: center;
 `;
 
-export const TouchTarget = styled.div`
-  display: none;
-
-  @media (max-width: 500px) {
-    display: block;
-    position: absolute;
-    width: 360px;
-    height: 360px;
-    border-radius: 50%;
-    z-index: 0;
-    cursor: pointer;
-    background: rgba(255, 0, 0, 0.1);
-  }
-`;
 
 export const ClubRow = styled.div`
   position: relative;
@@ -110,6 +96,10 @@ export const Button = styled.button<{ $clicking: boolean }>`
     width: 160px;
     height: 160px;
     font-size: 1.2rem;
+    padding: 50px;
+    margin: -50px;
+    box-sizing: content-box;
+    background-clip: content-box;
   }
 `;
 

--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.styles.ts
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.styles.ts
@@ -18,11 +18,19 @@ export const ButtonArea = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  cursor: pointer;
+`;
+
+export const TouchTarget = styled.div`
+  display: none;
 
   @media (max-width: 500px) {
-    padding: 30px;
-    margin: -30px;
+    display: block;
+    position: absolute;
+    width: 260px;
+    height: 260px;
+    border-radius: 50%;
+    z-index: 0;
+    cursor: pointer;
   }
 `;
 

--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
@@ -115,7 +115,6 @@ const ClickButton = ({
   return (
     <S.Wrapper>
       <S.ButtonArea>
-        <S.TouchTarget onClick={handleClick} />
         {bursts.map((id) => (
           <Firework key={id} />
         ))}

--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
@@ -114,12 +114,6 @@ const ClickButton = ({
 
   return (
     <S.Wrapper>
-      <S.ClubRow>
-        <S.ClubLabel $dark={isDark}>{clubName}</S.ClubLabel>
-        <S.ChangeButton $dark={isDark} onClick={onChangeClub}>
-          변경
-        </S.ChangeButton>
-      </S.ClubRow>
       <S.ButtonArea>
         {bursts.map((id) => (
           <Firework key={id} />
@@ -157,6 +151,13 @@ const ClickButton = ({
         </AnimatePresence>
         <S.CountLabel $dark={isDark}>회</S.CountLabel>
       </S.CountWrapper>
+
+      <S.ClubRow>
+        <S.ClubLabel $dark={isDark}>{clubName}</S.ClubLabel>
+        <S.ChangeButton $dark={isDark} onClick={onChangeClub}>
+          변경
+        </S.ChangeButton>
+      </S.ClubRow>
     </S.Wrapper>
   );
 };

--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
@@ -114,7 +114,7 @@ const ClickButton = ({
 
   return (
     <S.Wrapper>
-      <S.ButtonArea>
+      <S.ButtonArea onClick={handleClick}>
         {bursts.map((id) => (
           <Firework key={id} />
         ))}

--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
@@ -114,13 +114,15 @@ const ClickButton = ({
 
   return (
     <S.Wrapper>
-      <S.ButtonArea onClick={handleClick}>
+      <S.ButtonArea>
+        <S.TouchTarget onClick={handleClick} />
         {bursts.map((id) => (
           <Firework key={id} />
         ))}
         <S.Button
           as={motion.button}
           $clicking={false}
+          onClick={handleClick}
           onKeyDown={(e) =>
             e.repeat &&
             (e.key === 'Enter' || e.key === ' ') &&

--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
@@ -114,14 +114,13 @@ const ClickButton = ({
 
   return (
     <S.Wrapper>
-      <S.ButtonArea>
+      <S.ButtonArea onClick={handleClick}>
         {bursts.map((id) => (
           <Firework key={id} />
         ))}
         <S.Button
           as={motion.button}
           $clicking={false}
-          onClick={handleClick}
           onKeyDown={(e) =>
             e.repeat &&
             (e.key === 'Enter' || e.key === ' ') &&

--- a/frontend/src/pages/GamePage/components/ClubNameInput/ClubNameInput.styles.ts
+++ b/frontend/src/pages/GamePage/components/ClubNameInput/ClubNameInput.styles.ts
@@ -86,7 +86,7 @@ export const StartButton = styled.button`
   }
 
   ${media.mobile} {
-    padding: 10px 14px;
+    padding: 12px 18px;
     font-size: 0.875rem;
   }
 `;
@@ -108,7 +108,7 @@ export const Dropdown = styled.ul<{ $dark: boolean }>`
 `;
 
 export const DropdownItem = styled.li<{ $dark: boolean }>`
-  padding: 10px 16px;
+  padding: 12px 16px;
   font-size: 0.95rem;
   color: ${({ $dark, theme }) =>
     $dark ? theme.colors.gray[200] : theme.colors.gray[800]};

--- a/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.styles.ts
+++ b/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.styles.ts
@@ -35,7 +35,7 @@ export const Item = styled.div<{
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 10px 14px;
+  padding: 12px 16px;
   border-radius: 10px;
   background: ${({ $isMe, $dark, theme }) => {
     if ($dark) return $isMe ? 'rgba(255, 84, 20, 0.18)' : '#22222E';


### PR DESCRIPTION
## Summary
- 게임 페이지 모바일 터치 타겟이 작아 조작이 불편한 문제 개선
- ClickButton 140→160px, StartButton/DropdownItem/RankingItem 패딩 증가

## Changes
| 요소 | Before | After |
|---|---|---|
| ClickButton (모바일) | 140×140px | 160×160px |
| StartButton padding | 10px 14px | 12px 18px |
| DropdownItem padding | 10px 16px | 12px 16px |
| RankingBoard Item padding | 10px 14px | 12px 16px |

## Test plan
- [x] 모바일 뷰포트(500px 이하)에서 클릭 버튼 터치 영역 확인
- [x] 시작 버튼, 드롭다운, 랭킹 아이템 터치 편의성 확인
- [x] 데스크톱 레이아웃 영향 없음 확인

closes #1756

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 모바일 기기에서 버튼 크기를 조정하여 터치 영역을 개선했습니다.
  * 입력 필드와 드롭다운 항목의 패딩을 조정하여 간격을 개선했습니다.
  * 순위표 항목의 패딩을 개선하여 시각적 일관성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->