### PR TITLE
[hotfix] 지원자 페이지 프로덕션 크래시 수정 (React Compiler null 접근) (FE v1.8.15)

### DIFF
--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPage.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPage.tsx
@@ -132,14 +132,14 @@ const ApplicantDetailPage = () => {
   };
 
   const previousApplicant = () => {
-    const previousData = applicantsData.applicants[applicantIndex - 1];
+    const previousData = applicantsData?.applicants[applicantIndex - 1];
     if (applicantIndex < 0 || !previousData) return;
 
     navigate(`/admin/applicants-list/${applicationFormId}/${previousData.id}`);
   };
 
   const nextApplicant = () => {
-    const nextData = applicantsData.applicants[applicantIndex + 1];
+    const nextData = applicantsData?.applicants[applicantIndex + 1];
     if (applicantIndex < 0 || !nextData) return;
 
     navigate(`/admin/applicants-list/${applicationFormId}/${nextData.id}`);
@@ -165,7 +165,7 @@ const ApplicantDetailPage = () => {
                 )
               }
             >
-              {applicantsData.applicants.map((a) => (
+              {applicantsData?.applicants.map((a) => (
                 <option key={a.id} value={a.id}>
                   {a.answers[0].value}
                 </option>

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantsTab.tsx
@@ -209,7 +209,7 @@ const ApplicantsTab = () => {
 
   const updateAllApplicants = (status: ApplicationStatus) => {
     updateDetailApplicants(
-      applicantsData!.applicants
+      (applicantsData?.applicants ?? [])
         .filter((applicant) => checkedItem.get(applicant.id))
         .map((applicant) => ({
           applicantId: applicant.id,


### PR DESCRIPTION
## 긴급 핫픽스 (프로덕션 크래시)

프로덕션에서 어드민 **지원자 현황/상세 페이지**가 진입 즉시 크래시하고 있습니다.

- **터짐**: `/admin/applicants-list/:applicationFormId`(지원자 현황), `.../:questionId`(지원자 상세) → ErrorBoundary("페이지를 표시할 수 없습니다"). 관리자가 지원자를 볼 수 없음.
- **정상**: 지원서 목록(폼 리스트) 등 그 외 어드민 페이지.

## 원인
`applicantsData`는 `useApplicantSSE`에서 로딩 구간에 `null`인데, 아래를 무가드로 접근:
- `ApplicantsTab.tsx` — `applicantsData!.applicants` (논-널 단언)
- `ApplicantDetailPage.tsx` — `applicantsData.applicants[...]` / `.map`

이 프로젝트는 **React Compiler**(`config/vite.config.ts`에 배선)를 쓰는데, 컴파일러가 이 프로퍼티 접근을 **의존성 비교로 렌더 함수 상단에 호이스팅**합니다. 그래서 소스의 `if(!applicantsData) return` 가드보다 **먼저** `null.applicants`가 실행 → `TypeError: can't access property "applicants", s is null` → ErrorBoundary.

## 수정
해당 접근들을 옵셔널 체이닝으로 변경 (수동 memo 아님, 동작 변화 없음):
- `(applicantsData?.applicants ?? [])`
- `applicantsData?.applicants[...]` / `applicantsData?.applicants.map(...)`

`develop-fe`의 크래시 수정 커밋(`fc198cf2`)을 main으로 cherry-pick한 것입니다. 같은 수정이 진행 중인 PR #1819(상태 2-state 리팩터)에도 포함돼 있으나, 프로덕션 즉시 복구를 위해 이 2파일만 분리했습니다.

## 검증
- `tsc --noEmit` ✅
- 크래시 원인이 React Compiler 호이스팅임은 배포 번들에서 무가드 `.applicants` 의존성 읽기가 옵셔널로 바뀌는 것으로 확인 완료.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 지원자 데이터가 로딩 중이거나 없는 상태에서도 지원자 상세 화면이 오류 없이 표시되도록 개선했습니다.
  * 지원자 목록 선택 및 이전·다음 지원자 탐색 기능의 안정성을 높였습니다.
  * 일괄 상태 변경 시 데이터가 아직 준비되지 않아도 앱이 중단되지 않도록 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->