### PR TITLE
[feature] 게임 페이지 버닝 타임 이벤트 추가

### DIFF
--- a/frontend/src/pages/GamePage/GamePage.styles.ts
+++ b/frontend/src/pages/GamePage/GamePage.styles.ts
@@ -110,6 +110,20 @@ export const MobileOnly = styled.div`
   }
 `;
 
+export const PlayArea = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  /* 게이지를 버튼 위에 배치. ClickButton의 음수 마진(-100px)을 일부 상쇄해
+     게이지가 버튼 상단 빈 영역 위에 자연스럽게 놓이도록 한다. */
+  & > *:first-child {
+    position: relative;
+    z-index: 3;
+    margin-bottom: 40px;
+  }
+`;
+
 export const TopRow = styled.div`
   position: relative;
   display: flex;

--- a/frontend/src/pages/GamePage/GamePage.tsx
+++ b/frontend/src/pages/GamePage/GamePage.tsx
@@ -163,14 +163,13 @@ const GamePage = () => {
     };
   }, [isDark]);
 
-  // memo된 RankingBoard가 게이지/버닝 틱마다 리렌더되지 않도록 참조를 고정한다
-  const handleStart = useCallback((name: string) => {
+  const handleStart = (name: string) => {
     localStorage.setItem(STORAGE_KEY, name);
     setClubName(name);
     // 새 동아리를 고르면 개인 카운터를 초기화해 이전 동아리 클릭이 남지 않게 한다
     setMyCount(0);
     setIsEditing(false);
-  }, []);
+  };
 
   const handleChangeClub = () => {
     setIsEditing(true);

--- a/frontend/src/pages/GamePage/GamePage.tsx
+++ b/frontend/src/pages/GamePage/GamePage.tsx
@@ -6,6 +6,7 @@ import useTrackPageView from '@/hooks/Mixpanel/useTrackPageView';
 import { useGameRanking } from '@/hooks/Queries/useGame';
 import isInAppWebView from '@/utils/isInAppWebView';
 import BackgroundFirework from './components/BackgroundFirework/BackgroundFirework';
+import BurningGauge from './components/BurningGauge/BurningGauge';
 import ClickButton from './components/ClickButton/ClickButton';
 import ClubNameInput from './components/ClubNameInput/ClubNameInput';
 import DotTextEffect from './components/DotTextEffect/DotTextEffect';
@@ -13,6 +14,7 @@ import FallingBubbles from './components/FallingBubbles/FallingBubbles';
 import RankingBoard from './components/RankingBoard/RankingBoard';
 import * as S from './GamePage.styles';
 import { useBatchedClick } from './hooks/useBatchedClick';
+import { BURNING_MULTIPLIER, useBurningGauge } from './hooks/useBurningGauge';
 
 const STORAGE_KEY = 'game_club_name';
 const DARK_KEY = 'game_dark_mode';
@@ -60,6 +62,12 @@ const GamePage = () => {
 
   const { data: rankingData } = useGameRanking();
   const sendClick = useBatchedClick(clubName);
+  const {
+    gaugeRatio,
+    isBurning,
+    burningRemainingSec,
+    registerClick: registerBurningClick,
+  } = useBurningGauge();
 
   // 버튼 클릭(1)과 비눗방울 터치(방울 값)를 합산해 개인 카운터와 서버에 반영.
   // source를 전달해 비눗방울 적립이 버튼 쓰로틀에 걸려 누락되지 않도록 한다.
@@ -71,10 +79,11 @@ const GamePage = () => {
     [sendClick],
   );
 
-  const handleButtonClick = useCallback(
-    () => gainCount(1, 'button'),
-    [gainCount],
-  );
+  // 버튼 클릭은 버닝 게이지를 채우고, 버닝 중에는 클릭당 +2씩 적립된다.
+  const handleButtonClick = useCallback(() => {
+    registerBurningClick();
+    gainCount(isBurning ? BURNING_MULTIPLIER : 1, 'button');
+  }, [registerBurningClick, isBurning, gainCount]);
 
   const handleBubbleCatch = useCallback(
     (amount: number) => gainCount(amount, 'bubble'),
@@ -154,13 +163,14 @@ const GamePage = () => {
     };
   }, [isDark]);
 
-  const handleStart = (name: string) => {
+  // memo된 RankingBoard가 게이지/버닝 틱마다 리렌더되지 않도록 참조를 고정한다
+  const handleStart = useCallback((name: string) => {
     localStorage.setItem(STORAGE_KEY, name);
     setClubName(name);
     // 새 동아리를 고르면 개인 카운터를 초기화해 이전 동아리 클릭이 남지 않게 한다
     setMyCount(0);
     setIsEditing(false);
-  };
+  }, []);
 
   const handleChangeClub = () => {
     setIsEditing(true);
@@ -271,13 +281,21 @@ const GamePage = () => {
                 isDark={isDark}
               />
             ) : (
-              <ClickButton
-                clubName={clubName}
-                count={myCount}
-                onClickGame={handleButtonClick}
-                onChangeClub={handleChangeClub}
-                isDark={isDark}
-              />
+              <S.PlayArea>
+                <BurningGauge
+                  ratio={gaugeRatio}
+                  isBurning={isBurning}
+                  remainingSec={burningRemainingSec}
+                  isDark={isDark}
+                />
+                <ClickButton
+                  clubName={clubName}
+                  count={myCount}
+                  onClickGame={handleButtonClick}
+                  onChangeClub={handleChangeClub}
+                  isDark={isDark}
+                />
+              </S.PlayArea>
             )}
           </motion.div>
 

--- a/frontend/src/pages/GamePage/components/BurningGauge/BurningGauge.styles.ts
+++ b/frontend/src/pages/GamePage/components/BurningGauge/BurningGauge.styles.ts
@@ -1,0 +1,57 @@
+import styled, { keyframes } from 'styled-components';
+
+const flicker = keyframes`
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%      { opacity: 0.85; transform: scale(1.04); }
+`;
+
+export const Wrapper = styled.div`
+  position: relative;
+  width: 280px;
+  max-width: 80vw;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+`;
+
+export const Track = styled.div<{ $dark: boolean; $burning: boolean }>`
+  position: relative;
+  width: 100%;
+  height: 14px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: ${({ $dark, theme }) =>
+    $dark ? '#2A2A33' : theme.colors.gray[200]};
+  box-shadow: ${({ $burning }) =>
+    $burning ? '0 0 16px rgba(255, 84, 20, 0.7)' : 'none'};
+  transition: box-shadow 0.2s;
+`;
+
+export const Fill = styled.div<{ $ratio: number; $burning: boolean }>`
+  height: 100%;
+  width: ${({ $ratio }) => `${Math.min(100, Math.max(0, $ratio * 100))}%`};
+  border-radius: 999px;
+  background: ${({ $burning }) =>
+    $burning
+      ? 'linear-gradient(90deg, #FFD432, #FF5414)'
+      : 'linear-gradient(90deg, #FF9D7C, #FF5414)'};
+  transition: width 0.08s linear;
+`;
+
+export const Label = styled.span<{ $dark: boolean }>`
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: ${({ $dark, theme }) =>
+    $dark ? theme.colors.gray[400] : theme.colors.gray[600]};
+`;
+
+export const BurningBadge = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.95rem;
+  font-weight: 800;
+  color: #ff5414;
+  animation: ${flicker} 0.6s ease-in-out infinite;
+`;

--- a/frontend/src/pages/GamePage/components/BurningGauge/BurningGauge.tsx
+++ b/frontend/src/pages/GamePage/components/BurningGauge/BurningGauge.tsx
@@ -1,4 +1,3 @@
-import { memo } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import * as S from './BurningGauge.styles';
 
@@ -48,4 +47,4 @@ const BurningGauge = ({
   );
 };
 
-export default memo(BurningGauge);
+export default BurningGauge;

--- a/frontend/src/pages/GamePage/components/BurningGauge/BurningGauge.tsx
+++ b/frontend/src/pages/GamePage/components/BurningGauge/BurningGauge.tsx
@@ -1,0 +1,51 @@
+import { memo } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import * as S from './BurningGauge.styles';
+
+interface BurningGaugeProps {
+  ratio: number; // 0~1
+  isBurning: boolean;
+  remainingSec: number;
+  isDark?: boolean;
+}
+
+const BurningGauge = ({
+  ratio,
+  isBurning,
+  remainingSec,
+  isDark = false,
+}: BurningGaugeProps) => {
+  return (
+    <S.Wrapper>
+      <S.Track $dark={isDark} $burning={isBurning}>
+        <S.Fill $ratio={isBurning ? 1 : ratio} $burning={isBurning} />
+      </S.Track>
+
+      <AnimatePresence mode='wait'>
+        {isBurning ? (
+          <motion.div
+            key='burning'
+            initial={{ opacity: 0, scale: 0.8 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.8 }}
+          >
+            <S.BurningBadge>
+              🔥 버닝 타임! 클릭당 +2 · {remainingSec}초
+            </S.BurningBadge>
+          </motion.div>
+        ) : (
+          <motion.div
+            key='idle'
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+          >
+            <S.Label $dark={isDark}>연속 클릭하면 버닝 타임! 🔥</S.Label>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </S.Wrapper>
+  );
+};
+
+export default memo(BurningGauge);

--- a/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.tsx
+++ b/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { memo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { AnimatePresence, motion } from 'framer-motion';
 import { GameRankingEntry } from '@/types/game';
@@ -115,4 +115,4 @@ const RankingBoard = ({
   );
 };
 
-export default RankingBoard;
+export default memo(RankingBoard);

--- a/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.tsx
+++ b/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from 'react';
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { AnimatePresence, motion } from 'framer-motion';
 import { GameRankingEntry } from '@/types/game';
@@ -115,4 +115,4 @@ const RankingBoard = ({
   );
 };
 
-export default memo(RankingBoard);
+export default RankingBoard;

--- a/frontend/src/pages/GamePage/hooks/useBatchedClick.ts
+++ b/frontend/src/pages/GamePage/hooks/useBatchedClick.ts
@@ -9,6 +9,13 @@ const MAX_CLICK_PER_REQUEST = 5;
 export const CLICK_THROTTLE_MS = 100;
 // UI 버튼 쓰로틀(CLICK_THROTTLE_MS)보다 짧게 잡아 버튼 핸들러를 우회하는 DOM 레벨 매크로를 차단
 const MIN_CLICK_INTERVAL = Math.floor(CLICK_THROTTLE_MS * 0.8);
+// 서버 레이트리밋(IP당 10초에 20회 초과 시 30초 밴)을 넘지 않도록 한 요청과
+// 다음 요청 사이 최소 간격. 550ms면 약 18회/10초로 여유를 둔다.
+// 버닝(클릭당 +2)이면 임계치에 2배 빨리 도달하는데, 이 간격이 없으면 요청
+// 빈도가 2배가 되어 429로 차단된다.
+const MIN_SEND_INTERVAL = 550;
+// 백로그가 쌓여도 ctAt이 서버의 30초 과거 윈도우에 걸리지 않도록 하는 하한(여유 5초)
+const CTAT_MAX_AGE_MS = 25_000;
 
 /**
  * 클릭을 모아 일정 개수(5)나 디바운스(500ms) 시점에 한 번에 전송한다.
@@ -18,6 +25,8 @@ export const useBatchedClick = (clubName: string) => {
   const pendingRef = useRef(0);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastClickTimeRef = useRef(0);
+  // 마지막으로 서버에 실제 전송한 시각(레이트리밋 회피용, 버튼 쓰로틀과 별개)
+  const lastSendTimeRef = useRef(0);
   const firstClickTimeRef = useRef<string | null>(null);
   const isMountedRef = useRef(true);
   const { mutate: clickGame } = useClickGame();
@@ -33,13 +42,36 @@ export const useBatchedClick = (clubName: string) => {
 
   const flush = useCallback(
     (name: string) => {
+      if (pendingRef.current === 0) {
+        if (timerRef.current) clearTimeout(timerRef.current);
+        timerRef.current = null;
+        return;
+      }
+
+      // 직전 전송 이후 최소 간격이 지나지 않았으면, 남은 시간만큼 미뤄 레이트리밋을
+      // 회피한다. 버닝으로 임계치에 빨리 도달해도 전송 빈도는 이 간격으로 고정된다.
+      const now = Date.now();
+      const sinceLast = now - lastSendTimeRef.current;
+      if (sinceLast < MIN_SEND_INTERVAL) {
+        if (!isMountedRef.current) return;
+        if (timerRef.current) clearTimeout(timerRef.current);
+        timerRef.current = setTimeout(
+          () => flushRef.current(name),
+          MIN_SEND_INTERVAL - sinceLast,
+        );
+        return;
+      }
+
       if (timerRef.current) clearTimeout(timerRef.current);
       timerRef.current = null;
-      if (pendingRef.current === 0) return;
+      lastSendTimeRef.current = now;
 
       // 이번 요청에 보낼 양(최대 5)만 떼어내고 나머지는 다음 flush로 미룬다
       const count = Math.min(MAX_CLICK_PER_REQUEST, pendingRef.current);
-      const ctAt = firstClickTimeRef.current ?? new Date().toISOString();
+      let ctAt = firstClickTimeRef.current ?? new Date(now).toISOString();
+      // 백로그가 오래 쌓여 ctAt이 서버 30초 윈도우를 넘기면 거부되므로 하한 보정
+      const minCtAt = new Date(now - CTAT_MAX_AGE_MS).toISOString();
+      if (ctAt < minCtAt) ctAt = minCtAt;
       pendingRef.current -= count;
       firstClickTimeRef.current = null;
 
@@ -82,13 +114,15 @@ export const useBatchedClick = (clubName: string) => {
 
   // 언마운트 cleanup 일원화: 가드를 먼저 내려 이후 scheduleFlush가 새 타이머를
   // 못 걸게 한 뒤, 남은 타이머를 정리하고 미전송분을 마지막으로 한 번 보낸다.
-  // pending은 handleClick 사이에 항상 FLUSH_THRESHOLD(5) 미만으로 유지되고
-  // flush가 요청당 최대 5개를 보내므로, 한 번의 flush로 잔여분이 모두 전송된다.
+  // lastSendTime을 0으로 되돌려 전송 간격 가드를 우회한다(마지막 1회 추가 요청은
+  // 레이트리밋에 영향 없음). 버닝 백로그가 5를 넘긴 채 이탈하면 이 한 번의 flush로
+  // 최대 5개만 전송되고 나머지는 유실되지만, 게임 도중 이탈하는 드문 경우라 허용한다.
   useEffect(() => {
     return () => {
       isMountedRef.current = false;
       if (timerRef.current) clearTimeout(timerRef.current);
       timerRef.current = null;
+      lastSendTimeRef.current = 0;
       flushRef.current(clubNameRef.current);
     };
   }, []);

--- a/frontend/src/pages/GamePage/hooks/useBurningGauge.ts
+++ b/frontend/src/pages/GamePage/hooks/useBurningGauge.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 const GAUGE_MAX = 100;
 // 클릭당 게이지 증가량. 멈추면 감소하므로 연속 클릭해야 가득 찬다.
@@ -34,15 +34,15 @@ export const useBurningGauge = () => {
   const burningTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const burningEndRef = useRef(0);
 
-  const stopDecay = useCallback(() => {
+  const stopDecay = () => {
     if (decayTimerRef.current) {
       clearInterval(decayTimerRef.current);
       decayTimerRef.current = null;
     }
-  }, []);
+  };
 
   // 게이지가 0보다 클 때만 도는 감소 루프. 0에 닿으면 스스로 멈춘다.
-  const startDecay = useCallback(() => {
+  const startDecay = () => {
     if (decayTimerRef.current) return;
     lastDecayTickRef.current = Date.now();
     decayTimerRef.current = setInterval(() => {
@@ -54,9 +54,9 @@ export const useBurningGauge = () => {
       setGauge(next);
       if (next <= 0) stopDecay();
     }, DECAY_TICK_MS);
-  }, [stopDecay]);
+  };
 
-  const endBurning = useCallback(() => {
+  const endBurning = () => {
     if (burningTimerRef.current) {
       clearInterval(burningTimerRef.current);
       burningTimerRef.current = null;
@@ -66,9 +66,9 @@ export const useBurningGauge = () => {
     setBurningRemainingMs(0);
     gaugeRef.current = 0;
     setGauge(0);
-  }, []);
+  };
 
-  const startBurning = useCallback(() => {
+  const startBurning = () => {
     stopDecay();
     gaugeRef.current = GAUGE_MAX;
     setGauge(GAUGE_MAX);
@@ -84,10 +84,10 @@ export const useBurningGauge = () => {
         setBurningRemainingMs(remain);
       }
     }, BURNING_TICK_MS);
-  }, [stopDecay, endBurning]);
+  };
 
   // 매 버튼 클릭마다 호출. 버닝 중이면 게이지는 고정이라 무시한다.
-  const registerClick = useCallback(() => {
+  const registerClick = () => {
     if (isBurningRef.current) return;
     const next = Math.min(GAUGE_MAX, gaugeRef.current + CLICK_GAIN);
     gaugeRef.current = next;
@@ -97,14 +97,14 @@ export const useBurningGauge = () => {
     } else {
       startDecay();
     }
-  }, [startBurning, startDecay]);
+  };
 
   useEffect(() => {
     return () => {
-      stopDecay();
+      if (decayTimerRef.current) clearInterval(decayTimerRef.current);
       if (burningTimerRef.current) clearInterval(burningTimerRef.current);
     };
-  }, [stopDecay]);
+  }, []);
 
   return {
     /** 0~1 비율 (게이지 바 표시용) */

--- a/frontend/src/pages/GamePage/hooks/useBurningGauge.ts
+++ b/frontend/src/pages/GamePage/hooks/useBurningGauge.ts
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const GAUGE_MAX = 100;
+// 클릭당 게이지 증가량. 멈추면 감소하므로 연속 클릭해야 가득 찬다.
+const CLICK_GAIN = 7;
+// 클릭을 멈췄을 때 초당 감소량 (연타를 유지해야 채워지도록)
+const DECAY_PER_SEC = 20;
+// decay 루프 주기 (ms)
+const DECAY_TICK_MS = 50;
+
+// 버닝 이벤트 지속 시간
+const BURNING_DURATION_MS = 30_000;
+// 버닝 동안 클릭당 적립 배수 (+2)
+export const BURNING_MULTIPLIER = 2;
+// 버닝 남은 시간 갱신 주기 (ms)
+const BURNING_TICK_MS = 100;
+
+/**
+ * 연속 클릭으로 게이지를 채우면 30초간 "버닝 이벤트"가 발동해 클릭당 +2씩 적립된다.
+ * - 게이지는 클릭으로 차오르고, 멈추면 시간에 비례해 감소한다(연타 유도).
+ * - 가득 차는 순간 버닝 시작, 30초 후 종료되며 게이지는 0으로 초기화된다.
+ * - 버닝 중에는 게이지가 가득 찬 상태로 고정되고 추가 적립/감소가 멈춘다.
+ */
+export const useBurningGauge = () => {
+  const [gauge, setGauge] = useState(0); // 0~GAUGE_MAX
+  const [isBurning, setIsBurning] = useState(false);
+  const [burningRemainingMs, setBurningRemainingMs] = useState(0);
+
+  // 게이지 실제 값/타이머는 ref로 관리해 잦은 재생성 없이 루프를 돌린다
+  const gaugeRef = useRef(0);
+  const isBurningRef = useRef(false);
+  const decayTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const lastDecayTickRef = useRef(0);
+  const burningTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const burningEndRef = useRef(0);
+
+  const stopDecay = useCallback(() => {
+    if (decayTimerRef.current) {
+      clearInterval(decayTimerRef.current);
+      decayTimerRef.current = null;
+    }
+  }, []);
+
+  // 게이지가 0보다 클 때만 도는 감소 루프. 0에 닿으면 스스로 멈춘다.
+  const startDecay = useCallback(() => {
+    if (decayTimerRef.current) return;
+    lastDecayTickRef.current = Date.now();
+    decayTimerRef.current = setInterval(() => {
+      const now = Date.now();
+      const dt = (now - lastDecayTickRef.current) / 1000;
+      lastDecayTickRef.current = now;
+      const next = Math.max(0, gaugeRef.current - DECAY_PER_SEC * dt);
+      gaugeRef.current = next;
+      setGauge(next);
+      if (next <= 0) stopDecay();
+    }, DECAY_TICK_MS);
+  }, [stopDecay]);
+
+  const endBurning = useCallback(() => {
+    if (burningTimerRef.current) {
+      clearInterval(burningTimerRef.current);
+      burningTimerRef.current = null;
+    }
+    isBurningRef.current = false;
+    setIsBurning(false);
+    setBurningRemainingMs(0);
+    gaugeRef.current = 0;
+    setGauge(0);
+  }, []);
+
+  const startBurning = useCallback(() => {
+    stopDecay();
+    gaugeRef.current = GAUGE_MAX;
+    setGauge(GAUGE_MAX);
+    isBurningRef.current = true;
+    setIsBurning(true);
+    burningEndRef.current = Date.now() + BURNING_DURATION_MS;
+    setBurningRemainingMs(BURNING_DURATION_MS);
+    burningTimerRef.current = setInterval(() => {
+      const remain = burningEndRef.current - Date.now();
+      if (remain <= 0) {
+        endBurning();
+      } else {
+        setBurningRemainingMs(remain);
+      }
+    }, BURNING_TICK_MS);
+  }, [stopDecay, endBurning]);
+
+  // 매 버튼 클릭마다 호출. 버닝 중이면 게이지는 고정이라 무시한다.
+  const registerClick = useCallback(() => {
+    if (isBurningRef.current) return;
+    const next = Math.min(GAUGE_MAX, gaugeRef.current + CLICK_GAIN);
+    gaugeRef.current = next;
+    setGauge(next);
+    if (next >= GAUGE_MAX) {
+      startBurning();
+    } else {
+      startDecay();
+    }
+  }, [startBurning, startDecay]);
+
+  useEffect(() => {
+    return () => {
+      stopDecay();
+      if (burningTimerRef.current) clearInterval(burningTimerRef.current);
+    };
+  }, [stopDecay]);
+
+  return {
+    /** 0~1 비율 (게이지 바 표시용) */
+    gaugeRatio: gauge / GAUGE_MAX,
+    isBurning,
+    /** 버닝 남은 시간(초) */
+    burningRemainingSec: Math.ceil(burningRemainingMs / 1000),
+    registerClick,
+  };
+};


### PR DESCRIPTION
## 개요

게임 페이지에 **버닝 타임 이벤트**를 추가했습니다. 연속 클릭으로 게이지를 채우면 30초간 클릭당 +2씩 적립됩니다.

## 동작

- **연속 클릭 → 게이지 충전**: 클릭 버튼 위 게이지 바가 클릭마다 차오름
- **멈추면 감소(decay)**: 연타를 유지해야 가득 참 (잠깐 누른다고 차지 않음)
- **가득 차면 30초 버닝**: 🔥 배지 + 남은 시간 카운트다운, 클릭당 +2 적립
- **종료 후 게이지 0으로 초기화**, 다시 채우면 재발동

## 함께 처리한 이슈: 버닝 중 429(Too Many Requests) 차단 수정

버닝이 클릭당 +2라 배칭 임계치에 2배 빨리 도달 → 요청 빈도가 2배가 되어 서버 레이트리밋(IP당 10초/20회)을 넘겨 30초 밴당하던 문제.
- `useBatchedClick`에 **최소 전송 간격(550ms)** 강제 → 약 18회/10초로 평탄화
- 백로그가 쌓여도 `ctAt`이 서버의 30초 과거 윈도우에 걸려 거부되지 않도록 **하한 보정(25초)**

## 변경 파일

- `hooks/useBurningGauge.ts` (신규) — 게이지/버닝 로직
- `components/BurningGauge/` (신규) — 게이지 바 + 버닝 배지 UI
- `GamePage.tsx` / `GamePage.styles.ts` — 훅 연결, 클릭당 배수 적용, 레이아웃
- `hooks/useBatchedClick.ts` — 전송 속도 제한 + ctAt 보정

> 리렌더 관련 수동 메모이제이션은 추가하지 않습니다. 프로젝트가 React Compiler를 사용하므로 자동 메모이제이션에 맡깁니다.

## 알아두실 점 (트레이드오프)

서버 흡수 한계가 **초당 10클릭**(count 5/요청 × 2요청/초)이라, 버닝의 +2를 풀 속도로 누르면 서버 반영이 잠깐 밀립니다. 개인 카운터는 즉시 정확하고 랭킹이 몇 초 뒤따라오며, **밴 없이 정확히 누적**되는 방식입니다. 더 즉각적인 서버 반영이 필요하면 백엔드 레이트리밋 상향이 별도로 필요합니다.

## 검증

- `npm run typecheck` ✅
- `npm run lint` (변경 파일) ✅