### PR TITLE
[fix] 모바일 기본정보 수정 리뷰 반영

### DIFF
--- a/frontend/src/pages/AdminPage/components/editFields/TextField/TextField.tsx
+++ b/frontend/src/pages/AdminPage/components/editFields/TextField/TextField.tsx
@@ -9,6 +9,7 @@ interface TextFieldProps {
   value: string;
   onChange: (value: string) => void;
   onClear: () => void;
+  maxLength?: number;
 }
 
 const TextField = ({
@@ -17,6 +18,7 @@ const TextField = ({
   value,
   onChange,
   onClear,
+  maxLength,
 }: TextFieldProps) => {
   const [isActive, setIsActive] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -43,6 +45,7 @@ const TextField = ({
           value={value}
           placeholder={placeholder || label}
           rows={1}
+          maxLength={maxLength}
           onChange={(e) => onChange(e.target.value)}
           onFocus={() => setIsActive(true)}
           onBlur={() => setIsActive(false)}

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTabMobile.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTabMobile.tsx
@@ -109,6 +109,7 @@ const ClubInfoEditTabMobile = ({
             label='동아리명'
             placeholder='동아리명을 입력해주세요.'
             value={clubName}
+            maxLength={20}
             onChange={setClubName}
             onClear={() => {
               trackEvent(ADMIN_EVENT.CLUB_NAME_CLEAR_BUTTON_CLICKED);
@@ -120,6 +121,7 @@ const ClubInfoEditTabMobile = ({
             label='동아리소개'
             placeholder='한줄소개를 입력해주세요.'
             value={introduction}
+            maxLength={20}
             onChange={setIntroduction}
             onClear={() => {
               trackEvent(ADMIN_EVENT.CLUB_INTRODUCTION_CLEAR_BUTTON_CLICKED);

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/components/mobile/LinkEditPage/LinkField.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/components/mobile/LinkEditPage/LinkField.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import FieldClearButtonIcon from '@/assets/images/icons/field_clear_button_icon.svg?react';
 import EditField from '@/pages/AdminPage/components/editFields/EditField/EditField';
 import { colors } from '@/styles/theme/colors';
@@ -22,10 +22,12 @@ const LinkField = ({
   error,
 }: LinkFieldProps) => {
   const [isActive, setIsActive] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const handleClear = (e: React.MouseEvent) => {
     e.preventDefault();
     onClear();
+    inputRef.current?.focus();
   };
 
   return (
@@ -37,6 +39,7 @@ const LinkField = ({
       >
         <Styled.ContentRow>
           <Styled.Input
+            ref={inputRef}
             type='url'
             value={value}
             placeholder={placeholder}

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/hooks/useClubInfoEdit.ts
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/hooks/useClubInfoEdit.ts
@@ -172,9 +172,6 @@ const useClubInfoEdit = () => {
     if (!clubDetail || !clubDetail.id) return;
 
     const mergedLinks = { ...socialLinks, ...newLinks };
-    setInitialValues((prev) =>
-      prev ? { ...prev, socialLinks: mergedLinks } : null,
-    );
 
     updateClub(
       {
@@ -190,6 +187,11 @@ const useClubInfoEdit = () => {
         description: clubDetail.description,
       },
       {
+        onSuccess: () => {
+          setInitialValues((prev) =>
+            prev ? { ...prev, socialLinks: mergedLinks } : null,
+          );
+        },
         onError: (error) => {
           alert(`링크 저장에 실패했습니다: ${error.message}`);
         },
@@ -199,8 +201,6 @@ const useClubInfoEdit = () => {
 
   const handleUpdateClubWithTags = (newTags: string[]) => {
     if (!clubDetail || !clubDetail.id) return;
-
-    setInitialValues((prev) => (prev ? { ...prev, clubTags: newTags } : null));
 
     updateClub(
       {
@@ -216,6 +216,11 @@ const useClubInfoEdit = () => {
         description: clubDetail.description,
       },
       {
+        onSuccess: () => {
+          setInitialValues((prev) =>
+            prev ? { ...prev, clubTags: newTags } : null,
+          );
+        },
         onError: (error) => {
           alert(`자유태그 저장에 실패했습니다: ${error.message}`);
         },

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/hooks/useClubInfoEdit.ts
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/hooks/useClubInfoEdit.ts
@@ -75,8 +75,21 @@ const useClubInfoEdit = () => {
     x: '',
   });
 
+  const isDirty =
+    initialValues !== null &&
+    (clubName !== initialValues.clubName ||
+      introduction !== initialValues.introduction ||
+      selectedDivision !== initialValues.selectedDivision ||
+      selectedCategory !== initialValues.selectedCategory ||
+      clubTags.join(',') !== initialValues.clubTags.join(',') ||
+      socialLinks.instagram !== initialValues.socialLinks.instagram ||
+      socialLinks.youtube !== initialValues.socialLinks.youtube ||
+      socialLinks.x !== initialValues.socialLinks.x);
+
   useEffect(() => {
-    if (clubDetail) {
+    // 배너/로고 업로드 등으로 clubDetail이 refetch돼도, 편집 중(isDirty)이면
+    // 서버 값으로 덮어쓰지 않는다. (미저장 입력 유실 방지)
+    if (clubDetail && !isDirty) {
       const tags =
         clubDetail.tags.length >= 2
           ? clubDetail.tags
@@ -105,18 +118,10 @@ const useClubInfoEdit = () => {
         socialLinks: links,
       });
     }
+    // isDirty는 의도적으로 deps에서 제외한다 — clubDetail이 refetch되는 시점의
+    // 현재 편집 상태만 확인하면 되고, deps에 넣으면 재동기화 루프가 생긴다.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [clubDetail]);
-
-  const isDirty =
-    initialValues !== null &&
-    (clubName !== initialValues.clubName ||
-      introduction !== initialValues.introduction ||
-      selectedDivision !== initialValues.selectedDivision ||
-      selectedCategory !== initialValues.selectedCategory ||
-      clubTags.join(',') !== initialValues.clubTags.join(',') ||
-      socialLinks.instagram !== initialValues.socialLinks.instagram ||
-      socialLinks.youtube !== initialValues.socialLinks.youtube ||
-      socialLinks.x !== initialValues.socialLinks.x);
 
   const handleSocialLinkChange = (key: SNSPlatform, value: string) => {
     const errorMsg = validateSocialLink(key, value);
@@ -158,6 +163,14 @@ const useClubInfoEdit = () => {
     updateClub(updatedData, {
       onSuccess: () => {
         alert('동아리 정보가 성공적으로 수정되었습니다.');
+        setInitialValues({
+          clubName,
+          introduction,
+          selectedDivision,
+          selectedCategory,
+          clubTags,
+          socialLinks,
+        });
       },
       onError: (error) => {
         alert(`동아리 정보 수정에 실패했습니다: ${error.message}`);


### PR DESCRIPTION
## 개요
PR #1794 리뷰(수동 + gemini-code-assist) 중 유효한 지적을 반영한 후속 수정입니다. 관리자 `기본 정보 수정` 모바일 뷰 대상.

## 변경 사항
- **fix(admin): 모바일 기본정보 입력에 20자 제한 추가**
  - 데스크톱 `InputField`는 동아리명·한줄소개에 `maxLength=20`이 걸려 있으나 모바일 `TextField`엔 제한이 없어 20자 초과 입력·저장이 가능했습니다(데이터 정합성 리스크).
  - `TextField`에 `maxLength` prop 추가 후 모바일 두 필드에 `20` 연결.
- **fix(admin): 링크 필드 지우기 후 입력 포커스 유지**
  - 형제 컴포넌트 `TextField`와 동일하게 clear 후 입력 포커스 유지(gemini 리뷰 반영).
- **fix(admin): 링크·자유태그 저장 상태 동기화를 onSuccess로 이동**
  - 요청 전 동기적으로 `initialValues`를 갱신하던 것을 `onSuccess` 콜백으로 이동. 저장 실패 시 변경분이 저장된 것으로 오인돼 버튼이 비활성화되던 문제 방어.

## 반영하지 않은 리뷰
- gemini의 훅 내부 `queryClient.invalidateQueries` 추가 제안 → `useUpdateClubDetail`이 이미 `queryKeys.club.detail(id)`를 무효화하고 outlet context가 해당 쿼리로 backing되어 중복이며, `['clubDetail', id]` 하드코딩은 쿼리키 중앙관리 컨벤션 위반이라 제외.

## 확인
- [ ] CI typecheck / lint
- [ ] 모바일 기본정보 수정 화면 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 입력 필드에 글자 수 제한을 설정할 수 있게 되었습니다.
  * 모바일 클럽 정보 편집에서 동아리명과 동아리소개 입력이 20자로 제한됩니다.

* **버그 수정**
  * 입력 내용을 지운 뒤에도 커서가 다시 입력칸에 유지되도록 개선했습니다.
  * 편집 중인 내용이 서버 갱신으로 덮어써지지 않도록 동기화 동작을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->