### PR TITLE
[fix] CodeRabbit base_branches 정규식 오류 수정

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -11,6 +11,6 @@ reviews:
     enabled: true
     drafts: false
     base_branches:
-      - "**"
+      - ".*"
 chat:
   auto_reply: true


### PR DESCRIPTION
## 문제

`.coderabbit.yaml`의 `reviews.auto_review.base_branches`에 glob 패턴 `"**"`를 넣었는데, CodeRabbit은 이 필드를 **정규식**으로 파싱해요. 그래서 PR마다 아래 경고와 함께 설정이 기본값으로 폴백되고 있었어요:

> Validation error: Invalid regex pattern for base branch. at "reviews.auto_review.base_branches[0]"

## 수정

"모든 base 브랜치 대상"이라는 원래 의도를 유지하면서 유효한 정규식으로 바꿨어요.

```diff
 base_branches:
-  - "**"
+  - ".*"
```

PR #1787(harry 리뷰 룰 자동 제안) 리뷰 중 CodeRabbit이 발견한 별개 건이라 따로 분리했어요.