### PR TITLE
[feature] harry 리뷰 룰 자동 제안 job 추가

### DIFF
--- a/.github/workflows/harry-review.yml
+++ b/.github/workflows/harry-review.yml
@@ -45,7 +45,7 @@ jobs:
             모든 코멘트는 한국어 '해요체'로 작성해라 (예: "~하는 게 좋아요", "~해 주세요").
             룰 위반이 없으면 통과시키고 짧게 칭찬 한 줄만 남겨라.
           claude_args: |
-            --model claude-sonnet-4-6
+            --model claude-opus-4-8
             --allowedTools mcp__github_inline_comment__create_inline_comment
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -111,7 +111,7 @@ jobs:
                본문에는 "어떤 PR의 어떤 패턴에서 이 룰을 도출했는지"를 1~2줄로 적는다.
                이 룰 PR은 절대 자동 머지하지 마라. 사람이 검토 후 머지한다.
           claude_args: |
-            --model claude-sonnet-4-6
+            --model claude-opus-4-8
             --allowedTools Read,Edit,Write,Bash
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/harry-review.yml
+++ b/.github/workflows/harry-review.yml
@@ -59,6 +59,9 @@ jobs:
       ${{ github.event.action == 'opened'
       && github.event.pull_request.draft == false
       && github.event.pull_request.head.repo.full_name == github.repository }}
+    # 같은 PR을 re-run 하거나 직전 룰 PR이 아직 안 머지된 경우 같은 브랜치명이 겹쳐
+    # push가 실패할 수 있어, PR 단위로 동시 실행을 직렬화한다.
+    concurrency: harry-rule-${{ github.event.pull_request.number }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -90,7 +93,10 @@ jobs:
 
             절차:
             1. `.github/harry-review-rules.md`를 읽어 이미 있는 룰을 모두 파악한다.
-            2. 이 PR diff에서 "앞으로도 반복될 만한, 일반화 가능한 실수 패턴"을 찾는다.
+            2. `gh pr diff "$PR_NUMBER"`로 이 PR의 diff를 가져온다(checkout 기본 ref에
+               의존하지 말고 항상 이 명령으로 받아라). 이 diff 분석은 반드시 아래 5번의
+               git checkout 전에 끝내라(checkout 후엔 working tree가 base로 바뀐다).
+               그 diff에서 "앞으로도 반복될 만한, 일반화 가능한 실수 패턴"을 찾는다.
                - 기존 룰로 이미 잡히는 패턴이면 새 룰이 아니다. 무시한다.
                - 일회성이거나 사소한 문제는 룰로 만들지 않는다.
                - 레포 오너 취향(surgical change, React Compiler 전제, 불필요한
@@ -105,14 +111,15 @@ jobs:
                  git config user.email "harry@users.noreply.github.com"
                  git fetch origin "$PR_BASE"
                  git checkout -b "harry/rule-$PR_NUMBER" "origin/$PR_BASE"
-               그 위에서 `.github/harry-review-rules.md`만 수정·커밋하고 푸시한다.
+               그 위에서 `.github/harry-review-rules.md`만 셸 명령(heredoc 추가나 sed
+               등)으로 수정한 뒤 커밋·푸시한다. 파일 편집 전용 도구는 없으니 Bash로 한다.
             6. `gh pr create --base "$PR_BASE"`로 PR을 연다. 제목은
                `[chore] harry 리뷰 룰 추가 제안 (#${PR_NUMBER})`,
                본문에는 "어떤 PR의 어떤 패턴에서 이 룰을 도출했는지"를 1~2줄로 적는다.
                이 룰 PR은 절대 자동 머지하지 마라. 사람이 검토 후 머지한다.
           claude_args: |
             --model claude-opus-4-8
-            --allowedTools Read,Edit,Write,Bash
+            --allowedTools Read,Bash
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/harry-review.yml
+++ b/.github/workflows/harry-review.yml
@@ -49,3 +49,72 @@ jobs:
             --allowedTools mcp__github_inline_comment__create_inline_comment
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+  harry-rule-suggest:
+    # 리뷰에서 발견한 "반복될 만한" 실수 패턴을 harry의 룰 파일에 반영하는 PR을 따로 연다.
+    # - PR이 처음 열릴 때(opened)만 실행: 매 push마다 돌지 않게 해 비용/노이즈를 줄인다.
+    # - 포크 PR은 제외: 프롬프트 인젝션 + 쓰기 권한이 겹치면 위험하다(리뷰 job과 동일 정책).
+    # - 룰은 절대 자동 머지하지 않는다. 항상 사람이 검토 후 머지한다.
+    if: >-
+      ${{ github.event.action == 'opened'
+      && github.event.pull_request.draft == false
+      && github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Generate harry App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.HARRY_APP_ID }}
+          private-key: ${{ secrets.HARRY_APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: harry rule suggestion
+        uses: anthropics/claude-code-action@v1
+        with:
+          github_token: ${{ steps.app-token.outputs.token }}
+          prompt: |
+            너는 'harry'. 이 PR의 변경사항(diff)을 보고, harry의 리뷰 룰을
+            "스스로 키우는" 작업을 한다. 대상 파일은 `.github/harry-review-rules.md`.
+
+            대상 PR 번호와 base 브랜치는 환경변수 $PR_NUMBER, $PR_BASE 로 주어진다.
+            셸 명령에서는 반드시 이 환경변수를 그대로 써라(값을 직접 타이핑하지 마라).
+
+            절차:
+            1. `.github/harry-review-rules.md`를 읽어 이미 있는 룰을 모두 파악한다.
+            2. 이 PR diff에서 "앞으로도 반복될 만한, 일반화 가능한 실수 패턴"을 찾는다.
+               - 기존 룰로 이미 잡히는 패턴이면 새 룰이 아니다. 무시한다.
+               - 일회성이거나 사소한 문제는 룰로 만들지 않는다.
+               - 레포 오너 취향(surgical change, React Compiler 전제, 불필요한
+                 useEffect 금지, 데이터 패칭/ API 함수 위치 일관성 등)과 결이 맞아야 한다.
+            3. 룰로 만들 가치가 있는 패턴이 "없으면" 아무것도 하지 말고 그냥 끝낸다.
+               대부분의 PR은 여기서 끝난다. 억지로 룰을 만들지 마라.
+            4. 가치 있는 패턴이 있으면 "최대 1개"만 추가한다. 기존 파일의 알맞은
+               섹션에, 한국어 '해요체'로, 기존 룰과 같은 형식의 한 줄로 적는다.
+            5. 룰 PR은 base 브랜치에서 깨끗하게 따서 만든다(이 PR의 코드 변경이
+               섞이면 안 된다):
+                 git config user.name "harry"
+                 git config user.email "harry@users.noreply.github.com"
+                 git fetch origin "$PR_BASE"
+                 git checkout -b "harry/rule-$PR_NUMBER" "origin/$PR_BASE"
+               그 위에서 `.github/harry-review-rules.md`만 수정·커밋하고 푸시한다.
+            6. `gh pr create --base "$PR_BASE"`로 PR을 연다. 제목은
+               `[chore] harry 리뷰 룰 추가 제안 (#${PR_NUMBER})`,
+               본문에는 "어떤 PR의 어떤 패턴에서 이 룰을 도출했는지"를 1~2줄로 적는다.
+               이 룰 PR은 절대 자동 머지하지 마라. 사람이 검토 후 머지한다.
+          claude_args: |
+            --model claude-sonnet-4-6
+            --allowedTools Read,Edit,Write,Bash
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BASE: ${{ github.event.pull_request.base.ref }}


### PR DESCRIPTION
## 작업내용

harry PR 리뷰 워크플로우에 `harry-rule-suggest` job을 추가했어요. 리뷰에서 발견한 "반복될 만한" 실수 패턴을 harry의 룰 파일(`.github/harry-review-rules.md`)에 한 줄 추가하는 **별도 PR을 자동으로 열어주는** 루프예요.

> 배경: "Claude Code 창시자의 워크플로우" 글의 *"코드 리뷰 때 룰을 자동 갱신해 같은 실수 반복을 막는다"* 패턴을 모아동에 적용한 거예요.

## 동작

```
PR이 새로 열림(opened)
  → harry가 diff + 기존 룰 파일을 읽음
  → 반복될 만한 + 기존 룰에 없는 패턴을 찾음
  → 없으면 종료 (대부분의 PR)
  → 있으면 룰 한 줄 추가한 별도 PR(harry/rule-<번호>)을 염
  → 사람이 검토 후 머지
```

## 안전장치

- `opened`일 때만 실행 (매 push마다 안 돎 → 비용/노이즈 차단)
- fork PR 제외 (기존 리뷰 job과 동일 정책)
- 별도 PR + 사람 머지, 자동 머지 금지
- base 브랜치에서 새로 따서 룰 PR 생성 → 원본 코드 diff 안 섞임
- PR 번호/base 브랜치를 env 변수로 전달 → 프롬프트·셸 인젝션 표면 제거

