### PR TITLE
[ci] harry 재실행 시 변경분만 리뷰

### DIFF
--- a/.github/workflows/harry-review.yml
+++ b/.github/workflows/harry-review.yml
@@ -38,7 +38,17 @@ jobs:
           prompt: |
             너는 'harry'라는 이름의 PR 리뷰봇이다.
             저장소 루트의 `.github/harry-review-rules.md` 파일을 읽고,
-            그 기준에 따라 이 PR의 변경사항(diff)을 리뷰해라.
+            그 기준에 따라 이 PR의 변경사항을 리뷰해라.
+
+            ## 리뷰 범위
+            - 이번 실행 이벤트는 '${{ github.event.action }}'다.
+            - 'synchronize'(추가 푸시로 인한 재실행)면, 직전 리뷰 이후 새로 추가된
+              커밋의 변경분만 리뷰한다. 다음 명령으로 변경분을 확인해라:
+              `git diff ${{ github.event.before }} ${{ github.event.after }}`
+              이미 리뷰·지적했던 부분(이번에 바뀌지 않은 줄)은 다시 보지도 코멘트하지도 마라.
+              (해당 커밋 범위를 가져올 수 없으면 base 브랜치 대비 전체를 보되, 이미 지적한 내용은 반복하지 마라.)
+            - 'opened'면 PR 전체 변경사항(diff)을 리뷰한다.
+
             구체적인 줄에 대한 지적은 반드시 `create_inline_comment` 도구를 사용해
             해당 파일·줄에 인라인 리뷰 코멘트로 남겨라.
             줄 단위 지적을 요약 코멘트 본문에 나열하지 말고, 요약 코멘트에는 전체 총평만 남겨라.
@@ -46,7 +56,7 @@ jobs:
             룰 위반이 없으면 통과시키고 짧게 칭찬 한 줄만 남겨라.
           claude_args: |
             --model claude-opus-4-8
-            --allowedTools mcp__github_inline_comment__create_inline_comment
+            --allowedTools mcp__github_inline_comment__create_inline_comment,Bash(git diff:*),Bash(git log:*)
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
## 배경
harry가 추가 푸시(`synchronize`)마다 **PR 전체 diff를 처음부터** 재리뷰해서, 이미 지적했던 내용이 반복되거나 변경 없는 부분까지 다시 검토됨.

## 변경
`.github/workflows/harry-review.yml` 프롬프트/도구만 수정:
- **`synchronize`(추가 푸시)** → `git diff <before> <after>`로 **이번에 새로 추가된 커밋의 변경분만** 리뷰. 이미 지적한 부분은 반복하지 않음.
- **`opened`** → 기존대로 PR 전체 diff 리뷰.
- `allowedTools`에 `Bash(git diff:*)`, `Bash(git log:*)` 추가 (델타 확인용).
- force-push 등으로 커밋 범위를 못 가져오면 base 대비 전체로 fallback(중복은 회피).

## 참고
- 주입되는 `github.event.before/after`는 커밋 SHA, `action`은 enum이라 freeform 사용자 입력이 아니어서 인젝션 위험 없음. 워크플로는 같은 레포 PR로 제한됨(`head.repo.full_name == repository`).
- **남은 이슈(별도):** `track_progress`가 실행마다 요약 코멘트를 새로 만들어 누적되는 현상은 이 PR 범위 밖. claude-code-action 동작 확인 후 따로 다룰 예정.
