### PR TITLE
[feature] 관리자 지원서 원클릭 AI 초안 생성

### DIFF
--- a/frontend/src/apis/application.test.ts
+++ b/frontend/src/apis/application.test.ts
@@ -1,0 +1,66 @@
+import fetchMock from 'jest-fetch-mock';
+import { ApplicationDraftResponse } from '@/types/application';
+import { generateApplicationDraft } from './application';
+
+jest.mock('@/constants/api', () => ({
+  __esModule: true,
+  default: 'http://localhost:3000',
+}));
+
+jest.mock('./auth/secureFetch', () => ({
+  secureFetch: jest.fn((url: string, options?: RequestInit) => {
+    const token = localStorage.getItem('accessToken');
+    return fetch(url, {
+      ...options,
+      headers: {
+        ...options?.headers,
+        Authorization: token ? `Bearer ${token}` : '',
+      },
+    });
+  }),
+}));
+
+describe('generateApplicationDraft', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks();
+    localStorage.setItem('accessToken', 'mock-token');
+  });
+
+  it('응답의 data 필드를 unwrap하여 초안을 반환한다', async () => {
+    const draft: ApplicationDraftResponse = {
+      title: '매니아 신입 부원 모집 지원서',
+      description: '안녕하세요',
+      aiGenerated: true,
+      questions: [
+        {
+          id: 1,
+          title: '연락처',
+          description: '연락 가능한 전화번호를 입력해주세요.',
+          type: 'PHONE_NUMBER',
+          options: { required: true },
+          items: [],
+        },
+      ],
+    };
+    fetchMock.mockResponseOnce(JSON.stringify({ data: draft }), {
+      headers: { 'content-type': 'application/json' },
+    });
+
+    const result = await generateApplicationDraft();
+
+    expect(result).toEqual(draft);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:3000/api/club/application/ai-draft',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('서버 오류 시 에러를 던진다', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ message: 'fail' }), {
+      status: 500,
+      headers: { 'content-type': 'application/json' },
+    });
+
+    await expect(generateApplicationDraft()).rejects.toThrow();
+  });
+});

--- a/frontend/src/apis/application.test.ts
+++ b/frontend/src/apis/application.test.ts
@@ -1,5 +1,5 @@
 import fetchMock from 'jest-fetch-mock';
-import { ApplicationDraftResponse } from '@/types/application';
+import { ApplicationDraft } from '@/types/application';
 import { generateApplicationDraft } from './application';
 
 jest.mock('@/constants/api', () => ({
@@ -27,7 +27,7 @@ describe('generateApplicationDraft', () => {
   });
 
   it('응답의 data 필드를 unwrap하여 초안을 반환한다', async () => {
-    const draft: ApplicationDraftResponse = {
+    const draft: ApplicationDraft = {
       title: '매니아 신입 부원 모집 지원서',
       description: '안녕하세요',
       aiGenerated: true,

--- a/frontend/src/apis/application.ts
+++ b/frontend/src/apis/application.ts
@@ -2,7 +2,7 @@ import API_BASE_URL from '@/constants/api';
 import { UpdateApplicantParams } from '@/types/applicants';
 import {
   AnswerItem,
-  ApplicationDraftResponse,
+  ApplicationDraft,
   ApplicationForm,
   ApplicationFormData,
   ApplicationFormGroup,
@@ -167,7 +167,7 @@ export const generateApplicationDraft = async () => {
       method: 'POST',
     },
   );
-  return handleResponse<ApplicationDraftResponse>(
+  return handleResponse<ApplicationDraft>(
     response,
     '지원서 초안 생성에 실패했습니다.',
   );

--- a/frontend/src/apis/application.ts
+++ b/frontend/src/apis/application.ts
@@ -2,6 +2,7 @@ import API_BASE_URL from '@/constants/api';
 import { UpdateApplicantParams } from '@/types/applicants';
 import {
   AnswerItem,
+  ApplicationDraftResponse,
   ApplicationForm,
   ApplicationFormData,
   ApplicationFormGroup,
@@ -157,4 +158,17 @@ export const updateApplicationStatus = async (
     },
   );
   return handleResponse(response, '지원서 상태 수정에 실패했습니다.');
+};
+
+export const generateApplicationDraft = async () => {
+  const response = await secureFetch(
+    `${API_BASE_URL}/api/club/application/ai-draft`,
+    {
+      method: 'POST',
+    },
+  );
+  return handleResponse<ApplicationDraftResponse>(
+    response,
+    '지원서 초안 생성에 실패했습니다.',
+  );
 };

--- a/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.styles.ts
+++ b/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.styles.ts
@@ -164,6 +164,24 @@ export const ExternalApplicationFormHint = styled.div`
   margin-left: 4px;
 `;
 
+export const AiLoadingOverlay = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 20px;
+  background: rgba(0, 0, 0, 0.5);
+`;
+
+export const AiLoadingText = styled.p`
+  color: #fff;
+  font-size: 1.6rem;
+  font-weight: 600;
+`;
+
 export const AiDraftButton = styled.button`
   display: inline-flex;
   align-items: center;

--- a/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.styles.ts
+++ b/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.styles.ts
@@ -77,6 +77,8 @@ export const submitButton = styled.button`
 
 export const HeaderContainer = styled.div`
   display: flex;
+  justify-content: space-between;
+  align-items: center;
 `;
 
 export const ChangeButtonWrapper = styled.div`
@@ -160,4 +162,24 @@ export const ExternalApplicationFormHint = styled.div`
   font-weight: 400;
   margin-top: 8px;
   margin-left: 4px;
+`;
+
+export const AiDraftButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  height: 33px;
+  padding: 0 12px;
+  border: 1px solid ${({ theme }) => theme.colors.primary[900]};
+  border-radius: 6px;
+  background-color: ${({ theme }) => theme.colors.base.white};
+  color: ${({ theme }) => theme.colors.primary[900]};
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
 `;

--- a/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.styles.ts
+++ b/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.styles.ts
@@ -169,10 +169,10 @@ export const AiDraftButton = styled.button`
   align-items: center;
   height: 33px;
   padding: 0 12px;
-  border: 1px solid ${({ theme }) => theme.colors.primary[900]};
+  border: 1px solid var(--Main-Primary-900, #ff5414);
   border-radius: 6px;
-  background-color: ${({ theme }) => theme.colors.base.white};
-  color: ${({ theme }) => theme.colors.primary[900]};
+  background-color: #fff;
+  color: var(--Main-Primary-900, #ff5414);
   font-size: 12px;
   font-weight: 600;
   white-space: nowrap;

--- a/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.styles.ts
+++ b/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.styles.ts
@@ -1,4 +1,7 @@
 import styled, { css } from 'styled-components';
+import { colors } from '@/styles/theme/colors';
+import { setTypography, typography } from '@/styles/theme/typography';
+import { Z_INDEX } from '@/styles/zIndex';
 
 export const FormTitle = styled.input`
   width: 100%;
@@ -167,7 +170,7 @@ export const ExternalApplicationFormHint = styled.div`
 export const AiLoadingOverlay = styled.div`
   position: fixed;
   inset: 0;
-  z-index: 9999;
+  z-index: ${Z_INDEX.overlay};
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -177,9 +180,8 @@ export const AiLoadingOverlay = styled.div`
 `;
 
 export const AiLoadingText = styled.p`
-  color: #fff;
-  font-size: 1.6rem;
-  font-weight: 600;
+  ${setTypography(typography.paragraph.p2)};
+  color: ${colors.base.white};
 `;
 
 export const AiDraftButton = styled.button`

--- a/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { createApplication, updateApplication } from '@/apis/application';
+import { createApplication, generateApplicationDraft, updateApplication } from '@/apis/application';
 import Button from '@/components/common/Button/Button';
 import CustomTextArea from '@/components/common/CustomTextArea/CustomTextArea';
 import { APPLICATION_FORM } from '@/constants/applicationForm';
@@ -98,6 +98,46 @@ const ApplicationEditTab = () => {
       alert(`지원서 수정에 실패했습니다: ${err.message}`),
   });
 
+  const { mutate: generateDraft, isPending: isGenerating } = useMutation({
+    mutationFn: generateApplicationDraft,
+    onSuccess: (draft) => {
+      if (!draft) return;
+      const nameQuestion = INITIAL_FORM_DATA.questions![0];
+      const draftQuestions = draft.questions.map((q, index) => ({
+        ...q,
+        id: index + 2, // index 0은 이름 고정 질문(id 1)
+      }));
+      setFormData((prev) => ({
+        ...prev,
+        title: draft.title,
+        description: draft.description,
+        questions: [nameQuestion, ...draftQuestions],
+      }));
+      setNextId(draftQuestions.length + 2);
+      if (!draft.aiGenerated) {
+        alert('AI 생성에 실패해 기본 템플릿을 제공했어요. 질문을 직접 다듬어주세요.');
+      }
+    },
+    onError: (err: Error) =>
+      alert(`지원서 초안 생성에 실패했습니다: ${err.message}`),
+  });
+
+  const handleGenerateDraft = () => {
+    const hasUserInput =
+      formData.title.trim() !== '' ||
+      formData.description.trim() !== '' ||
+      (formData.questions ?? []).some(
+        (q, index) => index > 0 && q.title.trim() !== '',
+      );
+    if (
+      hasUserInput &&
+      !confirm('작성 중인 내용을 AI 초안으로 덮어씁니다. 계속할까요?')
+    ) {
+      return;
+    }
+    generateDraft();
+  };
+
   const handleFormTitleChange = (value: string) => {
     setFormData((prev) => ({
       ...prev,
@@ -183,6 +223,14 @@ const ApplicationEditTab = () => {
               외부지원서
             </Styled.ApplicationFormChangeButton>
           </Styled.ChangeButtonWrapper>
+          {!formId && applicationFormMode === ApplicationFormMode.INTERNAL && (
+            <Styled.AiDraftButton
+              onClick={handleGenerateDraft}
+              disabled={isGenerating}
+            >
+              {isGenerating ? '생성 중...' : '✨ AI로 초안 생성'}
+            </Styled.AiDraftButton>
+          )}
         </Styled.HeaderContainer>
         <Styled.FormTitle
           type='text'

--- a/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/apis/application';
 import Button from '@/components/common/Button/Button';
 import CustomTextArea from '@/components/common/CustomTextArea/CustomTextArea';
+import Spinner from '@/components/common/Spinner/Spinner';
 import { APPLICATION_FORM } from '@/constants/applicationForm';
 import INITIAL_FORM_DATA from '@/constants/initialFormData';
 import { queryKeys } from '@/constants/queryKeys';
@@ -210,6 +211,12 @@ const ApplicationEditTab = () => {
 
   return (
     <>
+      {isGenerating && (
+        <Styled.AiLoadingOverlay>
+          <Spinner height='auto' />
+          <Styled.AiLoadingText>지원서 자동 생성 중...</Styled.AiLoadingText>
+        </Styled.AiLoadingOverlay>
+      )}
       <PageContainer>
         <Styled.HeaderContainer>
           <Styled.ChangeButtonWrapper>
@@ -235,7 +242,7 @@ const ApplicationEditTab = () => {
               onClick={handleGenerateDraft}
               disabled={isGenerating}
             >
-              {isGenerating ? '생성 중...' : '✨ AI로 초안 생성'}
+              ✨ AI로 초안 생성
             </Styled.AiDraftButton>
           )}
         </Styled.HeaderContainer>

--- a/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.tsx
@@ -102,7 +102,7 @@ const ApplicationEditTab = () => {
     mutationFn: generateApplicationDraft,
     onSuccess: (draft) => {
       if (!draft) return;
-      const nameQuestion = INITIAL_FORM_DATA.questions![0];
+      const nameQuestion = { ...INITIAL_FORM_DATA.questions![0] };
       const draftQuestions = draft.questions.map((q, index) => ({
         ...q,
         id: index + 2, // index 0은 이름 고정 질문(id 1)
@@ -127,7 +127,9 @@ const ApplicationEditTab = () => {
       formData.title.trim() !== '' ||
       formData.description.trim() !== '' ||
       (formData.questions ?? []).some(
-        (q, index) => index > 0 && q.title.trim() !== '',
+        (q, index) =>
+          index > 0 &&
+          (q.title.trim() !== '' || q.description.trim() !== ''),
       );
     if (
       hasUserInput &&

--- a/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { createApplication, generateApplicationDraft, updateApplication } from '@/apis/application';
+import {
+  createApplication,
+  generateApplicationDraft,
+  updateApplication,
+} from '@/apis/application';
 import Button from '@/components/common/Button/Button';
 import CustomTextArea from '@/components/common/CustomTextArea/CustomTextArea';
 import { APPLICATION_FORM } from '@/constants/applicationForm';
@@ -115,7 +119,9 @@ const ApplicationEditTab = () => {
       }));
       setNextId(draftQuestions.length + 2);
       if (!draft.aiGenerated) {
-        alert('AI 생성에 실패해 기본 템플릿을 제공했어요. 질문을 직접 다듬어주세요.');
+        alert(
+          'AI 생성에 실패해 기본 템플릿을 제공했어요. 질문을 직접 다듬어주세요.',
+        );
       }
     },
     onError: (err: Error) =>
@@ -128,8 +134,7 @@ const ApplicationEditTab = () => {
       formData.description.trim() !== '' ||
       (formData.questions ?? []).some(
         (q, index) =>
-          index > 0 &&
-          (q.title.trim() !== '' || q.description.trim() !== ''),
+          index > 0 && (q.title.trim() !== '' || q.description.trim() !== ''),
       );
     if (
       hasUserInput &&

--- a/frontend/src/types/application.ts
+++ b/frontend/src/types/application.ts
@@ -89,7 +89,7 @@ export const ApplicationFormMode = {
 export type ApplicationFormMode =
   (typeof ApplicationFormMode)[keyof typeof ApplicationFormMode];
 
-export interface ApplicationDraftResponse {
+export interface ApplicationDraft {
   title: string;
   description: string;
   questions: Question[];

--- a/frontend/src/types/application.ts
+++ b/frontend/src/types/application.ts
@@ -88,3 +88,10 @@ export const ApplicationFormMode = {
 
 export type ApplicationFormMode =
   (typeof ApplicationFormMode)[keyof typeof ApplicationFormMode];
+
+export interface ApplicationDraftResponse {
+  title: string;
+  description: string;
+  questions: Question[];
+  aiGenerated: boolean;
+}


### PR DESCRIPTION
## 개요
관리자 지원서 편집 탭에 **원클릭 AI 초안 생성** 기능을 추가합니다. 동아리 상세정보를 바탕으로 백엔드가 지원서 초안(제목·설명·질문)을 생성하면, 프론트가 기존 폼 빌더에 주입합니다. UI는 새로 그리지 않고 기존 스키마 주도 폼을 그대로 활용합니다.

## 변경 사항 (프론트)
- `types/application.ts` — `ApplicationDraftResponse` 타입 추가
- `apis/application.ts` — `generateApplicationDraft()` (`POST /api/club/application/ai-draft`, `secureFetch`)
- `apis/application.test.ts` — API 함수 테스트 2개 (신규)
- `ApplicationEditTab.tsx` — `✨ AI로 초안 생성` 버튼 + mutation + 초안 주입
  - 신규 작성(`!formId`) · 모아동지원서(INTERNAL) 모드에서만 노출
  - 이름 질문(index 0) 유지 · id 재부여 · `nextId` 갱신
  - 작성 중 내용 있으면 덮어쓰기 `confirm`
  - `aiGenerated=false`(AI 실패 시 템플릿 폴백)면 안내
- `ApplicationEditTab.styles.ts` — `AiDraftButton`(헤더 우측 정렬, 토글 버튼과 크기 정렬)

## 백엔드
- 별도 레포(`moadong-be`)에서 구현 — 엔드포인트 `POST /api/club/application/ai-draft`.
- 프론트는 확정된 응답 계약(`{ title, description, questions[], aiGenerated }`)에 맞춰 구현. AI 실패 시에도 200 + 템플릿 문항.

## 검증
- `npm run typecheck` 클린, `npm run lint` 신규 에러 0
- 전체 테스트 통과 (신규 API 테스트 2개 포함)
- 로컬 백엔드 연동 E2E: 버튼→생성→폼 주입 동작 확인

## 참고
- 실제 AI 생성은 백엔드에 `ANTHROPIC_API_KEY` 필요.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 내부 지원서 신규 작성(내부 지원서 모드) 시 AI 초안 생성 버튼 제공
  * 생성된 제목/설명/질문이 지원서 작성 폼에 자동 반영
  * 입력 내용이 있는 경우 덮어쓰기 확인 후 생성 진행
* **개선 사항**
  * AI 생성 중 전 화면 로딩 오버레이 및 진행 상태 표시
  * 생성 실패 시 오류 안내와 기본 템플릿 제공
* **테스트**
  * AI 초안 생성 요청/응답 및 실패 시나리오 검증 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->