### PR TITLE
[feature] 미사용 이벤트(USER_EVENT·PAGE_VIEW) 트래킹 체크 CI 

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Tracking audit (미사용 USER_EVENT 검사)
+        run: npm run audit:tracking
+
       - name: Build
         env:
           SKIP_DYNAMIC_SITEMAP: 'true'

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "test": "jest",
     "coverage": "jest --coverage --config jest.config.js",
     "typecheck": "tsc --noEmit",
+    "audit:tracking": "node ./scripts/audit-tracking.mjs",
     "analyze:deps": "depcruise src --include-only \"^src\" --output-type err-long",
     "analyze:metrics": "depcruise src --focus \"^src/components\" --output-type metrics",
     "analyze:graph": "depcruise src/components --include-only \"^src\" --output-type dot | dot -T svg > deps-components.svg",

--- a/frontend/scripts/audit-tracking.mjs
+++ b/frontend/scripts/audit-tracking.mjs
@@ -1,0 +1,74 @@
+/**
+ * 미사용 USER_EVENT 감사 (CI 게이트)
+ *
+ * `src/constants/eventName.ts`의 USER_EVENT 키 중, 코드 어디에서도
+ * `USER_EVENT.KEY` 로 참조되지 않는 "죽은 이벤트"를 찾는다.
+ * 하나라도 있으면 비정상 종료(exit 1)하여 CI를 실패시킨다.
+ *
+ * `/check-tracking` 커맨드의 Step 4(정의만 되고 미사용)를 결정론적으로 자동화한 것.
+ * Step 1~3(인터랙션 누락 의심)은 사람/LLM 판단이 필요하므로 제외한다.
+ * ADMIN_EVENT / PAGE_VIEW 는 별도 트래킹 체계라 대상에서 제외한다.
+ *
+ * 한계: 코드가 USER_EVENT 를 구조분해(`const { X } = USER_EVENT`)하면 검출하지
+ * 못한다. 현재 코드베이스는 `USER_EVENT.KEY` 멤버 접근만 사용한다.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const SRC = join(ROOT, 'src');
+const DEF_FILE = join(SRC, 'constants', 'eventName.ts');
+
+/** USER_EVENT 블록에서 키 목록을 추출한다. */
+function extractUserEventKeys(source) {
+  const start = source.indexOf('USER_EVENT = {');
+  if (start === -1) throw new Error('eventName.ts 에서 USER_EVENT 정의를 찾지 못했습니다.');
+  const end = source.indexOf('} as const;', start);
+  if (end === -1) throw new Error('USER_EVENT 블록의 끝(`} as const;`)을 찾지 못했습니다.');
+  const block = source.slice(start, end);
+
+  const keys = new Map(); // key -> event name(value)
+  const re = /^\s*([A-Z][A-Z0-9_]*)\s*:\s*'([^']*)'/gm;
+  let m;
+  while ((m = re.exec(block)) !== null) keys.set(m[1], m[2]);
+  return keys;
+}
+
+/** src 아래 .ts/.tsx 를 모두 읽어 하나의 문자열로 합친다(정의 파일 제외). */
+function collectSource(dir) {
+  let buf = '';
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name);
+    const st = statSync(path);
+    if (st.isDirectory()) {
+      buf += collectSource(path);
+    } else if (/\.tsx?$/.test(name) && path !== DEF_FILE) {
+      buf += readFileSync(path, 'utf8') + '\n';
+    }
+  }
+  return buf;
+}
+
+const keys = extractUserEventKeys(readFileSync(DEF_FILE, 'utf8'));
+const corpus = collectSource(SRC);
+
+const unused = [];
+for (const [key, eventName] of keys) {
+  const re = new RegExp(`USER_EVENT\\.${key}\\b`);
+  if (!re.test(corpus)) unused.push([key, eventName]);
+}
+
+if (unused.length === 0) {
+  console.log(`✓ 미사용 USER_EVENT 없음 (${keys.size}개 전부 사용 중)`);
+  process.exit(0);
+}
+
+console.error(`✗ 정의만 되고 미사용인 USER_EVENT ${unused.length}개 발견:\n`);
+for (const [key, eventName] of unused) {
+  console.error(`  - ${key}  ('${eventName}')`);
+}
+console.error(
+  '\n해당 이벤트에 trackEvent 를 연결하거나, 더 이상 쓰지 않으면 eventName.ts 에서 제거하세요.',
+);
+process.exit(1);

--- a/frontend/scripts/audit-tracking.mjs
+++ b/frontend/scripts/audit-tracking.mjs
@@ -20,18 +20,26 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const SRC = join(ROOT, 'src');
 const DEF_FILE = join(SRC, 'constants', 'eventName.ts');
 
-/** USER_EVENT 블록에서 키 목록을 추출한다. */
+/**
+ * USER_EVENT 블록에서 키 목록을 추출한다.
+ * 따옴표 종류·공백·세미콜론 유무에 유연하게 대응하고, 파싱이 깨져 키를
+ * 0개로 읽으면(= 게이트가 조용히 통과해버리는 상황) 명시적으로 실패한다.
+ */
 function extractUserEventKeys(source) {
-  const start = source.indexOf('USER_EVENT = {');
-  if (start === -1) throw new Error('eventName.ts 에서 USER_EVENT 정의를 찾지 못했습니다.');
-  const end = source.indexOf('} as const;', start);
-  if (end === -1) throw new Error('USER_EVENT 블록의 끝(`} as const;`)을 찾지 못했습니다.');
-  const block = source.slice(start, end);
+  const startMatch = source.match(/USER_EVENT\s*=\s*\{/);
+  if (!startMatch) throw new Error('eventName.ts 에서 USER_EVENT 정의를 찾지 못했습니다.');
+  const start = startMatch.index;
+  const endMatch = source.slice(start).match(/\}\s*as\s+const\s*;?/);
+  if (!endMatch) throw new Error('USER_EVENT 블록의 끝(`} as const;`)을 찾지 못했습니다.');
+  const block = source.slice(start, start + endMatch.index);
 
   const keys = new Map(); // key -> event name(value)
-  const re = /^\s*([A-Z][A-Z0-9_]*)\s*:\s*'([^']*)'/gm;
+  const re = /^\s*([A-Z][A-Z0-9_]*)\s*:\s*(['"])(.*?)\2/gm;
   let m;
-  while ((m = re.exec(block)) !== null) keys.set(m[1], m[2]);
+  while ((m = re.exec(block)) !== null) keys.set(m[1], m[3]);
+  if (keys.size === 0) {
+    throw new Error('USER_EVENT 키를 하나도 파싱하지 못했습니다. 파서/포맷을 확인하세요.');
+  }
   return keys;
 }
 

--- a/frontend/scripts/audit-tracking.mjs
+++ b/frontend/scripts/audit-tracking.mjs
@@ -1,16 +1,16 @@
 /**
- * 미사용 USER_EVENT 감사 (CI 게이트)
+ * 미사용 이벤트 감사 (CI 게이트)
  *
- * `src/constants/eventName.ts`의 USER_EVENT 키 중, 코드 어디에서도
- * `USER_EVENT.KEY` 로 참조되지 않는 "죽은 이벤트"를 찾는다.
+ * `src/constants/eventName.ts`의 USER_EVENT / PAGE_VIEW 키 중, 코드 어디에서도
+ * `그룹명.KEY` 로 참조되지 않는 "죽은 이벤트"를 찾는다.
  * 하나라도 있으면 비정상 종료(exit 1)하여 CI를 실패시킨다.
  *
  * `/check-tracking` 커맨드의 Step 4(정의만 되고 미사용)를 결정론적으로 자동화한 것.
  * Step 1~3(인터랙션 누락 의심)은 사람/LLM 판단이 필요하므로 제외한다.
- * ADMIN_EVENT / PAGE_VIEW 는 별도 트래킹 체계라 대상에서 제외한다.
+ * ADMIN_EVENT 는 현재 미사용 키 정리(누락 트래킹 추가 여부 판단)가 필요해 제외한다.
  *
- * 한계: 코드가 USER_EVENT 를 구조분해(`const { X } = USER_EVENT`)하면 검출하지
- * 못한다. 현재 코드베이스는 `USER_EVENT.KEY` 멤버 접근만 사용한다.
+ * 한계: 코드가 그룹을 구조분해(`const { X } = USER_EVENT`)하면 검출하지 못한다.
+ * 현재 코드베이스는 `그룹명.KEY` 멤버 접근만 사용한다.
  */
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { join, dirname } from 'node:path';
@@ -20,17 +20,19 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const SRC = join(ROOT, 'src');
 const DEF_FILE = join(SRC, 'constants', 'eventName.ts');
 
+const GROUPS = ['USER_EVENT', 'PAGE_VIEW'];
+
 /**
- * USER_EVENT 블록에서 키 목록을 추출한다.
+ * `<group> = { ... } as const;` 블록에서 키 목록을 추출한다.
  * 따옴표 종류·공백·세미콜론 유무에 유연하게 대응하고, 파싱이 깨져 키를
  * 0개로 읽으면(= 게이트가 조용히 통과해버리는 상황) 명시적으로 실패한다.
  */
-function extractUserEventKeys(source) {
-  const startMatch = source.match(/USER_EVENT\s*=\s*\{/);
-  if (!startMatch) throw new Error('eventName.ts 에서 USER_EVENT 정의를 찾지 못했습니다.');
+function extractKeys(source, group) {
+  const startMatch = source.match(new RegExp(`${group}\\s*=\\s*\\{`));
+  if (!startMatch) throw new Error(`eventName.ts 에서 ${group} 정의를 찾지 못했습니다.`);
   const start = startMatch.index;
   const endMatch = source.slice(start).match(/\}\s*as\s+const\s*;?/);
-  if (!endMatch) throw new Error('USER_EVENT 블록의 끝(`} as const;`)을 찾지 못했습니다.');
+  if (!endMatch) throw new Error(`${group} 블록의 끝(\`} as const;\`)을 찾지 못했습니다.`);
   const block = source.slice(start, start + endMatch.index);
 
   const keys = new Map(); // key -> event name(value)
@@ -38,7 +40,7 @@ function extractUserEventKeys(source) {
   let m;
   while ((m = re.exec(block)) !== null) keys.set(m[1], m[3]);
   if (keys.size === 0) {
-    throw new Error('USER_EVENT 키를 하나도 파싱하지 못했습니다. 파서/포맷을 확인하세요.');
+    throw new Error(`${group} 키를 하나도 파싱하지 못했습니다. 파서/포맷을 확인하세요.`);
   }
   return keys;
 }
@@ -58,23 +60,27 @@ function collectSource(dir) {
   return buf;
 }
 
-const keys = extractUserEventKeys(readFileSync(DEF_FILE, 'utf8'));
+const source = readFileSync(DEF_FILE, 'utf8');
 const corpus = collectSource(SRC);
 
-const unused = [];
-for (const [key, eventName] of keys) {
-  const re = new RegExp(`USER_EVENT\\.${key}\\b`);
-  if (!re.test(corpus)) unused.push([key, eventName]);
+const unused = []; // [group, key, eventName]
+const summary = [];
+for (const group of GROUPS) {
+  const keys = extractKeys(source, group);
+  for (const [key, eventName] of keys) {
+    if (!new RegExp(`${group}\\.${key}\\b`).test(corpus)) unused.push([group, key, eventName]);
+  }
+  summary.push(`${group} ${keys.size}`);
 }
 
 if (unused.length === 0) {
-  console.log(`✓ 미사용 USER_EVENT 없음 (${keys.size}개 전부 사용 중)`);
+  console.log(`✓ 미사용 이벤트 없음 (${summary.join(', ')})`);
   process.exit(0);
 }
 
-console.error(`✗ 정의만 되고 미사용인 USER_EVENT ${unused.length}개 발견:\n`);
-for (const [key, eventName] of unused) {
-  console.error(`  - ${key}  ('${eventName}')`);
+console.error(`✗ 정의만 되고 미사용인 이벤트 ${unused.length}개 발견:\n`);
+for (const [group, key, eventName] of unused) {
+  console.error(`  - ${group}.${key}  ('${eventName}')`);
 }
 console.error(
   '\n해당 이벤트에 trackEvent 를 연결하거나, 더 이상 쓰지 않으면 eventName.ts 에서 제거하세요.',

--- a/frontend/src/constants/eventName.ts
+++ b/frontend/src/constants/eventName.ts
@@ -19,8 +19,6 @@ export const USER_EVENT = {
   // 네비게이션
   BACK_BUTTON_CLICKED: 'Back Button Clicked',
   HOME_BUTTON_CLICKED: 'Home Button Clicked',
-  MOBILE_MENU_BUTTON_CLICKED: 'Mobile Menu Button Clicked',
-  MOBILE_MENU_DELETE_BUTTON_CLICKED: 'Mobile Menubar delete Button Clicked',
   ADMIN_BUTTON_CLICKED: 'Admin Button Clicked',
 
   // 탭 & 섹션


### PR DESCRIPTION
## 변경 내용
- `frontend/scripts/audit-tracking.mjs` 추가: `USER_EVENT`/`PAGE_VIEW`에 정의됐지만 코드 어디서도 `그룹명.KEY`로 참조되지 않는 죽은 이벤트를 검출.
- `package.json`에 `audit:tracking` 스크립트 추가 (`npm run audit:tracking`).
- `frontend-ci.yml`의 Lint↔Build 사이에 `Tracking audit` 스텝 추가 → CI 게이트화.
- `eventName.ts`에서 고아 상수 2개 제거: `MOBILE_MENU_BUTTON_CLICKED`, `MOBILE_MENU_DELETE_BUTTON_CLICKED`.

## 변경 이유
- 기존 `/check-tracking`은 사람이 수동 실행하는 LLM 커맨드라, 정의만 되고 미사용인 이벤트가 방치되기 쉬움.
- 그중 **결정론적으로 판단 가능한 Step 4(미사용 이벤트)** 만 CI 게이트로 자동화해, 이벤트 상수 rot을 PR 단계에서 차단.
- 제거한 2개는 `49f1c57a refactor(header): 헤더를 로고+검색만으로 간소화`에서 모바일 메뉴 UI가 빠지며 고아가 된 상수.

## 검증 방법
- 로컬 `npm run audit:tracking` → `✓ 미사용 이벤트 없음 (USER_EVENT 42, PAGE_VIEW 19)` (exit 0).
- 고아 상수 제거 전에는 동일 명령이 미사용 검출 + exit 1로 게이트가 정상 동작함을 확인.
- 이 PR 자체에서 `Frontend CI`의 `Tracking audit` 스텝이 실행되어 자기 검증됨.

## 영향 범위
- CI/분석 트래킹 인프라(프론트엔드). 런타임/사용자 화면 동작 변경 없음.
- 범위: `USER_EVENT`, `PAGE_VIEW` 감사. 둘 다 구조분해 없이 `그룹명.KEY` 멤버 접근만 사용해 오탐 없음.
- 제외: `ADMIN_EVENT`는 현재 미사용 키 6개가 "트래킹 누락(붙여야 함)"인지 "죽은 상수(지워야 함)"인지 판단이 필요해, 별도 후속 작업으로 분리하고 이번 게이트에서 제외.
- 인터랙션 누락 의심(Step 1~3)은 사람 판단 영역이라 기존 `/check-tracking` 커맨드로 유지.
- 한계: 그룹을 구조분해해서 쓰면 검출 못 함(현재 코드베이스는 `그룹명.KEY` 멤버 접근만 사용).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI에 이벤트 사용 여부를 점검하는 추가 검사가 포함되어, 미사용 항목을 더 쉽게 찾아낼 수 있게 되었습니다.
  * 관련 스크립트가 추가되어, 정기 검사 흐름이 확장되었습니다.

* **Bug Fixes**
  * 사용되지 않는 일부 모바일 메뉴 이벤트 항목을 정리해 이벤트 목록을 더 깔끔하게 유지했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->