### PR TITLE
[perf] 버닝 게이지 렉 제거 (Fill width 클래스 churn)

### DIFF
--- a/frontend/src/pages/GamePage/components/BurningGauge/BurningGauge.styles.ts
+++ b/frontend/src/pages/GamePage/components/BurningGauge/BurningGauge.styles.ts
@@ -28,11 +28,16 @@ export const Track = styled.div<{ $dark: boolean; $burning: boolean }>`
   transition: box-shadow 0.2s;
 `;
 
+interface FillProps {
+  $ratio: number;
+  $burning: boolean;
+}
+
 // width는 매 decay 틱(20fps)마다 바뀌므로 CSS 템플릿이 아닌 inline style로 넘긴다.
 // 템플릿에 넣으면 값마다 새 클래스가 stylesheet에 주입돼 CSSOM 재파싱으로 렉이 생긴다.
-export const Fill = styled.div.attrs<{ $ratio: number }>(({ $ratio }) => ({
+export const Fill = styled.div.attrs<FillProps>(({ $ratio }) => ({
   style: { width: `${Math.min(100, Math.max(0, $ratio * 100))}%` },
-}))<{ $ratio: number; $burning: boolean }>`
+}))`
   height: 100%;
   border-radius: 999px;
   background: ${({ $burning }) =>

--- a/frontend/src/pages/GamePage/components/BurningGauge/BurningGauge.styles.ts
+++ b/frontend/src/pages/GamePage/components/BurningGauge/BurningGauge.styles.ts
@@ -28,9 +28,12 @@ export const Track = styled.div<{ $dark: boolean; $burning: boolean }>`
   transition: box-shadow 0.2s;
 `;
 
-export const Fill = styled.div<{ $ratio: number; $burning: boolean }>`
+// width는 매 decay 틱(20fps)마다 바뀌므로 CSS 템플릿이 아닌 inline style로 넘긴다.
+// 템플릿에 넣으면 값마다 새 클래스가 stylesheet에 주입돼 CSSOM 재파싱으로 렉이 생긴다.
+export const Fill = styled.div.attrs<{ $ratio: number }>(({ $ratio }) => ({
+  style: { width: `${Math.min(100, Math.max(0, $ratio * 100))}%` },
+}))<{ $ratio: number; $burning: boolean }>`
   height: 100%;
-  width: ${({ $ratio }) => `${Math.min(100, Math.max(0, $ratio * 100))}%`};
   border-radius: 999px;
   background: ${({ $burning }) =>
     $burning


### PR DESCRIPTION
## 문제

버닝 게이지를 연타하다 멈추면 화면이 약간 버벅이는 증상이 있었다.

원인은 게이지 바 `Fill`이 50ms(20fps) decay 틱마다 바뀌는 `$ratio`를 styled-components **CSS 템플릿에 직접 주입**한 것. 값이 바뀔 때마다 새 CSS 클래스가 해시 생성돼 `<style>`에 쌓이고 CSSOM이 계속 재파싱된다. 게이지가 100→0으로 떨어지는 ~5초 동안 100개 가까운 일회용 클래스가 주입된다.

## 수정

자주 바뀌는 `width`만 `.attrs`의 inline `style`로 분리. `$burning`(토글 시에만 변경)은 템플릿에 유지.

- 클래스는 1개로 고정 → stylesheet 주입/CSSOM 재파싱 제거
- 보이는 모습·애니메이션(`transition: width 0.08s`)·hook 로직은 그대로

## 참고

`width` 대신 `transform: scaleX`로 가면 layout reflow까지 없앨 수 있으나, pill 모양(`border-radius: 999px`) 오른쪽 캡이 찌그러질 수 있어 이번엔 보류. 이 수정만으로 체감 렉은 해소될 것으로 본다.