### PR TITLE
[feature] 관리자 지원서 원클릭 AI 생성

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -76,6 +76,9 @@ dependencies {
 
 	implementation 'net.javacrumbs.shedlock:shedlock-spring:7.6.0'
 	implementation 'net.javacrumbs.shedlock:shedlock-provider-mongo:7.6.0'
+
+	// Anthropic (AI 지원서 초안 생성)
+	implementation 'com.anthropic:anthropic-java:2.34.0'
 }
 
 apply from: 'gradle/infisical.gradle'

--- a/backend/src/main/java/moadong/anthropic/dto/DraftQuestion.java
+++ b/backend/src/main/java/moadong/anthropic/dto/DraftQuestion.java
@@ -1,0 +1,18 @@
+package moadong.anthropic.dto;
+
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import java.util.List;
+
+public record DraftQuestion(
+        @JsonPropertyDescription("질문 제목, 한국어 30자 이내")
+        String title,
+        @JsonPropertyDescription("답변 안내 문구, 200자 이내, 없으면 빈 문자열")
+        String description,
+        @JsonPropertyDescription("SHORT_TEXT | LONG_TEXT | CHOICE | MULTI_CHOICE 중 하나")
+        String type,
+        @JsonPropertyDescription("CHOICE/MULTI_CHOICE의 선택지(각 20자 이내). 그 외 타입은 빈 배열")
+        List<String> items,
+        @JsonPropertyDescription("필수 응답 여부")
+        boolean required
+) {
+}

--- a/backend/src/main/java/moadong/anthropic/dto/DraftQuestions.java
+++ b/backend/src/main/java/moadong/anthropic/dto/DraftQuestions.java
@@ -1,0 +1,6 @@
+package moadong.anthropic.dto;
+
+import java.util.List;
+
+public record DraftQuestions(List<DraftQuestion> questions) {
+}

--- a/backend/src/main/java/moadong/anthropic/service/AnthropicQuestionGenerator.java
+++ b/backend/src/main/java/moadong/anthropic/service/AnthropicQuestionGenerator.java
@@ -1,0 +1,40 @@
+package moadong.anthropic.service;
+
+import com.anthropic.client.AnthropicClient;
+import com.anthropic.core.JsonSchemaLocalValidation;
+import com.anthropic.models.messages.MessageCreateParams;
+import com.anthropic.models.messages.StructuredMessageCreateParams;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import moadong.anthropic.dto.DraftQuestion;
+import moadong.anthropic.dto.DraftQuestions;
+import moadong.global.config.properties.AnthropicProperties;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AnthropicQuestionGenerator {
+
+    private final AnthropicClient anthropicClient;
+    private final AnthropicProperties anthropicProperties;
+
+    /**
+     * structured output으로 스키마가 강제된 질문 목록을 생성한다.
+     * API 오류·빈 응답 시 unchecked 예외를 던진다(폴백은 호출부 책임).
+     */
+    public List<DraftQuestion> generate(String system, String userPrompt) {
+        StructuredMessageCreateParams<DraftQuestions> params = MessageCreateParams.builder()
+                .model(anthropicProperties.model())
+                .maxTokens(2048L)
+                .system(system)
+                .outputConfig(DraftQuestions.class, JsonSchemaLocalValidation.YES)
+                .addUserMessage(userPrompt)
+                .build();
+
+        return anthropicClient.messages().create(params).content().stream()
+                .flatMap(block -> block.text().stream())
+                .findFirst()
+                .map(typed -> typed.text().questions())
+                .orElseThrow(() -> new IllegalStateException("AI 응답에 질문이 없습니다."));
+    }
+}

--- a/backend/src/main/java/moadong/club/controller/ClubApplyAdminController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubApplyAdminController.java
@@ -11,6 +11,7 @@ import moadong.club.payload.request.ClubApplicantDeleteRequest;
 import moadong.club.payload.request.ClubApplicantEditRequest;
 import moadong.club.payload.request.ClubApplicationFormCreateRequest;
 import moadong.club.payload.request.ClubApplicationFormEditRequest;
+import moadong.club.service.AiApplicationDraftService;
 import moadong.club.service.ClubApplyAdminService;
 import moadong.global.payload.Response;
 import moadong.sse.service.ApplicantsStatusShareSse;
@@ -33,6 +34,7 @@ public class ClubApplyAdminController {
 
     private final ClubApplyAdminService clubApplyAdminService;
     private final ApplicantsStatusShareSse sse;
+    private final AiApplicationDraftService aiApplicationDraftService;
 
     @PostMapping("/application")
     @Operation(summary = "클럽 지원서 양식 생성", description = "클럽 지원서 양식을 생성합니다")
@@ -89,6 +91,16 @@ public class ClubApplyAdminController {
                                                           @CurrentUser CustomUserDetails user) {
         clubApplyAdminService.duplicateClubApplicationForm(applicationFormId, user);
         return Response.ok("success duplicate application");
+    }
+
+    @PostMapping("/application/ai-draft")
+    @Operation(summary = "AI 지원서 초안 생성",
+            description = "동아리 상세 정보를 바탕으로 지원서 초안(제목·설명·질문 목록)을 생성합니다.<br>"
+                    + "AI 생성 실패 시에도 200으로 기본 템플릿 문항을 반환하며, aiGenerated=false로 표시됩니다.")
+    @PreAuthorize("isAuthenticated()")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> generateApplicationDraft(@CurrentUser CustomUserDetails user) {
+        return Response.ok(aiApplicationDraftService.generateDraft(user));
     }
 
     @GetMapping("/apply/info/{applicationFormId}")

--- a/backend/src/main/java/moadong/club/payload/response/ClubApplicationDraftResponse.java
+++ b/backend/src/main/java/moadong/club/payload/response/ClubApplicationDraftResponse.java
@@ -1,0 +1,26 @@
+package moadong.club.payload.response;
+
+import java.util.List;
+
+public record ClubApplicationDraftResponse(
+        String title,
+        String description,
+        List<QuestionDto> questions,
+        boolean aiGenerated
+) {
+    public record QuestionDto(
+            long id,
+            String title,
+            String description,
+            String type,
+            OptionsDto options,
+            List<ItemDto> items
+    ) {
+    }
+
+    public record OptionsDto(boolean required) {
+    }
+
+    public record ItemDto(String value) {
+    }
+}

--- a/backend/src/main/java/moadong/club/service/AiApplicationDraftService.java
+++ b/backend/src/main/java/moadong/club/service/AiApplicationDraftService.java
@@ -1,0 +1,108 @@
+package moadong.club.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import moadong.anthropic.dto.DraftQuestion;
+import moadong.anthropic.service.AnthropicQuestionGenerator;
+import moadong.club.entity.Club;
+import moadong.club.payload.response.ClubApplicationDraftResponse;
+import moadong.club.payload.response.ClubApplicationDraftResponse.ItemDto;
+import moadong.club.payload.response.ClubApplicationDraftResponse.OptionsDto;
+import moadong.club.payload.response.ClubApplicationDraftResponse.QuestionDto;
+import moadong.club.repository.ClubRepository;
+import moadong.global.exception.ErrorCode;
+import moadong.global.exception.RestApiException;
+import moadong.user.payload.CustomUserDetails;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AiApplicationDraftService {
+
+    private static final Set<String> ALLOWED_TYPES =
+            Set.of("SHORT_TEXT", "LONG_TEXT", "CHOICE", "MULTI_CHOICE");
+    private static final Set<String> CHOICE_TYPES = Set.of("CHOICE", "MULTI_CHOICE");
+    private static final int MAX_TITLE = 50;
+    private static final int MAX_DESCRIPTION = 300;
+    private static final int MAX_ITEM = 20;
+
+    private final ClubRepository clubRepository;
+    private final AnthropicQuestionGenerator generator;
+
+    public ClubApplicationDraftResponse generateDraft(CustomUserDetails user) {
+        Club club = clubRepository.findClubByUserId(user.getId())
+                .orElseThrow(() -> new RestApiException(ErrorCode.CLUB_NOT_FOUND));
+
+        List<DraftQuestion> aiQuestions = List.of();
+        try {
+            aiQuestions = generator.generate(AiDraftPrompts.SYSTEM, AiDraftPrompts.buildUserPrompt(club))
+                    .stream()
+                    .filter(this::isValid)
+                    .toList();
+        } catch (Exception e) {
+            log.error("AI 지원서 초안 생성 실패, 템플릿으로 폴백. clubName={}", club.getName(), e);
+        }
+
+        boolean aiGenerated = !aiQuestions.isEmpty();
+        List<QuestionDto> questions = assemble(aiQuestions);
+        return new ClubApplicationDraftResponse(
+                buildTitle(club), buildDescription(club), questions, aiGenerated);
+    }
+
+    private boolean isValid(DraftQuestion q) {
+        if (q.title() == null || q.title().isBlank() || q.title().length() > MAX_TITLE) {
+            return false;
+        }
+        if (q.description() != null && q.description().length() > MAX_DESCRIPTION) {
+            return false;
+        }
+        if (q.type() == null || !ALLOWED_TYPES.contains(q.type())) {
+            return false;
+        }
+        List<String> items = q.items() == null ? List.of() : q.items();
+        if (CHOICE_TYPES.contains(q.type())) {
+            return !items.isEmpty() && items.stream()
+                    .allMatch(v -> v != null && !v.isBlank() && v.length() <= MAX_ITEM);
+        }
+        return true;
+    }
+
+    private List<QuestionDto> assemble(List<DraftQuestion> aiQuestions) {
+        List<QuestionDto> questions = new ArrayList<>();
+        questions.add(new QuestionDto(1, "연락처", "연락 가능한 전화번호를 입력해주세요.",
+                "PHONE_NUMBER", new OptionsDto(true), List.of()));
+        questions.add(new QuestionDto(2, "학과와 학번을 입력해주세요", "예: 컴퓨터공학과 20학번",
+                "SHORT_TEXT", new OptionsDto(true), List.of()));
+
+        long nextId = 3;
+        for (DraftQuestion q : aiQuestions) {
+            String description = q.description() == null ? "" : q.description();
+            List<ItemDto> items = CHOICE_TYPES.contains(q.type())
+                    ? q.items().stream().map(ItemDto::new).toList()
+                    : List.<ItemDto>of();
+            questions.add(new QuestionDto(nextId++, q.title(), description, q.type(),
+                    new OptionsDto(q.required()), items));
+        }
+        return questions;
+    }
+
+    private String buildTitle(Club club) {
+        String title = club.getName() + " 신입 부원 모집 지원서";
+        return title.length() > 50 ? title.substring(0, 50) : title;
+    }
+
+    private String buildDescription(Club club) {
+        String intro = club.getClubRecruitmentInformation() == null
+                ? null : club.getClubRecruitmentInformation().getIntroduction();
+        StringBuilder sb = new StringBuilder("안녕하세요, ").append(club.getName()).append("입니다.\n");
+        if (intro != null && !intro.isBlank()) {
+            sb.append(intro).append("\n");
+        }
+        sb.append("\n아래 지원서를 작성해 지원해주세요!");
+        return sb.toString();
+    }
+}

--- a/backend/src/main/java/moadong/club/service/AiDraftPrompts.java
+++ b/backend/src/main/java/moadong/club/service/AiDraftPrompts.java
@@ -1,0 +1,58 @@
+package moadong.club.service;
+
+import java.util.List;
+import moadong.club.entity.Club;
+import moadong.club.entity.ClubDescription;
+import moadong.club.entity.ClubIdealCandidate;
+import moadong.club.entity.ClubRecruitmentInformation;
+
+public final class AiDraftPrompts {
+
+    private AiDraftPrompts() {
+    }
+
+    public static final String SYSTEM = """
+            ### Role
+            너는 대학교 동아리의 신입 부원 모집 지원서를 설계하는 전문가다.
+
+            ### Task
+            [Club] 정보를 읽고 이 동아리의 성격에 맞는 지원서 질문을 만들어라.
+            - 이름/연락처/학과 같은 공통 질문은 이미 있으므로 절대 만들지 말 것.
+            - 이 동아리만의 특성(활동 내용, 분야, 분위기)이 드러나는 질문을 만들 것. 개수는 동아리 성격과 정보량에 맞게 스스로 판단할 것(정보가 풍부하면 더 많이, 부실하면 적게).
+
+            ### Rules
+            1. title: 핵심 질문만 간결하게. 반드시 30자 이내. 부연 설명은 title에 넣지 말고 description에 넣을 것.
+            2. description: 답변 안내 문구, 200자 이내. 없어도 되면 빈 문자열.
+            3. 모든 문장은 존댓말(해요체 또는 합쇼체)로 작성할 것. 반말 금지.
+            4. type: SHORT_TEXT(단답), LONG_TEXT(장문), CHOICE(단일선택), MULTI_CHOICE(복수선택) 중 하나.
+            5. 질문 중 최소 1개는 CHOICE 또는 MULTI_CHOICE로 만들 것. items에 선택지(각 20자 이내, 2~5개)를 넣을 것. SHORT_TEXT/LONG_TEXT는 items를 빈 배열로.
+            6. 선택지에는 실존하는 팀명·인물·작품명·전문용어를 나열하지 말 것. 동아리 정보에 언급된 내용이나 일반적인 항목(관심 분야, 경험 수준, 참여 가능 시간 등)만 사용할 것.
+            7. required: 필수 여부 (true/false).
+            8. 지원 동기를 묻는 질문과 동아리 특성을 묻는 질문을 함께 포함할 것.
+            9. 지원자가 부담 없이 답할 수 있는 친근한 난이도로 만들 것. 전문 지식을 시험하는 질문 금지.
+            """;
+
+    public static String buildUserPrompt(Club club) {
+        ClubRecruitmentInformation info = club.getClubRecruitmentInformation();
+        ClubDescription desc = club.getClubDescription();
+        ClubIdealCandidate ideal = desc == null ? null : desc.getIdealCandidate();
+
+        return "### Club\n"
+                + "- 이름: " + orNone(club.getName()) + "\n"
+                + "- 분류: " + orNone(club.getDivision()) + " / " + orNone(club.getCategory()) + "\n"
+                + "- 태그: " + joinOrNone(info == null ? null : info.getTags()) + "\n"
+                + "- 한줄소개: " + orNone(info == null ? null : info.getIntroduction()) + "\n"
+                + "- 소개: " + orNone(desc == null ? null : desc.getIntroDescription()) + "\n"
+                + "- 활동내용: " + orNone(desc == null ? null : desc.getActivityDescription()) + "\n"
+                + "- 인재상: " + orNone(ideal == null ? null : ideal.getContent()) + "\n"
+                + "- 혜택: " + orNone(desc == null ? null : desc.getBenefits());
+    }
+
+    private static String orNone(String value) {
+        return (value == null || value.isBlank()) ? "(없음)" : value;
+    }
+
+    private static String joinOrNone(List<String> values) {
+        return (values == null || values.isEmpty()) ? "(없음)" : String.join(", ", values);
+    }
+}

--- a/backend/src/main/java/moadong/global/config/AnthropicConfig.java
+++ b/backend/src/main/java/moadong/global/config/AnthropicConfig.java
@@ -14,7 +14,7 @@ public class AnthropicConfig {
     public AnthropicClient anthropicClient(AnthropicProperties anthropicProperties) {
         return AnthropicOkHttpClient.builder()
                 .apiKey(anthropicProperties.apiKey())
-                .timeout(Duration.ofSeconds(30))
+                .timeout(Duration.ofSeconds(60))
                 .build();
     }
 }

--- a/backend/src/main/java/moadong/global/config/AnthropicConfig.java
+++ b/backend/src/main/java/moadong/global/config/AnthropicConfig.java
@@ -3,6 +3,7 @@ package moadong.global.config;
 import com.anthropic.client.AnthropicClient;
 import com.anthropic.client.okhttp.AnthropicOkHttpClient;
 import java.time.Duration;
+import moadong.global.config.properties.AnthropicProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -10,9 +11,9 @@ import org.springframework.context.annotation.Configuration;
 public class AnthropicConfig {
 
     @Bean
-    public AnthropicClient anthropicClient() {
+    public AnthropicClient anthropicClient(AnthropicProperties anthropicProperties) {
         return AnthropicOkHttpClient.builder()
-                .fromEnv()
+                .apiKey(anthropicProperties.apiKey())
                 .timeout(Duration.ofSeconds(30))
                 .build();
     }

--- a/backend/src/main/java/moadong/global/config/AnthropicConfig.java
+++ b/backend/src/main/java/moadong/global/config/AnthropicConfig.java
@@ -1,0 +1,19 @@
+package moadong.global.config;
+
+import com.anthropic.client.AnthropicClient;
+import com.anthropic.client.okhttp.AnthropicOkHttpClient;
+import java.time.Duration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AnthropicConfig {
+
+    @Bean
+    public AnthropicClient anthropicClient() {
+        return AnthropicOkHttpClient.builder()
+                .fromEnv()
+                .timeout(Duration.ofSeconds(30))
+                .build();
+    }
+}

--- a/backend/src/main/java/moadong/global/config/properties/AnthropicProperties.java
+++ b/backend/src/main/java/moadong/global/config/properties/AnthropicProperties.java
@@ -1,0 +1,8 @@
+package moadong.global.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+@ConfigurationProperties(prefix = "anthropic")
+public record AnthropicProperties(@DefaultValue("claude-opus-4-8") String model) {
+}

--- a/backend/src/main/java/moadong/global/config/properties/AnthropicProperties.java
+++ b/backend/src/main/java/moadong/global/config/properties/AnthropicProperties.java
@@ -4,5 +4,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.DefaultValue;
 
 @ConfigurationProperties(prefix = "anthropic")
-public record AnthropicProperties(@DefaultValue("claude-opus-4-8") String model) {
+public record AnthropicProperties(String apiKey, @DefaultValue("claude-opus-4-8") String model) {
 }

--- a/backend/src/test/java/moadong/club/service/AiApplicationDraftServiceTest.java
+++ b/backend/src/test/java/moadong/club/service/AiApplicationDraftServiceTest.java
@@ -1,0 +1,113 @@
+package moadong.club.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import moadong.anthropic.dto.DraftQuestion;
+import moadong.anthropic.service.AnthropicQuestionGenerator;
+import moadong.club.entity.Club;
+import moadong.club.payload.response.ClubApplicationDraftResponse;
+import moadong.club.repository.ClubRepository;
+import moadong.global.exception.RestApiException;
+import moadong.user.payload.CustomUserDetails;
+import moadong.util.annotations.UnitTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@UnitTest
+class AiApplicationDraftServiceTest {
+
+    private ClubRepository clubRepository;
+    private AnthropicQuestionGenerator generator;
+    private AiApplicationDraftService service;
+    private CustomUserDetails user;
+
+    @BeforeEach
+    void setUp() {
+        clubRepository = mock(ClubRepository.class);
+        generator = mock(AnthropicQuestionGenerator.class);
+        service = new AiApplicationDraftService(clubRepository, generator);
+
+        user = mock(CustomUserDetails.class);
+        Club club = mock(Club.class);
+        lenient().when(club.getName()).thenReturn("매니아");
+        when(user.getId()).thenReturn("user-1");
+        lenient().when(clubRepository.findClubByUserId("user-1")).thenReturn(Optional.of(club));
+    }
+
+    private DraftQuestion validQuestion(String title) {
+        return new DraftQuestion(title, "설명", "LONG_TEXT", List.of(), true);
+    }
+
+    @Test
+    @DisplayName("AI 생성 성공 시 템플릿 2문항 + AI 문항이 순번 id로 조립된다")
+    void generateDraft_success() {
+        when(generator.generate(anyString(), anyString())).thenReturn(List.of(
+                validQuestion("지원 동기를 알려주세요"),
+                new DraftQuestion("선호하는 활동은?", "", "CHOICE", List.of("공연", "연습"), true),
+                validQuestion("밴드 경험이 있나요?")));
+
+        ClubApplicationDraftResponse response = service.generateDraft(user);
+
+        assertThat(response.aiGenerated()).isTrue();
+        assertThat(response.questions()).hasSize(5); // 연락처 + 학과/학번 + AI 3
+        assertThat(response.questions().get(0).type()).isEqualTo("PHONE_NUMBER");
+        assertThat(response.questions()).extracting("id").containsExactly(1L, 2L, 3L, 4L, 5L);
+        assertThat(response.title()).contains("매니아");
+    }
+
+    @Test
+    @DisplayName("AI 호출이 실패하면 템플릿 문항만으로 aiGenerated=false 응답한다")
+    void generateDraft_fallbackOnApiError() {
+        when(generator.generate(anyString(), anyString()))
+                .thenThrow(new IllegalStateException("api down"));
+
+        ClubApplicationDraftResponse response = service.generateDraft(user);
+
+        assertThat(response.aiGenerated()).isFalse();
+        assertThat(response.questions()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("검증에 걸리는 AI 문항은 제외된다 (title 50자 초과, CHOICE인데 items 없음, 허용 외 type)")
+    void generateDraft_filtersInvalidQuestions() {
+        when(generator.generate(anyString(), anyString())).thenReturn(List.of(
+                validQuestion("정상 질문"),
+                validQuestion("가".repeat(51)),
+                new DraftQuestion("선택지 없는 객관식", "", "CHOICE", List.of(), true),
+                new DraftQuestion("허용 외 타입", "", "NAME", List.of(), true)));
+
+        ClubApplicationDraftResponse response = service.generateDraft(user);
+
+        assertThat(response.aiGenerated()).isTrue();
+        assertThat(response.questions()).hasSize(3); // 템플릿 2 + 정상 1
+    }
+
+    @Test
+    @DisplayName("AI 문항이 전부 걸러지면 폴백으로 처리한다")
+    void generateDraft_fallbackWhenAllFiltered() {
+        when(generator.generate(anyString(), anyString())).thenReturn(List.of(
+                new DraftQuestion("선택지 없는 객관식", "", "CHOICE", List.of(), true)));
+
+        ClubApplicationDraftResponse response = service.generateDraft(user);
+
+        assertThat(response.aiGenerated()).isFalse();
+        assertThat(response.questions()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("동아리가 없으면 RestApiException")
+    void generateDraft_clubNotFound() {
+        when(clubRepository.findClubByUserId("user-1")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.generateDraft(user))
+                .isInstanceOf(RestApiException.class);
+    }
+}

--- a/backend/src/test/java/moadong/club/service/AiDraftPromptsTest.java
+++ b/backend/src/test/java/moadong/club/service/AiDraftPromptsTest.java
@@ -1,0 +1,64 @@
+package moadong.club.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import moadong.club.entity.Club;
+import moadong.club.entity.ClubDescription;
+import moadong.club.entity.ClubRecruitmentInformation;
+import moadong.util.annotations.UnitTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@UnitTest
+class AiDraftPromptsTest {
+
+    private Club mockClub(ClubRecruitmentInformation info, ClubDescription desc) {
+        Club club = mock(Club.class);
+        when(club.getName()).thenReturn("매니아");
+        when(club.getCategory()).thenReturn("공연");
+        when(club.getDivision()).thenReturn("중동");
+        when(club.getClubRecruitmentInformation()).thenReturn(info);
+        when(club.getClubDescription()).thenReturn(desc);
+        return club;
+    }
+
+    @Test
+    @DisplayName("동아리 정보가 모두 있으면 프롬프트에 각 항목이 포함된다")
+    void buildUserPrompt_withFullInfo() {
+        Club club = mockClub(
+                ClubRecruitmentInformation.builder()
+                        .introduction("부경대 락밴드 동아리")
+                        .tags(List.of("락밴드", "다양한장르"))
+                        .build(),
+                ClubDescription.builder()
+                        .introDescription("얼터너티브, 개러지, 펑크 등 다양한 장르를 시도합니다.")
+                        .activityDescription("연 2회 정기공연을 준비합니다.")
+                        .benefits("무대 경험")
+                        .build());
+
+        String prompt = AiDraftPrompts.buildUserPrompt(club);
+
+        assertThat(prompt).contains("매니아");
+        assertThat(prompt).contains("중동 / 공연");
+        assertThat(prompt).contains("락밴드, 다양한장르");
+        assertThat(prompt).contains("부경대 락밴드 동아리");
+        assertThat(prompt).contains("연 2회 정기공연");
+        assertThat(prompt).contains("무대 경험");
+    }
+
+    @Test
+    @DisplayName("null이거나 비어있는 필드는 (없음)으로 표기된다")
+    void buildUserPrompt_withMissingInfo() {
+        Club club = mockClub(
+                ClubRecruitmentInformation.builder().build(),
+                null);
+
+        String prompt = AiDraftPrompts.buildUserPrompt(club);
+
+        assertThat(prompt).contains("(없음)");
+        assertThat(prompt).doesNotContain("null");
+    }
+}


### PR DESCRIPTION
## 요약

관리자가 지원서를 새로 만들 때 버튼 한 번으로 동아리 성격이 반영된 지원서 초안(제목·설명·질문 목록)을 생성하는 백엔드 엔드포인트를 추가합니다. AI는 JSON만 생성하고 기존 폼 빌더가 그대로 렌더링하며, 저장은 항상 사람이 합니다.

## 변경 사항

- `POST /api/club/application/ai-draft` (인증: 기존 `@CurrentUser` 패턴)
  - 응답: `{ data: { title, description, questions[], aiGenerated } }` (전역 `Response` 래퍼)
  - `questions[]`: `{ id, title, description, type, options:{required}, items:[{value}] }` — 프론트 `Question` 타입과 정렬
  - 공통 템플릿 2문항(연락처=PHONE_NUMBER, 학과/학번=SHORT_TEXT) + AI 특화 문항 조립. **이름(NAME) 질문은 미포함**(프론트 고정 유지)
- Claude 호출: 공식 Java SDK(`com.anthropic:anthropic-java:2.34.0`) structured output, 모델 `claude-opus-4-8`
- 검증·폴백: 글자수/타입 검증 후 위반 문항 제외. AI 실패·전량 탈락 시 **템플릿만으로 200 + `aiGenerated:false`** (엔드포인트는 5xx를 내지 않음)
- 기존 `GemmaService`(지원자 요약)는 손대지 않음

## 구현 노트

- **모델 설정**: `application.yml`은 Infisical로 생성/관리되므로, `AnthropicProperties(model)`에 `@DefaultValue("claude-opus-4-8")`를 두어 프로퍼티(Infisical override 가능)이면서 기본값으로 동작하도록 함
- **SDK API**: anthropic-java 2.34.0 실제 시그니처에 맞춰 `outputConfig(DraftQuestions.class, JsonSchemaLocalValidation.YES)` 사용
- **API 키**: `AnthropicOkHttpClient.fromEnv()` → `ANTHROPIC_API_KEY` OS 환경변수. 운영은 Infisical에서 주입 필요

## 테스트

- `./gradlew unitTest` 전체 통과 (신규 단위 테스트 7개: 프롬프트 빌더 2 + 조립 서비스 5)
- 단위 테스트는 Anthropic 클라이언트를 모킹하므로 API 키 없이 통과
- 로컬 기동 + 실제 Claude 호출로 초안 생성까지 수동 검증 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 동아리 정보를 바탕으로 AI가 신입 부원 모집 지원서 초안을 생성합니다.
  * 기본 질문과 AI 생성 질문이 포함된 지원서 초안을 제공합니다.
  * 지원서 초안 생성을 위한 API가 추가되었습니다.
  * AI 생성 실패 또는 유효하지 않은 질문 발생 시 기본 질문으로 자동 대체됩니다.

* **테스트**
  * AI 질문 생성, 검증, 대체 처리 및 프롬프트 구성을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->