### PR TITLE
[feature] 비눗방울 클릭 이벤트 추가

### DIFF
--- a/frontend/src/pages/GamePage/GamePage.tsx
+++ b/frontend/src/pages/GamePage/GamePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
 import WebviewTopBar from '@/components/common/WebviewTopBar/WebviewTopBar';
 import { PAGE_VIEW } from '@/constants/eventName';
@@ -9,6 +9,7 @@ import BackgroundFirework from './components/BackgroundFirework/BackgroundFirewo
 import ClickButton from './components/ClickButton/ClickButton';
 import ClubNameInput from './components/ClubNameInput/ClubNameInput';
 import DotTextEffect from './components/DotTextEffect/DotTextEffect';
+import FallingBubbles from './components/FallingBubbles/FallingBubbles';
 import RankingBoard from './components/RankingBoard/RankingBoard';
 import * as S from './GamePage.styles';
 import { useBatchedClick } from './hooks/useBatchedClick';
@@ -55,8 +56,21 @@ const GamePage = () => {
     () => sessionStorage.getItem(DARK_KEY) === 'true',
   );
 
+  const [myCount, setMyCount] = useState(0);
+
   const { data: rankingData } = useGameRanking();
-  const handleClick = useBatchedClick(clubName);
+  const sendClick = useBatchedClick(clubName);
+
+  // 버튼 클릭(1)과 비눗방울 터치(방울 값)를 합산해 개인 카운터와 서버에 반영
+  const gainCount = useCallback(
+    (amount: number) => {
+      setMyCount((prev) => prev + amount);
+      sendClick(amount);
+    },
+    [sendClick],
+  );
+
+  const handleButtonClick = useCallback(() => gainCount(1), [gainCount]);
 
   useTrackPageView(PAGE_VIEW.GAME_PAGE);
 
@@ -161,6 +175,8 @@ const GamePage = () => {
           <BackgroundFirework key={id} />
         ))}
 
+        {clubName && !isEditing && <FallingBubbles onCatch={gainCount} />}
+
         <S.Content>
           <S.ToggleBar>
             <S.ToggleSwitch
@@ -244,7 +260,8 @@ const GamePage = () => {
             ) : (
               <ClickButton
                 clubName={clubName}
-                onClickGame={handleClick}
+                count={myCount}
+                onClickGame={handleButtonClick}
                 onChangeClub={handleChangeClub}
                 isDark={isDark}
               />

--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
@@ -5,6 +5,7 @@ import * as S from './ClickButton.styles';
 
 interface ClickButtonProps {
   clubName: string;
+  count: number;
   onClickGame: () => void;
   onChangeClub: () => void;
   isDark?: boolean;
@@ -77,11 +78,11 @@ const Firework = () => {
 
 const ClickButton = ({
   clubName,
+  count,
   onClickGame,
   onChangeClub,
   isDark = false,
 }: ClickButtonProps) => {
-  const [clickCount, setClickCount] = useState(0);
   const [bursts, setBursts] = useState<number[]>([]);
   const burstIdRef = useRef(0);
   const timersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
@@ -99,7 +100,6 @@ const ClickButton = ({
     if (now - lastClickRef.current < CLICK_THROTTLE_MS) return;
     lastClickRef.current = now;
 
-    setClickCount((prev) => prev + 1);
     onClickGame();
 
     const id = burstIdRef.current++;
@@ -139,14 +139,14 @@ const ClickButton = ({
       <S.CountWrapper>
         <AnimatePresence mode='popLayout'>
           <motion.span
-            key={clickCount}
+            key={count}
             initial={{ opacity: 0, y: -12, scale: 0.8 }}
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: 12, scale: 0.8 }}
             transition={{ type: 'spring', stiffness: 300, damping: 20 }}
             style={{ fontSize: '2rem', fontWeight: 800, color: '#FF5414' }}
           >
-            {clickCount.toLocaleString()}
+            {count.toLocaleString()}
           </motion.span>
         </AnimatePresence>
         <S.CountLabel $dark={isDark}>회</S.CountLabel>

--- a/frontend/src/pages/GamePage/components/FallingBubbles/FallingBubbles.tsx
+++ b/frontend/src/pages/GamePage/components/FallingBubbles/FallingBubbles.tsx
@@ -66,6 +66,8 @@ const FallingBubbles = ({ onCatch }: FallingBubblesProps) => {
   const [pops, setPops] = useState<Pop[]>([]);
   const bubbleIdRef = useRef(0);
   const popIdRef = useRef(0);
+  const poppedRef = useRef<Set<number>>(new Set());
+  const timeoutsRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set());
 
   // 랜덤 간격으로 방울을 생성 (화면에 MAX_BUBBLES 초과 시 생성 건너뜀)
   useEffect(() => {
@@ -73,7 +75,8 @@ const FallingBubbles = ({ onCatch }: FallingBubblesProps) => {
     let timeoutId: ReturnType<typeof setTimeout>;
 
     const scheduleNext = () => {
-      const delay = SPAWN_MIN_MS + Math.random() * (SPAWN_MAX_MS - SPAWN_MIN_MS);
+      const delay =
+        SPAWN_MIN_MS + Math.random() * (SPAWN_MAX_MS - SPAWN_MIN_MS);
       timeoutId = setTimeout(() => {
         if (!active) return;
         setBubbles((prev) =>
@@ -86,9 +89,11 @@ const FallingBubbles = ({ onCatch }: FallingBubblesProps) => {
     };
 
     scheduleNext();
+    const timeouts = timeoutsRef.current;
     return () => {
       active = false;
       clearTimeout(timeoutId);
+      timeouts.forEach(clearTimeout);
     };
   }, []);
 
@@ -97,6 +102,10 @@ const FallingBubbles = ({ onCatch }: FallingBubblesProps) => {
   };
 
   const handlePop = (bubble: Bubble, e: React.MouseEvent) => {
+    // 같은 방울의 중복 터치(더블탭/오토클릭) 시 이중 적립 방지
+    if (poppedRef.current.has(bubble.id)) return;
+    poppedRef.current.add(bubble.id);
+
     onCatch(bubble.value);
     removeBubble(bubble.id);
 
@@ -111,9 +120,13 @@ const FallingBubbles = ({ onCatch }: FallingBubblesProps) => {
         hue: bubble.hue,
       },
     ]);
-    setTimeout(() => {
+    const timerId = setTimeout(() => {
       setPops((prev) => prev.filter((p) => p.id !== popId));
+      // 방울이 이미 언마운트된 뒤이므로 가드를 깨지 않고 메모리 정리
+      poppedRef.current.delete(bubble.id);
+      timeoutsRef.current.delete(timerId);
     }, POP_DURATION_MS);
+    timeoutsRef.current.add(timerId);
   };
 
   return (

--- a/frontend/src/pages/GamePage/components/FallingBubbles/FallingBubbles.tsx
+++ b/frontend/src/pages/GamePage/components/FallingBubbles/FallingBubbles.tsx
@@ -1,0 +1,228 @@
+import { memo, useEffect, useRef, useState } from 'react';
+import { motion } from 'framer-motion';
+
+interface FallingBubblesProps {
+  /** 방울을 터치해 적립한 값을 부모에 전달 */
+  onCatch: (value: number) => void;
+}
+
+interface Bubble {
+  id: number;
+  value: number;
+  size: number;
+  xPct: number; // 가로 시작 위치(중심 기준 %)
+  duration: number; // 낙하 시간(초)
+  drift: number; // 좌우 흔들림(px)
+  hue: number;
+}
+
+interface Pop {
+  id: number;
+  value: number;
+  x: number; // 터치 지점(clientX)
+  y: number; // 터치 지점(clientY)
+  hue: number;
+}
+
+// 값이 클수록 크고 드물게 등장 (weight = 등장 확률)
+// 서버가 요청당 클릭 수를 1~5로 제한하므로 방울 값도 5를 넘지 않는다.
+const BUBBLE_TIERS = [
+  { value: 2, size: 58, weight: 42 },
+  { value: 3, size: 72, weight: 34 },
+  { value: 5, size: 92, weight: 24 },
+];
+const TOTAL_WEIGHT = BUBBLE_TIERS.reduce((sum, t) => sum + t.weight, 0);
+
+const BUBBLE_HUES = [190, 280, 330, 45, 150];
+const MAX_BUBBLES = 5;
+const SPAWN_MIN_MS = 1400;
+const SPAWN_MAX_MS = 3000;
+const POP_DURATION_MS = 900;
+
+const pickTier = () => {
+  let r = Math.random() * TOTAL_WEIGHT;
+  for (const tier of BUBBLE_TIERS) {
+    r -= tier.weight;
+    if (r <= 0) return tier;
+  }
+  return BUBBLE_TIERS[0];
+};
+
+const createBubble = (id: number): Bubble => {
+  const tier = pickTier();
+  return {
+    id,
+    value: tier.value,
+    size: tier.size,
+    xPct: 8 + Math.random() * 80,
+    duration: 6 + Math.random() * 4,
+    drift: 14 + Math.random() * 26,
+    hue: BUBBLE_HUES[Math.floor(Math.random() * BUBBLE_HUES.length)],
+  };
+};
+
+const FallingBubbles = ({ onCatch }: FallingBubblesProps) => {
+  const [bubbles, setBubbles] = useState<Bubble[]>([]);
+  const [pops, setPops] = useState<Pop[]>([]);
+  const bubbleIdRef = useRef(0);
+  const popIdRef = useRef(0);
+
+  // 랜덤 간격으로 방울을 생성 (화면에 MAX_BUBBLES 초과 시 생성 건너뜀)
+  useEffect(() => {
+    let active = true;
+    let timeoutId: ReturnType<typeof setTimeout>;
+
+    const scheduleNext = () => {
+      const delay = SPAWN_MIN_MS + Math.random() * (SPAWN_MAX_MS - SPAWN_MIN_MS);
+      timeoutId = setTimeout(() => {
+        if (!active) return;
+        setBubbles((prev) =>
+          prev.length >= MAX_BUBBLES
+            ? prev
+            : [...prev, createBubble(bubbleIdRef.current++)],
+        );
+        scheduleNext();
+      }, delay);
+    };
+
+    scheduleNext();
+    return () => {
+      active = false;
+      clearTimeout(timeoutId);
+    };
+  }, []);
+
+  const removeBubble = (id: number) => {
+    setBubbles((prev) => prev.filter((b) => b.id !== id));
+  };
+
+  const handlePop = (bubble: Bubble, e: React.MouseEvent) => {
+    onCatch(bubble.value);
+    removeBubble(bubble.id);
+
+    const popId = popIdRef.current++;
+    setPops((prev) => [
+      ...prev,
+      {
+        id: popId,
+        value: bubble.value,
+        x: e.clientX,
+        y: e.clientY,
+        hue: bubble.hue,
+      },
+    ]);
+    setTimeout(() => {
+      setPops((prev) => prev.filter((p) => p.id !== popId));
+    }, POP_DURATION_MS);
+  };
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 40,
+        pointerEvents: 'none',
+        overflow: 'hidden',
+      }}
+    >
+      {bubbles.map((bubble) => (
+        <motion.div
+          key={bubble.id}
+          initial={{ y: '-14vh', opacity: 0 }}
+          animate={{
+            y: '114vh',
+            x: [0, bubble.drift, -bubble.drift, bubble.drift * 0.5, 0],
+            opacity: 1,
+          }}
+          transition={{
+            duration: bubble.duration,
+            ease: 'linear',
+            x: { duration: bubble.duration, ease: 'easeInOut' },
+            opacity: { duration: 0.5 },
+          }}
+          onAnimationComplete={() => removeBubble(bubble.id)}
+          onClick={(e) => handlePop(bubble, e)}
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: `${bubble.xPct}%`,
+            marginLeft: -bubble.size / 2,
+            width: bubble.size,
+            height: bubble.size,
+            borderRadius: '50%',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            cursor: 'pointer',
+            pointerEvents: 'auto',
+            background: `radial-gradient(circle at 32% 26%, rgba(255,255,255,0.95), hsla(${bubble.hue},85%,78%,0.4) 46%, hsla(${bubble.hue},80%,66%,0.16) 72%, transparent 100%)`,
+            border: `1.5px solid hsla(${bubble.hue},70%,82%,0.65)`,
+            boxShadow: `inset 6px 6px 12px rgba(255,255,255,0.55), 0 0 16px hsla(${bubble.hue},80%,70%,0.4)`,
+            WebkitTapHighlightColor: 'transparent',
+          }}
+        >
+          <span
+            style={{
+              fontSize: Math.round(bubble.size * 0.34),
+              fontWeight: 800,
+              color: '#3A3A3A',
+              textShadow: '0 1px 2px rgba(255,255,255,0.8)',
+              userSelect: 'none',
+            }}
+          >
+            +{bubble.value}
+          </span>
+        </motion.div>
+      ))}
+
+      {pops.map((pop) => (
+        <div
+          key={pop.id}
+          style={{
+            position: 'fixed',
+            left: pop.x,
+            top: pop.y,
+            pointerEvents: 'none',
+          }}
+        >
+          {/* 터치 지점에서 퍼지는 링 */}
+          <motion.span
+            initial={{ scale: 0, opacity: 0.7 }}
+            animate={{ scale: 2.4, opacity: 0 }}
+            transition={{ duration: 0.5, ease: 'easeOut' }}
+            style={{
+              position: 'absolute',
+              left: -24,
+              top: -24,
+              width: 48,
+              height: 48,
+              borderRadius: '50%',
+              border: `3px solid hsla(${pop.hue},80%,70%,0.8)`,
+            }}
+          />
+          {/* 위로 떠오르는 +N */}
+          <motion.span
+            initial={{ y: 0, opacity: 0, scale: 0.6 }}
+            animate={{ y: -52, opacity: [0, 1, 1, 0], scale: 1.2 }}
+            transition={{ duration: POP_DURATION_MS / 1000, ease: 'easeOut' }}
+            style={{
+              position: 'absolute',
+              left: -20,
+              top: -14,
+              fontSize: '1.4rem',
+              fontWeight: 800,
+              color: `hsl(${pop.hue},70%,45%)`,
+              textShadow: '0 1px 3px rgba(255,255,255,0.9)',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            +{pop.value}
+          </motion.span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default memo(FallingBubbles);

--- a/frontend/src/pages/GamePage/hooks/useBatchedClick.ts
+++ b/frontend/src/pages/GamePage/hooks/useBatchedClick.ts
@@ -3,6 +3,9 @@ import { useClickGame } from '@/hooks/Queries/useGame';
 
 const FLUSH_THRESHOLD = 5;
 const FLUSH_DELAY = 500;
+// 서버는 요청당 1~5회만 허용하고 요청이 너무 잦으면 거부하므로,
+// 한 번에 최대 5회만 보내고 남은 양은 FLUSH_DELAY 간격으로 이어서 전송한다.
+const MAX_CLICK_PER_REQUEST = 5;
 export const CLICK_THROTTLE_MS = 100;
 // UI 버튼 쓰로틀(CLICK_THROTTLE_MS)보다 짧게 잡아 버튼 핸들러를 우회하는 DOM 레벨 매크로를 차단
 const MIN_CLICK_INTERVAL = Math.floor(CLICK_THROTTLE_MS * 0.8);
@@ -20,15 +23,24 @@ export const useBatchedClick = (clubName: string) => {
   const { mutate: clickGame } = useClickGame();
   const flushRef = useRef<(name: string) => void>(() => {});
 
+  const scheduleFlush = (name: string) => {
+    if (!timerRef.current) {
+      timerRef.current = setTimeout(() => flushRef.current(name), FLUSH_DELAY);
+    }
+  };
+
   const flush = useCallback(
     (name: string) => {
       if (timerRef.current) clearTimeout(timerRef.current);
       timerRef.current = null;
-      const count = pendingRef.current;
-      if (count === 0) return;
+      if (pendingRef.current === 0) return;
+
+      // 이번 요청에 보낼 양(최대 5)만 떼어내고 나머지는 다음 flush로 미룬다
+      const count = Math.min(MAX_CLICK_PER_REQUEST, pendingRef.current);
       const ctAt = firstClickTimeRef.current ?? new Date().toISOString();
-      pendingRef.current = 0;
+      pendingRef.current -= count;
       firstClickTimeRef.current = null;
+
       clickGame(
         { clubName: name, count, ctAt },
         {
@@ -40,15 +52,13 @@ export const useBatchedClick = (clubName: string) => {
               ctAt < firstClickTimeRef.current
             )
               firstClickTimeRef.current = ctAt;
-            if (!timerRef.current) {
-              timerRef.current = setTimeout(
-                () => flushRef.current(name),
-                FLUSH_DELAY,
-              );
-            }
+            scheduleFlush(name);
           },
         },
       );
+
+      // 남은 클릭이 있으면 레이트리밋을 피해 간격을 두고 이어서 전송
+      if (pendingRef.current > 0) scheduleFlush(name);
     },
     [clickGame],
   );
@@ -74,24 +84,28 @@ export const useBatchedClick = (clubName: string) => {
     };
   }, []);
 
-  const handleClick = useCallback(() => {
-    const now = Date.now();
-    if (now - lastClickTimeRef.current < MIN_CLICK_INTERVAL) return;
-    lastClickTimeRef.current = now;
+  // amount: 버튼 클릭은 1, 비눗방울 터치는 방울에 적힌 값만큼 한 번에 적립
+  const handleClick = useCallback(
+    (amount = 1) => {
+      const now = Date.now();
+      if (now - lastClickTimeRef.current < MIN_CLICK_INTERVAL) return;
+      lastClickTimeRef.current = now;
 
-    if (firstClickTimeRef.current === null) {
-      firstClickTimeRef.current = new Date().toISOString();
-    }
+      if (firstClickTimeRef.current === null) {
+        firstClickTimeRef.current = new Date().toISOString();
+      }
 
-    pendingRef.current += 1;
+      pendingRef.current += amount;
 
-    if (pendingRef.current >= FLUSH_THRESHOLD) {
-      flush(clubName);
-    } else {
-      if (timerRef.current) clearTimeout(timerRef.current);
-      timerRef.current = setTimeout(() => flush(clubName), FLUSH_DELAY);
-    }
-  }, [clubName, flush]);
+      if (pendingRef.current >= FLUSH_THRESHOLD) {
+        flush(clubName);
+      } else {
+        if (timerRef.current) clearTimeout(timerRef.current);
+        timerRef.current = setTimeout(() => flush(clubName), FLUSH_DELAY);
+      }
+    },
+    [clubName, flush],
+  );
 
   return handleClick;
 };

--- a/frontend/src/pages/GamePage/hooks/useBatchedClick.ts
+++ b/frontend/src/pages/GamePage/hooks/useBatchedClick.ts
@@ -24,6 +24,8 @@ export const useBatchedClick = (clubName: string) => {
   const flushRef = useRef<(name: string) => void>(() => {});
 
   const scheduleFlush = (name: string) => {
+    // 언마운트 후에는 새 타이머를 걸지 않아 백그라운드 재전송/누수를 막는다
+    if (!isMountedRef.current) return;
     if (!timerRef.current) {
       timerRef.current = setTimeout(() => flushRef.current(name), FLUSH_DELAY);
     }


### PR DESCRIPTION
## 작업 내용
화면에 떨어지는 비눗방울을 터치해 추가 카운트를 얻는 보너스 메커닉을 추가했습니다.

- **FallingBubbles** 컴포넌트 신규: 랜덤 값(2~5)의 비눗방울이 천천히 낙하·흔들리며, 터치 시 `+N` 팝업·링 이펙트와 함께 적립
- **useBatchedClick** 확장: `amount` 파라미터 추가, `flush`를 요청당 최대 5개로 분할하고 잔여분은 지연 전송
- **GamePage / ClickButton**: 개인 카운터를 페이지로 끌어올려 버튼·방울 합산 표시, 게임 진행 중에만 방울 렌더링

## 서버 제약 대응
백엔드는 요청당 클릭 1~5회, IP 레이트리밋(10초/20회·50ms 쿨다운)을 강제합니다. 이에 맞춰 방울 값은 5 이하로 제한하고, 합산이 5를 넘으면 5개 단위로 나눠 500ms 간격 전송하도록 했습니다.

## 검증
- 실제 백엔드 대상 버튼/방울 클릭 모두 200 (400·429 없음), 카운터·랭킹 반영 확인
- `typecheck`·`eslint` 통과

관련 이슈: #1766