### PR TITLE
[feature] 게임 랭킹보드 카드 선택/상세 이동 이벤트 트래킹

### DIFF
--- a/frontend/src/constants/eventName.ts
+++ b/frontend/src/constants/eventName.ts
@@ -75,6 +75,8 @@ export const USER_EVENT = {
 
   // 클릭배틀 게임
   GAME_START_BUTTON_CLICKED: 'Game Start Button Clicked',
+  GAME_RANKING_CLUB_SELECTED: 'Game Ranking Club Selected',
+  GAME_RANKING_DETAIL_CLICKED: 'Game Ranking Detail Clicked',
 } as const;
 
 export const WEBVIEW_LINK_TARGET = {

--- a/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.tsx
+++ b/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { AnimatePresence, motion } from 'framer-motion';
+import { USER_EVENT } from '@/constants/eventName';
+import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import { GameRankingEntry } from '@/types/game';
 import * as S from './RankingBoard.styles';
 
@@ -23,6 +25,7 @@ const RankingBoard = ({
   onSelectClub,
 }: RankingBoardProps) => {
   const [isExpanded, setIsExpanded] = useState(false);
+  const trackEvent = useMixpanelTrack();
 
   const visibleRanking = isExpanded ? ranking : ranking.slice(0, TOP_COUNT);
   const hasMore = ranking.length > TOP_COUNT;
@@ -57,7 +60,14 @@ const RankingBoard = ({
                   <S.Item
                     {...(onSelectClub
                       ? {
-                          onClick: () => onSelectClub(entry.clubName),
+                          onClick: () => {
+                            // 카드 클릭 = 게임 대상 동아리 변경 (상세 이동과 별개 이벤트)
+                            trackEvent(USER_EVENT.GAME_RANKING_CLUB_SELECTED, {
+                              clubName: entry.clubName,
+                              rank: entry.rank,
+                            });
+                            onSelectClub(entry.clubName);
+                          },
                         }
                       : {
                           as: Link,
@@ -87,7 +97,14 @@ const RankingBoard = ({
                       <S.DetailLink
                         as={Link}
                         to={`/clubDetail/@${encodeURIComponent(entry.clubName)}`}
-                        onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                        onClick={(e: React.MouseEvent) => {
+                          // 네비게이션 버튼 클릭 = 상세페이지 이동 (카드 선택과 별개 이벤트)
+                          e.stopPropagation();
+                          trackEvent(USER_EVENT.GAME_RANKING_DETAIL_CLICKED, {
+                            clubName: entry.clubName,
+                            rank: entry.rank,
+                          });
+                        }}
                         $dark={isDark}
                         aria-label={`${entry.clubName} 상세페이지`}
                       >


### PR DESCRIPTION
## 개요

게임 페이지 랭킹보드에서 **카드 클릭**과 **우측 네비게이션 버튼(→) 클릭**을 별개의 Mixpanel 이벤트로 분리해 트래킹합니다.

## 동작

랭킹 카드의 두 인터랙션은 서로 다른 동작이라 별개 이벤트로 기록합니다.

| 인터랙션 | 동작 | 이벤트 |
|---|---|---|
| 카드 본문 클릭 | 게임 대상 동아리 변경 | `GAME_RANKING_CLUB_SELECTED` |
| 우측 `→` 버튼 클릭 | 동아리 상세페이지 이동 | `GAME_RANKING_DETAIL_CLICKED` |

- 두 이벤트 모두 `{ clubName, rank }` 속성 전달
- `→` 버튼은 `stopPropagation`으로 카드 선택과 분리되어 두 이벤트가 섞이지 않음

## 변경 파일

- `src/constants/eventName.ts` — `USER_EVENT`에 게임 랭킹 이벤트 2개 추가
- `src/pages/GamePage/components/RankingBoard/RankingBoard.tsx` — 카드/네비 버튼에 트래킹 연결

## 검증

- `npm run typecheck` ✅
- `npm run lint` (변경 파일) ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 클릭배틀 게임의 순위판 사용자 상호작용 추적이 개선되었습니다. 랭킹 카드 선택 및 상세 정보 클릭 시 개별 이벤트가 기록되도록 변경되어, 사용자 행동에 대한 더욱 정확한 분석이 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->