### PR TITLE
[fix] 게임 클릭 버튼 파티클 최적화로 모바일 연속 클릭 렉 개선

### DIFF
--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
@@ -34,8 +34,7 @@ const Firework = ({ isMobile }: { isMobile: boolean }) => {
   const [particles] = useState(() => {
     const count = isMobile ? PARTICLE_COUNT_MOBILE : PARTICLE_COUNT_DESKTOP;
     return Array.from({ length: count }, (_, i) => {
-      const angle =
-        (i / count) * Math.PI * 2 + (Math.random() - 0.5) * 0.4;
+      const angle = (i / count) * Math.PI * 2 + (Math.random() - 0.5) * 0.4;
       const distance = 160 + Math.random() * 130;
       const size = 6 + Math.random() * 11;
       const isConfetti = Math.random() > 0.5;

--- a/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
+++ b/frontend/src/pages/GamePage/components/ClickButton/ClickButton.tsx
@@ -10,7 +10,16 @@ interface ClickButtonProps {
   isDark?: boolean;
 }
 
-const PARTICLE_COUNT = 36;
+const PARTICLE_COUNT_DESKTOP = 36;
+const PARTICLE_COUNT_MOBILE = 16;
+// 연속 클릭 시 버스트가 무한히 겹쳐 쌓이는 것을 방지 (모바일 렉 방지)
+const MAX_CONCURRENT_BURSTS = 4;
+
+const mobileQuery =
+  typeof window !== 'undefined'
+    ? window.matchMedia('(max-width: 699px)')
+    : null;
+
 const PARTICLE_COLORS = [
   '#FF5414',
   '#FFD432',
@@ -21,11 +30,12 @@ const PARTICLE_COLORS = [
   '#FF5FA2',
 ];
 
-const Firework = () => {
-  const [particles] = useState(() =>
-    Array.from({ length: PARTICLE_COUNT }, (_, i) => {
+const Firework = ({ isMobile }: { isMobile: boolean }) => {
+  const [particles] = useState(() => {
+    const count = isMobile ? PARTICLE_COUNT_MOBILE : PARTICLE_COUNT_DESKTOP;
+    return Array.from({ length: count }, (_, i) => {
       const angle =
-        (i / PARTICLE_COUNT) * Math.PI * 2 + (Math.random() - 0.5) * 0.4;
+        (i / count) * Math.PI * 2 + (Math.random() - 0.5) * 0.4;
       const distance = 160 + Math.random() * 130;
       const size = 6 + Math.random() * 11;
       const isConfetti = Math.random() > 0.5;
@@ -39,8 +49,8 @@ const Firework = () => {
         spin: (Math.random() - 0.5) * 720,
         duration: 0.7 + Math.random() * 0.4,
       };
-    }),
-  );
+    });
+  });
 
   return (
     <>
@@ -66,7 +76,7 @@ const Firework = () => {
             marginLeft: -p.size / 2,
             borderRadius: p.isConfetti ? '2px' : '50%',
             background: p.color,
-            boxShadow: `0 0 8px ${p.color}`,
+            boxShadow: isMobile ? 'none' : `0 0 8px ${p.color}`,
             pointerEvents: 'none',
           }}
         />
@@ -83,9 +93,17 @@ const ClickButton = ({
 }: ClickButtonProps) => {
   const [clickCount, setClickCount] = useState(0);
   const [bursts, setBursts] = useState<number[]>([]);
+  const [isMobile, setIsMobile] = useState(mobileQuery?.matches ?? false);
   const burstIdRef = useRef(0);
   const timersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
   const lastClickRef = useRef(0);
+
+  useEffect(() => {
+    if (!mobileQuery) return;
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mobileQuery.addEventListener('change', handler);
+    return () => mobileQuery.removeEventListener('change', handler);
+  }, []);
 
   useEffect(() => {
     return () => {
@@ -103,7 +121,13 @@ const ClickButton = ({
     onClickGame();
 
     const id = burstIdRef.current++;
-    setBursts((prev) => [...prev, id]);
+    // 연속 클릭 시 겹쳐 쌓이는 버스트를 최신 N개로 제한
+    setBursts((prev) => {
+      const next = [...prev, id];
+      return next.length > MAX_CONCURRENT_BURSTS
+        ? next.slice(next.length - MAX_CONCURRENT_BURSTS)
+        : next;
+    });
     let timer: ReturnType<typeof setTimeout>;
     timer = setTimeout(() => {
       setBursts((prev) => prev.filter((b) => b !== id));
@@ -116,7 +140,7 @@ const ClickButton = ({
     <S.Wrapper>
       <S.ButtonArea onClick={handleClick}>
         {bursts.map((id) => (
-          <Firework key={id} />
+          <Firework key={id} isMobile={isMobile} />
         ))}
         <S.Button
           as={motion.button}


### PR DESCRIPTION
## 개요

게임 페이지(`/game`)의 클릭 버튼 애니메이션이 모바일에서 **연속 클릭 시 렉이 발생**하는 문제를 최적화했습니다.

## 원인

`ClickButton`의 폭죽 애니메이션 구조:
- 클릭 1회(쓰로틀 100ms)마다 버스트 1개 생성 → 버스트당 **36개** `motion.span` 파티클 렌더
- 각 버스트는 **1200ms** 유지

→ 연속 클릭 시 버스트가 겹쳐 쌓여 최대 ~12개 × 36 = **~432개의 DOM 파티클이 동시에 애니메이션** + 파티클마다 `box-shadow`로 이동 중 매 프레임 repaint 발생. 이것이 모바일 렉의 핵심 원인입니다.

## 변경 사항

`ClickButton.tsx` 한 파일:
1. **겹치는 버스트 상한** — 동시 버스트를 최신 **4개**로 제한 (`MAX_CONCURRENT_BURSTS`)
2. **모바일 파티클 수 축소** — 버스트당 36 → **16개** (데스크탑은 36개 유지)
3. **모바일 `box-shadow` 제거** — repaint 비용 절감 (데스크탑은 글로우 유지)

## 효과

- 모바일 최악 동시 파티클 수: `12 × 36 = 432` → `4 × 16 = 64`개 (약 **85% 감소**)
- box-shadow repaint 제거로 연속 클릭 시 프레임 드랍 완화
- 데스크탑 시각 경험은 그대로 유지

## 영향 범위

- `BackgroundFirework`(100단위 달성 시에만 발동)는 연속 클릭 렉과 무관해 변경하지 않음
- 단발 클릭의 폭죽 모양은 동일

## 확인

- [x] `npm run typecheck` 통과
- [x] 모바일 환경에서 연속 클릭 체감 확인