### PR TITLE
[fix] WebviewTopBar 스크롤 시 상단 고정

### DIFF
--- a/frontend/docs/features/components/header.md
+++ b/frontend/docs/features/components/header.md
@@ -28,9 +28,22 @@ if (!isVisible) return null;
 
 네비게이션 이동과 Mixpanel 트래킹을 함께 처리한다. `handleMenuClose`를 통해 모바일 메뉴 닫기 트래킹도 담당.
 
+## WebviewTopBar
+
+웹뷰(인앱 브라우저) 환경에서 `Header` 대신 사용하는 상단바. 뒤로가기 버튼 + 타이틀로 구성.
+
+- `position: sticky; top: 0` — 스크롤 시 상단 고정. `fixed`가 아닌 `sticky`이므로 하위 페이지에서 별도 top offset 조정 불필요
+- `z-index: Z_INDEX.header` 적용
+
+```tsx
+<WebviewTopBar title="페이지 제목" onBack={handleBack} />
+```
+
 ## 관련 코드
 
 - `src/components/common/Header/Header.tsx` — UI 렌더링
+- `src/components/common/WebviewTopBar/WebviewTopBar.tsx` — 웹뷰 전용 상단바
+- `src/components/common/WebviewTopBar/WebviewTopBar.styles.ts` — sticky 포지셔닝
 - `src/hooks/Header/useHeaderVisibility.ts` — 렌더 조건 훅
 - `src/hooks/Header/useHeaderNavigation.ts` — 네비게이션 + 트래킹 훅
 - `src/types/device.ts` — DeviceType 공통 타입

--- a/frontend/src/components/common/WebviewTopBar/WebviewTopBar.styles.ts
+++ b/frontend/src/components/common/WebviewTopBar/WebviewTopBar.styles.ts
@@ -1,8 +1,11 @@
 import styled from 'styled-components';
 import { colors } from '@/styles/theme/colors';
+import { Z_INDEX } from '@/styles/zIndex';
 
 export const Container = styled.header`
-  position: relative;
+  position: sticky;
+  top: 0;
+  z-index: ${Z_INDEX.header};
   height: 48px;
   background: ${colors.base.white};
   border-bottom: 1px solid ${colors.gray[300]};


### PR DESCRIPTION
## #️⃣연관된 이슈

#1806

## 📝작업 내용

모바일 웹뷰 환경에서 스크롤 시 상단바가 함께 올라가는 문제를 수정했습니다.

### 변경 사항

| 항목 | 내용 |
|---|---|
| `WebviewTopBar` position | `relative` → `sticky top: 0` |
| z-index | `Z_INDEX.header` 추가 |

### 적용 페이지

`WebviewTopBar`를 사용하는 모든 페이지에 자동 적용됩니다.

- 어드민 모바일 (ClubInfoEditTab, FreeTagEditPage, LinkEditPage 등)
- 총동아리연합회 소개, 모아동 소개, 홍보 상세, 게임 페이지 등

## 🫡 참고사항

- `position: fixed`가 아닌 `sticky`를 사용하여 문서 흐름을 유지, 각 페이지의 top offset 조정이 불필요합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 웹뷰(인앱 브라우저) 환경용 상단 바가 문서에 추가되어 사용 방법을 더 쉽게 확인할 수 있습니다.
  * 상단 바가 화면 상단에 고정되도록 동작이 개선되어 스크롤 중에도 더 안정적으로 보입니다.

* **Documentation**
  * 관련 구성 요소와 예시 렌더 코드가 함께 정리되어 문서 가독성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->