### PR TITLE
[refactor] 어드민 텍스트 필드 글자수 제한 상수화 및 자동 높이 적용

### DIFF
--- a/frontend/src/constants/CLAUDE.md
+++ b/frontend/src/constants/CLAUDE.md
@@ -10,3 +10,4 @@
 - `snsConfig.ts` - SNS 플랫폼 설정
 - `applicationForm.ts` - 지원서 폼 설정
 - `uploadLimit.ts` - 파일 업로드 제한
+- `adminFieldLimits.ts` - 어드민 탭 텍스트 필드 최대 글자수 (ClubInfo, ClubIntro, Recruit, Account)

--- a/frontend/src/constants/CLAUDE.md
+++ b/frontend/src/constants/CLAUDE.md
@@ -11,3 +11,4 @@
 - `applicationForm.ts` - 지원서 폼 설정
 - `uploadLimit.ts` - 파일 업로드 제한
 - `adminFieldLimits.ts` - 어드민 탭 텍스트 필드 최대 글자수 (ClubInfo, ClubIntro, Recruit, Account)
+- `adminFieldPlaceholders.ts` - 어드민 탭 텍스트 필드 placeholder 문자열 (ClubInfoEditTab, ClubIntroEditTab 데스크탑/모바일 공유)

--- a/frontend/src/constants/adminFieldLimits.ts
+++ b/frontend/src/constants/adminFieldLimits.ts
@@ -1,0 +1,18 @@
+// 기본 정보 수정 (ClubInfoEditTab)
+export const CLUB_NAME_MAX = 20;
+export const CLUB_INTRODUCTION_MAX = 20;
+export const CLUB_TAG_MAX = 5;
+
+// 소개 정보 수정 (ClubIntroEditTab)
+export const INTRO_DESCRIPTION_MAX = 200;
+export const ACTIVITY_DESCRIPTION_MAX = 500;
+export const IDEAL_CANDIDATE_MAX = 500;
+export const BENEFITS_MAX = 500;
+export const FAQ_QUESTION_MAX = 100;
+export const FAQ_ANSWER_MAX = 300;
+
+// 모집 정보 수정 (RecruitEditTab)
+export const RECRUIT_TARGET_MAX = 10;
+
+// 계정 관리 (AccountEditTab)
+export const PASSWORD_MAX = 20;

--- a/frontend/src/constants/adminFieldPlaceholders.ts
+++ b/frontend/src/constants/adminFieldPlaceholders.ts
@@ -1,0 +1,15 @@
+// 기본 정보 수정 (ClubInfoEditTab)
+export const CLUB_NAME_PLACEHOLDER = '동아리명을 입력해주세요';
+export const CLUB_INTRODUCTION_PLACEHOLDER = '한줄소개를 입력해주세요';
+export const CLUB_TAG_PLACEHOLDER = '태그추가';
+
+// 소개 정보 수정 (ClubIntroEditTab)
+export const INTRO_DESCRIPTION_PLACEHOLDER = '동아리 소개 문구를 입력해주세요';
+export const ACTIVITY_DESCRIPTION_PLACEHOLDER =
+  '동아리에서 하는 활동 내용을 입력해주세요';
+export const IDEAL_CANDIDATE_PLACEHOLDER =
+  '동아리에 어울리는 사람의 특성을 입력해주세요';
+export const BENEFITS_PLACEHOLDER =
+  '동아리 부원이 누릴 수 있는 혜택을 입력해주세요';
+export const FAQ_QUESTION_PLACEHOLDER = '질문을 입력해주세요';
+export const FAQ_ANSWER_PLACEHOLDER = '답변을 입력해주세요';

--- a/frontend/src/pages/AdminPage/tabs/AccountEditTab/AccountEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/AccountEditTab/AccountEditTab.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { changePassword } from '@/apis/auth';
 import Button from '@/components/common/Button/Button';
 import InputField from '@/components/common/InputField/InputField';
+import { PASSWORD_MAX } from '@/constants/adminFieldLimits';
 import { ADMIN_EVENT, PAGE_VIEW } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import useTrackPageView from '@/hooks/Mixpanel/useTrackPageView';
@@ -95,7 +96,7 @@ const AccountEditTab = () => {
               setNewPassword('');
               trackEvent(ADMIN_EVENT.NEW_PASSWORD_CLEAR_BUTTON_CLICKED);
             }}
-            maxLength={20}
+            maxLength={PASSWORD_MAX}
             isError={isPasswordValid}
             isSuccess={newPassword.length > 0 && !isPasswordValid}
             helperText={
@@ -112,7 +113,7 @@ const AccountEditTab = () => {
               setConfirmPassword('');
               trackEvent(ADMIN_EVENT.CONFIRM_PASSWORD_CLEAR_BUTTON_CLICKED);
             }}
-            maxLength={20}
+            maxLength={PASSWORD_MAX}
             isError={isPasswordMatching}
             isSuccess={confirmPassword.length > 0 && !isPasswordMatching}
             helperText={

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTab.tsx
@@ -4,6 +4,10 @@ import {
   CLUB_INTRODUCTION_MAX,
   CLUB_NAME_MAX,
 } from '@/constants/adminFieldLimits';
+import {
+  CLUB_INTRODUCTION_PLACEHOLDER,
+  CLUB_NAME_PLACEHOLDER,
+} from '@/constants/adminFieldPlaceholders';
 import { ADMIN_EVENT } from '@/constants/eventName';
 import { SNS_CONFIG } from '@/constants/snsConfig';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
@@ -88,7 +92,7 @@ const ClubInfoEditTab = () => {
           <ClubCoverEditor coverImage={clubDetail?.cover} />
           <InputField
             label='동아리명'
-            placeholder='동아리명'
+            placeholder={CLUB_NAME_PLACEHOLDER}
             value={clubName}
             onChange={(e) => setClubName(e.target.value)}
             onClear={() => {
@@ -102,7 +106,7 @@ const ClubInfoEditTab = () => {
 
           <InputField
             label='한줄소개'
-            placeholder='한줄소개를 입력해주세요'
+            placeholder={CLUB_INTRODUCTION_PLACEHOLDER}
             type='text'
             maxLength={CLUB_INTRODUCTION_MAX}
             showMaxChar={true}

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTab.tsx
@@ -1,5 +1,9 @@
 import Button from '@/components/common/Button/Button';
 import InputField from '@/components/common/InputField/InputField';
+import {
+  CLUB_INTRODUCTION_MAX,
+  CLUB_NAME_MAX,
+} from '@/constants/adminFieldLimits';
 import { ADMIN_EVENT } from '@/constants/eventName';
 import { SNS_CONFIG } from '@/constants/snsConfig';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
@@ -92,7 +96,7 @@ const ClubInfoEditTab = () => {
               setClubName('');
             }}
             width='50%'
-            maxLength={20}
+            maxLength={CLUB_NAME_MAX}
             showMaxChar={true}
           />
 
@@ -100,7 +104,7 @@ const ClubInfoEditTab = () => {
             label='한줄소개'
             placeholder='한줄소개를 입력해주세요'
             type='text'
-            maxLength={20}
+            maxLength={CLUB_INTRODUCTION_MAX}
             showMaxChar={true}
             value={introduction}
             onChange={(e) => setIntroduction(e.target.value)}

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTabMobile.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTabMobile.tsx
@@ -5,6 +5,10 @@ import {
   CLUB_INTRODUCTION_MAX,
   CLUB_NAME_MAX,
 } from '@/constants/adminFieldLimits';
+import {
+  CLUB_INTRODUCTION_PLACEHOLDER,
+  CLUB_NAME_PLACEHOLDER,
+} from '@/constants/adminFieldPlaceholders';
 import { ADMIN_EVENT } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import EditField from '@/pages/AdminPage/components/editFields/EditField/EditField';
@@ -111,7 +115,7 @@ const ClubInfoEditTabMobile = ({
         <Styled.FormSection>
           <TextField
             label='동아리명'
-            placeholder='동아리명을 입력해주세요.'
+            placeholder={CLUB_NAME_PLACEHOLDER}
             value={clubName}
             maxLength={CLUB_NAME_MAX}
             onChange={setClubName}
@@ -123,7 +127,7 @@ const ClubInfoEditTabMobile = ({
 
           <TextField
             label='동아리소개'
-            placeholder='한줄소개를 입력해주세요.'
+            placeholder={CLUB_INTRODUCTION_PLACEHOLDER}
             value={introduction}
             maxLength={CLUB_INTRODUCTION_MAX}
             onChange={setIntroduction}

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTabMobile.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTabMobile.tsx
@@ -1,6 +1,10 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import WebviewTopBar from '@/components/common/WebviewTopBar/WebviewTopBar';
+import {
+  CLUB_INTRODUCTION_MAX,
+  CLUB_NAME_MAX,
+} from '@/constants/adminFieldLimits';
 import { ADMIN_EVENT } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import EditField from '@/pages/AdminPage/components/editFields/EditField/EditField';
@@ -109,7 +113,7 @@ const ClubInfoEditTabMobile = ({
             label='동아리명'
             placeholder='동아리명을 입력해주세요.'
             value={clubName}
-            maxLength={20}
+            maxLength={CLUB_NAME_MAX}
             onChange={setClubName}
             onClear={() => {
               trackEvent(ADMIN_EVENT.CLUB_NAME_CLEAR_BUTTON_CLICKED);
@@ -121,7 +125,7 @@ const ClubInfoEditTabMobile = ({
             label='동아리소개'
             placeholder='한줄소개를 입력해주세요.'
             value={introduction}
-            maxLength={20}
+            maxLength={CLUB_INTRODUCTION_MAX}
             onChange={setIntroduction}
             onClear={() => {
               trackEvent(ADMIN_EVENT.CLUB_INTRODUCTION_CLEAR_BUTTON_CLICKED);

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/components/desktop/MakeTags/MakeTags.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/components/desktop/MakeTags/MakeTags.tsx
@@ -1,5 +1,6 @@
 import clearButton from '@/assets/images/icons/input_clear_button_icon.svg';
 import { CLUB_TAG_MAX } from '@/constants/adminFieldLimits';
+import { CLUB_TAG_PLACEHOLDER } from '@/constants/adminFieldPlaceholders';
 import { ADMIN_EVENT } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import * as Styled from './MakeTags.styles';
@@ -50,7 +51,7 @@ const MakeTags = ({ value, onChange }: MakeTagsProps) => {
               value={tag}
               maxLength={CLUB_TAG_MAX}
               onChange={(e) => updateTag(index, e.target.value)}
-              placeholder={`자유 태그 ${index + 1}`}
+              placeholder={CLUB_TAG_PLACEHOLDER}
               aria-label={`자유 태그 ${index + 1}`}
             />
             {tag.length > 0 && (

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/components/desktop/MakeTags/MakeTags.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/components/desktop/MakeTags/MakeTags.tsx
@@ -1,4 +1,5 @@
 import clearButton from '@/assets/images/icons/input_clear_button_icon.svg';
+import { CLUB_TAG_MAX } from '@/constants/adminFieldLimits';
 import { ADMIN_EVENT } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import * as Styled from './MakeTags.styles';
@@ -47,7 +48,7 @@ const MakeTags = ({ value, onChange }: MakeTagsProps) => {
             <Styled.Hashtag>#</Styled.Hashtag>
             <Styled.TagTextInput
               value={tag}
-              maxLength={5}
+              maxLength={CLUB_TAG_MAX}
               onChange={(e) => updateTag(index, e.target.value)}
               placeholder={`자유 태그 ${index + 1}`}
               aria-label={`자유 태그 ${index + 1}`}

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/components/mobile/FreeTagEditPage/FreeTagEditPage.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/components/mobile/FreeTagEditPage/FreeTagEditPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import WebviewTopBar from '@/components/common/WebviewTopBar/WebviewTopBar';
+import { CLUB_TAG_MAX } from '@/constants/adminFieldLimits';
 import EditField from '@/pages/AdminPage/components/editFields/EditField/EditField';
 import MobileSaveButtonArea from '@/pages/AdminPage/components/MobileSaveButtonArea/MobileSaveButtonArea';
 import * as Styled from './FreeTagEditPage.styles';
@@ -47,7 +48,7 @@ const FreeTagEditPage = ({
                 </Styled.HashSymbol>
                 <Styled.TagInput
                   value={tag}
-                  maxLength={5}
+                  maxLength={CLUB_TAG_MAX}
                   placeholder='태그추가'
                   onChange={(e) => updateTag(index, e.target.value)}
                 />

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/components/mobile/FreeTagEditPage/FreeTagEditPage.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/components/mobile/FreeTagEditPage/FreeTagEditPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import WebviewTopBar from '@/components/common/WebviewTopBar/WebviewTopBar';
 import { CLUB_TAG_MAX } from '@/constants/adminFieldLimits';
+import { CLUB_TAG_PLACEHOLDER } from '@/constants/adminFieldPlaceholders';
 import EditField from '@/pages/AdminPage/components/editFields/EditField/EditField';
 import MobileSaveButtonArea from '@/pages/AdminPage/components/MobileSaveButtonArea/MobileSaveButtonArea';
 import * as Styled from './FreeTagEditPage.styles';
@@ -49,7 +50,7 @@ const FreeTagEditPage = ({
                 <Styled.TagInput
                   value={tag}
                   maxLength={CLUB_TAG_MAX}
-                  placeholder='태그추가'
+                  placeholder={CLUB_TAG_PLACEHOLDER}
                   onChange={(e) => updateTag(index, e.target.value)}
                 />
               </Styled.TagInputRow>

--- a/frontend/src/pages/AdminPage/tabs/ClubIntroEditTab/ClubIntroEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubIntroEditTab/ClubIntroEditTab.tsx
@@ -6,6 +6,12 @@ import {
   IDEAL_CANDIDATE_MAX,
   INTRO_DESCRIPTION_MAX,
 } from '@/constants/adminFieldLimits';
+import {
+  ACTIVITY_DESCRIPTION_PLACEHOLDER,
+  BENEFITS_PLACEHOLDER,
+  IDEAL_CANDIDATE_PLACEHOLDER,
+  INTRO_DESCRIPTION_PLACEHOLDER,
+} from '@/constants/adminFieldPlaceholders';
 import { PAGE_VIEW } from '@/constants/eventName';
 import useTrackPageView from '@/hooks/Mixpanel/useTrackPageView';
 import useDevice from '@/hooks/useDevice';
@@ -73,7 +79,7 @@ const ClubIntroEditTab = () => {
           <CustomTextArea
             variant='filled'
             label='동아리를 소개할게요'
-            placeholder='동아리 소개 문구를 입력해주세요'
+            placeholder={INTRO_DESCRIPTION_PLACEHOLDER}
             value={introDescription}
             onChange={(e) => setIntroDescription(e.target.value)}
             maxLength={INTRO_DESCRIPTION_MAX}
@@ -83,7 +89,7 @@ const ClubIntroEditTab = () => {
           <CustomTextArea
             variant='filled'
             label='이런 활동을 해요'
-            placeholder='동아리에서 하는 활동 내용을 입력해주세요'
+            placeholder={ACTIVITY_DESCRIPTION_PLACEHOLDER}
             value={activityDescription}
             onChange={(e) => setActivityDescription(e.target.value)}
             maxLength={ACTIVITY_DESCRIPTION_MAX}
@@ -95,7 +101,7 @@ const ClubIntroEditTab = () => {
           <CustomTextArea
             variant='filled'
             label='이런 사람이 오면 좋아요'
-            placeholder='동아리에 어울리는 사람의 특성을 입력해주세요'
+            placeholder={IDEAL_CANDIDATE_PLACEHOLDER}
             value={idealCandidate.content}
             onChange={(e) =>
               setIdealCandidate({ ...idealCandidate, content: e.target.value })
@@ -107,7 +113,7 @@ const ClubIntroEditTab = () => {
           <CustomTextArea
             variant='filled'
             label='부원이 되면 이런 혜택이 있어요'
-            placeholder='동아리 부원이 누릴 수 있는 혜택을 입력해주세요'
+            placeholder={BENEFITS_PLACEHOLDER}
             value={benefits}
             onChange={(e) => setBenefits(e.target.value)}
             maxLength={BENEFITS_MAX}

--- a/frontend/src/pages/AdminPage/tabs/ClubIntroEditTab/ClubIntroEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubIntroEditTab/ClubIntroEditTab.tsx
@@ -1,5 +1,11 @@
 import Button from '@/components/common/Button/Button';
 import CustomTextArea from '@/components/common/CustomTextArea/CustomTextArea';
+import {
+  ACTIVITY_DESCRIPTION_MAX,
+  BENEFITS_MAX,
+  IDEAL_CANDIDATE_MAX,
+  INTRO_DESCRIPTION_MAX,
+} from '@/constants/adminFieldLimits';
 import { PAGE_VIEW } from '@/constants/eventName';
 import useTrackPageView from '@/hooks/Mixpanel/useTrackPageView';
 import useDevice from '@/hooks/useDevice';
@@ -70,7 +76,7 @@ const ClubIntroEditTab = () => {
             placeholder='동아리 소개 문구를 입력해주세요'
             value={introDescription}
             onChange={(e) => setIntroDescription(e.target.value)}
-            maxLength={200}
+            maxLength={INTRO_DESCRIPTION_MAX}
             showMaxChar={true}
           />
 
@@ -80,7 +86,7 @@ const ClubIntroEditTab = () => {
             placeholder='동아리에서 하는 활동 내용을 입력해주세요'
             value={activityDescription}
             onChange={(e) => setActivityDescription(e.target.value)}
-            maxLength={500}
+            maxLength={ACTIVITY_DESCRIPTION_MAX}
             showMaxChar={true}
           />
 
@@ -94,7 +100,7 @@ const ClubIntroEditTab = () => {
             onChange={(e) =>
               setIdealCandidate({ ...idealCandidate, content: e.target.value })
             }
-            maxLength={500}
+            maxLength={IDEAL_CANDIDATE_MAX}
             showMaxChar={true}
           />
 
@@ -104,7 +110,7 @@ const ClubIntroEditTab = () => {
             placeholder='동아리 부원이 누릴 수 있는 혜택을 입력해주세요'
             value={benefits}
             onChange={(e) => setBenefits(e.target.value)}
-            maxLength={500}
+            maxLength={BENEFITS_MAX}
             showMaxChar={true}
           />
 

--- a/frontend/src/pages/AdminPage/tabs/ClubIntroEditTab/ClubIntroEditTabMobile.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubIntroEditTab/ClubIntroEditTabMobile.tsx
@@ -81,30 +81,6 @@ const ClubIntroEditTabMobile = ({
     }
   };
 
-  const handleIntroChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    if (e.target.value.length <= INTRO_MAX) {
-      setIntroDescription(e.target.value);
-    }
-  };
-
-  const handleActivityChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    if (e.target.value.length <= ACTIVITY_MAX) {
-      setActivityDescription(e.target.value);
-    }
-  };
-
-  const handleIdealChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    if (e.target.value.length <= IDEAL_MAX) {
-      setIdealCandidate({ ...idealCandidate, content: e.target.value });
-    }
-  };
-
-  const handleBenefitsChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    if (e.target.value.length <= BENEFITS_MAX) {
-      setBenefits(e.target.value);
-    }
-  };
-
   return (
     <>
       <Styled.MobileContainer>

--- a/frontend/src/pages/AdminPage/tabs/ClubIntroEditTab/ClubIntroEditTabMobile.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubIntroEditTab/ClubIntroEditTabMobile.tsx
@@ -1,5 +1,12 @@
 import { useNavigate } from 'react-router-dom';
 import WebviewTopBar from '@/components/common/WebviewTopBar/WebviewTopBar';
+import {
+  ACTIVITY_DESCRIPTION_MAX,
+  BENEFITS_MAX,
+  IDEAL_CANDIDATE_MAX,
+  INTRO_DESCRIPTION_MAX,
+} from '@/constants/adminFieldLimits';
+import useAutoGrow from '@/hooks/useAutoGrow';
 import MobileSaveButtonArea from '@/pages/AdminPage/components/MobileSaveButtonArea/MobileSaveButtonArea';
 import { Award, FAQ, IdealCandidate } from '@/types/club';
 import * as Styled from './ClubIntroEditTabMobile.styles';
@@ -23,11 +30,6 @@ interface ClubIntroEditTabMobileProps {
   handleUpdateClub: () => void;
 }
 
-const INTRO_MAX = 300;
-const ACTIVITY_MAX = 300;
-const IDEAL_MAX = 300;
-const BENEFITS_MAX = 300;
-
 const ClubIntroEditTabMobile = ({
   introDescription,
   setIntroDescription,
@@ -44,6 +46,34 @@ const ClubIntroEditTabMobile = ({
   handleUpdateClub,
 }: ClubIntroEditTabMobileProps) => {
   const navigate = useNavigate();
+  const introRef = useAutoGrow(introDescription);
+  const activityRef = useAutoGrow(activityDescription);
+  const idealRef = useAutoGrow(idealCandidate.content);
+  const benefitsRef = useAutoGrow(benefits);
+
+  const handleIntroChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    if (e.target.value.length <= INTRO_DESCRIPTION_MAX) {
+      setIntroDescription(e.target.value);
+    }
+  };
+
+  const handleActivityChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    if (e.target.value.length <= ACTIVITY_DESCRIPTION_MAX) {
+      setActivityDescription(e.target.value);
+    }
+  };
+
+  const handleIdealChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    if (e.target.value.length <= IDEAL_CANDIDATE_MAX) {
+      setIdealCandidate({ ...idealCandidate, content: e.target.value });
+    }
+  };
+
+  const handleBenefitsChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    if (e.target.value.length <= BENEFITS_MAX) {
+      setBenefits(e.target.value);
+    }
+  };
 
   return (
     <>
@@ -62,32 +92,26 @@ const ClubIntroEditTabMobile = ({
           <Styled.FieldList>
             <InfoSection
               label='동아리를 소개할게요'
-              maxLength={INTRO_MAX}
+              maxLength={INTRO_DESCRIPTION_MAX}
               currentLength={introDescription.length}
             >
               <Styled.TextArea
+                ref={introRef}
                 value={introDescription}
-                onChange={(e) => {
-                  if (e.target.value.length <= INTRO_MAX) {
-                    setIntroDescription(e.target.value);
-                  }
-                }}
+                onChange={handleIntroChange}
                 placeholder='동아리 소개 문구를 입력해주세요'
               />
             </InfoSection>
 
             <InfoSection
               label='이런 활동을 해요'
-              maxLength={ACTIVITY_MAX}
+              maxLength={ACTIVITY_DESCRIPTION_MAX}
               currentLength={activityDescription.length}
             >
               <Styled.TextArea
+                ref={activityRef}
                 value={activityDescription}
-                onChange={(e) => {
-                  if (e.target.value.length <= ACTIVITY_MAX) {
-                    setActivityDescription(e.target.value);
-                  }
-                }}
+                onChange={handleActivityChange}
                 placeholder='동아리에서 하는 활동 내용을 입력해주세요'
               />
             </InfoSection>
@@ -96,19 +120,13 @@ const ClubIntroEditTabMobile = ({
 
             <InfoSection
               label='이런 사람이 오면 좋아요'
-              maxLength={IDEAL_MAX}
+              maxLength={IDEAL_CANDIDATE_MAX}
               currentLength={idealCandidate.content.length}
             >
               <Styled.TextArea
+                ref={idealRef}
                 value={idealCandidate.content}
-                onChange={(e) => {
-                  if (e.target.value.length <= IDEAL_MAX) {
-                    setIdealCandidate({
-                      ...idealCandidate,
-                      content: e.target.value,
-                    });
-                  }
-                }}
+                onChange={handleIdealChange}
                 placeholder='동아리에 어울리는 사람의 특성을 입력해주세요'
               />
             </InfoSection>
@@ -119,12 +137,9 @@ const ClubIntroEditTabMobile = ({
               currentLength={benefits.length}
             >
               <Styled.TextArea
+                ref={benefitsRef}
                 value={benefits}
-                onChange={(e) => {
-                  if (e.target.value.length <= BENEFITS_MAX) {
-                    setBenefits(e.target.value);
-                  }
-                }}
+                onChange={handleBenefitsChange}
                 placeholder='동아리 부원이 누릴 수 있는 혜택을 입력해주세요'
               />
             </InfoSection>

--- a/frontend/src/pages/AdminPage/tabs/ClubIntroEditTab/ClubIntroEditTabMobile.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubIntroEditTab/ClubIntroEditTabMobile.tsx
@@ -6,6 +6,12 @@ import {
   IDEAL_CANDIDATE_MAX,
   INTRO_DESCRIPTION_MAX,
 } from '@/constants/adminFieldLimits';
+import {
+  ACTIVITY_DESCRIPTION_PLACEHOLDER,
+  BENEFITS_PLACEHOLDER,
+  IDEAL_CANDIDATE_PLACEHOLDER,
+  INTRO_DESCRIPTION_PLACEHOLDER,
+} from '@/constants/adminFieldPlaceholders';
 import useAutoGrow from '@/hooks/useAutoGrow';
 import MobileSaveButtonArea from '@/pages/AdminPage/components/MobileSaveButtonArea/MobileSaveButtonArea';
 import { Award, FAQ, IdealCandidate } from '@/types/club';
@@ -99,7 +105,7 @@ const ClubIntroEditTabMobile = ({
                 ref={introRef}
                 value={introDescription}
                 onChange={handleIntroChange}
-                placeholder='동아리 소개 문구를 입력해주세요'
+                placeholder={INTRO_DESCRIPTION_PLACEHOLDER}
               />
             </InfoSection>
 
@@ -112,7 +118,7 @@ const ClubIntroEditTabMobile = ({
                 ref={activityRef}
                 value={activityDescription}
                 onChange={handleActivityChange}
-                placeholder='동아리에서 하는 활동 내용을 입력해주세요'
+                placeholder={ACTIVITY_DESCRIPTION_PLACEHOLDER}
               />
             </InfoSection>
 
@@ -127,7 +133,7 @@ const ClubIntroEditTabMobile = ({
                 ref={idealRef}
                 value={idealCandidate.content}
                 onChange={handleIdealChange}
-                placeholder='동아리에 어울리는 사람의 특성을 입력해주세요'
+                placeholder={IDEAL_CANDIDATE_PLACEHOLDER}
               />
             </InfoSection>
 
@@ -140,7 +146,7 @@ const ClubIntroEditTabMobile = ({
                 ref={benefitsRef}
                 value={benefits}
                 onChange={handleBenefitsChange}
-                placeholder='동아리 부원이 누릴 수 있는 혜택을 입력해주세요'
+                placeholder={BENEFITS_PLACEHOLDER}
               />
             </InfoSection>
 

--- a/frontend/src/pages/AdminPage/tabs/ClubIntroEditTab/components/desktop/FAQEditor/FAQEditor.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubIntroEditTab/components/desktop/FAQEditor/FAQEditor.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import clearButton from '@/assets/images/icons/input_clear_button_icon.svg';
+import { FAQ_ANSWER_MAX, FAQ_QUESTION_MAX } from '@/constants/adminFieldLimits';
+import useAutoGrow from '@/hooks/useAutoGrow';
 import { FAQ } from '@/types/club';
 import * as Styled from './FAQEditor.styles';
 
@@ -7,6 +9,58 @@ interface FAQEditorProps {
   faqs: FAQ[];
   onChange: (faqs: FAQ[]) => void;
 }
+
+interface FAQItemEditorProps {
+  faq: FAQ & { id: string };
+  index: number;
+  onRemove: (id: string) => void;
+  onUpdateQuestion: (id: string, value: string) => void;
+  onUpdateAnswer: (id: string, value: string) => void;
+  inputRef: (el: HTMLInputElement | null) => void;
+}
+
+const FAQItemEditor = ({
+  faq,
+  index,
+  onRemove,
+  onUpdateQuestion,
+  onUpdateAnswer,
+  inputRef,
+}: FAQItemEditorProps) => {
+  const answerRef = useAutoGrow(faq.answer);
+
+  return (
+    <Styled.FAQItem>
+      <Styled.FAQHeader>
+        <Styled.FAQNumber>Q{index + 1}</Styled.FAQNumber>
+        <Styled.RemoveButton onClick={() => onRemove(faq.id)}>
+          <img src={clearButton} alt='삭제' />
+        </Styled.RemoveButton>
+      </Styled.FAQHeader>
+
+      <Styled.QuestionInput
+        ref={inputRef}
+        placeholder='질문을 입력하세요'
+        value={faq.question}
+        onChange={(e) => onUpdateQuestion(faq.id, e.target.value)}
+        maxLength={FAQ_QUESTION_MAX}
+      />
+
+      <Styled.AnswerTextArea
+        ref={answerRef}
+        placeholder='답변을 입력하세요'
+        value={faq.answer}
+        onChange={(e) => onUpdateAnswer(faq.id, e.target.value)}
+        maxLength={FAQ_ANSWER_MAX}
+      />
+
+      <Styled.CharCount>
+        질문: {faq.question.length}/{FAQ_QUESTION_MAX} | 답변:{' '}
+        {faq.answer.length}/{FAQ_ANSWER_MAX}
+      </Styled.CharCount>
+    </Styled.FAQItem>
+  );
+};
 
 const FAQEditor = ({ faqs, onChange }: FAQEditorProps) => {
   const [shouldFocusLast, setShouldFocusLast] = useState(false);
@@ -38,27 +92,22 @@ const FAQEditor = ({ faqs, onChange }: FAQEditorProps) => {
   };
 
   const handleUpdateQuestion = (id: string, value: string) => {
-    const updatedFAQs = faqs.map((faq) =>
-      faq.id === id ? { ...faq, question: value } : faq,
+    onChange(
+      faqs.map((faq) => (faq.id === id ? { ...faq, question: value } : faq)),
     );
-    onChange(updatedFAQs);
   };
 
   const handleUpdateAnswer = (id: string, value: string) => {
-    const updatedFAQs = faqs.map((faq) =>
-      faq.id === id ? { ...faq, answer: value } : faq,
+    onChange(
+      faqs.map((faq) => (faq.id === id ? { ...faq, answer: value } : faq)),
     );
-    onChange(updatedFAQs);
   };
 
   useEffect(() => {
     if (shouldFocusLast && faqs.length > 0) {
       const lastFAQ = faqs[faqs.length - 1];
       if (lastFAQ.id) {
-        const inputRef = questionInputRefs.current[lastFAQ.id];
-        if (inputRef) {
-          inputRef.focus();
-        }
+        questionInputRefs.current[lastFAQ.id]?.focus();
       }
       setShouldFocusLast(false);
     }
@@ -79,40 +128,17 @@ const FAQEditor = ({ faqs, onChange }: FAQEditorProps) => {
           {faqs
             .filter((faq): faq is FAQ & { id: string } => !!faq.id)
             .map((faq, index) => (
-              <Styled.FAQItem key={faq.id}>
-                <Styled.FAQHeader>
-                  <Styled.FAQNumber>Q{index + 1}</Styled.FAQNumber>
-                  <Styled.RemoveButton onClick={() => handleRemoveFAQ(faq.id)}>
-                    <img src={clearButton} alt='삭제' />
-                  </Styled.RemoveButton>
-                </Styled.FAQHeader>
-
-                <Styled.QuestionInput
-                  ref={(element) => {
-                    questionInputRefs.current[faq.id] = element;
-                  }}
-                  placeholder='질문을 입력하세요'
-                  value={faq.question}
-                  onChange={(event) =>
-                    handleUpdateQuestion(faq.id, event.target.value)
-                  }
-                  maxLength={100}
-                />
-
-                <Styled.AnswerTextArea
-                  placeholder='답변을 입력하세요'
-                  value={faq.answer}
-                  onChange={(event) =>
-                    handleUpdateAnswer(faq.id, event.target.value)
-                  }
-                  maxLength={300}
-                />
-
-                <Styled.CharCount>
-                  질문: {faq.question.length}/100 | 답변: {faq.answer.length}
-                  /300
-                </Styled.CharCount>
-              </Styled.FAQItem>
+              <FAQItemEditor
+                key={faq.id}
+                faq={faq}
+                index={index}
+                onRemove={handleRemoveFAQ}
+                onUpdateQuestion={handleUpdateQuestion}
+                onUpdateAnswer={handleUpdateAnswer}
+                inputRef={(el) => {
+                  questionInputRefs.current[faq.id] = el;
+                }}
+              />
             ))}
         </Styled.FAQList>
       )}

--- a/frontend/src/pages/AdminPage/tabs/ClubIntroEditTab/components/desktop/FAQEditor/FAQEditor.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubIntroEditTab/components/desktop/FAQEditor/FAQEditor.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
 import clearButton from '@/assets/images/icons/input_clear_button_icon.svg';
 import { FAQ_ANSWER_MAX, FAQ_QUESTION_MAX } from '@/constants/adminFieldLimits';
+import {
+  FAQ_ANSWER_PLACEHOLDER,
+  FAQ_QUESTION_PLACEHOLDER,
+} from '@/constants/adminFieldPlaceholders';
 import useAutoGrow from '@/hooks/useAutoGrow';
 import { FAQ } from '@/types/club';
 import * as Styled from './FAQEditor.styles';
@@ -40,7 +44,7 @@ const FAQItemEditor = ({
 
       <Styled.QuestionInput
         ref={inputRef}
-        placeholder='질문을 입력하세요'
+        placeholder={FAQ_QUESTION_PLACEHOLDER}
         value={faq.question}
         onChange={(e) => onUpdateQuestion(faq.id, e.target.value)}
         maxLength={FAQ_QUESTION_MAX}
@@ -48,7 +52,7 @@ const FAQItemEditor = ({
 
       <Styled.AnswerTextArea
         ref={answerRef}
-        placeholder='답변을 입력하세요'
+        placeholder={FAQ_ANSWER_PLACEHOLDER}
         value={faq.answer}
         onChange={(e) => onUpdateAnswer(faq.id, e.target.value)}
         maxLength={FAQ_ANSWER_MAX}

--- a/frontend/src/pages/AdminPage/tabs/ClubIntroEditTab/components/mobile/FAQSection/FAQSection.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubIntroEditTab/components/mobile/FAQSection/FAQSection.tsx
@@ -1,6 +1,10 @@
 import addIcon from '@/assets/images/icons/add_icon.svg';
 import closeCircleIcon from '@/assets/images/icons/close_circle_icon.svg';
 import { FAQ_ANSWER_MAX, FAQ_QUESTION_MAX } from '@/constants/adminFieldLimits';
+import {
+  FAQ_ANSWER_PLACEHOLDER,
+  FAQ_QUESTION_PLACEHOLDER,
+} from '@/constants/adminFieldPlaceholders';
 import useAutoGrow from '@/hooks/useAutoGrow';
 import { FAQ } from '@/types/club';
 import * as Styled from './FAQSection.styles';
@@ -34,7 +38,7 @@ const FAQItemEditor = ({
           <Styled.QuestionInput
             value={faq.question}
             onChange={(e) => onChange(index, 'question', e.target.value)}
-            placeholder='질문을 입력해주세요'
+            placeholder={FAQ_QUESTION_PLACEHOLDER}
             maxLength={FAQ_QUESTION_MAX}
           />
         </Styled.QuestionContent>
@@ -48,7 +52,7 @@ const FAQItemEditor = ({
             ref={answerRef}
             value={faq.answer}
             onChange={handleAnswerChange}
-            placeholder='답변을 입력해주세요'
+            placeholder={FAQ_ANSWER_PLACEHOLDER}
             rows={1}
           />
         </Styled.AnswerCard>

--- a/frontend/src/pages/AdminPage/tabs/ClubIntroEditTab/components/mobile/FAQSection/FAQSection.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubIntroEditTab/components/mobile/FAQSection/FAQSection.tsx
@@ -1,11 +1,9 @@
 import addIcon from '@/assets/images/icons/add_icon.svg';
 import closeCircleIcon from '@/assets/images/icons/close_circle_icon.svg';
+import { FAQ_ANSWER_MAX, FAQ_QUESTION_MAX } from '@/constants/adminFieldLimits';
 import useAutoGrow from '@/hooks/useAutoGrow';
 import { FAQ } from '@/types/club';
 import * as Styled from './FAQSection.styles';
-
-const QUESTION_MAX_LENGTH = 100;
-const ANSWER_MAX_LENGTH = 300;
 
 interface FAQItemEditorProps {
   faq: FAQ;
@@ -23,7 +21,7 @@ const FAQItemEditor = ({
   const answerRef = useAutoGrow(faq.answer);
 
   const handleAnswerChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    if (e.target.value.length <= ANSWER_MAX_LENGTH) {
+    if (e.target.value.length <= FAQ_ANSWER_MAX) {
       onChange(index, 'answer', e.target.value);
     }
   };
@@ -37,7 +35,7 @@ const FAQItemEditor = ({
             value={faq.question}
             onChange={(e) => onChange(index, 'question', e.target.value)}
             placeholder='질문을 입력해주세요'
-            maxLength={QUESTION_MAX_LENGTH}
+            maxLength={FAQ_QUESTION_MAX}
           />
         </Styled.QuestionContent>
         <Styled.DeleteButton onClick={() => onDelete(index)} type='button'>
@@ -55,8 +53,8 @@ const FAQItemEditor = ({
           />
         </Styled.AnswerCard>
         <Styled.CharCount>
-          질문: {faq.question.length}/{QUESTION_MAX_LENGTH} | 답변:{' '}
-          {faq.answer.length}/{ANSWER_MAX_LENGTH}
+          질문: {faq.question.length}/{FAQ_QUESTION_MAX} | 답변:{' '}
+          {faq.answer.length}/{FAQ_ANSWER_MAX}
         </Styled.CharCount>
       </Styled.AnswerWrapper>
     </Styled.FAQCard>

--- a/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.tsx
@@ -4,6 +4,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { setYear } from 'date-fns';
 import Button from '@/components/common/Button/Button';
 import InputField from '@/components/common/InputField/InputField';
+import { RECRUIT_TARGET_MAX } from '@/constants/adminFieldLimits';
 import { ADMIN_EVENT, PAGE_VIEW } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import useTrackPageView from '@/hooks/Mixpanel/useTrackPageView';
@@ -169,7 +170,7 @@ const RecruitEditTab = () => {
             value={recruitmentTarget}
             onChange={(e) => setRecruitmentTarget(e.target.value)}
             onClear={() => setRecruitmentTarget('')}
-            maxLength={10}
+            maxLength={RECRUIT_TARGET_MAX}
           />
         </ContentSection.Body>
       </ContentSection>


### PR DESCRIPTION
## Summary
#1805
위 PR에서 받은 리뷰에서의 수정입니다.

- `src/constants/adminFieldLimits.ts` 생성하여 어드민 탭 전체 텍스트 필드 maxLength를 한 곳에서 관리
- ClubInfo, ClubIntro, FAQ, Recruit, Account 탭의 매직넘버를 상수로 교체, 데스크톱/모바일 간 글자수 제한 통일
- ClubIntroEditTabMobile textarea에 `useAutoGrow` 적용으로 입력량에 따라 필드 높이 자동 확장
- FAQEditor(desktop) `AnswerTextArea`에 `useAutoGrow` 적용, FAQItemEditor 서브 컴포넌트로 분리

## Jira
MOA-1034

## Test plan
- [ ] 어드민 소개 정보 수정 모바일에서 텍스트 입력 시 필드 높이 자동 확장 확인
- [ ] 데스크톱 FAQ 답변 입력 시 높이 자동 확장 확인
- [ ] 모바일/데스크톱 글자수 카운터가 동일한 기준으로 표시되는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 관리자 입력 화면의 글자 수 제한과 안내 문구를 일관된 기준으로 적용했습니다.
  * 클럽 정보, 소개, 태그, FAQ, 모집 대상, 비밀번호 입력 필드의 입력 제한을 명확히 했습니다.
  * 데스크톱과 모바일 화면에서 동일한 placeholder와 글자 수 표시를 제공합니다.
  * FAQ 입력 UI를 개선해 질문·답변 작성과 항목 관리를 더 일관되게 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->