### PR TITLE
[refactor] 지원서 상태 모델 ACTIVE/INACTIVE 2-state 축소

### DIFF
--- a/backend/src/main/java/moadong/club/entity/ClubApplicationForm.java
+++ b/backend/src/main/java/moadong/club/entity/ClubApplicationForm.java
@@ -55,7 +55,7 @@ public class ClubApplicationForm implements Persistable<String> {
     private Integer semesterYear = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDate().getYear();
 
     @Builder.Default
-    private ApplicationFormStatus status = ApplicationFormStatus.UNPUBLISHED;
+    private ApplicationFormStatus status = ApplicationFormStatus.INACTIVE;
 
     @NotNull
     @Builder.Default
@@ -93,7 +93,7 @@ public class ClubApplicationForm implements Persistable<String> {
     }
 
     public void updateFormStatus(boolean activeFlag) {
-        this.status = ApplicationFormStatus.fromFlag(this.status, activeFlag);
+        this.status = ApplicationFormStatus.fromFlag(activeFlag);
     }
 
     public void updateFormMode(ApplicationFormMode formMode) {

--- a/backend/src/main/java/moadong/club/enums/ApplicationFormStatus.java
+++ b/backend/src/main/java/moadong/club/enums/ApplicationFormStatus.java
@@ -1,16 +1,10 @@
 package moadong.club.enums;
 
 public enum ApplicationFormStatus {
-    ACTIVE, //현재 게시 중
-    PUBLISHED, //게시된 적 있음
-    UNPUBLISHED; //게시된 적 없음
+    ACTIVE, //현재 게시 중 (활성)
+    INACTIVE; //비활성
 
-    public static ApplicationFormStatus fromFlag(ApplicationFormStatus current, boolean activeFlag) {
-
-        if (current == null) current = UNPUBLISHED;
-
-        if (activeFlag) { return ACTIVE; }
-
-        return (current == ACTIVE) ? PUBLISHED : current;
+    public static ApplicationFormStatus fromFlag(boolean activeFlag) {
+        return activeFlag ? ACTIVE : INACTIVE;
     }
 }

--- a/backend/src/main/java/moadong/club/enums/ApplicationFormStatusReadingConverter.java
+++ b/backend/src/main/java/moadong/club/enums/ApplicationFormStatusReadingConverter.java
@@ -1,0 +1,18 @@
+package moadong.club.enums;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
+
+/**
+ * DB에 저장된 status 문자열을 {@link ApplicationFormStatus}로 읽어들일 때 사용한다.
+ * ACTIVE 외의 값(레거시 PUBLISHED/UNPUBLISHED 포함)은 모두 INACTIVE로 흡수한다.
+ * enum을 2-state로 축소한 뒤에도 기존 문서를 안전하게 역직렬화하기 위한 컨버터.
+ */
+@ReadingConverter
+public class ApplicationFormStatusReadingConverter implements Converter<String, ApplicationFormStatus> {
+
+    @Override
+    public ApplicationFormStatus convert(String source) {
+        return "ACTIVE".equals(source) ? ApplicationFormStatus.ACTIVE : ApplicationFormStatus.INACTIVE;
+    }
+}

--- a/backend/src/main/java/moadong/club/enums/ApplicationFormStatusReadingConverter.java
+++ b/backend/src/main/java/moadong/club/enums/ApplicationFormStatusReadingConverter.java
@@ -13,6 +13,9 @@ public class ApplicationFormStatusReadingConverter implements Converter<String, 
 
     @Override
     public ApplicationFormStatus convert(String source) {
+        if (source == null) {
+            return null;
+        }
         return "ACTIVE".equals(source) ? ApplicationFormStatus.ACTIVE : ApplicationFormStatus.INACTIVE;
     }
 }

--- a/backend/src/main/java/moadong/global/config/MongoConfig.java
+++ b/backend/src/main/java/moadong/global/config/MongoConfig.java
@@ -1,6 +1,8 @@
 package moadong.global.config;
 
 import com.mongodb.client.MongoClient;
+import java.util.List;
+import moadong.club.enums.ApplicationFormStatusReadingConverter;
 import net.javacrumbs.shedlock.core.LockProvider;
 import net.javacrumbs.shedlock.provider.mongo.MongoLockProvider;
 import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
@@ -8,6 +10,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.MongoTransactionManager;
+import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
 
 @Configuration
 @EnableSchedulerLock(defaultLockAtMostFor = "2m", defaultLockAtLeastFor = "30s")
@@ -15,6 +18,11 @@ public class MongoConfig {
     @Bean
     public MongoTransactionManager transactionManager(MongoDatabaseFactory dbFactory) {
         return new MongoTransactionManager(dbFactory);
+    }
+
+    @Bean
+    public MongoCustomConversions mongoCustomConversions() {
+        return new MongoCustomConversions(List.of(new ApplicationFormStatusReadingConverter()));
     }
 
 


### PR DESCRIPTION
## 개요
지원서 상태 모델을 3-state(ACTIVE/PUBLISHED/UNPUBLISHED) → 2-state(ACTIVE/INACTIVE)로 축소합니다.

관련 스토리: MOA-1031 / 하위작업 #1816 (MOA-1032)

## 배경
지원서 분류를 (연도+활성상태)로 전환한 뒤 실제로는 활성/비활성 2개로만 동작하지만 enum은 3개로 남아있었습니다. `PUBLISHED`/`UNPUBLISHED` 구분은 공개 API·어드민 어디서도 소비되지 않음을 확인했습니다.

## 변경 사항
- `ApplicationFormStatus`를 `ACTIVE`/`INACTIVE`로 축소, `fromFlag(boolean)`으로 단순화
- 엔티티 기본 상태값 `UNPUBLISHED` → `INACTIVE`
- **레거시 값 호환**: `ApplicationFormStatusReadingConverter` 추가 — DB에 저장된 기존 `PUBLISHED`/`UNPUBLISHED` 문자열을 읽을 때 `INACTIVE`로 흡수. enum 축소 후에도 기존 문서가 안전하게 역직렬화됩니다. (`MongoConfig`에 `MongoCustomConversions`로 등록)

## 참고
- 기존 문서는 다음 저장 시 자연히 `INACTIVE`로 수렴하며, 컨버터가 계속 흡수하므로 별도 마이그레이션은 불필요합니다.
- 배포 순서: **BE 먼저 → FE**(#1817). FE는 표시용 문자열 비교뿐이라 배포 전이어도 INACTIVE를 비활성으로 정상 표시합니다.

## 검증
- `./gradlew compileJava` ✅
- `compileTestJava` + `ClubApplyAdminServiceTest` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 신청서 상태 체계가 `활성`과 `비활성`으로 정리되었습니다.
  * 신청서 활성화 여부에 따라 상태가 일관되게 표시됩니다.
  * 기존에 저장된 신청서 상태도 현재 상태 체계에 맞춰 정상적으로 읽을 수 있습니다.
  * 신청서가 비활성화된 경우 더 이상 게시 상태로 처리되지 않으며, 활성화된 경우에만 활성 상태로 관리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->