### PR TITLE
[refactor] 어드민 텍스트 필드 placeholder 상수화

### DIFF
--- a/frontend/src/constants/CLAUDE.md
+++ b/frontend/src/constants/CLAUDE.md
@@ -11,3 +11,4 @@
 - `applicationForm.ts` - 지원서 폼 설정
 - `uploadLimit.ts` - 파일 업로드 제한
 - `adminFieldLimits.ts` - 어드민 탭 텍스트 필드 최대 글자수 (ClubInfo, ClubIntro, Recruit, Account)
+- `adminFieldPlaceholders.ts` - 어드민 탭 텍스트 필드 placeholder 문자열 (ClubInfoEditTab, ClubIntroEditTab 데스크탑/모바일 공유)

--- a/frontend/src/constants/adminFieldPlaceholders.ts
+++ b/frontend/src/constants/adminFieldPlaceholders.ts
@@ -1,0 +1,15 @@
+// 기본 정보 수정 (ClubInfoEditTab)
+export const CLUB_NAME_PLACEHOLDER = '동아리명을 입력해주세요';
+export const CLUB_INTRODUCTION_PLACEHOLDER = '한줄소개를 입력해주세요';
+export const CLUB_TAG_PLACEHOLDER = '태그추가';
+
+// 소개 정보 수정 (ClubIntroEditTab)
+export const INTRO_DESCRIPTION_PLACEHOLDER = '동아리 소개 문구를 입력해주세요';
+export const ACTIVITY_DESCRIPTION_PLACEHOLDER =
+  '동아리에서 하는 활동 내용을 입력해주세요';
+export const IDEAL_CANDIDATE_PLACEHOLDER =
+  '동아리에 어울리는 사람의 특성을 입력해주세요';
+export const BENEFITS_PLACEHOLDER =
+  '동아리 부원이 누릴 수 있는 혜택을 입력해주세요';
+export const FAQ_QUESTION_PLACEHOLDER = '질문을 입력해주세요';
+export const FAQ_ANSWER_PLACEHOLDER = '답변을 입력해주세요';

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTab.tsx
@@ -4,6 +4,10 @@ import {
   CLUB_INTRODUCTION_MAX,
   CLUB_NAME_MAX,
 } from '@/constants/adminFieldLimits';
+import {
+  CLUB_INTRODUCTION_PLACEHOLDER,
+  CLUB_NAME_PLACEHOLDER,
+} from '@/constants/adminFieldPlaceholders';
 import { ADMIN_EVENT } from '@/constants/eventName';
 import { SNS_CONFIG } from '@/constants/snsConfig';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
@@ -88,7 +92,7 @@ const ClubInfoEditTab = () => {
           <ClubCoverEditor coverImage={clubDetail?.cover} />
           <InputField
             label='동아리명'
-            placeholder='동아리명'
+            placeholder={CLUB_NAME_PLACEHOLDER}
             value={clubName}
             onChange={(e) => setClubName(e.target.value)}
             onClear={() => {
@@ -102,7 +106,7 @@ const ClubInfoEditTab = () => {
 
           <InputField
             label='한줄소개'
-            placeholder='한줄소개를 입력해주세요'
+            placeholder={CLUB_INTRODUCTION_PLACEHOLDER}
             type='text'
             maxLength={CLUB_INTRODUCTION_MAX}
             showMaxChar={true}

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTabMobile.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTabMobile.tsx
@@ -5,6 +5,10 @@ import {
   CLUB_INTRODUCTION_MAX,
   CLUB_NAME_MAX,
 } from '@/constants/adminFieldLimits';
+import {
+  CLUB_INTRODUCTION_PLACEHOLDER,
+  CLUB_NAME_PLACEHOLDER,
+} from '@/constants/adminFieldPlaceholders';
 import { ADMIN_EVENT } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import EditField from '@/pages/AdminPage/components/editFields/EditField/EditField';
@@ -111,7 +115,7 @@ const ClubInfoEditTabMobile = ({
         <Styled.FormSection>
           <TextField
             label='동아리명'
-            placeholder='동아리명을 입력해주세요.'
+            placeholder={CLUB_NAME_PLACEHOLDER}
             value={clubName}
             maxLength={CLUB_NAME_MAX}
             onChange={setClubName}
@@ -123,7 +127,7 @@ const ClubInfoEditTabMobile = ({
 
           <TextField
             label='동아리소개'
-            placeholder='한줄소개를 입력해주세요.'
+            placeholder={CLUB_INTRODUCTION_PLACEHOLDER}
             value={introduction}
             maxLength={CLUB_INTRODUCTION_MAX}
             onChange={setIntroduction}

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/components/desktop/MakeTags/MakeTags.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/components/desktop/MakeTags/MakeTags.tsx
@@ -1,5 +1,6 @@
 import clearButton from '@/assets/images/icons/input_clear_button_icon.svg';
 import { CLUB_TAG_MAX } from '@/constants/adminFieldLimits';
+import { CLUB_TAG_PLACEHOLDER } from '@/constants/adminFieldPlaceholders';
 import { ADMIN_EVENT } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import * as Styled from './MakeTags.styles';
@@ -50,7 +51,7 @@ const MakeTags = ({ value, onChange }: MakeTagsProps) => {
               value={tag}
               maxLength={CLUB_TAG_MAX}
               onChange={(e) => updateTag(index, e.target.value)}
-              placeholder={`자유 태그 ${index + 1}`}
+              placeholder={CLUB_TAG_PLACEHOLDER}
               aria-label={`자유 태그 ${index + 1}`}
             />
             {tag.length > 0 && (

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/components/mobile/FreeTagEditPage/FreeTagEditPage.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/components/mobile/FreeTagEditPage/FreeTagEditPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import WebviewTopBar from '@/components/common/WebviewTopBar/WebviewTopBar';
 import { CLUB_TAG_MAX } from '@/constants/adminFieldLimits';
+import { CLUB_TAG_PLACEHOLDER } from '@/constants/adminFieldPlaceholders';
 import EditField from '@/pages/AdminPage/components/editFields/EditField/EditField';
 import MobileSaveButtonArea from '@/pages/AdminPage/components/MobileSaveButtonArea/MobileSaveButtonArea';
 import * as Styled from './FreeTagEditPage.styles';
@@ -49,7 +50,7 @@ const FreeTagEditPage = ({
                 <Styled.TagInput
                   value={tag}
                   maxLength={CLUB_TAG_MAX}
-                  placeholder='태그추가'
+                  placeholder={CLUB_TAG_PLACEHOLDER}
                   onChange={(e) => updateTag(index, e.target.value)}
                 />
               </Styled.TagInputRow>

--- a/frontend/src/pages/AdminPage/tabs/ClubIntroEditTab/ClubIntroEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubIntroEditTab/ClubIntroEditTab.tsx
@@ -6,6 +6,12 @@ import {
   IDEAL_CANDIDATE_MAX,
   INTRO_DESCRIPTION_MAX,
 } from '@/constants/adminFieldLimits';
+import {
+  ACTIVITY_DESCRIPTION_PLACEHOLDER,
+  BENEFITS_PLACEHOLDER,
+  IDEAL_CANDIDATE_PLACEHOLDER,
+  INTRO_DESCRIPTION_PLACEHOLDER,
+} from '@/constants/adminFieldPlaceholders';
 import { PAGE_VIEW } from '@/constants/eventName';
 import useTrackPageView from '@/hooks/Mixpanel/useTrackPageView';
 import useDevice from '@/hooks/useDevice';
@@ -73,7 +79,7 @@ const ClubIntroEditTab = () => {
           <CustomTextArea
             variant='filled'
             label='동아리를 소개할게요'
-            placeholder='동아리 소개 문구를 입력해주세요'
+            placeholder={INTRO_DESCRIPTION_PLACEHOLDER}
             value={introDescription}
             onChange={(e) => setIntroDescription(e.target.value)}
             maxLength={INTRO_DESCRIPTION_MAX}
@@ -83,7 +89,7 @@ const ClubIntroEditTab = () => {
           <CustomTextArea
             variant='filled'
             label='이런 활동을 해요'
-            placeholder='동아리에서 하는 활동 내용을 입력해주세요'
+            placeholder={ACTIVITY_DESCRIPTION_PLACEHOLDER}
             value={activityDescription}
             onChange={(e) => setActivityDescription(e.target.value)}
             maxLength={ACTIVITY_DESCRIPTION_MAX}
@@ -95,7 +101,7 @@ const ClubIntroEditTab = () => {
           <CustomTextArea
             variant='filled'
             label='이런 사람이 오면 좋아요'
-            placeholder='동아리에 어울리는 사람의 특성을 입력해주세요'
+            placeholder={IDEAL_CANDIDATE_PLACEHOLDER}
             value={idealCandidate.content}
             onChange={(e) =>
               setIdealCandidate({ ...idealCandidate, content: e.target.value })
@@ -107,7 +113,7 @@ const ClubIntroEditTab = () => {
           <CustomTextArea
             variant='filled'
             label='부원이 되면 이런 혜택이 있어요'
-            placeholder='동아리 부원이 누릴 수 있는 혜택을 입력해주세요'
+            placeholder={BENEFITS_PLACEHOLDER}
             value={benefits}
             onChange={(e) => setBenefits(e.target.value)}
             maxLength={BENEFITS_MAX}

--- a/frontend/src/pages/AdminPage/tabs/ClubIntroEditTab/ClubIntroEditTabMobile.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubIntroEditTab/ClubIntroEditTabMobile.tsx
@@ -6,6 +6,12 @@ import {
   IDEAL_CANDIDATE_MAX,
   INTRO_DESCRIPTION_MAX,
 } from '@/constants/adminFieldLimits';
+import {
+  ACTIVITY_DESCRIPTION_PLACEHOLDER,
+  BENEFITS_PLACEHOLDER,
+  IDEAL_CANDIDATE_PLACEHOLDER,
+  INTRO_DESCRIPTION_PLACEHOLDER,
+} from '@/constants/adminFieldPlaceholders';
 import useAutoGrow from '@/hooks/useAutoGrow';
 import MobileSaveButtonArea from '@/pages/AdminPage/components/MobileSaveButtonArea/MobileSaveButtonArea';
 import { Award, FAQ, IdealCandidate } from '@/types/club';
@@ -99,7 +105,7 @@ const ClubIntroEditTabMobile = ({
                 ref={introRef}
                 value={introDescription}
                 onChange={handleIntroChange}
-                placeholder='동아리 소개 문구를 입력해주세요'
+                placeholder={INTRO_DESCRIPTION_PLACEHOLDER}
               />
             </InfoSection>
 
@@ -112,7 +118,7 @@ const ClubIntroEditTabMobile = ({
                 ref={activityRef}
                 value={activityDescription}
                 onChange={handleActivityChange}
-                placeholder='동아리에서 하는 활동 내용을 입력해주세요'
+                placeholder={ACTIVITY_DESCRIPTION_PLACEHOLDER}
               />
             </InfoSection>
 
@@ -127,7 +133,7 @@ const ClubIntroEditTabMobile = ({
                 ref={idealRef}
                 value={idealCandidate.content}
                 onChange={handleIdealChange}
-                placeholder='동아리에 어울리는 사람의 특성을 입력해주세요'
+                placeholder={IDEAL_CANDIDATE_PLACEHOLDER}
               />
             </InfoSection>
 
@@ -140,7 +146,7 @@ const ClubIntroEditTabMobile = ({
                 ref={benefitsRef}
                 value={benefits}
                 onChange={handleBenefitsChange}
-                placeholder='동아리 부원이 누릴 수 있는 혜택을 입력해주세요'
+                placeholder={BENEFITS_PLACEHOLDER}
               />
             </InfoSection>
 

--- a/frontend/src/pages/AdminPage/tabs/ClubIntroEditTab/components/desktop/FAQEditor/FAQEditor.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubIntroEditTab/components/desktop/FAQEditor/FAQEditor.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
 import clearButton from '@/assets/images/icons/input_clear_button_icon.svg';
 import { FAQ_ANSWER_MAX, FAQ_QUESTION_MAX } from '@/constants/adminFieldLimits';
+import {
+  FAQ_ANSWER_PLACEHOLDER,
+  FAQ_QUESTION_PLACEHOLDER,
+} from '@/constants/adminFieldPlaceholders';
 import useAutoGrow from '@/hooks/useAutoGrow';
 import { FAQ } from '@/types/club';
 import * as Styled from './FAQEditor.styles';
@@ -40,7 +44,7 @@ const FAQItemEditor = ({
 
       <Styled.QuestionInput
         ref={inputRef}
-        placeholder='질문을 입력하세요'
+        placeholder={FAQ_QUESTION_PLACEHOLDER}
         value={faq.question}
         onChange={(e) => onUpdateQuestion(faq.id, e.target.value)}
         maxLength={FAQ_QUESTION_MAX}
@@ -48,7 +52,7 @@ const FAQItemEditor = ({
 
       <Styled.AnswerTextArea
         ref={answerRef}
-        placeholder='답변을 입력하세요'
+        placeholder={FAQ_ANSWER_PLACEHOLDER}
         value={faq.answer}
         onChange={(e) => onUpdateAnswer(faq.id, e.target.value)}
         maxLength={FAQ_ANSWER_MAX}

--- a/frontend/src/pages/AdminPage/tabs/ClubIntroEditTab/components/mobile/FAQSection/FAQSection.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubIntroEditTab/components/mobile/FAQSection/FAQSection.tsx
@@ -1,6 +1,10 @@
 import addIcon from '@/assets/images/icons/add_icon.svg';
 import closeCircleIcon from '@/assets/images/icons/close_circle_icon.svg';
 import { FAQ_ANSWER_MAX, FAQ_QUESTION_MAX } from '@/constants/adminFieldLimits';
+import {
+  FAQ_ANSWER_PLACEHOLDER,
+  FAQ_QUESTION_PLACEHOLDER,
+} from '@/constants/adminFieldPlaceholders';
 import useAutoGrow from '@/hooks/useAutoGrow';
 import { FAQ } from '@/types/club';
 import * as Styled from './FAQSection.styles';
@@ -34,7 +38,7 @@ const FAQItemEditor = ({
           <Styled.QuestionInput
             value={faq.question}
             onChange={(e) => onChange(index, 'question', e.target.value)}
-            placeholder='질문을 입력해주세요'
+            placeholder={FAQ_QUESTION_PLACEHOLDER}
             maxLength={FAQ_QUESTION_MAX}
           />
         </Styled.QuestionContent>
@@ -48,7 +52,7 @@ const FAQItemEditor = ({
             ref={answerRef}
             value={faq.answer}
             onChange={handleAnswerChange}
-            placeholder='답변을 입력해주세요'
+            placeholder={FAQ_ANSWER_PLACEHOLDER}
             rows={1}
           />
         </Styled.AnswerCard>


### PR DESCRIPTION
## #️⃣연관된 이슈

#1823

## 📝작업 내용

어드민 탭 텍스트 필드의 placeholder 문자열이 각 컴포넌트에 하드코딩되어 있어 데스크탑·모바일 간 불일치가 발생하는 문제를 해결합니다.

**`src/constants/adminFieldPlaceholders.ts` 신규 생성**
- ClubInfoEditTab: `CLUB_NAME_PLACEHOLDER`, `CLUB_INTRODUCTION_PLACEHOLDER`, `CLUB_TAG_PLACEHOLDER`
- ClubIntroEditTab: `INTRO_DESCRIPTION_PLACEHOLDER`, `ACTIVITY_DESCRIPTION_PLACEHOLDER`, `IDEAL_CANDIDATE_PLACEHOLDER`, `BENEFITS_PLACEHOLDER`, `FAQ_QUESTION_PLACEHOLDER`, `FAQ_ANSWER_PLACEHOLDER`

**ClubInfoEditTab 적용**
- 데스크탑(`ClubInfoEditTab.tsx`), 모바일(`ClubInfoEditTabMobile.tsx`) 동일 상수 참조
- `MakeTags`(데스크탑): 동적 `` `자유 태그 ${index + 1}` `` → `'태그추가'`로 모바일 기준 통일
- `FreeTagEditPage`(모바일): 상수 적용

**ClubIntroEditTab 적용**
- 데스크탑(`ClubIntroEditTab.tsx`), 모바일(`ClubIntroEditTabMobile.tsx`) 동일 상수 참조
- FAQ 데스크탑(`FAQEditor`): `'입력하세요'` → `'입력해주세요'`로 모바일 기준 통일
- FAQ 모바일(`FAQSection`): 상수 적용

## 중점적으로 리뷰받고 싶은 부분(선택)

- `adminFieldPlaceholders.ts` 파일명 및 상수 네이밍이 적절한지

## 🫡 참고사항

- `adminFieldLimits.ts`(maxLength 상수)와 같은 맥락의 작업으로, MOA-1034 하위작업입니다.
- 링크 추가 섹션은 이미 `SNS_CONFIG`에서 중앙 관리 중이므로 변경 없습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 관리자 페이지의 동아리 정보, 소개, 활동, 혜택 및 FAQ 입력란 안내 문구를 일관된 placeholder로 정리했습니다.
  * 데스크톱과 모바일 화면에서 동일한 입력 안내 문구가 표시됩니다.
  * 태그 입력란에도 통일된 안내 문구가 적용되어 입력해야 할 내용을 더 쉽게 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->