### PR TITLE
[feature] 클릭 게임 종료 - 클릭 API 차단

### DIFF
--- a/backend/src/main/java/moadong/club/controller/ClubClickController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubClickController.java
@@ -3,19 +3,16 @@ package moadong.club.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import moadong.club.payload.request.ClubClickRequest;
 import moadong.club.payload.response.ClubClickRankingResponse;
-import moadong.club.payload.response.ClubClickResponse;
 import moadong.club.service.ClubClickService;
+import moadong.global.exception.ErrorCode;
+import moadong.global.exception.RestApiException;
 import moadong.global.payload.Response;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import jakarta.servlet.http.HttpServletRequest;
 
 @RestController
 @RequestMapping("/api/game")
@@ -26,19 +23,9 @@ public class ClubClickController {
     private final ClubClickService clubClickService;
 
     @PostMapping("/click")
-    @Operation(summary = "동아리 클릭 기록", description = "실제 동아리 이름으로만 클릭 수를 누적합니다. IP당 1초 쿨다운이 적용됩니다.")
-    public ResponseEntity<?> recordClick(@RequestBody ClubClickRequest request, HttpServletRequest httpRequest) {
-        String clientIp = resolveClientIp(httpRequest);
-        ClubClickResponse result = clubClickService.recordClick(request.clubName(), request.count(), clientIp, request.ctAt());
-        return Response.ok(result);
-    }
-
-    private String resolveClientIp(HttpServletRequest request) {
-        String cfIp = request.getHeader("CF-Connecting-IP");
-        if (cfIp != null && !cfIp.isBlank()) {
-            return cfIp.trim();
-        }
-        return request.getRemoteAddr();
+    @Operation(summary = "동아리 클릭 기록 (종료됨)", description = "클릭 이벤트가 종료되어 더 이상 클릭 수를 기록하지 않습니다.")
+    public ResponseEntity<?> recordClick() {
+        throw new RestApiException(ErrorCode.CLICK_GAME_ENDED);
     }
 
     @GetMapping("/ranking")

--- a/backend/src/main/java/moadong/global/exception/ErrorCode.java
+++ b/backend/src/main/java/moadong/global/exception/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     CLICK_COUNT_INVALID(HttpStatus.BAD_REQUEST, "600-13", "클릭 수는 1 이상 5 이하이어야 합니다."),
     CLICK_RATE_LIMITED(HttpStatus.TOO_MANY_REQUESTS, "600-14", "비정상적인 요청이 감지되었습니다. 30초 후 다시 시도해주세요."),
     CLICK_TIMESTAMP_INVALID(HttpStatus.BAD_REQUEST, "600-15", "클릭 시각이 유효하지 않습니다."),
+    CLICK_GAME_ENDED(HttpStatus.GONE, "600-16", "클릭 이벤트가 종료되었습니다."),
 
     // 601xx: 파일/미디어 관련 오류
     IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "601-1", "이미지 업로드에 실패하였습니다."),


### PR DESCRIPTION
## 개요
클릭 게임 종료에 따라 클릭 기록 API를 차단합니다. (FE PR: Moadong/moadong#1798)

## 변경 사항
- `POST /api/game/click` 요청을 처리하지 않고 **410 Gone** 응답 반환 (`RestApiException(CLICK_GAME_ENDED)`)
- `ErrorCode.CLICK_GAME_ENDED(HttpStatus.GONE, "600-16", "클릭 이벤트가 종료되었습니다.")` 추가
- 사용되지 않게 된 `resolveClientIp` 및 관련 import 정리
- `GET /api/game/ranking` (랭킹 조회)은 그대로 유지

## 참고
- 게임 종료로 미사용이 된 `ClubClickService.recordClick` 및 쿨다운/레이트리밋 로직은 되돌림 여지를 위해 삭제하지 않고 남겨둠

## 검증
- `./gradlew compileJava` ✅ (기존 경고 외 신규 이슈 없음)