### PR TITLE
[fix] 지원서 학기 자동계산 월 경계 오류로 인한 800-7 방지

### DIFF
--- a/frontend/src/constants/initialFormData.ts
+++ b/frontend/src/constants/initialFormData.ts
@@ -4,7 +4,9 @@ const now = new Date();
 const currentYear = now.getFullYear();
 const currentMonth = now.getMonth();
 
-const currentSemesterTerm = currentMonth <= 6 ? 'FIRST' : 'SECOND';
+// getMonth()는 0-indexed(1월=0 … 7월=6)이므로, 백엔드 학기 경계(1-indexed month < 7)와
+// 동일하게 맞추려면 currentMonth < 6 (1~6월=FIRST, 7~12월=SECOND)이어야 한다.
+const currentSemesterTerm = currentMonth < 6 ? 'FIRST' : 'SECOND';
 
 const INITIAL_FORM_DATA: ApplicationFormData = {
   title: '',

--- a/frontend/src/constants/initialFormData.ts
+++ b/frontend/src/constants/initialFormData.ts
@@ -1,12 +1,5 @@
 import { ApplicationFormData, ApplicationFormMode } from '@/types/application';
-
-const now = new Date();
-const currentYear = now.getFullYear();
-const currentMonth = now.getMonth();
-
-// getMonth()는 0-indexed(1월=0 … 7월=6)이므로, 백엔드 학기 경계(1-indexed month < 7)와
-// 동일하게 맞추려면 currentMonth < 6 (1~6월=FIRST, 7~12월=SECOND)이어야 한다.
-const currentSemesterTerm = currentMonth < 6 ? 'FIRST' : 'SECOND';
+import { getSemesterTerm } from '@/utils/semester';
 
 const INITIAL_FORM_DATA: ApplicationFormData = {
   title: '',
@@ -38,8 +31,14 @@ const INITIAL_FORM_DATA: ApplicationFormData = {
       items: [{ value: '' }, { value: '' }],
     },
   ],
-  semesterYear: currentYear,
-  semesterTerm: currentSemesterTerm,
+  // now를 모듈 로드 시점에 한 번만 계산하면, 탭을 학기/연도 경계를 넘겨 오래 열어둘 때
+  // stale 값이 전송될 수 있다. getter로 폼 초기화·제출 시점에 현재 날짜를 동적 계산한다.
+  get semesterYear() {
+    return new Date().getFullYear();
+  },
+  get semesterTerm() {
+    return getSemesterTerm(new Date().getMonth());
+  },
   formMode: ApplicationFormMode.INTERNAL,
   externalApplicationUrl: '',
   active: 'unpublished',

--- a/frontend/src/utils/CLAUDE.md
+++ b/frontend/src/utils/CLAUDE.md
@@ -6,6 +6,7 @@
 - `recruitmentDateParser.ts` - 모집 기간 파싱
 - `debounce.ts` - 디바운스 함수
 - `validateSocialLink.ts` - SNS 링크 유효성 검사
+- `semester.ts` - 학기(FIRST/SECOND) 판정. 백엔드 경계(1-indexed `month < 7`)와 일치하도록 0-indexed `getMonth()` 기준 `< 6`으로 계산
 - `isInAppWebView.ts` - 인앱 WebView 감지 (UA의 `MoadongApp`)
 - `webviewBridge.ts` - 네이티브 앱과 통신
 - `initSDK.ts` - 외부 SDK 초기화

--- a/frontend/src/utils/semester.test.ts
+++ b/frontend/src/utils/semester.test.ts
@@ -1,0 +1,21 @@
+import { SemesterTerm } from '@/types/club';
+import { getSemesterTerm } from './semester';
+
+describe('getSemesterTerm', () => {
+  it('1~6월(0-indexed 0~5)은 FIRST를 반환한다', () => {
+    for (let month = 0; month <= 5; month += 1) {
+      expect(getSemesterTerm(month)).toBe(SemesterTerm.FIRST);
+    }
+  });
+
+  it('7~12월(0-indexed 6~11)은 SECOND를 반환한다', () => {
+    for (let month = 6; month <= 11; month += 1) {
+      expect(getSemesterTerm(month)).toBe(SemesterTerm.SECOND);
+    }
+  });
+
+  it('6월/7월 경계에서 백엔드 규칙과 일치한다 (800-7 방지)', () => {
+    expect(getSemesterTerm(5)).toBe(SemesterTerm.FIRST); // 6월
+    expect(getSemesterTerm(6)).toBe(SemesterTerm.SECOND); // 7월
+  });
+});

--- a/frontend/src/utils/semester.ts
+++ b/frontend/src/utils/semester.ts
@@ -1,0 +1,9 @@
+import { SemesterTerm, SemesterTermType } from '@/types/club';
+
+/**
+ * 0-indexed 월(`Date.getMonth()`, 1월=0 … 12월=11)로 학기를 판정한다.
+ * 백엔드 판정 규칙(1-indexed `month < 7` → FIRST)과 동일하게 맞추기 위해
+ * 0-indexed 기준 `< 6`(1~6월)을 FIRST, 그 외(7~12월)를 SECOND로 본다.
+ */
+export const getSemesterTerm = (month0Indexed: number): SemesterTermType =>
+  month0Indexed < 6 ? SemesterTerm.FIRST : SemesterTerm.SECOND;


### PR DESCRIPTION
## 문제

지원서 양식 생성(POST `/api/club/application`) 시 백엔드에서 `400 (800-7, "올바르지 않은 학기입니다.")`가 발생.

## 원인

지원서 생성 화면에는 학기 선택 UI가 없고, `semesterYear`/`semesterTerm`은 `initialFormData.ts`에서 현재 날짜로 자동 계산해 그대로 전송한다.

```js
const currentMonth = now.getMonth();                          // 0-indexed (1월=0 … 7월=6)
const currentSemesterTerm = currentMonth <= 6 ? 'FIRST' : 'SECOND';
```

`getMonth()`가 **0-indexed**라 `currentMonth <= 6` 조건이 **7월을 FIRST로 분류**한다. 반면 백엔드는 `month < 7`(1-indexed) 기준으로 **7월을 SECOND로 판정**한다.

- 프론트 경계: 1~7월 = FIRST, 8~12월 = SECOND
- 백엔드 경계: 1~6월 = FIRST, 7~12월 = SECOND
- **7월만 불일치** → 7월에 프론트가 `그 해 FIRST`를 보내는데, 백엔드 허용 목록(현재 학기 + 다음 2학기 = SECOND / 다음해 FIRST / 다음해 SECOND)에서 빠져 800-7 거부.

## 수정

경계 조건을 백엔드와 동일하게 `currentMonth < 6`으로 맞춤 (0-indexed 기준 1~6월 FIRST, 7~12월 SECOND).

## 참고

- 백엔드가 "선택 가능한 학기 옵션" API를 내려주지 않는 한, 프론트 자동계산과 백엔드 판정 규칙이 완전히 동일해야 재발을 막을 수 있음. 근본적으로는 서버가 생성 시 현재 학기를 결정하거나 옵션 API를 제공하는 방향이 더 안전함.
- `now`는 모듈 로드 시점 1회 계산됨(이번 버그 원인 아님).

## 검증

- `npm run typecheck` 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 학기 구분 기준이 조정되어, 월 경계에 따라 표시되는 학기 정보가 한 달 더 정확하게 반영됩니다.
  * 학기 시작/종료 시점에 일부 사용자에게 잘못 보일 수 있던 학기 표시가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->