### PR TITLE
[feature] 어드민 자유태그 모바일 편집 페이지 구현

### DIFF
--- a/frontend/docs/features/admin/info/mobile-free-tag-edit.md
+++ b/frontend/docs/features/admin/info/mobile-free-tag-edit.md
@@ -1,0 +1,19 @@
+# 자유태그 모바일 편집 페이지
+
+`ClubInfoEditTabMobile`의 "자유태그" 항목을 탭하면 `activePage` state가 `'freeTags'`로 전환되어 `FreeTagEditPage`가 풀스크린으로 노출된다. 라우트 변경 없이 state 기반으로 서브뷰를 전환하는 패턴으로, `LinkEditPage`와 동일한 구조다.
+
+## 태그 입력 UI
+
+`initialTags` 배열 길이만큼 `EditField` 카드를 렌더링한다. 각 카드 내부에 `#` prefix와 단일 `<input>`(최대 5자)이 있으며, 값이 없을 때는 점선 배경 SVG(`DashedBgSvg`)가 표시된다.
+
+점선 배경은 `DashedBoxBg` SVG를 `styled()`로 래핑해 사용한다. `preserveAspectRatio='none'`으로 가로 방향으로 늘어나며, 코너 아티팩트는 `stroke-dashoffset: 4` CSS 오버라이드로 완화한다.
+
+## 저장 조건
+
+`tags.join(',') !== initialTags.join(',')`으로 dirty 여부를 판단하며, 변경이 없으면 저장 버튼이 비활성화된다.
+
+## 관련 코드
+
+- `src/pages/AdminPage/tabs/ClubInfoEditTab/components/mobile/FreeTagEditPage/FreeTagEditPage.tsx` — 메인 서브페이지 컴포넌트
+- `src/pages/AdminPage/tabs/ClubInfoEditTab/components/mobile/FreeTagEditPage/FreeTagEditPage.styles.ts` — `DashedBgSvg` styled component (점선 배경 SVG)
+- `src/pages/AdminPage/components/editFields/EditField/EditField.tsx` — 카드 래퍼

--- a/frontend/src/assets/images/backgrounds/bg_dashed_box.svg
+++ b/frontend/src/assets/images/backgrounds/bg_dashed_box.svg
@@ -1,0 +1,3 @@
+<svg width="300" height="26" viewBox="0 0 300 26" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="0.5" y="0.5" width="299" height="25" rx="8" stroke="#DCDCDC" stroke-dasharray="4 5"/>
+</svg>

--- a/frontend/src/pages/AdminPage/components/MobileSaveButtonArea/MobileSaveButtonArea.styles.ts
+++ b/frontend/src/pages/AdminPage/components/MobileSaveButtonArea/MobileSaveButtonArea.styles.ts
@@ -1,0 +1,35 @@
+import styled from 'styled-components';
+import { media } from '@/styles/mediaQuery';
+import { colors } from '@/styles/theme/colors';
+import { Z_INDEX } from '@/styles/zIndex';
+
+export const SaveButtonArea = styled.div`
+  position: fixed;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100%;
+  max-width: 500px;
+  padding: 10px 24px calc(20px + env(safe-area-inset-bottom));
+  background: ${colors.base.white};
+  box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.1);
+  z-index: ${Z_INDEX.clubDetailFooter};
+
+  ${media.mobile} {
+    left: 0;
+    transform: none;
+    max-width: 100%;
+  }
+
+  button {
+    width: 100%;
+    height: 50px;
+    border-radius: 10px;
+  }
+
+  button:disabled {
+    background-color: ${colors.gray[500]};
+    color: ${colors.base.white};
+    opacity: 1;
+  }
+`;

--- a/frontend/src/pages/AdminPage/components/MobileSaveButtonArea/MobileSaveButtonArea.tsx
+++ b/frontend/src/pages/AdminPage/components/MobileSaveButtonArea/MobileSaveButtonArea.tsx
@@ -1,0 +1,17 @@
+import Button from '@/components/common/Button/Button';
+import * as Styled from './MobileSaveButtonArea.styles';
+
+interface MobileSaveButtonAreaProps {
+  onClick: () => void;
+  disabled?: boolean;
+}
+
+const MobileSaveButtonArea = ({ onClick, disabled }: MobileSaveButtonAreaProps) => (
+  <Styled.SaveButtonArea>
+    <Button onClick={onClick} disabled={disabled}>
+      저장하기
+    </Button>
+  </Styled.SaveButtonArea>
+);
+
+export default MobileSaveButtonArea;

--- a/frontend/src/pages/AdminPage/components/MobileSaveButtonArea/MobileSaveButtonArea.tsx
+++ b/frontend/src/pages/AdminPage/components/MobileSaveButtonArea/MobileSaveButtonArea.tsx
@@ -6,7 +6,10 @@ interface MobileSaveButtonAreaProps {
   disabled?: boolean;
 }
 
-const MobileSaveButtonArea = ({ onClick, disabled }: MobileSaveButtonAreaProps) => (
+const MobileSaveButtonArea = ({
+  onClick,
+  disabled,
+}: MobileSaveButtonAreaProps) => (
   <Styled.SaveButtonArea>
     <Button onClick={onClick} disabled={disabled}>
       저장하기

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTab.tsx
@@ -38,6 +38,7 @@ const ClubInfoEditTab = () => {
     setSnsErrors,
     handleSocialLinkChange,
     handleUpdateClub,
+    handleUpdateClubWithTags,
     isDirty,
   } = useClubInfoEdit();
 
@@ -55,6 +56,7 @@ const ClubInfoEditTab = () => {
         setClubTags={setClubTags}
         socialLinks={socialLinks}
         handleUpdateClub={handleUpdateClub}
+        handleUpdateClubWithTags={handleUpdateClubWithTags}
         isDirty={isDirty}
       />
     );

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTab.tsx
@@ -52,6 +52,7 @@ const ClubInfoEditTab = () => {
         selectedCategory={selectedCategory}
         setSelectedCategory={setSelectedCategory}
         clubTags={clubTags}
+        setClubTags={setClubTags}
         socialLinks={socialLinks}
         handleUpdateClub={handleUpdateClub}
         isDirty={isDirty}

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTabMobile.styles.ts
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTabMobile.styles.ts
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 import { media } from '@/styles/mediaQuery';
 import { colors } from '@/styles/theme/colors';
 import { setTypography, typography } from '@/styles/theme/typography';
-import { Z_INDEX } from '@/styles/zIndex';
 
 export const MobileContainer = styled.div`
   display: flex;
@@ -75,35 +74,4 @@ export const NavFieldContent = styled.span`
   ${setTypography(typography.paragraph.p2)}
   line-height: 140%;
   color: ${colors.gray[500]};
-`;
-
-export const SaveButtonArea = styled.div`
-  position: fixed;
-  bottom: 0;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 100%;
-  max-width: 500px;
-  padding: 10px 24px calc(20px + env(safe-area-inset-bottom));
-  background: ${colors.base.white};
-  box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.1);
-  z-index: ${Z_INDEX.clubDetailFooter};
-
-  ${media.mobile} {
-    left: 0;
-    transform: none;
-    max-width: 100%;
-  }
-
-  button {
-    width: 100%;
-    height: 50px;
-    border-radius: 10px;
-  }
-
-  button:disabled {
-    background-color: ${colors.gray[500]};
-    color: ${colors.base.white};
-    opacity: 1;
-  }
 `;

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTabMobile.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTabMobile.tsx
@@ -10,8 +10,8 @@ import MobileSaveButtonArea from '@/pages/AdminPage/components/MobileSaveButtonA
 import { TAG_COLORS } from '@/styles/clubTags';
 import { colors } from '@/styles/theme/colors';
 import { ClubDetail, SNSPlatform } from '@/types/club';
-import FreeTagEditPage from './components/mobile/FreeTagEditPage/FreeTagEditPage';
 import * as Styled from './ClubInfoEditTabMobile.styles';
+import FreeTagEditPage from './components/mobile/FreeTagEditPage/FreeTagEditPage';
 import MobileBannerSection from './components/mobile/MobileBannerSection/MobileBannerSection';
 import { categories } from './hooks/useClubInfoEdit';
 
@@ -27,6 +27,7 @@ interface ClubInfoEditTabMobileProps {
   setClubTags: (tags: string[]) => void;
   socialLinks: Record<SNSPlatform, string>;
   handleUpdateClub: () => void;
+  handleUpdateClubWithTags: (newTags: string[]) => void;
   isDirty: boolean;
 }
 
@@ -44,6 +45,7 @@ const ClubInfoEditTabMobile = ({
   setClubTags,
   socialLinks,
   handleUpdateClub,
+  handleUpdateClubWithTags,
   isDirty,
 }: ClubInfoEditTabMobileProps) => {
   const navigate = useNavigate();
@@ -61,6 +63,7 @@ const ClubInfoEditTabMobile = ({
       <FreeTagEditPage
         initialTags={clubTags}
         onSave={setClubTags}
+        onSaveToServer={handleUpdateClubWithTags}
         onBack={() => setActivePage('main')}
       />
     );
@@ -69,7 +72,10 @@ const ClubInfoEditTabMobile = ({
   return (
     <>
       <Styled.MobileContainer>
-        <WebviewTopBar title='기본 정보 수정' onBack={() => navigate('/admin')} />
+        <WebviewTopBar
+          title='기본 정보 수정'
+          onBack={() => navigate('/admin')}
+        />
         <MobileBannerSection
           coverUrl={clubDetail?.cover}
           logoUrl={clubDetail?.logo}

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTabMobile.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTabMobile.tsx
@@ -1,14 +1,16 @@
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import Button from '@/components/common/Button/Button';
 import WebviewTopBar from '@/components/common/WebviewTopBar/WebviewTopBar';
 import { ADMIN_EVENT } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import EditField from '@/pages/AdminPage/components/editFields/EditField/EditField';
 import NavField from '@/pages/AdminPage/components/editFields/NavField/NavField';
 import TextField from '@/pages/AdminPage/components/editFields/TextField/TextField';
+import MobileSaveButtonArea from '@/pages/AdminPage/components/MobileSaveButtonArea/MobileSaveButtonArea';
 import { TAG_COLORS } from '@/styles/clubTags';
 import { colors } from '@/styles/theme/colors';
 import { ClubDetail, SNSPlatform } from '@/types/club';
+import FreeTagEditPage from './components/mobile/FreeTagEditPage/FreeTagEditPage';
 import * as Styled from './ClubInfoEditTabMobile.styles';
 import MobileBannerSection from './components/mobile/MobileBannerSection/MobileBannerSection';
 import { categories } from './hooks/useClubInfoEdit';
@@ -22,10 +24,13 @@ interface ClubInfoEditTabMobileProps {
   selectedCategory: string;
   setSelectedCategory: (v: string) => void;
   clubTags: string[];
+  setClubTags: (tags: string[]) => void;
   socialLinks: Record<SNSPlatform, string>;
   handleUpdateClub: () => void;
   isDirty: boolean;
 }
+
+type ActivePage = 'main' | 'freeTags';
 
 const ClubInfoEditTabMobile = ({
   clubDetail,
@@ -36,18 +41,30 @@ const ClubInfoEditTabMobile = ({
   selectedCategory,
   setSelectedCategory,
   clubTags,
+  setClubTags,
   socialLinks,
   handleUpdateClub,
   isDirty,
 }: ClubInfoEditTabMobileProps) => {
   const navigate = useNavigate();
   const trackEvent = useMixpanelTrack();
+  const [activePage, setActivePage] = useState<ActivePage>('main');
 
   const bannerColor = TAG_COLORS[selectedCategory] || colors.gray[400];
   const snsLinkCount = Object.values(socialLinks).filter(
     (link) => link.trim() !== '',
   ).length;
   const filledTags = clubTags.filter((t) => t.trim() !== '');
+
+  if (activePage === 'freeTags') {
+    return (
+      <FreeTagEditPage
+        initialTags={clubTags}
+        onSave={setClubTags}
+        onBack={() => setActivePage('main')}
+      />
+    );
+  }
 
   return (
     <>
@@ -100,9 +117,8 @@ const ClubInfoEditTabMobile = ({
           <NavField
             label='자유태그 (5자이내)'
             onNavigate={() => {
-              trackEvent(ADMIN_EVENT.TAB_CLICKED, {
-                tabName: '자유태그 수정',
-              });
+              trackEvent(ADMIN_EVENT.TAB_CLICKED, { tabName: '자유태그' });
+              setActivePage('freeTags');
             }}
           >
             {filledTags.length > 0 ? (
@@ -119,9 +135,7 @@ const ClubInfoEditTabMobile = ({
           <NavField
             label='링크 추가'
             onNavigate={() => {
-              trackEvent(ADMIN_EVENT.TAB_CLICKED, {
-                tabName: '링크 추가',
-              });
+              trackEvent(ADMIN_EVENT.TAB_CLICKED, { tabName: '링크 추가' });
             }}
           >
             {snsLinkCount > 0 ? (
@@ -133,11 +147,7 @@ const ClubInfoEditTabMobile = ({
         </Styled.FormSection>
       </Styled.MobileContainer>
 
-      <Styled.SaveButtonArea>
-        <Button onClick={handleUpdateClub} disabled={!isDirty}>
-          저장하기
-        </Button>
-      </Styled.SaveButtonArea>
+      <MobileSaveButtonArea onClick={handleUpdateClub} disabled={!isDirty} />
     </>
   );
 };

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/components/mobile/FreeTagEditPage/FreeTagEditPage.styles.ts
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/components/mobile/FreeTagEditPage/FreeTagEditPage.styles.ts
@@ -31,6 +31,7 @@ export const TagInputRow = styled.div<{ $hasValue: boolean }>`
   display: flex;
   flex-direction: row;
   align-items: center;
+  align-self: stretch;
   padding: 4px 8px;
   gap: 2px;
   height: 25px;

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/components/mobile/FreeTagEditPage/FreeTagEditPage.styles.ts
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/components/mobile/FreeTagEditPage/FreeTagEditPage.styles.ts
@@ -1,0 +1,63 @@
+import styled from 'styled-components';
+import { media } from '@/styles/mediaQuery';
+import { colors } from '@/styles/theme/colors';
+import { setTypography, typography } from '@/styles/theme/typography';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding-bottom: 100px;
+  width: 100%;
+  max-width: 500px;
+  min-height: 100vh;
+  margin: 0 auto;
+  box-shadow: 0px 2px 12px rgba(0, 0, 0, 0.04);
+
+  ${media.mobile} {
+    max-width: 100%;
+    margin: 0;
+    box-shadow: none;
+  }
+`;
+
+export const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 20px;
+`;
+
+export const TagInputRow = styled.div<{ $hasValue: boolean }>`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 4px 8px;
+  gap: 2px;
+  height: 25px;
+  border-radius: 8px;
+  background: ${({ $hasValue }) =>
+    $hasValue ? colors.gray[200] : 'transparent'};
+  border: ${({ $hasValue }) =>
+    $hasValue
+      ? `1px solid ${colors.gray[300]}`
+      : `1px dashed ${colors.gray[400]}`};
+`;
+
+export const HashSymbol = styled.span<{ $hasValue: boolean }>`
+  ${setTypography(typography.button.button2)}
+  color: ${({ $hasValue }) =>
+    $hasValue ? colors.base.black : colors.gray[400]};
+`;
+
+export const TagInput = styled.input`
+  border: none;
+  outline: none;
+  background: transparent;
+  flex: 1;
+  ${setTypography(typography.button.button2)}
+  color: ${colors.base.black};
+
+  &::placeholder {
+    color: ${colors.gray[400]};
+  }
+`;

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/components/mobile/FreeTagEditPage/FreeTagEditPage.styles.ts
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/components/mobile/FreeTagEditPage/FreeTagEditPage.styles.ts
@@ -1,4 +1,5 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
+import DashedBoxBg from '@/assets/images/backgrounds/bg_dashed_box.svg?react';
 import { media } from '@/styles/mediaQuery';
 import { colors } from '@/styles/theme/colors';
 import { setTypography, typography } from '@/styles/theme/typography';
@@ -28,20 +29,33 @@ export const Content = styled.div`
 `;
 
 export const TagInputRow = styled.div<{ $hasValue: boolean }>`
+  position: relative;
   display: flex;
   flex-direction: row;
   align-items: center;
-  align-self: stretch;
+  width: 100%;
   padding: 4px 8px;
   gap: 2px;
-  height: 25px;
+  height: 26px;
   border-radius: 8px;
-  background: ${({ $hasValue }) =>
-    $hasValue ? colors.gray[200] : 'transparent'};
-  border: ${({ $hasValue }) =>
+  ${({ $hasValue }) =>
     $hasValue
-      ? `1px solid ${colors.gray[300]}`
-      : `1px dashed ${colors.gray[400]}`};
+      ? css`
+          background-color: ${colors.gray[200]};
+          border: 1px solid ${colors.gray[300]};
+        `
+      : css`
+          border: none;
+        `}
+`;
+
+export const DashedBgSvg = styled(DashedBoxBg)`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
 `;
 
 export const HashSymbol = styled.span<{ $hasValue: boolean }>`

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/components/mobile/FreeTagEditPage/FreeTagEditPage.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/components/mobile/FreeTagEditPage/FreeTagEditPage.tsx
@@ -36,6 +36,9 @@ const FreeTagEditPage = ({
           {tags.map((tag, index) => (
             <EditField key={index} label={`태그${index + 1}`}>
               <Styled.TagInputRow $hasValue={tag.length > 0}>
+                {tag.length === 0 && (
+                  <Styled.DashedBgSvg preserveAspectRatio='none' />
+                )}
                 <Styled.HashSymbol $hasValue={tag.length > 0}>
                   #
                 </Styled.HashSymbol>

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/components/mobile/FreeTagEditPage/FreeTagEditPage.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/components/mobile/FreeTagEditPage/FreeTagEditPage.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+import WebviewTopBar from '@/components/common/WebviewTopBar/WebviewTopBar';
+import EditField from '@/pages/AdminPage/components/editFields/EditField/EditField';
+import MobileSaveButtonArea from '@/pages/AdminPage/components/MobileSaveButtonArea/MobileSaveButtonArea';
+import * as Styled from './FreeTagEditPage.styles';
+
+interface FreeTagEditPageProps {
+  initialTags: string[];
+  onSave: (tags: string[]) => void;
+  onBack: () => void;
+}
+
+const FreeTagEditPage = ({
+  initialTags,
+  onSave,
+  onBack,
+}: FreeTagEditPageProps) => {
+  const [tags, setTags] = useState(initialTags);
+
+  const isDirty = tags.join(',') !== initialTags.join(',');
+
+  const updateTag = (index: number, value: string) => {
+    setTags((prev) => prev.map((t, i) => (i === index ? value : t)));
+  };
+
+  const handleSave = () => {
+    onSave(tags);
+    onBack();
+  };
+
+  return (
+    <>
+      <Styled.Container>
+        <WebviewTopBar title='자유태그' onBack={onBack} />
+        <Styled.Content>
+          {tags.map((tag, index) => (
+            <EditField key={index} label={`태그${index + 1}`}>
+              <Styled.TagInputRow $hasValue={tag.length > 0}>
+                <Styled.HashSymbol $hasValue={tag.length > 0}>
+                  #
+                </Styled.HashSymbol>
+                <Styled.TagInput
+                  value={tag}
+                  maxLength={5}
+                  placeholder='태그추가'
+                  onChange={(e) => updateTag(index, e.target.value)}
+                />
+              </Styled.TagInputRow>
+            </EditField>
+          ))}
+        </Styled.Content>
+      </Styled.Container>
+      <MobileSaveButtonArea onClick={handleSave} disabled={!isDirty} />
+    </>
+  );
+};
+
+export default FreeTagEditPage;

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/components/mobile/FreeTagEditPage/FreeTagEditPage.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/components/mobile/FreeTagEditPage/FreeTagEditPage.tsx
@@ -7,12 +7,14 @@ import * as Styled from './FreeTagEditPage.styles';
 interface FreeTagEditPageProps {
   initialTags: string[];
   onSave: (tags: string[]) => void;
+  onSaveToServer: (tags: string[]) => void;
   onBack: () => void;
 }
 
 const FreeTagEditPage = ({
   initialTags,
   onSave,
+  onSaveToServer,
   onBack,
 }: FreeTagEditPageProps) => {
   const [tags, setTags] = useState(initialTags);
@@ -25,6 +27,7 @@ const FreeTagEditPage = ({
 
   const handleSave = () => {
     onSave(tags);
+    onSaveToServer(tags);
     onBack();
   };
 

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/hooks/useClubInfoEdit.ts
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/hooks/useClubInfoEdit.ts
@@ -168,6 +168,8 @@ const useClubInfoEdit = () => {
   const handleUpdateClubWithTags = (newTags: string[]) => {
     if (!clubDetail || !clubDetail.id) return;
 
+    setInitialValues((prev) => (prev ? { ...prev, clubTags: newTags } : null));
+
     updateClub(
       {
         id: clubDetail.id,

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/hooks/useClubInfoEdit.ts
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/hooks/useClubInfoEdit.ts
@@ -165,6 +165,30 @@ const useClubInfoEdit = () => {
     });
   };
 
+  const handleUpdateClubWithTags = (newTags: string[]) => {
+    if (!clubDetail || !clubDetail.id) return;
+
+    updateClub(
+      {
+        id: clubDetail.id,
+        name: clubName,
+        category: selectedCategory,
+        division: selectedDivision,
+        tags: newTags,
+        introduction: introduction,
+        presidentName: clubPresidentName,
+        presidentPhoneNumber: telephoneNumber,
+        socialLinks: socialLinks,
+        description: clubDetail.description,
+      },
+      {
+        onError: (error) => {
+          alert(`자유태그 저장에 실패했습니다: ${error.message}`);
+        },
+      },
+    );
+  };
+
   return {
     clubDetail,
     clubName,
@@ -187,6 +211,7 @@ const useClubInfoEdit = () => {
     setSnsErrors,
     handleSocialLinkChange,
     handleUpdateClub,
+    handleUpdateClubWithTags,
     isDirty,
   };
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

#1760

## 📝작업 내용

자유태그 모바일 편집 페이지(`FreeTagEditPage`)를 구현하였습니다.

- `FreeTagEditPage` 구현: 자유태그 항목별 입력 필드와 점선 배경이 포함된 모바일 편집 페이지
- `MobileSaveButtonArea` 공통 컴포넌트 추출: 모바일 하단 저장 버튼 영역을 공통 컴포넌트로 분리
- `WebviewTopBar`에 `onBack` prop 추가: 페이지별 뒤로가기 동작을 외부에서 주입할 수 있도록 개선

| 자유태그 편집 페이지 |
|:---:|
| <img width="280" height="593" alt="image" src="https://github.com/user-attachments/assets/f87387e5-b0aa-4592-9cf3-2cdd0307503c" /> |


## 논의하고 싶은 부분(선택)

### 별도 라우트 분리를 하지 않은 이유
자유태그 편집 페이지에서 내용을 수정하더라도, 실제 저장은 기본 정보 수정 페이지의 "저장하기" 버튼을 눌러야 서버에 반영됩니다. 편집 페이지는 기본 정보 수정 탭의 상태를 임시로 변경하는 역할에 불과하므로, 새로고침 시 편집 페이지에서 나가지는 동작은 자연스러운 흐름이라고 판단했습니다. 이에 불필요한 라우트 추가로 인한 복잡성을 피하고자 별도 라우트 분리를 하지 않았습니다.

### 점선 배경 구현 방식 (디자이너분과 논의 예정)
자유태그 입력 필드의 빈 상태 배경에 점선을 구현하는 과정에서 아래와 같은 시도를 거쳤습니다.

**1. CSS `border-style: dashed` 적용**
구현은 간단하지만, 브라우저가 dash/gap 비율을 자체적으로 결정합니다. 디자인 스펙(`stroke-dasharray: 4 5`)의 점선 간격을 정밀하게 재현하기 어려워 채택하지 않았습니다.
<img width="500" height="auto" alt="image" src="https://github.com/user-attachments/assets/3c0b4e50-96d4-42fd-a258-45040408a443" />

**2. SVG `bg_dashed_box.svg` 적용 (현재 방식)**
`?react` import 후 `styled(DashedBoxBg)`로 컨테이너 내부에 절대 위치로 배치하는 방식으로 구현하였습니다.
<img width="500" height="auto" alt="image" src="https://github.com/user-attachments/assets/0d493792-e320-44ca-9260-006db88c2d38" />

다만 `preserveAspectRatio="none"`으로 컨테이너 너비에 맞게 SVG를 늘리는 과정에서, `rect` 경로의 시작·끝 지점이 왼쪽 상단 부근에 위치하기 때문에 전체 둘레가 dash 사이클(4+5=9px)의 배수가 아닌 경우 해당 지점에서 점선이 겹쳐 보이는 현상이 발생합니다. `stroke-dashoffset`으로 시작점을 조정해보았으나 모든 너비에서 완전히 해소되지 않았고 오히려 이상한 것 같아서 되돌린 상태입니다.

서치 후 dashed를 react에서 간격을 자유로 넣는 방법을 찾아보았지만, 적절한 라이브러리가 없었습니다...
더 좋은 구현 방법이 있다면 의견 부탁드립니다!

## 🫡 참고사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

**새로운 기능**
* 동아리 정보 수정 화면의 모바일 최적화 UI 추가
* 자유 태그 편집 기능 추가
* 텍스트 입력 필드의 플레이스홀더 커스터마이징 가능
* 모바일 저장 버튼 추가

**스타일**
* 신청 버튼 애니메이션 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->