### PR TITLE
[refactor] AdminTabAdapter 도입 및 어드민 탭 모바일/데스크탑 분리

### DIFF
--- a/frontend/src/pages/AdminPage/AdminRoutes.tsx
+++ b/frontend/src/pages/AdminPage/AdminRoutes.tsx
@@ -1,6 +1,7 @@
 import { Navigate, Route, Routes } from 'react-router-dom';
 import useDevice from '@/hooks/useDevice';
 import AdminPage from '@/pages/AdminPage/AdminPage';
+import AdminTabAdapter from '@/pages/AdminPage/AdminTabAdapter';
 import AccountEditTab from '@/pages/AdminPage/tabs/AccountEditTab/AccountEditTab';
 import ApplicantDetailPage from '@/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPage';
 import ApplicantsListTab from '@/pages/AdminPage/tabs/ApplicantsTab/ApplicantsListTab/ApplicantsListTab';
@@ -9,7 +10,9 @@ import ApplicationEditTab from '@/pages/AdminPage/tabs/ApplicationEditTab/Applic
 import ApplicationListTab from '@/pages/AdminPage/tabs/ApplicationListTab/ApplicationListTab';
 import CalendarSyncTab from '@/pages/AdminPage/tabs/CalendarSyncTab/CalendarSyncTab';
 import ClubInfoEditTab from '@/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTab';
+import ClubInfoEditTabMobile from '@/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTabMobile';
 import ClubIntroEditTab from '@/pages/AdminPage/tabs/ClubIntroEditTab/ClubIntroEditTab';
+import ClubIntroEditTabMobile from '@/pages/AdminPage/tabs/ClubIntroEditTab/ClubIntroEditTabMobile';
 import PhotoEditTab from '@/pages/AdminPage/tabs/PhotoEditTab/PhotoEditTab';
 import RecruitEditTab from '@/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab';
 import SettingsTab from '@/pages/AdminPage/tabs/SettingsTab/SettingsTab';
@@ -25,11 +28,33 @@ export default function AdminRoutes() {
     <Routes>
       <Route path='' element={<AdminPage />}>
         <Route index element={<AdminIndexRoute />} />
-        <Route path='club-info' element={<ClubInfoEditTab />} />
-        <Route path='recruit-edit' element={<RecruitEditTab />} />
-        <Route path='calendar-sync' element={<CalendarSyncTab />} />
+
+        {/* 동아리 프로필 */}
+        <Route
+          path='club-info'
+          element={
+            <AdminTabAdapter
+              desktop={<ClubInfoEditTab />}
+              mobile={<ClubInfoEditTabMobile />}
+            />
+          }
+        />
+        <Route
+          path='club-intro'
+          element={
+            <AdminTabAdapter
+              desktop={<ClubIntroEditTab />}
+              mobile={<ClubIntroEditTabMobile />}
+            />
+          }
+        />
         <Route path='photo-edit' element={<PhotoEditTab />} />
-        <Route path='account-edit' element={<AccountEditTab />} />
+
+        {/* 동아리 활동 */}
+        <Route path='calendar-sync' element={<CalendarSyncTab />} />
+        <Route path='recruit-edit' element={<RecruitEditTab />} />
+
+        {/* 지원 관리 */}
         <Route path='application-list' element={<ApplicationListTab />} />
         <Route
           path='application-list/:applicationFormId/edit'
@@ -45,7 +70,9 @@ export default function AdminRoutes() {
           path='applicants-list/:applicationFormId/:questionId'
           element={<ApplicantDetailPage />}
         />
-        <Route path='club-intro' element={<ClubIntroEditTab />} />
+
+        {/* 계정 관리 */}
+        <Route path='account-edit' element={<AccountEditTab />} />
       </Route>
     </Routes>
   );

--- a/frontend/src/pages/AdminPage/AdminTabAdapter.tsx
+++ b/frontend/src/pages/AdminPage/AdminTabAdapter.tsx
@@ -1,0 +1,13 @@
+import useDevice from '@/hooks/useDevice';
+
+interface AdminTabAdapterProps {
+  desktop: React.ReactNode;
+  mobile: React.ReactNode;
+}
+
+const AdminTabAdapter = ({ desktop, mobile }: AdminTabAdapterProps) => {
+  const { isMobile, isTablet } = useDevice();
+  return <>{isMobile || isTablet ? mobile : desktop}</>;
+};
+
+export default AdminTabAdapter;

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTab.tsx
@@ -11,11 +11,9 @@ import {
 import { ADMIN_EVENT } from '@/constants/eventName';
 import { SNS_CONFIG } from '@/constants/snsConfig';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
-import useDevice from '@/hooks/useDevice';
 import ClubCoverEditor from '@/pages/AdminPage/components/ClubCoverEditor/ClubCoverEditor';
 import ClubLogoEditor from '@/pages/AdminPage/components/ClubLogoEditor/ClubLogoEditor';
 import { ContentSection } from '@/pages/AdminPage/components/ContentSection/ContentSection';
-import ClubInfoEditTabMobile from '@/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTabMobile';
 import MakeTags from '@/pages/AdminPage/tabs/ClubInfoEditTab/components/desktop/MakeTags/MakeTags';
 import SelectTags from '@/pages/AdminPage/tabs/ClubInfoEditTab/components/desktop/SelectTags/SelectTags';
 import { SNSPlatform } from '@/types/club';
@@ -26,7 +24,6 @@ import useClubInfoEdit, {
 } from './hooks/useClubInfoEdit';
 
 const ClubInfoEditTab = () => {
-  const { isMobile, isTablet } = useDevice();
   const trackEvent = useMixpanelTrack();
   const {
     clubDetail,
@@ -46,34 +43,7 @@ const ClubInfoEditTab = () => {
     setSnsErrors,
     handleSocialLinkChange,
     handleUpdateClub,
-    handleUpdateClubWithLinks,
-    handleUpdateClubWithTags,
-    isDirty,
   } = useClubInfoEdit();
-
-  if (isMobile || isTablet) {
-    return (
-      <ClubInfoEditTabMobile
-        clubDetail={clubDetail}
-        clubName={clubName}
-        setClubName={setClubName}
-        introduction={introduction}
-        setIntroduction={setIntroduction}
-        selectedCategory={selectedCategory}
-        setSelectedCategory={setSelectedCategory}
-        clubTags={clubTags}
-        setClubTags={setClubTags}
-        socialLinks={socialLinks}
-        onSocialLinksChange={(links) =>
-          setSocialLinks((prev) => ({ ...prev, ...links }))
-        }
-        handleUpdateClub={handleUpdateClub}
-        handleUpdateClubWithLinks={handleUpdateClubWithLinks}
-        handleUpdateClubWithTags={handleUpdateClubWithTags}
-        isDirty={isDirty}
-      />
-    );
-  }
 
   return (
     <Styled.Container>

--- a/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTabMobile.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubInfoEditTab/ClubInfoEditTabMobile.tsx
@@ -14,7 +14,6 @@ import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import MobileSaveButtonArea from '@/pages/AdminPage/components/MobileSaveButtonArea/MobileSaveButtonArea';
 import { TAG_COLORS } from '@/styles/clubTags';
 import { colors } from '@/styles/theme/colors';
-import { ClubDetail, SNSPlatform } from '@/types/club';
 import * as Styled from './ClubInfoEditTabMobile.styles';
 import EditField from './components/mobile/EditField/EditField';
 import FreeTagEditPage from './components/mobile/FreeTagEditPage/FreeTagEditPage';
@@ -22,51 +21,32 @@ import LinkEditPage from './components/mobile/LinkEditPage/LinkEditPage';
 import MobileBannerSection from './components/mobile/MobileBannerSection/MobileBannerSection';
 import NavField from './components/mobile/NavField/NavField';
 import TextField from './components/mobile/TextField/TextField';
-import { categories } from './hooks/useClubInfoEdit';
-
-interface ClubInfoEditTabMobileProps {
-  clubDetail: ClubDetail | null;
-  clubName: string;
-  setClubName: (v: string) => void;
-  introduction: string;
-  setIntroduction: (v: string) => void;
-  selectedCategory: string;
-  setSelectedCategory: (v: string) => void;
-  clubTags: string[];
-  setClubTags: (tags: string[]) => void;
-  socialLinks: Record<SNSPlatform, string>;
-  onSocialLinksChange: (links: { instagram: string; youtube: string }) => void;
-  handleUpdateClub: () => void;
-  handleUpdateClubWithLinks: (links: {
-    instagram: string;
-    youtube: string;
-  }) => void;
-  handleUpdateClubWithTags: (newTags: string[]) => void;
-  isDirty: boolean;
-}
+import useClubInfoEdit, { categories } from './hooks/useClubInfoEdit';
 
 type ActivePage = 'main' | 'freeTags' | 'links';
 
-const ClubInfoEditTabMobile = ({
-  clubDetail,
-  clubName,
-  setClubName,
-  introduction,
-  setIntroduction,
-  selectedCategory,
-  setSelectedCategory,
-  clubTags,
-  setClubTags,
-  socialLinks,
-  onSocialLinksChange,
-  handleUpdateClub,
-  handleUpdateClubWithLinks,
-  handleUpdateClubWithTags,
-  isDirty,
-}: ClubInfoEditTabMobileProps) => {
+const ClubInfoEditTabMobile = () => {
   const navigate = useNavigate();
   const trackEvent = useMixpanelTrack();
   const [activePage, setActivePage] = useState<ActivePage>('main');
+
+  const {
+    clubDetail,
+    clubName,
+    setClubName,
+    introduction,
+    setIntroduction,
+    selectedCategory,
+    setSelectedCategory,
+    clubTags,
+    setClubTags,
+    socialLinks,
+    setSocialLinks,
+    handleUpdateClub,
+    handleUpdateClubWithLinks,
+    handleUpdateClubWithTags,
+    isDirty,
+  } = useClubInfoEdit();
 
   const bannerColor = TAG_COLORS[selectedCategory] || colors.gray[400];
   const snsLinkCount = (['instagram', 'youtube'] as const).filter(
@@ -92,7 +72,7 @@ const ClubInfoEditTabMobile = ({
           instagram: socialLinks.instagram,
           youtube: socialLinks.youtube,
         }}
-        onSave={onSocialLinksChange}
+        onSave={(links) => setSocialLinks((prev) => ({ ...prev, ...links }))}
         onSaveToServer={handleUpdateClubWithLinks}
         onBack={() => setActivePage('main')}
       />

--- a/frontend/src/pages/AdminPage/tabs/ClubIntroEditTab/ClubIntroEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubIntroEditTab/ClubIntroEditTab.tsx
@@ -14,16 +14,13 @@ import {
 } from '@/constants/adminFieldPlaceholders';
 import { PAGE_VIEW } from '@/constants/eventName';
 import useTrackPageView from '@/hooks/Mixpanel/useTrackPageView';
-import useDevice from '@/hooks/useDevice';
 import { ContentSection } from '@/pages/AdminPage/components/ContentSection/ContentSection';
 import * as Styled from './ClubIntroEditTab.styles';
-import ClubIntroEditTabMobile from './ClubIntroEditTabMobile';
 import AwardEditor from './components/desktop/AwardEditor/AwardEditor';
 import FAQEditor from './components/desktop/FAQEditor/FAQEditor';
 import useClubIntroEdit from './hooks/useClubIntroEdit';
 
 const ClubIntroEditTab = () => {
-  const { isMobile, isTablet } = useDevice();
   useTrackPageView(PAGE_VIEW.CLUB_INTRO_EDIT_PAGE);
 
   const {
@@ -42,26 +39,6 @@ const ClubIntroEditTab = () => {
     isDirty,
     handleUpdateClub,
   } = useClubIntroEdit();
-
-  if (isMobile || isTablet) {
-    return (
-      <ClubIntroEditTabMobile
-        introDescription={introDescription}
-        setIntroDescription={setIntroDescription}
-        activityDescription={activityDescription}
-        setActivityDescription={setActivityDescription}
-        awards={awards}
-        idealCandidate={idealCandidate}
-        setIdealCandidate={setIdealCandidate}
-        benefits={benefits}
-        setBenefits={setBenefits}
-        faqs={faqs}
-        setFaqs={setFaqs}
-        isDirty={isDirty}
-        handleUpdateClub={handleUpdateClub}
-      />
-    );
-  }
 
   return (
     <Styled.Container>

--- a/frontend/src/pages/AdminPage/tabs/ClubIntroEditTab/ClubIntroEditTabMobile.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ClubIntroEditTab/ClubIntroEditTabMobile.tsx
@@ -14,44 +14,31 @@ import {
 } from '@/constants/adminFieldPlaceholders';
 import useAutoGrow from '@/hooks/useAutoGrow';
 import MobileSaveButtonArea from '@/pages/AdminPage/components/MobileSaveButtonArea/MobileSaveButtonArea';
-import { Award, FAQ, IdealCandidate } from '@/types/club';
 import * as Styled from './ClubIntroEditTabMobile.styles';
 import AwardSection from './components/mobile/AwardSection/AwardSection';
 import FAQSection from './components/mobile/FAQSection/FAQSection';
 import InfoSection from './components/mobile/InfoSection/InfoSection';
+import useClubIntroEdit from './hooks/useClubIntroEdit';
 
-interface ClubIntroEditTabMobileProps {
-  introDescription: string;
-  setIntroDescription: (v: string) => void;
-  activityDescription: string;
-  setActivityDescription: (v: string) => void;
-  awards: Award[];
-  idealCandidate: IdealCandidate;
-  setIdealCandidate: (v: IdealCandidate) => void;
-  benefits: string;
-  setBenefits: (v: string) => void;
-  faqs: FAQ[];
-  setFaqs: (v: FAQ[]) => void;
-  isDirty: boolean;
-  handleUpdateClub: () => void;
-}
-
-const ClubIntroEditTabMobile = ({
-  introDescription,
-  setIntroDescription,
-  activityDescription,
-  setActivityDescription,
-  awards,
-  idealCandidate,
-  setIdealCandidate,
-  benefits,
-  setBenefits,
-  faqs,
-  setFaqs,
-  isDirty,
-  handleUpdateClub,
-}: ClubIntroEditTabMobileProps) => {
+const ClubIntroEditTabMobile = () => {
   const navigate = useNavigate();
+
+  const {
+    introDescription,
+    setIntroDescription,
+    activityDescription,
+    setActivityDescription,
+    awards,
+    idealCandidate,
+    setIdealCandidate,
+    benefits,
+    setBenefits,
+    faqs,
+    setFaqs,
+    isDirty,
+    handleUpdateClub,
+  } = useClubIntroEdit();
+
   const introRef = useAutoGrow(introDescription);
   const activityRef = useAutoGrow(activityDescription);
   const idealRef = useAutoGrow(idealCandidate.content);


### PR DESCRIPTION
## #️⃣연관된 이슈

#1840

## 📝작업 내용

어드민 탭의 모바일/데스크탑 분기 로직을 기존 각 탭 컴포넌트에서 분리하여 `AdminTabAdapter`로 중앙화했습니다.

### 변경 내용

**`AdminTabAdapter` 도입**
- `useDevice`로 device를 감지해 `desktop` / `mobile` 중 하나를 렌더링하는 전담 컴포넌트 추가
- 앞으로 모바일을 지원하는 탭은 `AdminRoutes`에서 `AdminTabAdapter`로 감싸는 방식으로 일관되게 확장 가능

**`AdminRoutes` 라우트 구조 개선**
- `AdminTabAdapter` 적용 (`club-info`, `club-intro`)
- 카테고리 주석(`동아리 프로필` / `동아리 활동` / `지원 관리` / `계정 관리`)으로 라우트 그룹 명확화
- 라우트 순서를 `ADMIN_TABS` 상수 순서와 일치하도록 정렬

**`ClubInfoEditTab` / `ClubIntroEditTab` 모바일 컴포넌트 독립화**
- Desktop 컴포넌트에서 `useDevice` 분기 제거 → 데스크탑 렌더링만 담당
- Mobile 컴포넌트가 부모로부터 props를 받는 대신 훅을 직접 호출하도록 변경 → 완전히 독립적으로 동작

### Before / After

**Before**: 각 탭이 훅 호출 → device 분기 → mobile에 props 전달
```
ClubInfoEditTab
  ├─ useClubInfoEdit() ← 모바일에서도 실행됨
  ├─ if (isMobile) return <ClubInfoEditTabMobile ...12개 props />
  └─ return <Desktop />
```

**After**: `AdminTabAdapter`가 분기, 각 컴포넌트는 독립
```
AdminTabAdapter (useDevice)
  ├─ <ClubInfoEditTab />   ← 데스크탑에서만 useClubInfoEdit 호출
  └─ <ClubInfoEditTabMobile /> ← 모바일에서만 useClubInfoEdit 호출
```

## 중점적으로 리뷰받고 싶은 부분(선택)

- `AdminTabAdapter`의 props 타입으로 `React.ReactNode`를 사용한 것이 적절한지 (vs `React.ComponentType`)

## 🫡 참고사항

- `PhotoEditTab`은 별도 브랜치(`feature/#1839`)에서 동일한 패턴으로 작업 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 관리자 페이지의 동아리 프로필 편집 화면이 기기 유형에 맞는 데스크톱·모바일 레이아웃을 제공합니다.
  * 동아리 정보 및 소개 편집 기능이 모바일과 태블릿 환경에 최적화되었습니다.
* **개선 사항**
  * 동아리 정보와 소개 편집 상태가 화면 간 일관되게 유지됩니다.
  * 관리자 메뉴가 동아리 프로필, 활동, 지원 관리, 계정 관리 영역으로 명확하게 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->