### PR TITLE
[fix] MOA-1008 바텀네비 모바일 floating 글리치 수정

### DIFF
--- a/frontend/src/components/common/BottomNavigation/BottomNavigation.styles.ts
+++ b/frontend/src/components/common/BottomNavigation/BottomNavigation.styles.ts
@@ -16,8 +16,6 @@ export const Nav = styled.nav`
     border-top: 1px solid #f0f0f0;
     padding-bottom: env(safe-area-inset-bottom);
     z-index: ${Z_INDEX.bottomNav};
-    /* iOS/안드로이드 fixed-bottom 글리치 방지: 레이어 승격으로 visual viewport 추적 */
-    transform: translateZ(0);
   }
 `;
 


### PR DESCRIPTION
## 개요
GamePage 등 긴 페이지를 거쳐 메인 복귀 후 스크롤하면 바텀네비가 화면 중간으로 떠버리는 글리치 수정. (콘텐츠가 바텀네비 아래로 보임)

## 원인
바텀네비에 적용돼 있던 `transform: translateZ(0)`(레이어 승격)가 원인. fixed 요소가 별도 합성 레이어로 승격되면 iOS/웹뷰가 주소창 등 viewport 변화 시 위치를 다시 계산하지 않고 **이전 위치에 박제**됨 → 화면 중간에 뜸.

## 변경
- `BottomNavigation.styles.ts`에서 `transform: translateZ(0)` 제거 (1줄)
- 네이티브 `position: fixed; bottom: 0` 추적에 맡김

> translateZ(0)는 과거 floating 방지 목적으로 추가됐으나, 실제로는 이 글리치를 **유발**하고 있었음(첨부 스샷이 translateZ가 있어도 뜨는 것을 증명).

## 검증
- ⚠️ 모바일 컴포지터 동작 의존이라 **실기기(iOS/웹뷰) 확인 필요**
- 만약 제거 후 Android에서 다른 floating이 재발하면, 레이어 승격 없이 해당 케이스만 별도 대응 검토

Closes #1764

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 스타일
* 하단 네비게이션의 태블릿 화면 스타일을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->