### PR TITLE
[feature] 클릭 게임 종료 - 최종 순위(Top 3)만 노출

### DIFF
--- a/frontend/src/constants/eventName.ts
+++ b/frontend/src/constants/eventName.ts
@@ -73,8 +73,6 @@ export const USER_EVENT = {
 
   // 클릭배틀 게임
   GAME_START_BUTTON_CLICKED: 'Game Start Button Clicked',
-  GAME_RANKING_CLUB_SELECTED: 'Game Ranking Club Selected',
-  GAME_RANKING_DETAIL_CLICKED: 'Game Ranking Detail Clicked',
 } as const;
 
 export const WEBVIEW_LINK_TARGET = {

--- a/frontend/src/pages/GamePage/GamePage.tsx
+++ b/frontend/src/pages/GamePage/GamePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
 import WebviewTopBar from '@/components/common/WebviewTopBar/WebviewTopBar';
 import { PAGE_VIEW } from '@/constants/eventName';
@@ -6,17 +6,13 @@ import useTrackPageView from '@/hooks/Mixpanel/useTrackPageView';
 import { useGameRanking } from '@/hooks/Queries/useGame';
 import isInAppWebView from '@/utils/isInAppWebView';
 import BackgroundFirework from './components/BackgroundFirework/BackgroundFirework';
-import ClubNameInput from './components/ClubNameInput/ClubNameInput';
 import DotTextEffect from './components/DotTextEffect/DotTextEffect';
-import FallingBubbles from './components/FallingBubbles/FallingBubbles';
-import GamePlaySection from './components/GamePlaySection/GamePlaySection';
 import RankingBoard from './components/RankingBoard/RankingBoard';
 import * as S from './GamePage.styles';
-import { useBatchedClick } from './hooks/useBatchedClick';
 
-const STORAGE_KEY = 'game_club_name';
 const DARK_KEY = 'game_dark_mode';
-const MILESTONE_UNIT = 100;
+const FIREWORK_INTERVAL = 10000;
+const FIREWORK_DURATION = 2200;
 
 const SunIcon = () => (
   <svg
@@ -47,98 +43,29 @@ const MoonIcon = () => (
 );
 
 const GamePage = () => {
-  const [clubName, setClubName] = useState<string>(
-    () => localStorage.getItem(STORAGE_KEY) ?? '',
-  );
-  const [isEditing, setIsEditing] = useState(false);
   const [bgBursts, setBgBursts] = useState<number[]>([]);
   const [isDark, setIsDark] = useState<boolean>(
     () => sessionStorage.getItem(DARK_KEY) === 'true',
   );
 
-  const [myCount, setMyCount] = useState(0);
-
   const { data: rankingData } = useGameRanking();
-  const sendClick = useBatchedClick(clubName);
-
-  // 버튼 클릭(1)과 비눗방울 터치(방울 값)를 합산해 개인 카운터와 서버에 반영.
-  // source를 전달해 비눗방울 적립이 버튼 쓰로틀에 걸려 누락되지 않도록 한다.
-  const gainCount = useCallback(
-    (amount: number, source: 'button' | 'bubble' = 'button') => {
-      setMyCount((prev) => prev + amount);
-      sendClick(amount, source);
-    },
-    [sendClick],
-  );
-
-  const handleBubbleCatch = useCallback(
-    (amount: number) => gainCount(amount, 'bubble'),
-    [gainCount],
-  );
 
   useTrackPageView(PAGE_VIEW.GAME_PAGE);
 
   const top1Club = rankingData?.clubs[0];
 
-  // 직전 카운트와 비교해 어떤 동아리든 100단위를 넘기면 배경 폭죽 발사
-  const prevCountsRef = useRef<Map<string, number>>(new Map());
-  const initializedRef = useRef(false);
+  // 게임 종료: 10초마다 축하 폭죽을 자동으로 발사
   const burstIdRef = useRef(0);
-
-  // 순위 변동 추적
-  const prevRanksRef = useRef<Map<string, number>>(new Map());
-  const [rankDelta, setRankDelta] = useState<Map<string, number>>(new Map());
-
   useEffect(() => {
-    const clubs = rankingData?.clubs;
-    if (!clubs) return;
-
-    if (!initializedRef.current) {
-      clubs.forEach((c) => prevCountsRef.current.set(c.clubName, c.clickCount));
-      clubs.forEach((c) => prevRanksRef.current.set(c.clubName, c.rank));
-      initializedRef.current = true;
-      return;
-    }
-
-    // 순위 변동 계산 (양수 = 상승, 음수 = 하락), 변동이 있을 때만 갱신
-    let hasRankChange = false;
-    clubs.forEach((c) => {
-      const prevRank = prevRanksRef.current.get(c.clubName);
-      if (prevRank !== undefined && prevRank !== c.rank) {
-        hasRankChange = true;
-      }
-    });
-
-    if (hasRankChange) {
-      const newDelta = new Map<string, number>();
-      clubs.forEach((c) => {
-        const prevRank = prevRanksRef.current.get(c.clubName);
-        if (prevRank !== undefined) {
-          newDelta.set(c.clubName, prevRank - c.rank);
-        }
-      });
-      setRankDelta(newDelta);
-    }
-    clubs.forEach((c) => prevRanksRef.current.set(c.clubName, c.rank));
-
-    const crossed = clubs.some((c) => {
-      const prev = prevCountsRef.current.get(c.clubName) ?? 0;
-      return (
-        Math.floor(c.clickCount / MILESTONE_UNIT) >
-        Math.floor(prev / MILESTONE_UNIT)
-      );
-    });
-
-    clubs.forEach((c) => prevCountsRef.current.set(c.clubName, c.clickCount));
-
-    if (crossed) {
+    const interval = setInterval(() => {
       const id = burstIdRef.current++;
       setBgBursts((prev) => [...prev, id]);
       setTimeout(() => {
         setBgBursts((prev) => prev.filter((b) => b !== id));
-      }, 2200);
-    }
-  }, [rankingData]);
+      }, FIREWORK_DURATION);
+    }, FIREWORK_INTERVAL);
+    return () => clearInterval(interval);
+  }, []);
 
   useEffect(() => {
     const prevBackground = document.body.style.background;
@@ -148,22 +75,6 @@ const GamePage = () => {
       document.body.style.background = prevBackground;
     };
   }, [isDark]);
-
-  const handleStart = (name: string) => {
-    localStorage.setItem(STORAGE_KEY, name);
-    setClubName(name);
-    // 새 동아리를 고르면 개인 카운터를 초기화해 이전 동아리 클릭이 남지 않게 한다
-    setMyCount(0);
-    setIsEditing(false);
-  };
-
-  const handleChangeClub = () => {
-    setIsEditing(true);
-  };
-
-  const handleCancelChange = () => {
-    setIsEditing(false);
-  };
 
   const toggleDark = () => {
     setIsDark((prev) => {
@@ -181,10 +92,6 @@ const GamePage = () => {
           <BackgroundFirework key={id} />
         ))}
 
-        {clubName && !isEditing && (
-          <FallingBubbles onCatch={handleBubbleCatch} />
-        )}
-
         <S.Content>
           <S.ToggleBar>
             <S.ToggleSwitch
@@ -199,7 +106,7 @@ const GamePage = () => {
             </S.ToggleSwitch>
           </S.ToggleBar>
 
-          {/* 상단: 타이틀(좌) + 실시간 순위(우) */}
+          {/* 상단: 타이틀(좌) + 최종 순위(우) */}
           <S.TopRow>
             <motion.div
               initial={{ opacity: 0, y: -16 }}
@@ -208,7 +115,7 @@ const GamePage = () => {
             >
               <S.PageTitle $dark={isDark}>동아리 클릭 배틀</S.PageTitle>
               <S.PageDescription $dark={isDark}>
-                우리 동아리를 응원해주세요! 클릭할수록 순위가 올라가요.
+                클릭 배틀이 종료되었어요! 최종 순위를 확인해보세요.
               </S.PageDescription>
             </motion.div>
 
@@ -218,13 +125,7 @@ const GamePage = () => {
                 animate={{ opacity: 1, x: 0 }}
                 transition={{ duration: 0.5, delay: 0.3 }}
               >
-                <RankingBoard
-                  ranking={rankingData?.clubs ?? []}
-                  myClubName={clubName}
-                  isDark={isDark}
-                  rankDelta={rankDelta}
-                  onSelectClub={handleStart}
-                />
+                <RankingBoard ranking={rankingData?.clubs ?? []} isDark={isDark} />
               </motion.div>
             </S.DesktopOnly>
           </S.TopRow>
@@ -252,30 +153,6 @@ const GamePage = () => {
             </motion.div>
           )}
 
-          {/* 하단: 클릭 버튼 */}
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.4, delay: 0.25 }}
-            style={{ marginTop: '40px' }}
-          >
-            {!clubName || isEditing ? (
-              <ClubNameInput
-                onStart={handleStart}
-                onCancel={isEditing ? handleCancelChange : undefined}
-                isDark={isDark}
-              />
-            ) : (
-              <GamePlaySection
-                clubName={clubName}
-                myCount={myCount}
-                gainCount={gainCount}
-                onChangeClub={handleChangeClub}
-                isDark={isDark}
-              />
-            )}
-          </motion.div>
-
           {/* 모바일 전용: 순위표 최하단 */}
           <S.MobileOnly>
             <motion.div
@@ -283,13 +160,7 @@ const GamePage = () => {
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.5, delay: 0.3 }}
             >
-              <RankingBoard
-                ranking={rankingData?.clubs ?? []}
-                myClubName={clubName}
-                isDark={isDark}
-                rankDelta={rankDelta}
-                onSelectClub={handleStart}
-              />
+              <RankingBoard ranking={rankingData?.clubs ?? []} isDark={isDark} />
             </motion.div>
           </S.MobileOnly>
         </S.Content>

--- a/frontend/src/pages/GamePage/GamePage.tsx
+++ b/frontend/src/pages/GamePage/GamePage.tsx
@@ -54,17 +54,27 @@ const GamePage = () => {
 
   const top1Club = rankingData?.clubs[0];
 
-  // 게임 종료: 10초마다 축하 폭죽을 자동으로 발사
+  // 게임 종료: 진입 시 한 번 + 이후 10초마다 축하 폭죽 자동 발사
   const burstIdRef = useRef(0);
   useEffect(() => {
-    const interval = setInterval(() => {
+    const timeouts: ReturnType<typeof setTimeout>[] = [];
+
+    const fireBurst = () => {
       const id = burstIdRef.current++;
       setBgBursts((prev) => [...prev, id]);
-      setTimeout(() => {
+      const timeout = setTimeout(() => {
         setBgBursts((prev) => prev.filter((b) => b !== id));
       }, FIREWORK_DURATION);
-    }, FIREWORK_INTERVAL);
-    return () => clearInterval(interval);
+      timeouts.push(timeout);
+    };
+
+    fireBurst();
+    const interval = setInterval(fireBurst, FIREWORK_INTERVAL);
+
+    return () => {
+      clearInterval(interval);
+      timeouts.forEach(clearTimeout);
+    };
   }, []);
 
   useEffect(() => {

--- a/frontend/src/pages/GamePage/GamePage.tsx
+++ b/frontend/src/pages/GamePage/GamePage.tsx
@@ -135,7 +135,10 @@ const GamePage = () => {
                 animate={{ opacity: 1, x: 0 }}
                 transition={{ duration: 0.5, delay: 0.3 }}
               >
-                <RankingBoard ranking={rankingData?.clubs ?? []} isDark={isDark} />
+                <RankingBoard
+                  ranking={rankingData?.clubs ?? []}
+                  isDark={isDark}
+                />
               </motion.div>
             </S.DesktopOnly>
           </S.TopRow>
@@ -170,7 +173,10 @@ const GamePage = () => {
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.5, delay: 0.3 }}
             >
-              <RankingBoard ranking={rankingData?.clubs ?? []} isDark={isDark} />
+              <RankingBoard
+                ranking={rankingData?.clubs ?? []}
+                isDark={isDark}
+              />
             </motion.div>
           </S.MobileOnly>
         </S.Content>

--- a/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.styles.ts
+++ b/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.styles.ts
@@ -28,7 +28,6 @@ export const List = styled.ol`
 `;
 
 export const Item = styled.div<{
-  $isMe: boolean;
   $rank: number;
   $dark: boolean;
 }>`
@@ -37,18 +36,11 @@ export const Item = styled.div<{
   gap: 12px;
   padding: 12px 16px;
   border-radius: 10px;
-  background: ${({ $isMe, $dark, theme }) => {
-    if ($dark) return $isMe ? 'rgba(255, 84, 20, 0.18)' : '#22222E';
-    return $isMe ? theme.colors.primary[500] : '#FFFFFF';
-  }};
-  border: ${({ $isMe, $dark, theme }) => {
-    if ($isMe) return `2px solid ${theme.colors.primary[900]}`;
-    return $dark
-      ? '2px solid transparent'
-      : `2px solid ${theme.colors.gray[300]}`;
-  }};
-  box-shadow: ${({ $isMe, $dark }) =>
-    !$isMe && !$dark ? '0 1px 3px rgba(0, 0, 0, 0.06)' : 'none'};
+  background: ${({ $dark }) => ($dark ? '#22222E' : '#FFFFFF')};
+  border: ${({ $dark, theme }) =>
+    $dark ? '2px solid transparent' : `2px solid ${theme.colors.gray[300]}`};
+  box-shadow: ${({ $dark }) =>
+    $dark ? 'none' : '0 1px 3px rgba(0, 0, 0, 0.06)'};
   transition: background 0.3s;
   cursor: pointer;
   text-decoration: none;
@@ -78,54 +70,10 @@ export const ClubName = styled.span<{ $dark: boolean }>`
   white-space: nowrap;
 `;
 
-export const RankDelta = styled.span<{ $direction: 'up' | 'down' }>`
-  font-size: 0.75rem;
-  font-weight: 700;
-  color: ${({ $direction }) => ($direction === 'up' ? '#E53935' : '#1E88E5')};
-  white-space: nowrap;
-`;
-
 export const ClickCount = styled.span`
   font-size: 0.875rem;
   font-weight: 700;
   color: ${({ theme }) => theme.colors.primary[900]};
-`;
-
-export const DetailLink = styled.span<{ $dark: boolean }>`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  font-size: 0.875rem;
-  color: ${({ $dark, theme }) =>
-    $dark ? theme.colors.gray[500] : theme.colors.gray[400]};
-  text-decoration: none;
-  flex-shrink: 0;
-
-  &:hover {
-    color: ${({ theme }) => theme.colors.primary[900]};
-  }
-`;
-
-export const MoreButton = styled.button<{ $dark: boolean }>`
-  display: block;
-  width: 100%;
-  margin-top: 12px;
-  padding: 12px 0;
-  border: none;
-  border-radius: 10px;
-  background: ${({ $dark }) => ($dark ? '#2A2A36' : '#F0F0F0')};
-  color: ${({ $dark, theme }) =>
-    $dark ? theme.colors.gray[300] : theme.colors.gray[600]};
-  font-size: 0.9rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background 0.2s;
-
-  &:hover {
-    background: ${({ $dark }) => ($dark ? '#33333F' : '#E5E5E5')};
-  }
 `;
 
 export const EmptyMessage = styled.p<{ $dark: boolean }>`

--- a/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.tsx
+++ b/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { AnimatePresence, motion } from 'framer-motion';
 import { USER_EVENT } from '@/constants/eventName';
@@ -15,7 +14,7 @@ interface RankingBoardProps {
 }
 
 const MEDAL = ['🥇', '🥈', '🥉'];
-const TOP_COUNT = 20;
+const TOP_COUNT = 3;
 
 const RankingBoard = ({
   ranking,
@@ -24,16 +23,14 @@ const RankingBoard = ({
   rankDelta,
   onSelectClub,
 }: RankingBoardProps) => {
-  const [isExpanded, setIsExpanded] = useState(false);
   const trackEvent = useMixpanelTrack();
 
-  const visibleRanking = isExpanded ? ranking : ranking.slice(0, TOP_COUNT);
-  const hasMore = ranking.length > TOP_COUNT;
+  const visibleRanking = ranking.slice(0, TOP_COUNT);
 
   return (
     <S.Wrapper>
       <S.Header>
-        <S.Title $dark={isDark}>🏆 Top 20 실시간 순위</S.Title>
+        <S.Title $dark={isDark}>🏆 Top 3 최종 순위</S.Title>
       </S.Header>
       {ranking.length === 0 ? (
         <S.EmptyMessage $dark={isDark}>
@@ -52,8 +49,7 @@ const RankingBoard = ({
                   exit={{ opacity: 0, x: 20 }}
                   transition={{
                     duration: 0.2,
-                    delay:
-                      (isExpanded && i >= TOP_COUNT ? i - TOP_COUNT : i) * 0.02,
+                    delay: Math.min(i * 0.02, 0.4),
                   }}
                   style={{ listStyle: 'none' }}
                 >
@@ -116,16 +112,6 @@ const RankingBoard = ({
               ))}
             </AnimatePresence>
           </S.List>
-          {hasMore && (
-            <S.MoreButton
-              $dark={isDark}
-              onClick={() => setIsExpanded((prev) => !prev)}
-            >
-              {isExpanded
-                ? '접기'
-                : `더보기 (${ranking.length - TOP_COUNT}개 동아리)`}
-            </S.MoreButton>
-          )}
         </>
       )}
     </S.Wrapper>

--- a/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.tsx
+++ b/frontend/src/pages/GamePage/components/RankingBoard/RankingBoard.tsx
@@ -1,30 +1,17 @@
 import { Link } from 'react-router-dom';
 import { AnimatePresence, motion } from 'framer-motion';
-import { USER_EVENT } from '@/constants/eventName';
-import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import { GameRankingEntry } from '@/types/game';
 import * as S from './RankingBoard.styles';
 
 interface RankingBoardProps {
   ranking: GameRankingEntry[];
-  myClubName?: string;
   isDark?: boolean;
-  rankDelta?: Map<string, number>;
-  onSelectClub?: (clubName: string) => void;
 }
 
 const MEDAL = ['🥇', '🥈', '🥉'];
 const TOP_COUNT = 3;
 
-const RankingBoard = ({
-  ranking,
-  myClubName,
-  isDark = false,
-  rankDelta,
-  onSelectClub,
-}: RankingBoardProps) => {
-  const trackEvent = useMixpanelTrack();
-
+const RankingBoard = ({ ranking, isDark = false }: RankingBoardProps) => {
   const visibleRanking = ranking.slice(0, TOP_COUNT);
 
   return (
@@ -34,85 +21,39 @@ const RankingBoard = ({
       </S.Header>
       {ranking.length === 0 ? (
         <S.EmptyMessage $dark={isDark}>
-          아직 참여한 동아리가 없어요. 첫 번째로 클릭해보세요!
+          아직 집계된 최종 순위가 없어요.
         </S.EmptyMessage>
       ) : (
-        <>
-          <S.List>
-            <AnimatePresence initial={false}>
-              {visibleRanking.map((entry, i) => (
-                <motion.li
-                  key={entry.clubName}
-                  layout
-                  initial={{ opacity: 0, x: -20 }}
-                  animate={{ opacity: 1, x: 0 }}
-                  exit={{ opacity: 0, x: 20 }}
-                  transition={{
-                    duration: 0.2,
-                    delay: Math.min(i * 0.02, 0.4),
-                  }}
-                  style={{ listStyle: 'none' }}
+        <S.List>
+          <AnimatePresence initial={false}>
+            {visibleRanking.map((entry, i) => (
+              <motion.li
+                key={entry.clubName}
+                layout
+                initial={{ opacity: 0, x: -20 }}
+                animate={{ opacity: 1, x: 0 }}
+                exit={{ opacity: 0, x: 20 }}
+                transition={{ duration: 0.2, delay: i * 0.1 }}
+                style={{ listStyle: 'none' }}
+              >
+                <S.Item
+                  as={Link}
+                  to={`/clubDetail/@${encodeURIComponent(entry.clubName)}`}
+                  $rank={entry.rank}
+                  $dark={isDark}
                 >
-                  <S.Item
-                    {...(onSelectClub
-                      ? {
-                          onClick: () => {
-                            // 카드 클릭 = 게임 대상 동아리 변경 (상세 이동과 별개 이벤트)
-                            trackEvent(USER_EVENT.GAME_RANKING_CLUB_SELECTED, {
-                              clubName: entry.clubName,
-                              rank: entry.rank,
-                            });
-                            onSelectClub(entry.clubName);
-                          },
-                        }
-                      : {
-                          as: Link,
-                          to: `/clubDetail/@${encodeURIComponent(entry.clubName)}`,
-                        })}
-                    $isMe={entry.clubName === myClubName}
-                    $rank={entry.rank}
-                    $dark={isDark}
-                  >
-                    <S.Rank $rank={entry.rank}>
-                      {MEDAL[entry.rank - 1] ?? entry.rank}
-                    </S.Rank>
-                    <S.ClubName $dark={isDark}>{entry.clubName}</S.ClubName>
-                    {(() => {
-                      const delta = rankDelta?.get(entry.clubName) ?? 0;
-                      if (delta === 0) return null;
-                      return (
-                        <S.RankDelta $direction={delta > 0 ? 'up' : 'down'}>
-                          {delta > 0 ? '▲' + delta : '▼' + Math.abs(delta)}
-                        </S.RankDelta>
-                      );
-                    })()}
-                    <S.ClickCount>
-                      {entry.clickCount.toLocaleString()}회
-                    </S.ClickCount>
-                    {onSelectClub && (
-                      <S.DetailLink
-                        as={Link}
-                        to={`/clubDetail/@${encodeURIComponent(entry.clubName)}`}
-                        onClick={(e: React.MouseEvent) => {
-                          // 네비게이션 버튼 클릭 = 상세페이지 이동 (카드 선택과 별개 이벤트)
-                          e.stopPropagation();
-                          trackEvent(USER_EVENT.GAME_RANKING_DETAIL_CLICKED, {
-                            clubName: entry.clubName,
-                            rank: entry.rank,
-                          });
-                        }}
-                        $dark={isDark}
-                        aria-label={`${entry.clubName} 상세페이지`}
-                      >
-                        →
-                      </S.DetailLink>
-                    )}
-                  </S.Item>
-                </motion.li>
-              ))}
-            </AnimatePresence>
-          </S.List>
-        </>
+                  <S.Rank $rank={entry.rank}>
+                    {MEDAL[entry.rank - 1] ?? entry.rank}
+                  </S.Rank>
+                  <S.ClubName $dark={isDark}>{entry.clubName}</S.ClubName>
+                  <S.ClickCount>
+                    {entry.clickCount.toLocaleString()}회
+                  </S.ClickCount>
+                </S.Item>
+              </motion.li>
+            ))}
+          </AnimatePresence>
+        </S.List>
       )}
     </S.Wrapper>
   );


### PR DESCRIPTION
## 개요
클릭 게임을 종료하고, 페이지를 최종 순위 발표용으로 전환합니다.

## 변경 사항
- **입력·클릭 UI 제거**: 동아리 이름 입력, 클릭 버튼, 비눗방울(FallingBubbles) 렌더링 제거 → 랭킹만 표시
- **폭죽 자동화**: 마일스톤 돌파 시 발사 → **10초마다 자동 발사**
- **랭킹 Top 3만 노출**: `TOP_COUNT` 3, 제목 "🏆 Top 3 최종 순위", 더보기/접기 버튼 제거
- 안내 문구를 종료 안내로 변경, 다크모드 토글·1위 도트 텍스트 연출은 유지

## 참고
- 백엔드 클릭 API 차단(`POST /api/game/click` → 410)은 별도 백엔드 레포에서 진행 (본 PR 미포함)
- 게임 종료로 미사용이 된 컴포넌트/훅(ClubNameInput, GamePlaySection, useBatchedClick 등)은 되돌림 여지를 위해 삭제하지 않고 남겨둠

## 검증
- `npm run typecheck` ✅
- 변경 파일 `eslint` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 최종 순위 화면이 더 간단하게 정리되어, 진입 시 상위 3개 순위만 바로 확인할 수 있습니다.
  * 배경 효과가 일정 간격으로 자동 재생되도록 바뀌어, 화면 분위기가 더 자연스럽게 유지됩니다.

* **UI/UX**
  * 순위 보드의 더보기/접기 동작이 사라지고, 핵심 순위만 고정 표시되도록 변경되었습니다.
  * 안내 문구가 실시간 순위 중심에서 클릭 배틀 종료 후 최종 순위 중심으로 바뀌었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->