### PR TITLE
[test] useNavigator 웹뷰 라우팅 통일에 맞춰 테스트 수정

### DIFF
--- a/frontend/src/hooks/useNavigator.test.ts
+++ b/frontend/src/hooks/useNavigator.test.ts
@@ -139,10 +139,10 @@ describe('useNavigator - 사용자가 링크를 클릭했을 때', () => {
         expect(mockNavigate).toHaveBeenCalledWith('/promotions/123');
       });
 
-      it('leading slash가 있는 경로도 그대로 React Router로 이동한다', () => {
-        handleLink.result.current('/promotions/club-fest-2026');
+      it('상대 경로도 React Router로 이동한다', () => {
+        handleLink.result.current('promotions/club-fest-2026');
 
-        expect(mockNavigate).toHaveBeenCalledWith('/promotions/club-fest-2026');
+        expect(mockNavigate).toHaveBeenCalledWith('promotions/club-fest-2026');
       });
     });
   });

--- a/frontend/src/hooks/useNavigator.test.ts
+++ b/frontend/src/hooks/useNavigator.test.ts
@@ -2,22 +2,17 @@ import { useNavigate } from 'react-router-dom';
 import { renderHook, RenderHookResult } from '@testing-library/react';
 import useNavigator from '@/hooks/useNavigator';
 import isInAppWebView from '@/utils/isInAppWebView';
-import {
-  requestNavigateWebview,
-  requestOpenExternalUrl,
-} from '@/utils/webviewBridge';
+import { requestOpenExternalUrl } from '@/utils/webviewBridge';
 
 jest.mock('react-router-dom', () => ({
   useNavigate: jest.fn(),
 }));
 jest.mock('@/utils/isInAppWebView');
 jest.mock('@/utils/webviewBridge', () => ({
-  requestNavigateWebview: jest.fn(),
   requestOpenExternalUrl: jest.fn(),
 }));
 
 const mockIsInAppWebView = isInAppWebView as jest.Mock;
-const mockRequestNavigateWebview = requestNavigateWebview as jest.Mock;
 const mockRequestOpenExternalUrl = requestOpenExternalUrl as jest.Mock;
 
 describe('useNavigator - 사용자가 링크를 클릭했을 때', () => {
@@ -138,21 +133,16 @@ describe('useNavigator - 사용자가 링크를 클릭했을 때', () => {
     });
 
     describe('내부 경로를 클릭하면', () => {
-      it('requestNavigateWebview로 앱에 위임한다', () => {
+      it('React Router로 이동한다', () => {
         handleLink.result.current('/promotions/123');
 
-        expect(mockRequestNavigateWebview).toHaveBeenCalledWith(
-          'promotions/123',
-        );
-        expect(mockNavigate).not.toHaveBeenCalled();
+        expect(mockNavigate).toHaveBeenCalledWith('/promotions/123');
       });
 
-      it('leading slash를 제거한 slug로 전달한다', () => {
+      it('leading slash가 있는 경로도 그대로 React Router로 이동한다', () => {
         handleLink.result.current('/promotions/club-fest-2026');
 
-        expect(mockRequestNavigateWebview).toHaveBeenCalledWith(
-          'promotions/club-fest-2026',
-        );
+        expect(mockNavigate).toHaveBeenCalledWith('/promotions/club-fest-2026');
       });
     });
   });


### PR DESCRIPTION
## 무엇을

`useNavigator` 테스트 2개가 깨지던 것을 수정합니다.

## 원인

커밋 `8dbdc095 (fix(webview): 웹뷰 내부 라우팅 React Router 통일, #1662)`에서 구현은 바뀌었으나 테스트가 갱신되지 않았습니다.

- 해당 커밋이 `useNavigator.ts`에서 웹뷰 내부 경로를 `requestNavigateWebview(toSlug(...))`로 앱에 위임하던 분기를 제거하고, 웹·웹뷰 모두 React Router `navigate()`로 통일했습니다.
- 하지만 테스트는 여전히 옛 동작(`requestNavigateWebview('promotions/123')` 호출)을 기대해 `Number of calls: 0`으로 실패했습니다.

## 변경 (테스트만, 구현 변경 없음)

- 웹뷰 내부 경로 테스트 2개를 `navigate('/promotions/123')` 호출 검증으로 갱신
- 더 이상 쓰이지 않게 된 `requestNavigateWebview` mock/import 정리

## 검증

- `npm test` → **26 suites / 259 tests 전부 통과**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 웹뷰/외부 링크 이동 관련 테스트 기대값이 조정되었습니다.
  * 앱 내 웹뷰 환경에서 내부 경로 클릭 시, 기존 브릿지 위임 대신 라우터 이동이 반영되도록 검증이 변경되었습니다.
  * 외부 URL 처리에 대한 모킹 방식이 간소화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->