### PR TITLE
[refactor] 지원서 학기 분리 제거·연도+활성 그룹핑 전환

### DIFF
--- a/backend/src/main/java/moadong/club/controller/ClubApplyAdminController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubApplyAdminController.java
@@ -52,8 +52,7 @@ public class ClubApplyAdminController {
                     "- 지원서 설명 (description)<br>" +
                     "- 활성화 여부 (active)<br>" +
                     "- 질문 목록 (questions)<br>" +
-                    "- 모집 학년도 (semesterYear)<br>" +
-                    "- 모집 학기 (semesterTerm)"
+                    "- 모집 학년도 (semesterYear)"
     )
     @PreAuthorize("isAuthenticated()")
     @SecurityRequirement(name = "BearerAuth")
@@ -65,7 +64,7 @@ public class ClubApplyAdminController {
     }
 
     @GetMapping("/application")
-    @Operation(summary = "클럽의 모든 지원서 양식 목록 불러오기", description = "클럽의 모든 지원서 양식들을 학기별로 분류하여 불러옵니다")
+    @Operation(summary = "클럽의 모든 지원서 양식 목록 불러오기", description = "클럽의 모든 지원서 양식들을 연도·활성화 여부별로 분류하여 불러옵니다")
     @PreAuthorize("isAuthenticated()")
     @SecurityRequirement(name = "BearerAuth")
     public ResponseEntity<?> getClubApplications(@CurrentUser CustomUserDetails user) {

--- a/backend/src/main/java/moadong/club/entity/ClubApplicationForm.java
+++ b/backend/src/main/java/moadong/club/entity/ClubApplicationForm.java
@@ -7,7 +7,6 @@ import lombok.Builder;
 import lombok.Getter;
 import moadong.club.enums.ApplicationFormMode;
 import moadong.club.enums.ApplicationFormStatus;
-import moadong.club.enums.SemesterTerm;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
 import org.springframework.data.annotation.Version;
@@ -55,11 +54,6 @@ public class ClubApplicationForm implements Persistable<String> {
     @Builder.Default
     private Integer semesterYear = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDate().getYear();
 
-    @NotNull
-    @Builder.Default
-    private SemesterTerm semesterTerm = (ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDate().getMonthValue() < 7)
-            ? SemesterTerm.FIRST : SemesterTerm.SECOND; //1학기, 2학기
-
     @Builder.Default
     private ApplicationFormStatus status = ApplicationFormStatus.UNPUBLISHED;
 
@@ -96,10 +90,6 @@ public class ClubApplicationForm implements Persistable<String> {
 
     public void updateSemesterYear(Integer semesterYear) {
         this.semesterYear = semesterYear;
-    }
-
-    public void updateSemesterTerm(SemesterTerm semesterTerm) {
-        this.semesterTerm = semesterTerm;
     }
 
     public void updateFormStatus(boolean activeFlag) {

--- a/backend/src/main/java/moadong/club/payload/dto/ClubApplicationFormsResult.java
+++ b/backend/src/main/java/moadong/club/payload/dto/ClubApplicationFormsResult.java
@@ -1,10 +1,9 @@
 package moadong.club.payload.dto;
 
-import moadong.club.enums.SemesterTerm;
 import java.util.List;
 
 public record ClubApplicationFormsResult(
         Integer semesterYear,
-        SemesterTerm semesterTerm,
+        Boolean active,
         List<ClubApplicationFormsResultItem> forms
 ){ }

--- a/backend/src/main/java/moadong/club/payload/request/ClubApplicationFormCreateRequest.java
+++ b/backend/src/main/java/moadong/club/payload/request/ClubApplicationFormCreateRequest.java
@@ -3,7 +3,6 @@ package moadong.club.payload.request;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
 import moadong.club.enums.ApplicationFormMode;
-import moadong.club.enums.SemesterTerm;
 import org.springframework.util.StringUtils;
 
 import java.util.List;
@@ -27,10 +26,7 @@ public record ClubApplicationFormCreateRequest(
         @NotNull
         @Min(2000)
         @Max(2999)
-        Integer semesterYear,
-
-        @NotNull
-        SemesterTerm semesterTerm
+        Integer semesterYear
 ) {
 
     @AssertTrue(message = "지원서 양식에 필요한 필드가 누락되었습니다.")

--- a/backend/src/main/java/moadong/club/payload/request/ClubApplicationFormEditRequest.java
+++ b/backend/src/main/java/moadong/club/payload/request/ClubApplicationFormEditRequest.java
@@ -3,7 +3,6 @@ package moadong.club.payload.request;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
 import moadong.club.enums.ApplicationFormMode;
-import moadong.club.enums.SemesterTerm;
 
 import java.util.List;
 
@@ -25,8 +24,6 @@ public record ClubApplicationFormEditRequest(
 
         @Min(2000)
         @Max(2999)
-        Integer semesterYear,
-
-        SemesterTerm semesterTerm
+        Integer semesterYear
 ) {
 }

--- a/backend/src/main/java/moadong/club/payload/response/ClubApplicationFormResponse.java
+++ b/backend/src/main/java/moadong/club/payload/response/ClubApplicationFormResponse.java
@@ -4,7 +4,6 @@ import lombok.Builder;
 import moadong.club.entity.ClubApplicationFormQuestion;
 import moadong.club.enums.ApplicationFormMode;
 import moadong.club.enums.ApplicationFormStatus;
-import moadong.club.enums.SemesterTerm;
 
 import java.util.List;
 
@@ -16,7 +15,6 @@ public record ClubApplicationFormResponse(
         String externalApplicationUrl,
         ApplicationFormMode formMode,
         Integer semesterYear,
-        SemesterTerm semesterTerm,
         ApplicationFormStatus status
 ) {
 }

--- a/backend/src/main/java/moadong/club/repository/ClubApplicationFormsRepositoryCustom.java
+++ b/backend/src/main/java/moadong/club/repository/ClubApplicationFormsRepositoryCustom.java
@@ -6,6 +6,7 @@ import org.bson.Document;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.AggregationExpression;
 import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
 import org.springframework.data.mongodb.core.aggregation.GroupOperation;
 import org.springframework.data.mongodb.core.query.Criteria;
@@ -31,7 +32,8 @@ public class ClubApplicationFormsRepositoryCustom {
                 .and("editedAt").as("editedAt")
                 .and("status").as("status")
                 .and("semesterYear").as("semesterYear")
-                .and("semesterTerm").as("semesterTerm"));
+                .and((AggregationExpression) context ->
+                        new Document("$eq", Arrays.asList("$status", "ACTIVE"))).as("active"));
 
         //1차 정렬 -> 그룹 내에서 최종수정날짜 순으로 정렬됨
         operations.add(Aggregation.sort(Sort.by(
@@ -39,8 +41,8 @@ public class ClubApplicationFormsRepositoryCustom {
                 Sort.Order.desc("id")
         )));
 
-        //그룹화
-        GroupOperation groupOperation = Aggregation.group("semesterYear","semesterTerm")
+        //연도 + 활성화 여부로 그룹화
+        GroupOperation groupOperation = Aggregation.group("semesterYear","active")
                 .push(new Document("_id", "$_id")
                         .append("title", "$title")
                         .append("editedAt", "$editedAt")
@@ -48,18 +50,14 @@ public class ClubApplicationFormsRepositoryCustom {
                 .as("forms");
         operations.add(groupOperation);
 
-        //그룹들 학기순 정렬
-        operations.add(Aggregation.addFields()
-                .addFieldWithValue("termOrder", new Document("$indexOfArray",
-                        Arrays.asList(Arrays.asList("FIRST", "SECOND"), "$_id.semesterTerm")))
-                .build());
+        //그룹들 정렬 (연도 최신순 -> 활성 그룹 우선)
         operations.add(Aggregation.sort(Sort.by(
                 Sort.Order.desc("_id.semesterYear"),
-                Sort.Order.desc("termOrder"))));
+                Sort.Order.desc("_id.active"))));
 
         operations.add(Aggregation.project("forms")
                 .and("_id.semesterYear").as("semesterYear")
-                .and("_id.semesterTerm").as("semesterTerm"));
+                .and("_id.active").as("active"));
 
         Aggregation aggregation = Aggregation.newAggregation(operations);
         return mongoTemplate

--- a/backend/src/main/java/moadong/club/repository/ClubApplicationFormsRepositoryCustom.java
+++ b/backend/src/main/java/moadong/club/repository/ClubApplicationFormsRepositoryCustom.java
@@ -6,14 +6,13 @@ import org.bson.Document;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
-import org.springframework.data.mongodb.core.aggregation.AggregationExpression;
 import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
+import org.springframework.data.mongodb.core.aggregation.ComparisonOperators;
 import org.springframework.data.mongodb.core.aggregation.GroupOperation;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.stereotype.Repository;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 @Repository
@@ -32,8 +31,7 @@ public class ClubApplicationFormsRepositoryCustom {
                 .and("editedAt").as("editedAt")
                 .and("status").as("status")
                 .and("semesterYear").as("semesterYear")
-                .and((AggregationExpression) context ->
-                        new Document("$eq", Arrays.asList("$status", "ACTIVE"))).as("active"));
+                .and(ComparisonOperators.valueOf("status").equalToValue("ACTIVE")).as("active"));
 
         //1차 정렬 -> 그룹 내에서 최종수정날짜 순으로 정렬됨
         operations.add(Aggregation.sort(Sort.by(

--- a/backend/src/main/java/moadong/club/service/ClubApplyAdminService.java
+++ b/backend/src/main/java/moadong/club/service/ClubApplyAdminService.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import moadong.club.entity.*;
 import moadong.club.enums.ApplicationFormMode;
-import moadong.club.enums.SemesterTerm;
 import moadong.club.payload.dto.ApplicantStatusEvent;
 import moadong.club.payload.dto.ClubApplicantsResult;
 import moadong.club.payload.request.*;
@@ -24,7 +23,6 @@ import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.util.StringUtils;
 
-import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.*;
@@ -40,41 +38,6 @@ public class ClubApplyAdminService {
     private final AESCipher cipher;
     private final ClubApplicationFormsRepositoryCustom clubApplicationFormsRepositoryCustom;
     private final ApplicantsStatusShareSse applicantsStatusShareSse;
-
-    private record OptionItem(int year, SemesterTerm term) {
-    }
-
-    private List<OptionItem> buildOptionItems(LocalDate baseDate, int count) {
-        List<OptionItem> items = new ArrayList<>();
-
-        int year = baseDate.getYear();
-        int month = baseDate.getMonthValue();
-
-        SemesterTerm startTerm = (month < 7) ? SemesterTerm.FIRST : SemesterTerm.SECOND;
-
-        int semesterYear = year;
-        SemesterTerm semesterTerm = startTerm;
-        for (int i = 0; i < count; i++) {
-            items.add(new OptionItem(semesterYear, semesterTerm));
-            if (semesterTerm == SemesterTerm.FIRST) {
-                semesterTerm = SemesterTerm.SECOND;
-            } else {
-                semesterTerm = SemesterTerm.FIRST;
-                semesterYear += 1;
-            }
-        }
-        return items;
-    }
-
-    private void validateSemester(Integer semesterYear, SemesterTerm semesterTerm) {
-        LocalDate baseDate = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDate();
-        List<OptionItem> items = buildOptionItems(baseDate, 3);
-        boolean allowed = items.stream().anyMatch(it -> it.year() == semesterYear && it.term() == semesterTerm);
-        if (!allowed) {
-            throw new RestApiException(ErrorCode.APPLICATION_SEMESTER_INVALID);
-        }
-
-    }
 
     private void validateFinalApplicationFormState(ClubApplicationForm clubApplicationForm, ClubApplicationFormEditRequest request) {
         ApplicationFormMode finalFormMode = Optional.ofNullable(request.formMode()).orElse(clubApplicationForm.getFormMode());
@@ -97,8 +60,6 @@ public class ClubApplyAdminService {
     }
 
     public void createClubApplicationForm(CustomUserDetails user, ClubApplicationFormCreateRequest request) {
-        validateSemester(request.semesterYear(), request.semesterTerm());
-
         ClubApplicationForm clubApplicationForm = createApplicationForm(ClubApplicationForm.builder().clubId(user.getClubId()).build(), request);
         clubApplicationFormsRepository.save(clubApplicationForm);
     }
@@ -242,7 +203,6 @@ public class ClubApplyAdminService {
         clubApplicationForm.updateFormTitle(request.title());
         clubApplicationForm.updateFormDescription(request.description());
         clubApplicationForm.updateSemesterYear(request.semesterYear());
-        clubApplicationForm.updateSemesterTerm(request.semesterTerm());
         clubApplicationForm.updateFormMode(request.formMode());
 
         return clubApplicationForm;
@@ -260,13 +220,8 @@ public class ClubApplyAdminService {
         if (request.externalApplicationUrl() != null)
             clubApplicationForm.updateExternalApplicationUrl(request.externalApplicationUrl());
 
-        if (request.semesterYear() != null || request.semesterTerm() != null) {
-            Integer semesterYear = Optional.ofNullable(request.semesterYear()).orElse(clubApplicationForm.getSemesterYear());
-            SemesterTerm semesterTerm = Optional.ofNullable(request.semesterTerm()).orElse(clubApplicationForm.getSemesterTerm());
-            validateSemester(semesterYear, semesterTerm);
-
-            clubApplicationForm.updateSemesterYear(semesterYear);
-            clubApplicationForm.updateSemesterTerm(semesterTerm);
+        if (request.semesterYear() != null) {
+            clubApplicationForm.updateSemesterYear(request.semesterYear());
         }
 
         return clubApplicationForm;

--- a/backend/src/main/java/moadong/club/service/ClubApplyPublicService.java
+++ b/backend/src/main/java/moadong/club/service/ClubApplyPublicService.java
@@ -62,7 +62,6 @@ public class ClubApplyPublicService {
                 .formMode(clubApplicationForm.getFormMode())
                 .externalApplicationUrl(clubApplicationForm.getExternalApplicationUrl())
                 .semesterYear(clubApplicationForm.getSemesterYear())
-                .semesterTerm(clubApplicationForm.getSemesterTerm())
                 .status(clubApplicationForm.getStatus())
                 .build();
 

--- a/backend/src/main/java/moadong/global/exception/ErrorCode.java
+++ b/backend/src/main/java/moadong/global/exception/ErrorCode.java
@@ -60,7 +60,6 @@ public enum ErrorCode {
     QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "800-4", "존재하지 않은 질문입니다."),
     REQUIRED_QUESTION_MISSING(HttpStatus.BAD_REQUEST, "800-5", "필수 응답 질문이 누락되었습니다."),
     ACTIVE_APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "800-6", "활성화된 지원서 양식이 존재하지 않습니다."),
-    APPLICATION_SEMESTER_INVALID(HttpStatus.BAD_REQUEST, "800-7", "올바르지 않은 학기입니다."),
     NOT_ALLOWED_EXTERNAL_URL(HttpStatus.BAD_REQUEST, "800-8", "형식에 맞지않은 외부지원서 URL 입니다."),
     DUPLICATE_QUESTIONS_ITEMS(HttpStatus.BAD_REQUEST, "800-9", "중복된 질문 선택지가 존재합니다."),
     APPLICATION_REQUIRED_FIELDS_MISSING(HttpStatus.BAD_REQUEST, "800-10", "지원서 양식에 필요한 필드가 누락되었습니다."),

--- a/backend/src/test/java/moadong/fixture/ClubApplicationEditFixture.java
+++ b/backend/src/test/java/moadong/fixture/ClubApplicationEditFixture.java
@@ -1,7 +1,6 @@
 package moadong.fixture;
 
 import moadong.club.enums.ApplicationFormMode;
-import moadong.club.enums.SemesterTerm;
 import moadong.club.payload.request.ClubApplicationFormEditRequest;
 import java.util.ArrayList;
 
@@ -23,8 +22,7 @@ public class ClubApplicationEditFixture {
                 new ArrayList<>(),
                 "",
                 ApplicationFormMode.INTERNAL,
-                2025,
-                SemesterTerm.SECOND
+                2025
         );
     }
 }


### PR DESCRIPTION
## 요약
관리자 지원서 분류를 날짜 기반 학기(1학기/2학기)에서 **연도 + 활성/비활성 상태**(활성=`ACTIVE`, 비활성=`PUBLISHED`·`UNPUBLISHED`) 기준으로 전환합니다.

## 변경사항
- 날짜 기반 학기 판정 및 `semesterTerm` 제거 (`semesterYear`는 유지, 생성 시 현재연도)
- 목록 집계를 `(연도, 활성)` 그룹핑으로 변경 (`ClubApplicationFormsRepositoryCustom`)
- 학기 검증 로직(`validateSemester`)·에러코드(`APPLICATION_SEMESTER_INVALID`) 제거
- 요청/응답 DTO에서 `semesterTerm` 필드 제거

관련 이슈: #1809
