### PR TITLE
[fix] 게임 페이지 클릭 배틀 리뷰 반영

### DIFF
--- a/frontend/src/pages/GamePage/GamePage.tsx
+++ b/frontend/src/pages/GamePage/GamePage.tsx
@@ -61,16 +61,25 @@ const GamePage = () => {
   const { data: rankingData } = useGameRanking();
   const sendClick = useBatchedClick(clubName);
 
-  // 버튼 클릭(1)과 비눗방울 터치(방울 값)를 합산해 개인 카운터와 서버에 반영
+  // 버튼 클릭(1)과 비눗방울 터치(방울 값)를 합산해 개인 카운터와 서버에 반영.
+  // source를 전달해 비눗방울 적립이 버튼 쓰로틀에 걸려 누락되지 않도록 한다.
   const gainCount = useCallback(
-    (amount: number) => {
+    (amount: number, source: 'button' | 'bubble' = 'button') => {
       setMyCount((prev) => prev + amount);
-      sendClick(amount);
+      sendClick(amount, source);
     },
     [sendClick],
   );
 
-  const handleButtonClick = useCallback(() => gainCount(1), [gainCount]);
+  const handleButtonClick = useCallback(
+    () => gainCount(1, 'button'),
+    [gainCount],
+  );
+
+  const handleBubbleCatch = useCallback(
+    (amount: number) => gainCount(amount, 'bubble'),
+    [gainCount],
+  );
 
   useTrackPageView(PAGE_VIEW.GAME_PAGE);
 
@@ -148,6 +157,8 @@ const GamePage = () => {
   const handleStart = (name: string) => {
     localStorage.setItem(STORAGE_KEY, name);
     setClubName(name);
+    // 새 동아리를 고르면 개인 카운터를 초기화해 이전 동아리 클릭이 남지 않게 한다
+    setMyCount(0);
     setIsEditing(false);
   };
 
@@ -175,7 +186,9 @@ const GamePage = () => {
           <BackgroundFirework key={id} />
         ))}
 
-        {clubName && !isEditing && <FallingBubbles onCatch={gainCount} />}
+        {clubName && !isEditing && (
+          <FallingBubbles onCatch={handleBubbleCatch} />
+        )}
 
         <S.Content>
           <S.ToggleBar>

--- a/frontend/src/pages/GamePage/components/FallingBubbles/FallingBubbles.styles.ts
+++ b/frontend/src/pages/GamePage/components/FallingBubbles/FallingBubbles.styles.ts
@@ -1,0 +1,71 @@
+import styled from 'styled-components';
+import { motion } from 'framer-motion';
+
+export const Layer = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  pointer-events: none;
+  overflow: hidden;
+`;
+
+export const Bubble = styled(motion.div)<{
+  $size: number;
+  $hue: number;
+  $xPct: number;
+}>`
+  position: absolute;
+  top: 0;
+  left: ${({ $xPct }) => `${$xPct}%`};
+  margin-left: ${({ $size }) => `${-$size / 2}px`};
+  width: ${({ $size }) => `${$size}px`};
+  height: ${({ $size }) => `${$size}px`};
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  pointer-events: auto;
+  background: ${({ $hue }) =>
+    `radial-gradient(circle at 32% 26%, rgba(255, 255, 255, 0.95), hsla(${$hue}, 85%, 78%, 0.4) 46%, hsla(${$hue}, 80%, 66%, 0.16) 72%, transparent 100%)`};
+  border: ${({ $hue }) => `1.5px solid hsla(${$hue}, 70%, 82%, 0.65)`};
+  box-shadow: ${({ $hue }) =>
+    `inset 6px 6px 12px rgba(255, 255, 255, 0.55), 0 0 16px hsla(${$hue}, 80%, 70%, 0.4)`};
+  -webkit-tap-highlight-color: transparent;
+`;
+
+export const BubbleValue = styled.span<{ $size: number }>`
+  font-size: ${({ $size }) => `${Math.round($size * 0.34)}px`};
+  font-weight: 800;
+  color: #3a3a3a;
+  text-shadow: 0 1px 2px rgba(255, 255, 255, 0.8);
+  user-select: none;
+`;
+
+export const Pop = styled.div<{ $x: number; $y: number }>`
+  position: fixed;
+  left: ${({ $x }) => `${$x}px`};
+  top: ${({ $y }) => `${$y}px`};
+  pointer-events: none;
+`;
+
+export const PopRing = styled(motion.span)<{ $hue: number }>`
+  position: absolute;
+  left: -24px;
+  top: -24px;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: ${({ $hue }) => `3px solid hsla(${$hue}, 80%, 70%, 0.8)`};
+`;
+
+export const PopValue = styled(motion.span)<{ $hue: number }>`
+  position: absolute;
+  left: -20px;
+  top: -14px;
+  font-size: 1.4rem;
+  font-weight: 800;
+  color: ${({ $hue }) => `hsl(${$hue}, 70%, 45%)`};
+  text-shadow: 0 1px 3px rgba(255, 255, 255, 0.9);
+  white-space: nowrap;
+`;

--- a/frontend/src/pages/GamePage/components/FallingBubbles/FallingBubbles.styles.ts
+++ b/frontend/src/pages/GamePage/components/FallingBubbles/FallingBubbles.styles.ts
@@ -1,5 +1,5 @@
-import styled from 'styled-components';
 import { motion } from 'framer-motion';
+import styled from 'styled-components';
 
 export const Layer = styled.div`
   position: fixed;

--- a/frontend/src/pages/GamePage/components/FallingBubbles/FallingBubbles.tsx
+++ b/frontend/src/pages/GamePage/components/FallingBubbles/FallingBubbles.tsx
@@ -1,5 +1,5 @@
 import { memo, useEffect, useRef, useState } from 'react';
-import { motion } from 'framer-motion';
+import * as S from './FallingBubbles.styles';
 
 interface FallingBubblesProps {
   /** 방울을 터치해 적립한 값을 부모에 전달 */
@@ -130,18 +130,13 @@ const FallingBubbles = ({ onCatch }: FallingBubblesProps) => {
   };
 
   return (
-    <div
-      style={{
-        position: 'fixed',
-        inset: 0,
-        zIndex: 40,
-        pointerEvents: 'none',
-        overflow: 'hidden',
-      }}
-    >
+    <S.Layer>
       {bubbles.map((bubble) => (
-        <motion.div
+        <S.Bubble
           key={bubble.id}
+          $size={bubble.size}
+          $hue={bubble.hue}
+          $xPct={bubble.xPct}
           initial={{ y: '-14vh', opacity: 0 }}
           animate={{
             y: '114vh',
@@ -156,85 +151,32 @@ const FallingBubbles = ({ onCatch }: FallingBubblesProps) => {
           }}
           onAnimationComplete={() => removeBubble(bubble.id)}
           onClick={(e) => handlePop(bubble, e)}
-          style={{
-            position: 'absolute',
-            top: 0,
-            left: `${bubble.xPct}%`,
-            marginLeft: -bubble.size / 2,
-            width: bubble.size,
-            height: bubble.size,
-            borderRadius: '50%',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            cursor: 'pointer',
-            pointerEvents: 'auto',
-            background: `radial-gradient(circle at 32% 26%, rgba(255,255,255,0.95), hsla(${bubble.hue},85%,78%,0.4) 46%, hsla(${bubble.hue},80%,66%,0.16) 72%, transparent 100%)`,
-            border: `1.5px solid hsla(${bubble.hue},70%,82%,0.65)`,
-            boxShadow: `inset 6px 6px 12px rgba(255,255,255,0.55), 0 0 16px hsla(${bubble.hue},80%,70%,0.4)`,
-            WebkitTapHighlightColor: 'transparent',
-          }}
         >
-          <span
-            style={{
-              fontSize: Math.round(bubble.size * 0.34),
-              fontWeight: 800,
-              color: '#3A3A3A',
-              textShadow: '0 1px 2px rgba(255,255,255,0.8)',
-              userSelect: 'none',
-            }}
-          >
-            +{bubble.value}
-          </span>
-        </motion.div>
+          <S.BubbleValue $size={bubble.size}>+{bubble.value}</S.BubbleValue>
+        </S.Bubble>
       ))}
 
       {pops.map((pop) => (
-        <div
-          key={pop.id}
-          style={{
-            position: 'fixed',
-            left: pop.x,
-            top: pop.y,
-            pointerEvents: 'none',
-          }}
-        >
+        <S.Pop key={pop.id} $x={pop.x} $y={pop.y}>
           {/* 터치 지점에서 퍼지는 링 */}
-          <motion.span
+          <S.PopRing
+            $hue={pop.hue}
             initial={{ scale: 0, opacity: 0.7 }}
             animate={{ scale: 2.4, opacity: 0 }}
             transition={{ duration: 0.5, ease: 'easeOut' }}
-            style={{
-              position: 'absolute',
-              left: -24,
-              top: -24,
-              width: 48,
-              height: 48,
-              borderRadius: '50%',
-              border: `3px solid hsla(${pop.hue},80%,70%,0.8)`,
-            }}
           />
           {/* 위로 떠오르는 +N */}
-          <motion.span
+          <S.PopValue
+            $hue={pop.hue}
             initial={{ y: 0, opacity: 0, scale: 0.6 }}
             animate={{ y: -52, opacity: [0, 1, 1, 0], scale: 1.2 }}
             transition={{ duration: POP_DURATION_MS / 1000, ease: 'easeOut' }}
-            style={{
-              position: 'absolute',
-              left: -20,
-              top: -14,
-              fontSize: '1.4rem',
-              fontWeight: 800,
-              color: `hsl(${pop.hue},70%,45%)`,
-              textShadow: '0 1px 3px rgba(255,255,255,0.9)',
-              whiteSpace: 'nowrap',
-            }}
           >
             +{pop.value}
-          </motion.span>
-        </div>
+          </S.PopValue>
+        </S.Pop>
       ))}
-    </div>
+    </S.Layer>
   );
 };
 

--- a/frontend/src/pages/GamePage/hooks/useBatchedClick.ts
+++ b/frontend/src/pages/GamePage/hooks/useBatchedClick.ts
@@ -70,18 +70,28 @@ export const useBatchedClick = (clubName: string) => {
   useEffect(() => {
     flushRef.current = flush;
   }, [flush]);
+  // 동아리가 바뀌면 이전 동아리에 쌓인 미전송 클릭을 먼저 보낸다. 그렇지 않으면
+  // 다음 flush에서 이전 동아리 클릭이 새 동아리 이름으로 합산돼 오적립된다.
   useEffect(() => {
+    const prevClubName = clubNameRef.current;
+    if (prevClubName && prevClubName !== clubName && pendingRef.current > 0) {
+      flushRef.current(prevClubName);
+    }
     clubNameRef.current = clubName;
   }, [clubName]);
 
   // 언마운트 cleanup 일원화: 가드를 먼저 내려 이후 scheduleFlush가 새 타이머를
-  // 못 걸게 한 뒤, 남은 타이머를 정리하고 미전송분을 마지막으로 한 번 보낸다.
+  // 못 걸게 한 뒤, 남은 타이머를 정리하고 미전송분을 모두 보낸다. flush는 요청당
+  // 최대 5개만 보내므로, 언마운트 후 재예약이 막힌 상태에서 5개 초과분이 유실되지
+  // 않도록 pending이 빌 때까지 동기적으로 반복 flush한다.
   useEffect(() => {
     return () => {
       isMountedRef.current = false;
       if (timerRef.current) clearTimeout(timerRef.current);
       timerRef.current = null;
-      flushRef.current(clubNameRef.current);
+      while (pendingRef.current > 0) {
+        flushRef.current(clubNameRef.current);
+      }
     };
   }, []);
 

--- a/frontend/src/pages/GamePage/hooks/useBatchedClick.ts
+++ b/frontend/src/pages/GamePage/hooks/useBatchedClick.ts
@@ -74,24 +74,27 @@ export const useBatchedClick = (clubName: string) => {
     clubNameRef.current = clubName;
   }, [clubName]);
 
+  // 언마운트 cleanup 일원화: 가드를 먼저 내려 이후 scheduleFlush가 새 타이머를
+  // 못 걸게 한 뒤, 남은 타이머를 정리하고 미전송분을 마지막으로 한 번 보낸다.
   useEffect(() => {
     return () => {
       isMountedRef.current = false;
-    };
-  }, []);
-
-  useEffect(() => {
-    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = null;
       flushRef.current(clubNameRef.current);
     };
   }, []);
 
-  // amount: 버튼 클릭은 1, 비눗방울 터치는 방울에 적힌 값만큼 한 번에 적립
+  // amount: 버튼 클릭은 1, 비눗방울 터치는 방울에 적힌 값만큼 한 번에 적립.
+  // source: 버튼 클릭만 매크로 방지 쓰로틀을 적용한다. 비눗방울은 방울당 1회만
+  // 터치 가능하므로(중복 가드 존재) 쓰로틀로 누락돼 서버 카운트와 어긋나지 않도록 우회한다.
   const handleClick = useCallback(
-    (amount = 1) => {
-      const now = Date.now();
-      if (now - lastClickTimeRef.current < MIN_CLICK_INTERVAL) return;
-      lastClickTimeRef.current = now;
+    (amount = 1, source: 'button' | 'bubble' = 'button') => {
+      if (source === 'button') {
+        const now = Date.now();
+        if (now - lastClickTimeRef.current < MIN_CLICK_INTERVAL) return;
+        lastClickTimeRef.current = now;
+      }
 
       if (firstClickTimeRef.current === null) {
         firstClickTimeRef.current = new Date().toISOString();

--- a/frontend/src/pages/GamePage/hooks/useBatchedClick.ts
+++ b/frontend/src/pages/GamePage/hooks/useBatchedClick.ts
@@ -81,17 +81,15 @@ export const useBatchedClick = (clubName: string) => {
   }, [clubName]);
 
   // 언마운트 cleanup 일원화: 가드를 먼저 내려 이후 scheduleFlush가 새 타이머를
-  // 못 걸게 한 뒤, 남은 타이머를 정리하고 미전송분을 모두 보낸다. flush는 요청당
-  // 최대 5개만 보내므로, 언마운트 후 재예약이 막힌 상태에서 5개 초과분이 유실되지
-  // 않도록 pending이 빌 때까지 동기적으로 반복 flush한다.
+  // 못 걸게 한 뒤, 남은 타이머를 정리하고 미전송분을 마지막으로 한 번 보낸다.
+  // pending은 handleClick 사이에 항상 FLUSH_THRESHOLD(5) 미만으로 유지되고
+  // flush가 요청당 최대 5개를 보내므로, 한 번의 flush로 잔여분이 모두 전송된다.
   useEffect(() => {
     return () => {
       isMountedRef.current = false;
       if (timerRef.current) clearTimeout(timerRef.current);
       timerRef.current = null;
-      while (pendingRef.current > 0) {
-        flushRef.current(clubNameRef.current);
-      }
+      flushRef.current(clubNameRef.current);
     };
   }, []);
 


### PR DESCRIPTION
## 개요
PR #1770 리뷰(Gemini / CodeRabbit) 검토 후 유효한 지적을 반영합니다.

## 변경 사항
### 비눗방울 적립 desync 수정 (critical)
- `useBatchedClick.handleClick`이 `MIN_CLICK_INTERVAL` 쓰로틀을 모든 클릭에 적용해, 빠른 비눗방울 터치가 누락되면서 로컬 `myCount`만 오르고 서버 카운트와 어긋나는 문제가 있었습니다.
- `handleClick(amount, source)` / `gainCount(amount, source)`에 `source: 'button' | 'bubble'`를 추가해 **버튼 클릭만 쓰로틀**하고, 비눗방울은 우회하도록 변경했습니다. (비눗방울은 방울당 1회만 터치 가능한 중복 가드가 이미 있어 매크로 우려 없음)
- 버튼 경로는 `ClickButton`의 100ms 쓰로틀(≥ 내부 80ms 가드)로 이미 동기화되어 있어 별도 반영 누락이 없습니다.

### 동아리 변경 시 개인 카운터 초기화
- `handleStart`에서 `setMyCount(0)` 호출. (리뷰는 `useEffect` 제안이었으나 프로젝트 lint 규칙 `react-hooks/set-state-in-effect` 경고를 피하고, `clubName`의 유일한 변경 지점인 `handleStart`에서 처리)

### 언마운트 cleanup 레이스 제거
- 분리돼 있던 두 cleanup `useEffect`를 하나로 합쳐, `isMountedRef`를 먼저 내린 뒤 타이머 정리 → 최종 flush 순서를 보장. 언마운트 후 백그라운드 flush 타이머 생성 가능성 제거.

### 인라인 스타일 → styled-components
- `FallingBubbles`의 인라인 `style`을 `FallingBubbles.styles.ts`로 분리(코드베이스 컨벤션 일치). 동적 값(hue/size/위치)은 transient props로 전달.

## 검토했으나 반영하지 않은 항목
- **Framer Motion `onAnimationComplete` 조기 실행 우려(high)**: `onAnimationComplete`는 `animate`의 모든 값이 끝났을 때(가장 긴 `y` 낙하 = `duration`) 호출되며 opacity(0.5s) 시점에 조기 실행되지 않습니다. 실제로 방울이 화면 전체를 낙하한 뒤 제거되어 정상 동작 → false positive로 판단해 보류.

## 검증
- `tsc --noEmit` 통과
- `eslint` (변경 파일) 0 errors / 0 warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 버블 캐치와 버튼 클릭을 구분하여 추적하는 기능 추가

* **Bug Fixes**
  * 동아리 변경 시 카운터 잔여 문제 수정
  * 미전송 클릭 누락 방지 로직 강화

* **Style**
  * 버블 낙하 및 팝 애니메이션 UI 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->