### PR TITLE
[fix] PR #1733 코드리뷰 피드백 반영

### DIFF
--- a/.github/workflows/close-issue-on-pr-merge.yml
+++ b/.github/workflows/close-issue-on-pr-merge.yml
@@ -13,7 +13,7 @@ jobs:
       issues: write
     steps:
       - name: Close referenced issues
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const body = context.payload.pull_request.body || '';

--- a/frontend/docs/features/club-detail/sticky-tab-dedup.md
+++ b/frontend/docs/features/club-detail/sticky-tab-dedup.md
@@ -15,7 +15,7 @@
 
 `IntersectionObserver`로 인라인 탭 요소가 TopBar 뒤로 잘리는 시점을 감지해 두 탭을 정확히 교체한다.
 
-```
+```text
 인라인 탭 요소 상단이 TopBar(73px) 아래로 잘리기 시작
   → showStickyTabs = true
   → ClubDetailTopBar: showTabs prop으로 헤더 탭 표시

--- a/frontend/docs/features/components/dependency-analysis.md
+++ b/frontend/docs/features/components/dependency-analysis.md
@@ -34,7 +34,7 @@ npm run analyze:graph     # SVG 그래프 생성 (graphviz 필요)
 
 첫 실행에서 `common-no-pages` 규칙이 다음 위반을 잡았다.
 
-```
+```text
 Header.tsx → pages/MainPage/components/SearchBox/SearchBox.tsx
 ```
 

--- a/frontend/src/components/common/Modal/Modal.tsx
+++ b/frontend/src/components/common/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, ReactNode, useEffect } from 'react';
+import { MouseEvent, ReactNode, useEffect, useRef } from 'react';
 import Portal from '../Portal/Portal';
 import * as Styled from './Modal.styles';
 
@@ -15,6 +15,11 @@ const Modal = ({
   children,
   closeOnBackdrop = true,
 }: ModalProps) => {
+  const onCloseRef = useRef(onClose);
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
+
   useEffect(() => {
     if (!isOpen) return;
 
@@ -24,7 +29,7 @@ const Modal = ({
     document.body.style.width = '100%';
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
+      if (e.key === 'Escape') onCloseRef.current();
     };
 
     document.addEventListener('keydown', handleKeyDown);
@@ -36,7 +41,7 @@ const Modal = ({
       window.scrollTo(0, scrollY);
       document.removeEventListener('keydown', handleKeyDown);
     };
-  }, [isOpen, onClose]);
+  }, [isOpen]);
 
   if (!isOpen) return null;
 

--- a/frontend/src/constants/api.ts
+++ b/frontend/src/constants/api.ts
@@ -1,6 +1,6 @@
 const API_BASE_URL = import.meta.env.DEV
-  ? (typeof window !== 'undefined'
-      ? window.location.origin
-      : import.meta.env.VITE_API_BASE_URL)
+  ? typeof window !== 'undefined'
+    ? window.location.origin
+    : import.meta.env.VITE_API_BASE_URL
   : import.meta.env.VITE_API_BASE_URL;
 export default API_BASE_URL;

--- a/frontend/src/constants/api.ts
+++ b/frontend/src/constants/api.ts
@@ -1,4 +1,6 @@
 const API_BASE_URL = import.meta.env.DEV
-  ? window.location.origin
+  ? (typeof window !== 'undefined'
+      ? window.location.origin
+      : import.meta.env.VITE_API_BASE_URL)
   : import.meta.env.VITE_API_BASE_URL;
 export default API_BASE_URL;

--- a/frontend/src/pages/ClubUnionPage/ClubUnionPage.tsx
+++ b/frontend/src/pages/ClubUnionPage/ClubUnionPage.tsx
@@ -59,12 +59,17 @@ const ClubUnionPage = () => {
   const trackEvent = useMixpanelTrack();
   const [isMobile, setIsMobile] = useState(
     () =>
+      typeof window !== 'undefined' &&
       typeof window.matchMedia === 'function' &&
       window.matchMedia(MOBILE_BREAKPOINT).matches,
   );
 
   useEffect(() => {
-    if (typeof window.matchMedia !== 'function') return;
+    if (
+      typeof window === 'undefined' ||
+      typeof window.matchMedia !== 'function'
+    )
+      return;
     const mq = window.matchMedia(MOBILE_BREAKPOINT);
     const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
     mq.addEventListener('change', handler);

--- a/frontend/src/pages/GamePage/GamePage.tsx
+++ b/frontend/src/pages/GamePage/GamePage.tsx
@@ -123,10 +123,11 @@ const GamePage = () => {
   }, [rankingData]);
 
   useEffect(() => {
+    const prevBackground = document.body.style.background;
     const bg = isDark ? '#111111' : '#F5F5F5';
     document.body.style.background = bg;
     return () => {
-      document.body.style.background = '';
+      document.body.style.background = prevBackground;
     };
   }, [isDark]);
 

--- a/frontend/src/pages/GamePage/components/DotTextEffect/DotTextEffect.tsx
+++ b/frontend/src/pages/GamePage/components/DotTextEffect/DotTextEffect.tsx
@@ -1,6 +1,9 @@
 import { memo, useEffect, useRef, useState } from 'react';
 
-const mobileQuery = window.matchMedia('(max-width: 699px)');
+const mobileQuery =
+  typeof window !== 'undefined'
+    ? window.matchMedia('(max-width: 699px)')
+    : null;
 
 interface Dot {
   x: number;
@@ -82,10 +85,11 @@ const DotTextEffect = ({
   sweepSpeed = 0.12,
   dotColor = '#000000',
 }: DotTextEffectProps) => {
-  const [isMobile, setIsMobile] = useState(mobileQuery.matches);
-  const isMobileRef = useRef(mobileQuery.matches);
+  const [isMobile, setIsMobile] = useState(mobileQuery?.matches ?? false);
+  const isMobileRef = useRef(mobileQuery?.matches ?? false);
 
   useEffect(() => {
+    if (!mobileQuery) return;
     const handler = (e: MediaQueryListEvent) => {
       isMobileRef.current = e.matches;
       setIsMobile(e.matches);


### PR DESCRIPTION
## Summary

PR #1733 (develop-fe → main 릴리즈 PR)에 달린 Gemini / CodeRabbit 리뷰 코멘트 중 유효한 이슈 수정

### 수정 내역

**버그 수정 (Major)**
- **Modal.tsx**: `onClose`를 ref로 관리하여, 함수 identity 변경 시 스크롤 복원 위치가 깨지는 문제 방지
- **GamePage.tsx**: body background cleanup에서 빈 문자열 대신 이전 값을 보존/복원

**방어적 코딩 (SSR/테스트 환경 안전성)**
- **api.ts**: `window.location.origin` 접근 전 `typeof window !== 'undefined'` 가드 추가
- **ClubUnionPage.tsx**: `window.matchMedia` 호출 전 `typeof window !== 'undefined'` 가드 추가
- **DotTextEffect.tsx**: 모듈 레벨 `window.matchMedia` 호출에 가드 추가 (import 시점 ReferenceError 방지)

**CI/보안**
- **close-issue-on-pr-merge.yml**: `actions/github-script@v7` → commit SHA 고정 (supply chain 보안)

**문서**
- **sticky-tab-dedup.md**, **dependency-analysis.md**: 코드펜스 언어 식별자 누락 수정 (MD040)

### 반영하지 않은 코멘트

- **adminTabs.ts** `typeof __VERCEL_PREVIEW__` 체크 → 이미 반영됨
- **BuskingPage/IntroductionPage** 탭별 체류 시간 측정 → 이미 `activeDayId`/`activeTab` deps로 수정됨
- **package.json** Graphviz 문서화 → 이미 dependency-analysis.md에 "graphviz 필요" 명시되어 있으므로 skip

## Test plan

- [x] TypeScript 타입 체크 통과 (`npm run typecheck`)
- [ ] 모달 열기/닫기 시 스크롤 위치 정상 복원 확인
- [ ] 다크모드 토글 후 페이지 이탈 시 body background 원복 확인