### PR TITLE
[ci] main 대상 PR은 harry 리뷰 건너뛰기

### DIFF
--- a/.github/workflows/harry-review.yml
+++ b/.github/workflows/harry-review.yml
@@ -11,9 +11,11 @@ permissions:
 jobs:
   harry-review:
     # 같은 레포 브랜치 PR만 리뷰한다. 포크 PR(외부 공격자)은 프롬프트 인젝션 위험이 있어 제외.
+    # main으로 올라오는 PR은 리뷰하지 않는다(develop 등 상위 브랜치에서 이미 리뷰됨).
     if: >-
       ${{ github.event.pull_request.draft == false
-      && github.event.pull_request.head.repo.full_name == github.repository }}
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && github.event.pull_request.base.ref != 'main' }}
     runs-on: ubuntu-latest
     steps:
       - name: Generate harry App token
@@ -68,7 +70,8 @@ jobs:
     if: >-
       ${{ github.event.action == 'opened'
       && github.event.pull_request.draft == false
-      && github.event.pull_request.head.repo.full_name == github.repository }}
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && github.event.pull_request.base.ref != 'main' }}
     # 같은 PR을 re-run 하거나 직전 룰 PR이 아직 안 머지된 경우 같은 브랜치명이 겹쳐
     # push가 실패할 수 있어, PR 단위로 동시 실행을 직렬화한다.
     concurrency: harry-rule-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## 변경 사항
harry 자동 리뷰봇이 **base 브랜치가 \`main\`인 PR**은 리뷰하지 않도록 CI 조건을 추가했어요.

- \`harry-review\` job: 리뷰 skip
- \`harry-rule-suggest\` job: 룰 제안 skip

두 job의 \`if\` 조건에 \`github.event.pull_request.base.ref != 'main'\` 을 추가했어요.

## 이유
main으로 올라오는 PR은 develop 등 상위 브랜치에서 이미 리뷰된 변경이라 중복 리뷰를 방지하기 위함이에요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * `main` 브랜치로 들어오는 PR에서는 자동 리뷰와 규칙 제안 작업이 실행되지 않도록 조건이 추가되었습니다.
  * 관련 안내 주석이 추가되어 동작 의도를 더 쉽게 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->