### PR TITLE
feat(calendar): 커스텀 캘린더 이벤트 CRUD 및 OAuth 이벤트 숨김 기능 추가

### DIFF
--- a/backend/src/main/java/moadong/calendar/custom/controller/CustomCalendarEventController.java
+++ b/backend/src/main/java/moadong/calendar/custom/controller/CustomCalendarEventController.java
@@ -1,0 +1,68 @@
+package moadong.calendar.custom.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import moadong.calendar.custom.payload.request.CustomCalendarEventRequest;
+import moadong.calendar.custom.service.CustomCalendarEventService;
+import moadong.global.payload.Response;
+import moadong.user.annotation.CurrentUser;
+import moadong.user.payload.CustomUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/integration/custom-events")
+@RequiredArgsConstructor
+@Tag(name = "Custom Calendar Events", description = "커스텀 캘린더 이벤트 관리 API")
+public class CustomCalendarEventController {
+
+    private final CustomCalendarEventService customCalendarEventService;
+
+    @PostMapping
+    @Operation(summary = "커스텀 캘린더 이벤트 생성", description = "관리자가 직접 입력한 캘린더 이벤트를 생성합니다.")
+    @PreAuthorize("isAuthenticated()")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> createEvent(@CurrentUser CustomUserDetails user,
+                                         @RequestBody @Valid CustomCalendarEventRequest request) {
+        return Response.ok(customCalendarEventService.create(user, request));
+    }
+
+    @GetMapping
+    @Operation(summary = "커스텀 캘린더 이벤트 목록 조회", description = "동아리의 커스텀 캘린더 이벤트 목록을 조회합니다.")
+    @PreAuthorize("isAuthenticated()")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> getEvents(@CurrentUser CustomUserDetails user) {
+        return Response.ok(customCalendarEventService.list(user));
+    }
+
+    @PutMapping("/{eventId}")
+    @Operation(summary = "커스텀 캘린더 이벤트 수정", description = "커스텀 캘린더 이벤트를 수정합니다.")
+    @PreAuthorize("isAuthenticated()")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> updateEvent(@CurrentUser CustomUserDetails user,
+                                         @PathVariable String eventId,
+                                         @RequestBody @Valid CustomCalendarEventRequest request) {
+        return Response.ok(customCalendarEventService.update(user, eventId, request));
+    }
+
+    @DeleteMapping("/{eventId}")
+    @Operation(summary = "커스텀 캘린더 이벤트 삭제", description = "커스텀 캘린더 이벤트를 삭제합니다.")
+    @PreAuthorize("isAuthenticated()")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> deleteEvent(@CurrentUser CustomUserDetails user,
+                                         @PathVariable String eventId) {
+        customCalendarEventService.delete(user, eventId);
+        return Response.ok("커스텀 캘린더 이벤트가 삭제되었습니다.");
+    }
+}

--- a/backend/src/main/java/moadong/calendar/custom/controller/CustomCalendarEventController.java
+++ b/backend/src/main/java/moadong/calendar/custom/controller/CustomCalendarEventController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -57,12 +58,15 @@ public class CustomCalendarEventController {
     }
 
     @DeleteMapping("/{eventId}")
-    @Operation(summary = "커스텀 캘린더 이벤트 삭제", description = "커스텀 캘린더 이벤트를 삭제합니다.")
+    @Operation(summary = "커스텀 캘린더 이벤트 삭제",
+            description = "커스텀 캘린더 이벤트를 삭제합니다. 반복 일정은 scope(ALL/THIS/THIS_AND_FOLLOWING)와 기준 발생일 date로 삭제 범위를 지정합니다.")
     @PreAuthorize("isAuthenticated()")
     @SecurityRequirement(name = "BearerAuth")
     public ResponseEntity<?> deleteEvent(@CurrentUser CustomUserDetails user,
-                                         @PathVariable String eventId) {
-        customCalendarEventService.delete(user, eventId);
+                                         @PathVariable String eventId,
+                                         @RequestParam(required = false) String scope,
+                                         @RequestParam(required = false) String date) {
+        customCalendarEventService.delete(user, eventId, scope, date);
         return Response.ok("커스텀 캘린더 이벤트가 삭제되었습니다.");
     }
 }

--- a/backend/src/main/java/moadong/calendar/custom/entity/CustomCalendarEvent.java
+++ b/backend/src/main/java/moadong/calendar/custom/entity/CustomCalendarEvent.java
@@ -1,0 +1,45 @@
+package moadong.calendar.custom.entity;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document("custom_calendar_events")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CustomCalendarEvent {
+
+    @Id
+    private String id;
+
+    @Indexed
+    private String clubId;
+
+    private String title;
+
+    private String start;
+
+    private String end;
+
+    private String url;
+
+    private String description;
+
+    private LocalDateTime updatedAt;
+
+    public void update(String title, String start, String end, String url, String description) {
+        this.title = title;
+        this.start = start;
+        this.end = end;
+        this.url = url;
+        this.description = description;
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/moadong/calendar/custom/entity/CustomCalendarEvent.java
+++ b/backend/src/main/java/moadong/calendar/custom/entity/CustomCalendarEvent.java
@@ -1,6 +1,7 @@
 package moadong.calendar.custom.entity;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -32,14 +33,43 @@ public class CustomCalendarEvent {
 
     private String description;
 
+    private String eventType;
+
+    private String color;
+
+    private List<String> dates;
+
+    private CustomEventRecurrence recurrence;
+
     private LocalDateTime updatedAt;
 
-    public void update(String title, String start, String end, String url, String description) {
+    public void update(String title, String start, String end, String url, String description,
+                       String eventType, String color, List<String> dates, CustomEventRecurrence recurrence) {
         this.title = title;
         this.start = start;
         this.end = end;
         this.url = url;
         this.description = description;
+        this.eventType = eventType;
+        this.color = color;
+        this.dates = dates;
+        this.recurrence = recurrence;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void excludeDate(String date) {
+        if (recurrence == null) {
+            return;
+        }
+        this.recurrence = recurrence.withExcludedDate(date);
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updateRecurrenceEnd(String recurrenceEnd) {
+        if (recurrence == null) {
+            return;
+        }
+        this.recurrence = recurrence.withEnd(recurrenceEnd);
         this.updatedAt = LocalDateTime.now();
     }
 }

--- a/backend/src/main/java/moadong/calendar/custom/entity/CustomCalendarEvent.java
+++ b/backend/src/main/java/moadong/calendar/custom/entity/CustomCalendarEvent.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import moadong.calendar.custom.payload.request.CustomCalendarEventRequest;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -43,17 +44,16 @@ public class CustomCalendarEvent {
 
     private LocalDateTime updatedAt;
 
-    public void update(String title, String start, String end, String url, String description,
-                       String eventType, String color, List<String> dates, CustomEventRecurrence recurrence) {
-        this.title = title;
-        this.start = start;
-        this.end = end;
-        this.url = url;
-        this.description = description;
+    public void update(CustomCalendarEventRequest request, String eventType) {
+        this.title = request.title();
+        this.start = request.start();
+        this.end = request.end();
+        this.url = request.url();
+        this.description = request.description();
         this.eventType = eventType;
-        this.color = color;
-        this.dates = dates;
-        this.recurrence = recurrence;
+        this.color = request.color();
+        this.dates = request.dates();
+        this.recurrence = request.recurrence();
         this.updatedAt = LocalDateTime.now();
     }
 

--- a/backend/src/main/java/moadong/calendar/custom/entity/CustomEventRecurrence.java
+++ b/backend/src/main/java/moadong/calendar/custom/entity/CustomEventRecurrence.java
@@ -1,0 +1,23 @@
+package moadong.calendar.custom.entity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public record CustomEventRecurrence(
+        String frequency,
+        List<Integer> weekdays,
+        String end,
+        List<String> excludedDates
+) {
+    public CustomEventRecurrence withExcludedDate(String date) {
+        List<String> updated = excludedDates == null ? new ArrayList<>() : new ArrayList<>(excludedDates);
+        if (!updated.contains(date)) {
+            updated.add(date);
+        }
+        return new CustomEventRecurrence(frequency, weekdays, end, updated);
+    }
+
+    public CustomEventRecurrence withEnd(String newEnd) {
+        return new CustomEventRecurrence(frequency, weekdays, newEnd, excludedDates);
+    }
+}

--- a/backend/src/main/java/moadong/calendar/custom/payload/request/CustomCalendarEventRequest.java
+++ b/backend/src/main/java/moadong/calendar/custom/payload/request/CustomCalendarEventRequest.java
@@ -1,0 +1,12 @@
+package moadong.calendar.custom.payload.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CustomCalendarEventRequest(
+        @NotBlank String title,
+        @NotBlank String start,
+        String end,
+        String url,
+        String description
+) {
+}

--- a/backend/src/main/java/moadong/calendar/custom/payload/request/CustomCalendarEventRequest.java
+++ b/backend/src/main/java/moadong/calendar/custom/payload/request/CustomCalendarEventRequest.java
@@ -1,12 +1,18 @@
 package moadong.calendar.custom.payload.request;
 
 import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+import moadong.calendar.custom.entity.CustomEventRecurrence;
 
 public record CustomCalendarEventRequest(
         @NotBlank String title,
         @NotBlank String start,
         String end,
         String url,
-        String description
+        String description,
+        String eventType,
+        String color,
+        List<String> dates,
+        CustomEventRecurrence recurrence
 ) {
 }

--- a/backend/src/main/java/moadong/calendar/custom/payload/response/CustomCalendarEventResponse.java
+++ b/backend/src/main/java/moadong/calendar/custom/payload/response/CustomCalendarEventResponse.java
@@ -1,0 +1,35 @@
+package moadong.calendar.custom.payload.response;
+
+import java.util.List;
+import moadong.calendar.custom.entity.CustomCalendarEvent;
+import moadong.calendar.custom.entity.CustomEventRecurrence;
+
+public record CustomCalendarEventResponse(
+        String id,
+        String title,
+        String start,
+        String end,
+        String url,
+        String description,
+        String source,
+        String eventType,
+        String color,
+        List<String> dates,
+        CustomEventRecurrence recurrence
+) {
+    public static CustomCalendarEventResponse from(CustomCalendarEvent event) {
+        return new CustomCalendarEventResponse(
+                event.getId(),
+                event.getTitle(),
+                event.getStart(),
+                event.getEnd(),
+                event.getUrl(),
+                event.getDescription(),
+                "CUSTOM",
+                event.getEventType() == null ? "SINGLE" : event.getEventType(),
+                event.getColor(),
+                event.getDates(),
+                event.getRecurrence()
+        );
+    }
+}

--- a/backend/src/main/java/moadong/calendar/custom/repository/CustomCalendarEventRepository.java
+++ b/backend/src/main/java/moadong/calendar/custom/repository/CustomCalendarEventRepository.java
@@ -1,0 +1,17 @@
+package moadong.calendar.custom.repository;
+
+import java.util.List;
+import java.util.Optional;
+import moadong.calendar.custom.entity.CustomCalendarEvent;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface CustomCalendarEventRepository extends MongoRepository<CustomCalendarEvent, String> {
+
+    List<CustomCalendarEvent> findByClubId(String clubId);
+
+    Optional<CustomCalendarEvent> findByIdAndClubId(String id, String clubId);
+
+    long deleteByIdAndClubId(String id, String clubId);
+
+    boolean existsByClubId(String clubId);
+}

--- a/backend/src/main/java/moadong/calendar/custom/repository/CustomCalendarEventRepository.java
+++ b/backend/src/main/java/moadong/calendar/custom/repository/CustomCalendarEventRepository.java
@@ -11,7 +11,5 @@ public interface CustomCalendarEventRepository extends MongoRepository<CustomCal
 
     Optional<CustomCalendarEvent> findByIdAndClubId(String id, String clubId);
 
-    long deleteByIdAndClubId(String id, String clubId);
-
     boolean existsByClubId(String clubId);
 }

--- a/backend/src/main/java/moadong/calendar/custom/service/CustomCalendarEventService.java
+++ b/backend/src/main/java/moadong/calendar/custom/service/CustomCalendarEventService.java
@@ -1,0 +1,107 @@
+package moadong.calendar.custom.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import moadong.calendar.custom.entity.CustomCalendarEvent;
+import moadong.calendar.custom.payload.request.CustomCalendarEventRequest;
+import moadong.calendar.custom.repository.CustomCalendarEventRepository;
+import moadong.club.entity.Club;
+import moadong.club.payload.dto.ClubCalendarEventResult;
+import moadong.club.repository.ClubRepository;
+import moadong.global.exception.ErrorCode;
+import moadong.global.exception.RestApiException;
+import moadong.user.payload.CustomUserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+public class CustomCalendarEventService {
+
+    private final CustomCalendarEventRepository customCalendarEventRepository;
+    private final ClubRepository clubRepository;
+
+    public ClubCalendarEventResult create(CustomUserDetails user, CustomCalendarEventRequest request) {
+        String clubId = requireAuthenticatedClubId(user);
+
+        CustomCalendarEvent event = CustomCalendarEvent.builder()
+                .clubId(clubId)
+                .title(request.title())
+                .start(request.start())
+                .end(request.end())
+                .url(request.url())
+                .description(request.description())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        return toResult(customCalendarEventRepository.save(event));
+    }
+
+    public List<ClubCalendarEventResult> list(CustomUserDetails user) {
+        String clubId = requireAuthenticatedClubId(user);
+        return getClubCalendarEvents(clubId);
+    }
+
+    public ClubCalendarEventResult update(CustomUserDetails user, String eventId, CustomCalendarEventRequest request) {
+        String clubId = requireAuthenticatedClubId(user);
+
+        CustomCalendarEvent event = customCalendarEventRepository.findByIdAndClubId(eventId, clubId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.CUSTOM_EVENT_NOT_FOUND));
+
+        event.update(request.title(), request.start(), request.end(), request.url(), request.description());
+
+        return toResult(customCalendarEventRepository.save(event));
+    }
+
+    public void delete(CustomUserDetails user, String eventId) {
+        String clubId = requireAuthenticatedClubId(user);
+
+        long deletedCount = customCalendarEventRepository.deleteByIdAndClubId(eventId, clubId);
+        if (deletedCount == 0) {
+            throw new RestApiException(ErrorCode.CUSTOM_EVENT_NOT_FOUND);
+        }
+    }
+
+    public List<ClubCalendarEventResult> getClubCalendarEvents(String clubId) {
+        if (!StringUtils.hasText(clubId)) {
+            return List.of();
+        }
+
+        return customCalendarEventRepository.findByClubId(clubId).stream()
+                .map(this::toResult)
+                .toList();
+    }
+
+    public boolean hasCalendarConnection(String clubId) {
+        if (!StringUtils.hasText(clubId)) {
+            return false;
+        }
+        return customCalendarEventRepository.existsByClubId(clubId);
+    }
+
+    private ClubCalendarEventResult toResult(CustomCalendarEvent event) {
+        return ClubCalendarEventResult.ofCustom(
+                event.getId(),
+                event.getTitle(),
+                event.getStart(),
+                event.getEnd(),
+                event.getUrl(),
+                event.getDescription()
+        );
+    }
+
+    private String requireAuthenticatedClubId(CustomUserDetails user) {
+        if (user == null || !StringUtils.hasText(user.getId())) {
+            throw new RestApiException(ErrorCode.USER_UNAUTHORIZED);
+        }
+
+        Club club = clubRepository.findClubByUserId(user.getId())
+                .orElseThrow(() -> new RestApiException(ErrorCode.CUSTOM_EVENT_CLUB_NOT_FOUND));
+
+        if (!StringUtils.hasText(club.getId())) {
+            throw new RestApiException(ErrorCode.CUSTOM_EVENT_CLUB_NOT_FOUND);
+        }
+        return club.getId();
+    }
+}

--- a/backend/src/main/java/moadong/calendar/custom/service/CustomCalendarEventService.java
+++ b/backend/src/main/java/moadong/calendar/custom/service/CustomCalendarEventService.java
@@ -126,6 +126,7 @@ public class CustomCalendarEventService {
 
     /**
      * 공개 캘린더는 발생일마다 하나씩 펼쳐 내려준다.
+     * 단, PERIOD는 start/end를 가진 한 건으로 유지해 프론트가 연속 막대로 그릴 수 있게 한다.
      * 발생일이 여러 개면 프론트에서 구분할 수 있도록 id에 날짜를 덧붙인다.
      */
     private List<ClubCalendarEventResult> toPublicResults(CustomCalendarEvent event) {
@@ -135,6 +136,8 @@ public class CustomCalendarEventService {
             return List.of();
         }
 
+        String eventType = StringUtils.hasText(event.getEventType()) ? event.getEventType() : "SINGLE";
+
         if (occurrences.size() == 1) {
             return List.of(ClubCalendarEventResult.ofCustom(
                     event.getId(),
@@ -142,7 +145,9 @@ public class CustomCalendarEventService {
                     occurrences.get(0),
                     event.getEnd(),
                     event.getUrl(),
-                    event.getDescription()
+                    event.getDescription(),
+                    eventType,
+                    event.getColor()
             ));
         }
 
@@ -153,7 +158,9 @@ public class CustomCalendarEventService {
                         date,
                         null,
                         event.getUrl(),
-                        event.getDescription()
+                        event.getDescription(),
+                        eventType,
+                        event.getColor()
                 ))
                 .toList();
     }

--- a/backend/src/main/java/moadong/calendar/custom/service/CustomCalendarEventService.java
+++ b/backend/src/main/java/moadong/calendar/custom/service/CustomCalendarEventService.java
@@ -1,5 +1,7 @@
 package moadong.calendar.custom.service;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -27,6 +29,7 @@ public class CustomCalendarEventService {
     private static final Set<String> COLORS = Set.of("PINK", "YELLOW", "MINT", "BLUE", "PURPLE", "ORANGE");
     private static final Set<String> FREQUENCIES = Set.of("WEEKLY", "MONTHLY", "YEARLY");
     private static final Set<String> DELETE_SCOPES = Set.of("ALL", "THIS", "THIS_AND_FOLLOWING");
+    private static final int MAX_EVENT_DATES = 365;
 
     private final CustomCalendarEventRepository customCalendarEventRepository;
     private final ClubRepository clubRepository;
@@ -69,8 +72,7 @@ public class CustomCalendarEventService {
         CustomCalendarEvent event = customCalendarEventRepository.findByIdAndClubId(eventId, clubId)
                 .orElseThrow(() -> new RestApiException(ErrorCode.CUSTOM_EVENT_NOT_FOUND));
 
-        event.update(request.title(), request.start(), request.end(), request.url(), request.description(),
-                eventType, request.color(), request.dates(), request.recurrence());
+        event.update(request, eventType);
 
         return CustomCalendarEventResponse.from(customCalendarEventRepository.save(event));
     }
@@ -174,7 +176,12 @@ public class CustomCalendarEventService {
         LocalDate start = validateDates(request.start(), request.end());
         String eventType = resolveEventType(request.eventType());
         validateAllowedValue(request.color(), COLORS);
+        validateUrl(request.url());
 
+        validateCollectionSize(request.dates());
+        if ("MULTI".equals(eventType) && (request.dates() == null || request.dates().isEmpty())) {
+            throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
+        }
         if (request.dates() != null) {
             request.dates().forEach(this::parseRequiredDate);
             if (!request.dates().isEmpty() && !request.start().equals(request.dates().get(0))) {
@@ -195,6 +202,7 @@ public class CustomCalendarEventService {
         }
 
         validateRequiredAllowedValue(recurrence.frequency(), FREQUENCIES);
+        validateCollectionSize(recurrence.weekdays());
         validateWeekdays(recurrence.weekdays());
 
         if (StringUtils.hasText(recurrence.end())) {
@@ -204,6 +212,7 @@ public class CustomCalendarEventService {
             }
         }
         if (recurrence.excludedDates() != null) {
+            validateCollectionSize(recurrence.excludedDates());
             recurrence.excludedDates().forEach(this::parseRequiredDate);
         }
         return eventType;
@@ -235,6 +244,26 @@ public class CustomCalendarEventService {
         }
         boolean hasInvalidWeekday = weekdays.stream().anyMatch(weekday -> weekday == null || weekday < 0 || weekday > 6);
         if (hasInvalidWeekday) {
+            throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
+        }
+    }
+
+    private void validateCollectionSize(List<?> values) {
+        if (values != null && values.size() > MAX_EVENT_DATES) {
+            throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
+        }
+    }
+
+    private void validateUrl(String url) {
+        if (!StringUtils.hasText(url)) {
+            return;
+        }
+        try {
+            String scheme = new URI(url).getScheme();
+            if (!"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme)) {
+                throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
+            }
+        } catch (URISyntaxException e) {
             throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
         }
     }

--- a/backend/src/main/java/moadong/calendar/custom/service/CustomCalendarEventService.java
+++ b/backend/src/main/java/moadong/calendar/custom/service/CustomCalendarEventService.java
@@ -3,9 +3,12 @@ package moadong.calendar.custom.service;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import moadong.calendar.custom.entity.CustomCalendarEvent;
+import moadong.calendar.custom.entity.CustomEventRecurrence;
 import moadong.calendar.custom.payload.request.CustomCalendarEventRequest;
+import moadong.calendar.custom.payload.response.CustomCalendarEventResponse;
 import moadong.calendar.custom.repository.CustomCalendarEventRepository;
 import moadong.club.entity.Club;
 import moadong.club.payload.dto.ClubCalendarEventResult;
@@ -20,12 +23,18 @@ import org.springframework.util.StringUtils;
 @RequiredArgsConstructor
 public class CustomCalendarEventService {
 
+    private static final Set<String> EVENT_TYPES = Set.of("SINGLE", "PERIOD", "RECURRING", "MULTI");
+    private static final Set<String> COLORS = Set.of("PINK", "YELLOW", "MINT", "BLUE", "PURPLE", "ORANGE");
+    private static final Set<String> FREQUENCIES = Set.of("WEEKLY", "MONTHLY", "YEARLY");
+    private static final Set<String> DELETE_SCOPES = Set.of("ALL", "THIS", "THIS_AND_FOLLOWING");
+
     private final CustomCalendarEventRepository customCalendarEventRepository;
     private final ClubRepository clubRepository;
+    private final CustomEventOccurrenceExpander occurrenceExpander;
 
-    public ClubCalendarEventResult create(CustomUserDetails user, CustomCalendarEventRequest request) {
+    public CustomCalendarEventResponse create(CustomUserDetails user, CustomCalendarEventRequest request) {
         String clubId = requireAuthenticatedClubId(user);
-        validateDates(request.start(), request.end());
+        String eventType = validateRequest(request);
 
         CustomCalendarEvent event = CustomCalendarEvent.builder()
                 .clubId(clubId)
@@ -34,36 +43,66 @@ public class CustomCalendarEventService {
                 .end(request.end())
                 .url(request.url())
                 .description(request.description())
+                .eventType(eventType)
+                .color(request.color())
+                .dates(request.dates())
+                .recurrence(request.recurrence())
                 .updatedAt(LocalDateTime.now())
                 .build();
 
-        return toResult(customCalendarEventRepository.save(event));
+        return CustomCalendarEventResponse.from(customCalendarEventRepository.save(event));
     }
 
-    public List<ClubCalendarEventResult> list(CustomUserDetails user) {
+    public List<CustomCalendarEventResponse> list(CustomUserDetails user) {
         String clubId = requireAuthenticatedClubId(user);
-        return getClubCalendarEvents(clubId);
+
+        return customCalendarEventRepository.findByClubId(clubId).stream()
+                .map(CustomCalendarEventResponse::from)
+                .toList();
     }
 
-    public ClubCalendarEventResult update(CustomUserDetails user, String eventId, CustomCalendarEventRequest request) {
+    public CustomCalendarEventResponse update(CustomUserDetails user, String eventId,
+                                              CustomCalendarEventRequest request) {
         String clubId = requireAuthenticatedClubId(user);
-        validateDates(request.start(), request.end());
+        String eventType = validateRequest(request);
 
         CustomCalendarEvent event = customCalendarEventRepository.findByIdAndClubId(eventId, clubId)
                 .orElseThrow(() -> new RestApiException(ErrorCode.CUSTOM_EVENT_NOT_FOUND));
 
-        event.update(request.title(), request.start(), request.end(), request.url(), request.description());
+        event.update(request.title(), request.start(), request.end(), request.url(), request.description(),
+                eventType, request.color(), request.dates(), request.recurrence());
 
-        return toResult(customCalendarEventRepository.save(event));
+        return CustomCalendarEventResponse.from(customCalendarEventRepository.save(event));
     }
 
-    public void delete(CustomUserDetails user, String eventId) {
+    public void delete(CustomUserDetails user, String eventId, String scope, String date) {
         String clubId = requireAuthenticatedClubId(user);
+        String resolvedScope = resolveDeleteScope(scope);
 
-        long deletedCount = customCalendarEventRepository.deleteByIdAndClubId(eventId, clubId);
-        if (deletedCount == 0) {
-            throw new RestApiException(ErrorCode.CUSTOM_EVENT_NOT_FOUND);
+        CustomCalendarEvent event = customCalendarEventRepository.findByIdAndClubId(eventId, clubId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.CUSTOM_EVENT_NOT_FOUND));
+
+        if ("ALL".equals(resolvedScope) || !isRecurring(event)) {
+            customCalendarEventRepository.delete(event);
+            return;
         }
+
+        LocalDate targetDate = parseRequiredDate(date);
+
+        if ("THIS".equals(resolvedScope)) {
+            event.excludeDate(targetDate.toString());
+            customCalendarEventRepository.save(event);
+            return;
+        }
+
+        LocalDate newRecurrenceEnd = targetDate.minusDays(1);
+        if (newRecurrenceEnd.isBefore(parseRequiredDate(event.getStart()))) {
+            customCalendarEventRepository.delete(event);
+            return;
+        }
+
+        event.updateRecurrenceEnd(newRecurrenceEnd.toString());
+        customCalendarEventRepository.save(event);
     }
 
     public List<ClubCalendarEventResult> getClubCalendarEvents(String clubId) {
@@ -72,7 +111,7 @@ public class CustomCalendarEventService {
         }
 
         return customCalendarEventRepository.findByClubId(clubId).stream()
-                .map(this::toResult)
+                .flatMap(event -> toPublicResults(event).stream())
                 .toList();
     }
 
@@ -83,39 +122,142 @@ public class CustomCalendarEventService {
         return customCalendarEventRepository.existsByClubId(clubId);
     }
 
-    private void validateDates(String start, String end) {
-        LocalDate parsedStart;
-        try {
-            parsedStart = LocalDate.parse(start);
-        } catch (Exception e) {
-            throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_DATE_FORMAT);
+    /**
+     * 공개 캘린더는 발생일마다 하나씩 펼쳐 내려준다.
+     * 발생일이 여러 개면 프론트에서 구분할 수 있도록 id에 날짜를 덧붙인다.
+     */
+    private List<ClubCalendarEventResult> toPublicResults(CustomCalendarEvent event) {
+        List<String> occurrences = occurrenceExpander.expand(event);
+
+        if (occurrences.isEmpty()) {
+            return List.of();
         }
 
-        if (!StringUtils.hasText(end)) {
-            return;
+        if (occurrences.size() == 1) {
+            return List.of(ClubCalendarEventResult.ofCustom(
+                    event.getId(),
+                    event.getTitle(),
+                    occurrences.get(0),
+                    event.getEnd(),
+                    event.getUrl(),
+                    event.getDescription()
+            ));
         }
 
-        LocalDate parsedEnd;
-        try {
-            parsedEnd = LocalDate.parse(end);
-        } catch (Exception e) {
-            throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_DATE_FORMAT);
+        return occurrences.stream()
+                .map(date -> ClubCalendarEventResult.ofCustom(
+                        event.getId() + ":" + date,
+                        event.getTitle(),
+                        date,
+                        null,
+                        event.getUrl(),
+                        event.getDescription()
+                ))
+                .toList();
+    }
+
+    private boolean isRecurring(CustomCalendarEvent event) {
+        return "RECURRING".equals(event.getEventType()) && event.getRecurrence() != null;
+    }
+
+    private String resolveDeleteScope(String scope) {
+        if (!StringUtils.hasText(scope)) {
+            return "ALL";
+        }
+        if (!DELETE_SCOPES.contains(scope)) {
+            throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_DELETE_SCOPE);
+        }
+        return scope;
+    }
+
+    private String validateRequest(CustomCalendarEventRequest request) {
+        LocalDate start = validateDates(request.start(), request.end());
+        String eventType = resolveEventType(request.eventType());
+        validateAllowedValue(request.color(), COLORS);
+
+        if (request.dates() != null) {
+            request.dates().forEach(this::parseRequiredDate);
+            if (!request.dates().isEmpty() && !request.start().equals(request.dates().get(0))) {
+                throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
+            }
         }
 
-        if (parsedStart.isAfter(parsedEnd)) {
-            throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_DATE_RANGE);
+        CustomEventRecurrence recurrence = request.recurrence();
+        if (recurrence == null) {
+            if ("RECURRING".equals(eventType)) {
+                throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
+            }
+            return eventType;
+        }
+
+        if (!"RECURRING".equals(eventType)) {
+            throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
+        }
+
+        validateRequiredAllowedValue(recurrence.frequency(), FREQUENCIES);
+        validateWeekdays(recurrence.weekdays());
+
+        if (StringUtils.hasText(recurrence.end())) {
+            LocalDate recurrenceEnd = parseRequiredDate(recurrence.end());
+            if (start.isAfter(recurrenceEnd)) {
+                throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_DATE_RANGE);
+            }
+        }
+        if (recurrence.excludedDates() != null) {
+            recurrence.excludedDates().forEach(this::parseRequiredDate);
+        }
+        return eventType;
+    }
+
+    private String resolveEventType(String eventType) {
+        if (!StringUtils.hasText(eventType)) {
+            return "SINGLE";
+        }
+        validateAllowedValue(eventType, EVENT_TYPES);
+        return eventType;
+    }
+
+    private void validateAllowedValue(String value, Set<String> allowedValues) {
+        if (StringUtils.hasText(value) && !allowedValues.contains(value)) {
+            throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
         }
     }
 
-    private ClubCalendarEventResult toResult(CustomCalendarEvent event) {
-        return ClubCalendarEventResult.ofCustom(
-                event.getId(),
-                event.getTitle(),
-                event.getStart(),
-                event.getEnd(),
-                event.getUrl(),
-                event.getDescription()
-        );
+    private void validateRequiredAllowedValue(String value, Set<String> allowedValues) {
+        if (!StringUtils.hasText(value) || !allowedValues.contains(value)) {
+            throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
+        }
+    }
+
+    private void validateWeekdays(List<Integer> weekdays) {
+        if (weekdays == null) {
+            return;
+        }
+        boolean hasInvalidWeekday = weekdays.stream().anyMatch(weekday -> weekday == null || weekday < 0 || weekday > 6);
+        if (hasInvalidWeekday) {
+            throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
+        }
+    }
+
+    private LocalDate validateDates(String start, String end) {
+        LocalDate parsedStart = parseRequiredDate(start);
+
+        if (!StringUtils.hasText(end)) {
+            return parsedStart;
+        }
+
+        if (parsedStart.isAfter(parseRequiredDate(end))) {
+            throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_DATE_RANGE);
+        }
+        return parsedStart;
+    }
+
+    private LocalDate parseRequiredDate(String value) {
+        try {
+            return LocalDate.parse(value);
+        } catch (Exception e) {
+            throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_DATE_FORMAT);
+        }
     }
 
     private String requireAuthenticatedClubId(CustomUserDetails user) {

--- a/backend/src/main/java/moadong/calendar/custom/service/CustomCalendarEventService.java
+++ b/backend/src/main/java/moadong/calendar/custom/service/CustomCalendarEventService.java
@@ -1,5 +1,6 @@
 package moadong.calendar.custom.service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +25,7 @@ public class CustomCalendarEventService {
 
     public ClubCalendarEventResult create(CustomUserDetails user, CustomCalendarEventRequest request) {
         String clubId = requireAuthenticatedClubId(user);
+        validateDates(request.start(), request.end());
 
         CustomCalendarEvent event = CustomCalendarEvent.builder()
                 .clubId(clubId)
@@ -45,6 +47,7 @@ public class CustomCalendarEventService {
 
     public ClubCalendarEventResult update(CustomUserDetails user, String eventId, CustomCalendarEventRequest request) {
         String clubId = requireAuthenticatedClubId(user);
+        validateDates(request.start(), request.end());
 
         CustomCalendarEvent event = customCalendarEventRepository.findByIdAndClubId(eventId, clubId)
                 .orElseThrow(() -> new RestApiException(ErrorCode.CUSTOM_EVENT_NOT_FOUND));
@@ -78,6 +81,30 @@ public class CustomCalendarEventService {
             return false;
         }
         return customCalendarEventRepository.existsByClubId(clubId);
+    }
+
+    private void validateDates(String start, String end) {
+        LocalDate parsedStart;
+        try {
+            parsedStart = LocalDate.parse(start);
+        } catch (Exception e) {
+            throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_DATE_FORMAT);
+        }
+
+        if (!StringUtils.hasText(end)) {
+            return;
+        }
+
+        LocalDate parsedEnd;
+        try {
+            parsedEnd = LocalDate.parse(end);
+        } catch (Exception e) {
+            throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_DATE_FORMAT);
+        }
+
+        if (parsedStart.isAfter(parsedEnd)) {
+            throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_DATE_RANGE);
+        }
     }
 
     private ClubCalendarEventResult toResult(CustomCalendarEvent event) {

--- a/backend/src/main/java/moadong/calendar/custom/service/CustomEventOccurrenceExpander.java
+++ b/backend/src/main/java/moadong/calendar/custom/service/CustomEventOccurrenceExpander.java
@@ -14,6 +14,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * 커스텀 이벤트 원형을 공개 캘린더에 표시할 발생일 목록으로 전개한다.
+ * PERIOD는 여러 날에 걸친 하나의 일정이므로 전개하지 않고 start 한 건만 반환한다(end는 호출부가 그대로 유지한다).
  * 무기한 반복은 오늘 기준 1년까지만 전개하고, 전체 발생일은 최대 500건으로 제한한다.
  */
 @Component
@@ -32,26 +33,10 @@ public class CustomEventOccurrenceExpander {
         String eventType = StringUtils.hasText(event.getEventType()) ? event.getEventType() : "SINGLE";
 
         return switch (eventType) {
-            case "PERIOD" -> expandPeriod(start, parseOrNull(event.getEnd()));
             case "MULTI" -> expandMulti(event.getDates(), start);
             case "RECURRING" -> expandRecurring(event.getRecurrence(), start);
             default -> List.of(start.toString());
         };
-    }
-
-    private List<String> expandPeriod(LocalDate start, LocalDate end) {
-        if (end == null || end.isBefore(start)) {
-            return List.of(start.toString());
-        }
-
-        List<String> occurrences = new ArrayList<>();
-        for (LocalDate date = start; !date.isAfter(end); date = date.plusDays(1)) {
-            if (isFull(occurrences, start)) {
-                break;
-            }
-            occurrences.add(date.toString());
-        }
-        return occurrences;
     }
 
     private List<String> expandMulti(List<String> dates, LocalDate start) {

--- a/backend/src/main/java/moadong/calendar/custom/service/CustomEventOccurrenceExpander.java
+++ b/backend/src/main/java/moadong/calendar/custom/service/CustomEventOccurrenceExpander.java
@@ -1,0 +1,185 @@
+package moadong.calendar.custom.service;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import moadong.calendar.custom.entity.CustomCalendarEvent;
+import moadong.calendar.custom.entity.CustomEventRecurrence;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * 커스텀 이벤트 원형을 공개 캘린더에 표시할 발생일 목록으로 전개한다.
+ * 무기한 반복은 오늘 기준 1년까지만 전개하고, 전체 발생일은 최대 500건으로 제한한다.
+ */
+@Component
+@Slf4j
+public class CustomEventOccurrenceExpander {
+
+    private static final int MAX_OCCURRENCES = 500;
+    private static final int FUTURE_WINDOW_YEARS = 1;
+
+    public List<String> expand(CustomCalendarEvent event) {
+        LocalDate start = parseOrNull(event.getStart());
+        if (start == null) {
+            return List.of();
+        }
+
+        String eventType = StringUtils.hasText(event.getEventType()) ? event.getEventType() : "SINGLE";
+
+        return switch (eventType) {
+            case "PERIOD" -> expandPeriod(start, parseOrNull(event.getEnd()));
+            case "MULTI" -> expandMulti(event.getDates(), start);
+            case "RECURRING" -> expandRecurring(event.getRecurrence(), start);
+            default -> List.of(start.toString());
+        };
+    }
+
+    private List<String> expandPeriod(LocalDate start, LocalDate end) {
+        if (end == null || end.isBefore(start)) {
+            return List.of(start.toString());
+        }
+
+        List<String> occurrences = new ArrayList<>();
+        for (LocalDate date = start; !date.isAfter(end); date = date.plusDays(1)) {
+            if (isFull(occurrences, start)) {
+                break;
+            }
+            occurrences.add(date.toString());
+        }
+        return occurrences;
+    }
+
+    private List<String> expandMulti(List<String> dates, LocalDate start) {
+        if (dates == null || dates.isEmpty()) {
+            return List.of(start.toString());
+        }
+
+        Set<String> occurrences = new LinkedHashSet<>();
+        for (String date : dates) {
+            if (parseOrNull(date) != null) {
+                occurrences.add(date);
+            }
+        }
+        return occurrences.isEmpty() ? List.of(start.toString()) : List.copyOf(occurrences);
+    }
+
+    private List<String> expandRecurring(CustomEventRecurrence recurrence, LocalDate start) {
+        if (recurrence == null || !StringUtils.hasText(recurrence.frequency())) {
+            return List.of(start.toString());
+        }
+
+        LocalDate windowLimit = LocalDate.now().plusYears(FUTURE_WINDOW_YEARS);
+        LocalDate recurrenceEnd = parseOrNull(recurrence.end());
+        LocalDate windowEnd = (recurrenceEnd != null && recurrenceEnd.isBefore(windowLimit))
+                ? recurrenceEnd
+                : windowLimit;
+
+        if (windowEnd.isBefore(start)) {
+            return List.of();
+        }
+
+        Set<String> excludedDates = recurrence.excludedDates() == null
+                ? Set.of()
+                : Set.copyOf(recurrence.excludedDates());
+
+        return switch (recurrence.frequency()) {
+            case "WEEKLY" -> expandWeekly(recurrence.weekdays(), start, windowEnd, excludedDates);
+            case "MONTHLY" -> expandMonthly(start, windowEnd, excludedDates);
+            case "YEARLY" -> expandYearly(start, windowEnd, excludedDates);
+            default -> List.of(start.toString());
+        };
+    }
+
+    private List<String> expandWeekly(List<Integer> weekdays, LocalDate start, LocalDate windowEnd,
+                                      Set<String> excludedDates) {
+        Set<Integer> targetWeekdays = (weekdays == null || weekdays.isEmpty())
+                ? Set.of(toWeekdayIndex(start))
+                : Set.copyOf(weekdays);
+
+        List<String> occurrences = new ArrayList<>();
+        for (LocalDate date = start; !date.isAfter(windowEnd); date = date.plusDays(1)) {
+            if (isFull(occurrences, start)) {
+                break;
+            }
+            if (targetWeekdays.contains(toWeekdayIndex(date))) {
+                addUnlessExcluded(occurrences, date, excludedDates);
+            }
+        }
+        return occurrences;
+    }
+
+    private List<String> expandMonthly(LocalDate start, LocalDate windowEnd, Set<String> excludedDates) {
+        int dayOfMonth = start.getDayOfMonth();
+
+        List<String> occurrences = new ArrayList<>();
+        for (YearMonth month = YearMonth.from(start); !month.atDay(1).isAfter(windowEnd); month = month.plusMonths(1)) {
+            if (isFull(occurrences, start)) {
+                break;
+            }
+            if (dayOfMonth > month.lengthOfMonth()) {
+                continue;
+            }
+            LocalDate date = month.atDay(dayOfMonth);
+            if (!date.isBefore(start) && !date.isAfter(windowEnd)) {
+                addUnlessExcluded(occurrences, date, excludedDates);
+            }
+        }
+        return occurrences;
+    }
+
+    private List<String> expandYearly(LocalDate start, LocalDate windowEnd, Set<String> excludedDates) {
+        List<String> occurrences = new ArrayList<>();
+        for (int year = start.getYear(); year <= windowEnd.getYear(); year++) {
+            if (isFull(occurrences, start)) {
+                break;
+            }
+            YearMonth month = YearMonth.of(year, start.getMonth());
+            if (start.getDayOfMonth() > month.lengthOfMonth()) {
+                continue;
+            }
+            LocalDate date = month.atDay(start.getDayOfMonth());
+            if (!date.isBefore(start) && !date.isAfter(windowEnd)) {
+                addUnlessExcluded(occurrences, date, excludedDates);
+            }
+        }
+        return occurrences;
+    }
+
+    private void addUnlessExcluded(List<String> occurrences, LocalDate date, Set<String> excludedDates) {
+        String value = date.toString();
+        if (!excludedDates.contains(value)) {
+            occurrences.add(value);
+        }
+    }
+
+    private boolean isFull(List<String> occurrences, LocalDate start) {
+        if (occurrences.size() < MAX_OCCURRENCES) {
+            return false;
+        }
+        log.warn("커스텀 이벤트 발생일 전개 상한 도달. start={}, max={}", start, MAX_OCCURRENCES);
+        return true;
+    }
+
+    /**
+     * 프론트 계약(0=일 ~ 6=토)에 맞춰 요일 인덱스를 변환한다.
+     */
+    private int toWeekdayIndex(LocalDate date) {
+        return date.getDayOfWeek().getValue() % 7;
+    }
+
+    private LocalDate parseOrNull(String value) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        try {
+            return LocalDate.parse(value);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/backend/src/main/java/moadong/calendar/custom/service/CustomEventOccurrenceExpander.java
+++ b/backend/src/main/java/moadong/calendar/custom/service/CustomEventOccurrenceExpander.java
@@ -78,8 +78,11 @@ public class CustomEventOccurrenceExpander {
         LocalDate windowEnd = (recurrenceEnd != null && recurrenceEnd.isBefore(windowLimit))
                 ? recurrenceEnd
                 : windowLimit;
+        LocalDate visibleStart = recurrenceEnd == null && start.isBefore(LocalDate.now())
+                ? LocalDate.now()
+                : start;
 
-        if (windowEnd.isBefore(start)) {
+        if (windowEnd.isBefore(visibleStart)) {
             return List.of();
         }
 
@@ -88,21 +91,22 @@ public class CustomEventOccurrenceExpander {
                 : Set.copyOf(recurrence.excludedDates());
 
         return switch (recurrence.frequency()) {
-            case "WEEKLY" -> expandWeekly(recurrence.weekdays(), start, windowEnd, excludedDates);
-            case "MONTHLY" -> expandMonthly(start, windowEnd, excludedDates);
-            case "YEARLY" -> expandYearly(start, windowEnd, excludedDates);
+            case "WEEKLY" -> expandWeekly(recurrence.weekdays(), start, visibleStart, windowEnd, excludedDates);
+            case "MONTHLY" -> expandMonthly(start, visibleStart, windowEnd, excludedDates);
+            case "YEARLY" -> expandYearly(start, visibleStart, windowEnd, excludedDates);
             default -> List.of(start.toString());
         };
     }
 
-    private List<String> expandWeekly(List<Integer> weekdays, LocalDate start, LocalDate windowEnd,
+    private List<String> expandWeekly(List<Integer> weekdays, LocalDate start, LocalDate visibleStart,
+                                      LocalDate windowEnd,
                                       Set<String> excludedDates) {
         Set<Integer> targetWeekdays = (weekdays == null || weekdays.isEmpty())
                 ? Set.of(toWeekdayIndex(start))
                 : Set.copyOf(weekdays);
 
         List<String> occurrences = new ArrayList<>();
-        for (LocalDate date = start; !date.isAfter(windowEnd); date = date.plusDays(1)) {
+        for (LocalDate date = visibleStart; !date.isAfter(windowEnd); date = date.plusDays(1)) {
             if (isFull(occurrences, start)) {
                 break;
             }
@@ -113,11 +117,12 @@ public class CustomEventOccurrenceExpander {
         return occurrences;
     }
 
-    private List<String> expandMonthly(LocalDate start, LocalDate windowEnd, Set<String> excludedDates) {
+    private List<String> expandMonthly(LocalDate start, LocalDate visibleStart, LocalDate windowEnd,
+                                       Set<String> excludedDates) {
         int dayOfMonth = start.getDayOfMonth();
 
         List<String> occurrences = new ArrayList<>();
-        for (YearMonth month = YearMonth.from(start); !month.atDay(1).isAfter(windowEnd); month = month.plusMonths(1)) {
+        for (YearMonth month = YearMonth.from(visibleStart); !month.atDay(1).isAfter(windowEnd); month = month.plusMonths(1)) {
             if (isFull(occurrences, start)) {
                 break;
             }
@@ -125,16 +130,17 @@ public class CustomEventOccurrenceExpander {
                 continue;
             }
             LocalDate date = month.atDay(dayOfMonth);
-            if (!date.isBefore(start) && !date.isAfter(windowEnd)) {
+            if (!date.isBefore(visibleStart) && !date.isAfter(windowEnd)) {
                 addUnlessExcluded(occurrences, date, excludedDates);
             }
         }
         return occurrences;
     }
 
-    private List<String> expandYearly(LocalDate start, LocalDate windowEnd, Set<String> excludedDates) {
+    private List<String> expandYearly(LocalDate start, LocalDate visibleStart, LocalDate windowEnd,
+                                      Set<String> excludedDates) {
         List<String> occurrences = new ArrayList<>();
-        for (int year = start.getYear(); year <= windowEnd.getYear(); year++) {
+        for (int year = visibleStart.getYear(); year <= windowEnd.getYear(); year++) {
             if (isFull(occurrences, start)) {
                 break;
             }
@@ -143,7 +149,7 @@ public class CustomEventOccurrenceExpander {
                 continue;
             }
             LocalDate date = month.atDay(start.getDayOfMonth());
-            if (!date.isBefore(start) && !date.isAfter(windowEnd)) {
+            if (!date.isBefore(visibleStart) && !date.isAfter(windowEnd)) {
                 addUnlessExcluded(occurrences, date, excludedDates);
             }
         }

--- a/backend/src/main/java/moadong/calendar/hidden/controller/HiddenCalendarEventController.java
+++ b/backend/src/main/java/moadong/calendar/hidden/controller/HiddenCalendarEventController.java
@@ -1,0 +1,57 @@
+package moadong.calendar.hidden.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import moadong.calendar.hidden.payload.request.HiddenCalendarEventRequest;
+import moadong.calendar.hidden.service.HiddenCalendarEventService;
+import moadong.global.payload.Response;
+import moadong.user.annotation.CurrentUser;
+import moadong.user.payload.CustomUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/integration/calendar-events/hidden")
+@RequiredArgsConstructor
+@Tag(name = "Hidden Calendar Events", description = "OAuth 캘린더 이벤트 숨김 관리 API")
+public class HiddenCalendarEventController {
+
+    private final HiddenCalendarEventService hiddenCalendarEventService;
+
+    @PostMapping
+    @Operation(summary = "캘린더 이벤트 숨김", description = "Google/Notion 캘린더 이벤트를 공개 캘린더에서 숨깁니다.")
+    @PreAuthorize("isAuthenticated()")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> hideEvent(@CurrentUser CustomUserDetails user,
+                                       @RequestBody @Valid HiddenCalendarEventRequest request) {
+        hiddenCalendarEventService.hide(user, request.source(), request.eventId());
+        return Response.ok("이벤트가 숨김 처리되었습니다.");
+    }
+
+    @DeleteMapping
+    @Operation(summary = "캘린더 이벤트 숨김 해제", description = "숨김 처리된 Google/Notion 캘린더 이벤트를 다시 표시합니다.")
+    @PreAuthorize("isAuthenticated()")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> unhideEvent(@CurrentUser CustomUserDetails user,
+                                         @RequestBody @Valid HiddenCalendarEventRequest request) {
+        hiddenCalendarEventService.unhide(user, request.source(), request.eventId());
+        return Response.ok("이벤트 숨김이 해제되었습니다.");
+    }
+
+    @GetMapping
+    @Operation(summary = "숨김 이벤트 목록 조회", description = "숨김 처리된 캘린더 이벤트 목록을 조회합니다.")
+    @PreAuthorize("isAuthenticated()")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> getHiddenEvents(@CurrentUser CustomUserDetails user) {
+        return Response.ok(hiddenCalendarEventService.list(user));
+    }
+}

--- a/backend/src/main/java/moadong/calendar/hidden/entity/HiddenCalendarEvent.java
+++ b/backend/src/main/java/moadong/calendar/hidden/entity/HiddenCalendarEvent.java
@@ -1,0 +1,27 @@
+package moadong.calendar.hidden.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document("hidden_calendar_events")
+@CompoundIndex(name = "club_source_event_idx", def = "{'clubId': 1, 'source': 1, 'eventId': 1}", unique = true)
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HiddenCalendarEvent {
+
+    @Id
+    private String id;
+
+    private String clubId;
+
+    private String source;
+
+    private String eventId;
+}

--- a/backend/src/main/java/moadong/calendar/hidden/payload/dto/HiddenCalendarEventResult.java
+++ b/backend/src/main/java/moadong/calendar/hidden/payload/dto/HiddenCalendarEventResult.java
@@ -1,0 +1,7 @@
+package moadong.calendar.hidden.payload.dto;
+
+public record HiddenCalendarEventResult(
+        String source,
+        String eventId
+) {
+}

--- a/backend/src/main/java/moadong/calendar/hidden/payload/request/HiddenCalendarEventRequest.java
+++ b/backend/src/main/java/moadong/calendar/hidden/payload/request/HiddenCalendarEventRequest.java
@@ -1,0 +1,9 @@
+package moadong.calendar.hidden.payload.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record HiddenCalendarEventRequest(
+        @NotBlank String source,
+        @NotBlank String eventId
+) {
+}

--- a/backend/src/main/java/moadong/calendar/hidden/repository/HiddenCalendarEventRepository.java
+++ b/backend/src/main/java/moadong/calendar/hidden/repository/HiddenCalendarEventRepository.java
@@ -1,0 +1,14 @@
+package moadong.calendar.hidden.repository;
+
+import java.util.List;
+import moadong.calendar.hidden.entity.HiddenCalendarEvent;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface HiddenCalendarEventRepository extends MongoRepository<HiddenCalendarEvent, String> {
+
+    List<HiddenCalendarEvent> findByClubId(String clubId);
+
+    boolean existsByClubIdAndSourceAndEventId(String clubId, String source, String eventId);
+
+    long deleteByClubIdAndSourceAndEventId(String clubId, String source, String eventId);
+}

--- a/backend/src/main/java/moadong/calendar/hidden/service/HiddenCalendarEventService.java
+++ b/backend/src/main/java/moadong/calendar/hidden/service/HiddenCalendarEventService.java
@@ -1,0 +1,86 @@
+package moadong.calendar.hidden.service;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import moadong.calendar.hidden.entity.HiddenCalendarEvent;
+import moadong.calendar.hidden.payload.dto.HiddenCalendarEventResult;
+import moadong.calendar.hidden.repository.HiddenCalendarEventRepository;
+import moadong.club.entity.Club;
+import moadong.club.repository.ClubRepository;
+import moadong.global.exception.ErrorCode;
+import moadong.global.exception.RestApiException;
+import moadong.user.payload.CustomUserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+public class HiddenCalendarEventService {
+
+    private static final Set<String> HIDEABLE_SOURCES = Set.of("GOOGLE", "NOTION");
+
+    private final HiddenCalendarEventRepository hiddenCalendarEventRepository;
+    private final ClubRepository clubRepository;
+
+    public void hide(CustomUserDetails user, String source, String eventId) {
+        String clubId = requireAuthenticatedClubId(user);
+        validateSource(source);
+
+        if (hiddenCalendarEventRepository.existsByClubIdAndSourceAndEventId(clubId, source, eventId)) {
+            return;
+        }
+
+        hiddenCalendarEventRepository.save(HiddenCalendarEvent.builder()
+                .clubId(clubId)
+                .source(source)
+                .eventId(eventId)
+                .build());
+    }
+
+    public void unhide(CustomUserDetails user, String source, String eventId) {
+        String clubId = requireAuthenticatedClubId(user);
+        validateSource(source);
+
+        hiddenCalendarEventRepository.deleteByClubIdAndSourceAndEventId(clubId, source, eventId);
+    }
+
+    public List<HiddenCalendarEventResult> list(CustomUserDetails user) {
+        String clubId = requireAuthenticatedClubId(user);
+
+        return hiddenCalendarEventRepository.findByClubId(clubId).stream()
+                .map(hidden -> new HiddenCalendarEventResult(hidden.getSource(), hidden.getEventId()))
+                .toList();
+    }
+
+    public Set<String> getHiddenKeys(String clubId) {
+        if (!StringUtils.hasText(clubId)) {
+            return Set.of();
+        }
+
+        return hiddenCalendarEventRepository.findByClubId(clubId).stream()
+                .map(hidden -> hidden.getSource() + ":" + hidden.getEventId())
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private void validateSource(String source) {
+        if (!HIDEABLE_SOURCES.contains(source)) {
+            throw new RestApiException(ErrorCode.HIDDEN_EVENT_INVALID_SOURCE);
+        }
+    }
+
+    private String requireAuthenticatedClubId(CustomUserDetails user) {
+        if (user == null || !StringUtils.hasText(user.getId())) {
+            throw new RestApiException(ErrorCode.USER_UNAUTHORIZED);
+        }
+
+        Club club = clubRepository.findClubByUserId(user.getId())
+                .orElseThrow(() -> new RestApiException(ErrorCode.HIDDEN_EVENT_CLUB_NOT_FOUND));
+
+        if (!StringUtils.hasText(club.getId())) {
+            throw new RestApiException(ErrorCode.HIDDEN_EVENT_CLUB_NOT_FOUND);
+        }
+        return club.getId();
+    }
+}

--- a/backend/src/main/java/moadong/calendar/hidden/service/HiddenCalendarEventService.java
+++ b/backend/src/main/java/moadong/calendar/hidden/service/HiddenCalendarEventService.java
@@ -12,6 +12,7 @@ import moadong.club.repository.ClubRepository;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
 import moadong.user.payload.CustomUserDetails;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
@@ -32,11 +33,15 @@ public class HiddenCalendarEventService {
             return;
         }
 
-        hiddenCalendarEventRepository.save(HiddenCalendarEvent.builder()
-                .clubId(clubId)
-                .source(source)
-                .eventId(eventId)
-                .build());
+        try {
+            hiddenCalendarEventRepository.save(HiddenCalendarEvent.builder()
+                    .clubId(clubId)
+                    .source(source)
+                    .eventId(eventId)
+                    .build());
+        } catch (DuplicateKeyException ignored) {
+            // 동시에 동일 이벤트를 숨긴 요청도 멱등적으로 처리한다.
+        }
     }
 
     public void unhide(CustomUserDetails user, String source, String eventId) {

--- a/backend/src/main/java/moadong/calendar/hidden/service/HiddenCalendarEventService.java
+++ b/backend/src/main/java/moadong/calendar/hidden/service/HiddenCalendarEventService.java
@@ -65,7 +65,7 @@ public class HiddenCalendarEventService {
     }
 
     private void validateSource(String source) {
-        if (!HIDEABLE_SOURCES.contains(source)) {
+        if (source == null || !HIDEABLE_SOURCES.contains(source)) {
             throw new RestApiException(ErrorCode.HIDDEN_EVENT_INVALID_SOURCE);
         }
     }

--- a/backend/src/main/java/moadong/calendar/service/CalendarAggregationService.java
+++ b/backend/src/main/java/moadong/calendar/service/CalendarAggregationService.java
@@ -3,8 +3,11 @@ package moadong.calendar.service;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import moadong.calendar.custom.service.CustomCalendarEventService;
+import moadong.calendar.hidden.service.HiddenCalendarEventService;
 import moadong.calendar.google.service.GoogleOAuthService;
 import moadong.calendar.notion.service.NotionOAuthService;
 import moadong.club.payload.dto.ClubCalendarEventResult;
@@ -18,6 +21,8 @@ public class CalendarAggregationService {
 
     private final NotionOAuthService notionOAuthService;
     private final GoogleOAuthService googleOAuthService;
+    private final CustomCalendarEventService customCalendarEventService;
+    private final HiddenCalendarEventService hiddenCalendarEventService;
 
     public List<ClubCalendarEventResult> getAggregatedEvents(String clubId) {
         List<ClubCalendarEventResult> allEvents = new ArrayList<>();
@@ -38,7 +43,24 @@ public class CalendarAggregationService {
             log.warn("Google 이벤트 조회 실패. clubId={}, message={}", clubId, e.getMessage());
         }
 
+        try {
+            List<ClubCalendarEventResult> customEvents = customCalendarEventService.getClubCalendarEvents(clubId);
+            allEvents.addAll(customEvents);
+            log.debug("커스텀 이벤트 조회 성공. clubId={}, count={}", clubId, customEvents.size());
+        } catch (Exception e) {
+            log.warn("커스텀 이벤트 조회 실패. clubId={}, message={}", clubId, e.getMessage());
+        }
+
+        Set<String> hiddenKeys = Set.of();
+        try {
+            hiddenKeys = hiddenCalendarEventService.getHiddenKeys(clubId);
+        } catch (Exception e) {
+            log.warn("숨김 이벤트 목록 조회 실패. clubId={}, message={}", clubId, e.getMessage());
+        }
+        final Set<String> resolvedHiddenKeys = hiddenKeys;
+
         return allEvents.stream()
+                .filter(event -> !resolvedHiddenKeys.contains(event.source() + ":" + event.id()))
                 .sorted(Comparator.comparing(
                         ClubCalendarEventResult::start,
                         Comparator.nullsLast(String::compareTo)
@@ -53,6 +75,7 @@ public class CalendarAggregationService {
 
         boolean hasNotion = false;
         boolean hasGoogle = false;
+        boolean hasCustom = false;
 
         try {
             hasNotion = notionOAuthService.hasCalendarConnection(clubId);
@@ -66,6 +89,12 @@ public class CalendarAggregationService {
             log.debug("Google 연결 상태 확인 실패. clubId={}", clubId);
         }
 
-        return hasNotion || hasGoogle;
+        try {
+            hasCustom = customCalendarEventService.hasCalendarConnection(clubId);
+        } catch (Exception e) {
+            log.debug("커스텀 이벤트 상태 확인 실패. clubId={}", clubId);
+        }
+
+        return hasNotion || hasGoogle || hasCustom;
     }
 }

--- a/backend/src/main/java/moadong/club/payload/dto/ClubCalendarEventResult.java
+++ b/backend/src/main/java/moadong/club/payload/dto/ClubCalendarEventResult.java
@@ -7,20 +7,23 @@ public record ClubCalendarEventResult(
         String end,
         String url,
         String description,
-        String source
+        String source,
+        String eventType,
+        String color
 ) {
     public static ClubCalendarEventResult ofNotion(
             String id, String title, String start, String end, String url, String description) {
-        return new ClubCalendarEventResult(id, title, start, end, url, description, "NOTION");
+        return new ClubCalendarEventResult(id, title, start, end, url, description, "NOTION", null, null);
     }
 
     public static ClubCalendarEventResult ofGoogle(
             String id, String title, String start, String end, String url, String description) {
-        return new ClubCalendarEventResult(id, title, start, end, url, description, "GOOGLE");
+        return new ClubCalendarEventResult(id, title, start, end, url, description, "GOOGLE", null, null);
     }
 
     public static ClubCalendarEventResult ofCustom(
-            String id, String title, String start, String end, String url, String description) {
-        return new ClubCalendarEventResult(id, title, start, end, url, description, "CUSTOM");
+            String id, String title, String start, String end, String url, String description,
+            String eventType, String color) {
+        return new ClubCalendarEventResult(id, title, start, end, url, description, "CUSTOM", eventType, color);
     }
 }

--- a/backend/src/main/java/moadong/club/payload/dto/ClubCalendarEventResult.java
+++ b/backend/src/main/java/moadong/club/payload/dto/ClubCalendarEventResult.java
@@ -18,4 +18,9 @@ public record ClubCalendarEventResult(
             String id, String title, String start, String end, String url, String description) {
         return new ClubCalendarEventResult(id, title, start, end, url, description, "GOOGLE");
     }
+
+    public static ClubCalendarEventResult ofCustom(
+            String id, String title, String start, String end, String url, String description) {
+        return new ClubCalendarEventResult(id, title, start, end, url, description, "CUSTOM");
+    }
 }

--- a/backend/src/main/java/moadong/global/exception/ErrorCode.java
+++ b/backend/src/main/java/moadong/global/exception/ErrorCode.java
@@ -109,6 +109,8 @@ public enum ErrorCode {
     CUSTOM_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "970-2", "커스텀 캘린더 이벤트를 찾을 수 없습니다."),
     CUSTOM_EVENT_INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "970-3", "날짜 형식이 올바르지 않습니다. YYYY-MM-DD 형식을 사용해주세요."),
     CUSTOM_EVENT_INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "970-4", "시작일은 종료일보다 이전이거나 같아야 합니다."),
+    CUSTOM_EVENT_INVALID_FIELD_VALUE(HttpStatus.BAD_REQUEST, "970-5", "이벤트 유형, 색상 또는 반복 주기 값이 올바르지 않습니다."),
+    CUSTOM_EVENT_INVALID_DELETE_SCOPE(HttpStatus.BAD_REQUEST, "970-6", "삭제 범위 값이 올바르지 않습니다."),
 
     HIDDEN_EVENT_CLUB_NOT_FOUND(HttpStatus.BAD_REQUEST, "971-1", "동아리 정보를 찾을 수 없습니다."),
     HIDDEN_EVENT_INVALID_SOURCE(HttpStatus.BAD_REQUEST, "971-2", "숨김 처리할 수 없는 이벤트 소스입니다.")

--- a/backend/src/main/java/moadong/global/exception/ErrorCode.java
+++ b/backend/src/main/java/moadong/global/exception/ErrorCode.java
@@ -107,6 +107,8 @@ public enum ErrorCode {
 
     CUSTOM_EVENT_CLUB_NOT_FOUND(HttpStatus.BAD_REQUEST, "970-1", "동아리 정보를 찾을 수 없습니다."),
     CUSTOM_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "970-2", "커스텀 캘린더 이벤트를 찾을 수 없습니다."),
+    CUSTOM_EVENT_INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "970-3", "날짜 형식이 올바르지 않습니다. YYYY-MM-DD 형식을 사용해주세요."),
+    CUSTOM_EVENT_INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "970-4", "시작일은 종료일보다 이전이거나 같아야 합니다."),
 
     HIDDEN_EVENT_CLUB_NOT_FOUND(HttpStatus.BAD_REQUEST, "971-1", "동아리 정보를 찾을 수 없습니다."),
     HIDDEN_EVENT_INVALID_SOURCE(HttpStatus.BAD_REQUEST, "971-2", "숨김 처리할 수 없는 이벤트 소스입니다.")

--- a/backend/src/main/java/moadong/global/exception/ErrorCode.java
+++ b/backend/src/main/java/moadong/global/exception/ErrorCode.java
@@ -103,7 +103,13 @@ public enum ErrorCode {
     GOOGLE_API_FAILED(HttpStatus.BAD_GATEWAY, "960-6", "Google API 호출에 실패했습니다."),
     GOOGLE_CLUB_NOT_FOUND(HttpStatus.BAD_REQUEST, "960-7", "연동할 동아리 정보를 찾을 수 없습니다."),
     GOOGLE_INVALID_TIME_FORMAT(HttpStatus.BAD_REQUEST, "960-8", "시간 형식이 올바르지 않습니다. RFC3339 형식을 사용해주세요."),
-    GOOGLE_INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST, "960-9", "시작 시간은 종료 시간보다 이전이어야 합니다.")
+    GOOGLE_INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST, "960-9", "시작 시간은 종료 시간보다 이전이어야 합니다."),
+
+    CUSTOM_EVENT_CLUB_NOT_FOUND(HttpStatus.BAD_REQUEST, "970-1", "동아리 정보를 찾을 수 없습니다."),
+    CUSTOM_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "970-2", "커스텀 캘린더 이벤트를 찾을 수 없습니다."),
+
+    HIDDEN_EVENT_CLUB_NOT_FOUND(HttpStatus.BAD_REQUEST, "971-1", "동아리 정보를 찾을 수 없습니다."),
+    HIDDEN_EVENT_INVALID_SOURCE(HttpStatus.BAD_REQUEST, "971-2", "숨김 처리할 수 없는 이벤트 소스입니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/backend/src/test/java/moadong/calendar/custom/service/CustomCalendarEventServiceTest.java
+++ b/backend/src/test/java/moadong/calendar/custom/service/CustomCalendarEventServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Collections;
 import java.util.Optional;
 import moadong.calendar.custom.entity.CustomCalendarEvent;
 import moadong.calendar.custom.entity.CustomEventRecurrence;
@@ -239,6 +240,45 @@ class CustomCalendarEventServiceTest {
 
         assertThatThrownBy(() -> customCalendarEventService.create(
                 user, request("2026-08-01", null, "MULTI", null, List.of("2026-08-02"), null)))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
+    }
+
+    @Test
+    @DisplayName("MULTI 일정에 dates가 없으면 예외가 발생한다")
+    void create_multiWithoutDates_throws() {
+        givenAuthenticatedClub();
+
+        assertThatThrownBy(() -> customCalendarEventService.create(
+                user, request("2026-08-01", null, "MULTI", null, null, null)))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
+    }
+
+    @Test
+    @DisplayName("위험한 URL 스킴은 예외가 발생한다")
+    void create_unsafeUrl_throws() {
+        givenAuthenticatedClub();
+        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
+                "정기 모임", "2026-08-01", null, "javascript:alert(1)", null,
+                "SINGLE", null, null, null);
+
+        assertThatThrownBy(() -> customCalendarEventService.create(user, request))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
+    }
+
+    @Test
+    @DisplayName("날짜 배열이 365개를 초과하면 예외가 발생한다")
+    void create_tooManyDates_throws() {
+        givenAuthenticatedClub();
+
+        assertThatThrownBy(() -> customCalendarEventService.create(
+                user, request("2026-08-01", null, "MULTI", null,
+                        Collections.nCopies(366, "2026-08-01"), null)))
                 .isInstanceOf(RestApiException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);

--- a/backend/src/test/java/moadong/calendar/custom/service/CustomCalendarEventServiceTest.java
+++ b/backend/src/test/java/moadong/calendar/custom/service/CustomCalendarEventServiceTest.java
@@ -147,6 +147,60 @@ class CustomCalendarEventServiceTest {
     }
 
     @Test
+    @DisplayName("start가 YYYY-MM-DD 형식이 아니면 예외가 발생한다")
+    void create_invalidStartFormat_throws() {
+        givenAuthenticatedClub();
+        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
+                "정기 모임", "2026/08/01", null, null, null);
+
+        assertThatThrownBy(() -> customCalendarEventService.create(user, request))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_DATE_FORMAT);
+    }
+
+    @Test
+    @DisplayName("end가 YYYY-MM-DD 형식이 아니면 예외가 발생한다")
+    void create_invalidEndFormat_throws() {
+        givenAuthenticatedClub();
+        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
+                "정기 모임", "2026-08-01", "08-02", null, null);
+
+        assertThatThrownBy(() -> customCalendarEventService.create(user, request))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_DATE_FORMAT);
+    }
+
+    @Test
+    @DisplayName("start가 end보다 이후면 예외가 발생한다")
+    void create_startAfterEnd_throws() {
+        givenAuthenticatedClub();
+        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
+                "정기 모임", "2026-08-02", "2026-08-01", null, null);
+
+        assertThatThrownBy(() -> customCalendarEventService.create(user, request))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_DATE_RANGE);
+    }
+
+    @Test
+    @DisplayName("start와 end가 같은 날짜면 정상 생성된다")
+    void create_sameStartAndEnd_succeeds() {
+        givenAuthenticatedClub();
+        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
+                "정기 모임", "2026-08-01", "2026-08-01", null, null);
+        when(customCalendarEventRepository.save(any(CustomCalendarEvent.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        ClubCalendarEventResult result = customCalendarEventService.create(user, request);
+
+        assertThat(result.start()).isEqualTo("2026-08-01");
+        assertThat(result.end()).isEqualTo("2026-08-01");
+    }
+
+    @Test
     @DisplayName("인증된 사용자에게 동아리가 없으면 예외가 발생한다")
     void create_noClub_throws() {
         when(user.getId()).thenReturn(USER_ID);

--- a/backend/src/test/java/moadong/calendar/custom/service/CustomCalendarEventServiceTest.java
+++ b/backend/src/test/java/moadong/calendar/custom/service/CustomCalendarEventServiceTest.java
@@ -3,12 +3,16 @@ package moadong.calendar.custom.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Optional;
 import moadong.calendar.custom.entity.CustomCalendarEvent;
+import moadong.calendar.custom.entity.CustomEventRecurrence;
 import moadong.calendar.custom.payload.request.CustomCalendarEventRequest;
+import moadong.calendar.custom.payload.response.CustomCalendarEventResponse;
 import moadong.calendar.custom.repository.CustomCalendarEventRepository;
 import moadong.club.entity.Club;
 import moadong.club.payload.dto.ClubCalendarEventResult;
@@ -20,6 +24,7 @@ import moadong.util.annotations.UnitTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
 @UnitTest
@@ -45,7 +50,8 @@ class CustomCalendarEventServiceTest {
 
     @BeforeEach
     void setUp() {
-        customCalendarEventService = new CustomCalendarEventService(customCalendarEventRepository, clubRepository);
+        customCalendarEventService = new CustomCalendarEventService(
+                customCalendarEventRepository, clubRepository, new CustomEventOccurrenceExpander());
     }
 
     private void givenAuthenticatedClub() {
@@ -54,119 +60,209 @@ class CustomCalendarEventServiceTest {
         when(clubRepository.findClubByUserId(USER_ID)).thenReturn(Optional.of(club));
     }
 
-    @Test
-    @DisplayName("커스텀 이벤트를 생성하면 source가 CUSTOM인 결과를 반환한다")
-    void create_returnsCustomResult() {
-        givenAuthenticatedClub();
-        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
-                "정기 모임", "2026-08-01", "2026-08-02", "https://example.com", "설명");
+    private void givenSaveReturnsArgument() {
         when(customCalendarEventRepository.save(any(CustomCalendarEvent.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
-
-        ClubCalendarEventResult result = customCalendarEventService.create(user, request);
-
-        assertThat(result.source()).isEqualTo("CUSTOM");
-        assertThat(result.title()).isEqualTo("정기 모임");
-        assertThat(result.start()).isEqualTo("2026-08-01");
-        assertThat(result.end()).isEqualTo("2026-08-02");
     }
 
-    @Test
-    @DisplayName("clubId로 커스텀 이벤트 목록을 CUSTOM 결과로 매핑한다")
-    void getClubCalendarEvents_mapsToCustomResults() {
-        CustomCalendarEvent event = CustomCalendarEvent.builder()
+    private CustomCalendarEventRequest request(String start, String end, String eventType, String color,
+                                               List<String> dates, CustomEventRecurrence recurrence) {
+        return new CustomCalendarEventRequest("정기 모임", start, end, null, null, eventType, color, dates, recurrence);
+    }
+
+    private CustomCalendarEvent storedEvent(String eventType, String start, String end,
+                                            List<String> dates, CustomEventRecurrence recurrence) {
+        return CustomCalendarEvent.builder()
                 .id(EVENT_ID)
                 .clubId(CLUB_ID)
                 .title("정기 모임")
-                .start("2026-08-01")
+                .start(start)
+                .end(end)
+                .eventType(eventType)
+                .dates(dates)
+                .recurrence(recurrence)
                 .build();
-        when(customCalendarEventRepository.findByClubId(CLUB_ID)).thenReturn(List.of(event));
-
-        List<ClubCalendarEventResult> results = customCalendarEventService.getClubCalendarEvents(CLUB_ID);
-
-        assertThat(results).hasSize(1);
-        assertThat(results.get(0).id()).isEqualTo(EVENT_ID);
-        assertThat(results.get(0).source()).isEqualTo("CUSTOM");
     }
 
     @Test
-    @DisplayName("clubId가 비어있으면 빈 리스트를 반환한다")
-    void getClubCalendarEvents_blankClubId_returnsEmpty() {
-        List<ClubCalendarEventResult> results = customCalendarEventService.getClubCalendarEvents(" ");
-
-        assertThat(results).isEmpty();
-    }
-
-    @Test
-    @DisplayName("다른 동아리의 이벤트를 수정하면 예외가 발생한다")
-    void update_otherClubEvent_throwsNotFound() {
+    @DisplayName("SINGLE 이벤트를 생성하면 source가 CUSTOM인 결과를 반환한다")
+    void create_single() {
         givenAuthenticatedClub();
-        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
-                "수정", "2026-08-01", null, null, null);
-        when(customCalendarEventRepository.findByIdAndClubId(EVENT_ID, CLUB_ID)).thenReturn(Optional.empty());
+        givenSaveReturnsArgument();
 
-        assertThatThrownBy(() -> customCalendarEventService.update(user, EVENT_ID, request))
+        CustomCalendarEventResponse response = customCalendarEventService.create(
+                user, request("2026-08-01", null, "SINGLE", "PINK", null, null));
+
+        assertThat(response.source()).isEqualTo("CUSTOM");
+        assertThat(response.eventType()).isEqualTo("SINGLE");
+        assertThat(response.color()).isEqualTo("PINK");
+        assertThat(response.start()).isEqualTo("2026-08-01");
+    }
+
+    @Test
+    @DisplayName("eventType이 없으면 SINGLE로 저장하고 반환한다")
+    void create_withoutEventType_defaultsToSingle() {
+        givenAuthenticatedClub();
+        givenSaveReturnsArgument();
+
+        CustomCalendarEventResponse response = customCalendarEventService.create(
+                user, request("2026-08-01", null, null, null, null, null));
+
+        assertThat(response.eventType()).isEqualTo("SINGLE");
+    }
+
+    @Test
+    @DisplayName("PERIOD 이벤트를 생성하면 start/end가 그대로 저장된다")
+    void create_period() {
+        givenAuthenticatedClub();
+        givenSaveReturnsArgument();
+
+        CustomCalendarEventResponse response = customCalendarEventService.create(
+                user, request("2026-08-01", "2026-08-05", "PERIOD", "MINT", null, null));
+
+        assertThat(response.eventType()).isEqualTo("PERIOD");
+        assertThat(response.start()).isEqualTo("2026-08-01");
+        assertThat(response.end()).isEqualTo("2026-08-05");
+    }
+
+    @Test
+    @DisplayName("MULTI 이벤트를 생성하면 dates가 그대로 저장된다")
+    void create_multi() {
+        givenAuthenticatedClub();
+        givenSaveReturnsArgument();
+        List<String> dates = List.of("2026-08-01", "2026-08-10");
+
+        CustomCalendarEventResponse response = customCalendarEventService.create(
+                user, request("2026-08-01", null, "MULTI", "BLUE", dates, null));
+
+        assertThat(response.eventType()).isEqualTo("MULTI");
+        assertThat(response.dates()).containsExactlyElementsOf(dates);
+    }
+
+    @Test
+    @DisplayName("RECURRING 이벤트를 생성하면 recurrence가 그대로 저장된다")
+    void create_recurring() {
+        givenAuthenticatedClub();
+        givenSaveReturnsArgument();
+        CustomEventRecurrence recurrence =
+                new CustomEventRecurrence("WEEKLY", List.of(5, 6), "2026-09-30", List.of("2026-08-15"));
+
+        CustomCalendarEventResponse response = customCalendarEventService.create(
+                user, request("2026-08-01", null, "RECURRING", "PURPLE", null, recurrence));
+
+        assertThat(response.eventType()).isEqualTo("RECURRING");
+        assertThat(response.recurrence().frequency()).isEqualTo("WEEKLY");
+        assertThat(response.recurrence().weekdays()).containsExactly(5, 6);
+        assertThat(response.recurrence().end()).isEqualTo("2026-09-30");
+        assertThat(response.recurrence().excludedDates()).containsExactly("2026-08-15");
+    }
+
+    @Test
+    @DisplayName("허용되지 않은 eventType이면 예외가 발생한다")
+    void create_invalidEventType_throws() {
+        givenAuthenticatedClub();
+
+        assertThatThrownBy(() -> customCalendarEventService.create(
+                user, request("2026-08-01", null, "DAILY", null, null, null)))
                 .isInstanceOf(RestApiException.class)
                 .extracting("errorCode")
-                .isEqualTo(ErrorCode.CUSTOM_EVENT_NOT_FOUND);
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
     }
 
     @Test
-    @DisplayName("커스텀 이벤트를 수정하면 변경된 값이 반영된다")
-    void update_updatesFields() {
+    @DisplayName("허용되지 않은 color면 예외가 발생한다")
+    void create_invalidColor_throws() {
         givenAuthenticatedClub();
-        CustomCalendarEvent event = CustomCalendarEvent.builder()
-                .id(EVENT_ID)
-                .clubId(CLUB_ID)
-                .title("이전 제목")
-                .start("2026-08-01")
-                .build();
-        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
-                "새 제목", "2026-09-01", null, null, null);
-        when(customCalendarEventRepository.findByIdAndClubId(EVENT_ID, CLUB_ID)).thenReturn(Optional.of(event));
-        when(customCalendarEventRepository.save(any(CustomCalendarEvent.class)))
-                .thenAnswer(invocation -> invocation.getArgument(0));
 
-        ClubCalendarEventResult result = customCalendarEventService.update(user, EVENT_ID, request);
-
-        assertThat(result.title()).isEqualTo("새 제목");
-        assertThat(result.start()).isEqualTo("2026-09-01");
-        assertThat(result.source()).isEqualTo("CUSTOM");
-    }
-
-    @Test
-    @DisplayName("존재하지 않는 이벤트를 삭제하면 예외가 발생한다")
-    void delete_notFound_throws() {
-        givenAuthenticatedClub();
-        when(customCalendarEventRepository.deleteByIdAndClubId(EVENT_ID, CLUB_ID)).thenReturn(0L);
-
-        assertThatThrownBy(() -> customCalendarEventService.delete(user, EVENT_ID))
+        assertThatThrownBy(() -> customCalendarEventService.create(
+                user, request("2026-08-01", null, "SINGLE", "RED", null, null)))
                 .isInstanceOf(RestApiException.class)
                 .extracting("errorCode")
-                .isEqualTo(ErrorCode.CUSTOM_EVENT_NOT_FOUND);
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
     }
 
     @Test
-    @DisplayName("start가 YYYY-MM-DD 형식이 아니면 예외가 발생한다")
-    void create_invalidStartFormat_throws() {
+    @DisplayName("허용되지 않은 반복 주기면 예외가 발생한다")
+    void create_invalidFrequency_throws() {
         givenAuthenticatedClub();
-        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
-                "정기 모임", "2026/08/01", null, null, null);
+        CustomEventRecurrence recurrence = new CustomEventRecurrence("DAILY", null, null, null);
 
-        assertThatThrownBy(() -> customCalendarEventService.create(user, request))
+        assertThatThrownBy(() -> customCalendarEventService.create(
+                user, request("2026-08-01", null, "RECURRING", null, null, recurrence)))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
+    }
+
+    @Test
+    @DisplayName("WEEKLY weekdays가 0에서 6 범위를 벗어나면 예외가 발생한다")
+    void create_invalidWeekday_throws() {
+        givenAuthenticatedClub();
+        CustomEventRecurrence recurrence = new CustomEventRecurrence("WEEKLY", List.of(7), null, null);
+
+        assertThatThrownBy(() -> customCalendarEventService.create(
+                user, request("2026-08-01", null, "RECURRING", null, null, recurrence)))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
+    }
+
+    @Test
+    @DisplayName("RECURRING 이벤트에 recurrence가 없으면 예외가 발생한다")
+    void create_recurringWithoutRecurrence_throws() {
+        givenAuthenticatedClub();
+
+        assertThatThrownBy(() -> customCalendarEventService.create(
+                user, request("2026-08-01", null, "RECURRING", null, null, null)))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
+    }
+
+    @Test
+    @DisplayName("반복 종료일이 시작일보다 앞이면 예외가 발생한다")
+    void create_recurrenceEndBeforeStart_throws() {
+        givenAuthenticatedClub();
+        CustomEventRecurrence recurrence = new CustomEventRecurrence("MONTHLY", null, "2026-07-31", null);
+
+        assertThatThrownBy(() -> customCalendarEventService.create(
+                user, request("2026-08-01", null, "RECURRING", null, null, recurrence)))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_DATE_RANGE);
+    }
+
+    @Test
+    @DisplayName("MULTI 일정의 start는 dates 첫 날짜와 같아야 한다")
+    void create_multiStartMustMatchFirstDate_throws() {
+        givenAuthenticatedClub();
+
+        assertThatThrownBy(() -> customCalendarEventService.create(
+                user, request("2026-08-01", null, "MULTI", null, List.of("2026-08-02"), null)))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
+    }
+
+    @Test
+    @DisplayName("dates에 잘못된 날짜 형식이 있으면 예외가 발생한다")
+    void create_invalidDatesFormat_throws() {
+        givenAuthenticatedClub();
+
+        assertThatThrownBy(() -> customCalendarEventService.create(
+                user, request("2026-08-01", null, "MULTI", null, List.of("2026/08/10"), null)))
                 .isInstanceOf(RestApiException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_DATE_FORMAT);
     }
 
     @Test
-    @DisplayName("end가 YYYY-MM-DD 형식이 아니면 예외가 발생한다")
-    void create_invalidEndFormat_throws() {
+    @DisplayName("start가 YYYY-MM-DD 형식이 아니면 예외가 발생한다")
+    void create_invalidStartFormat_throws() {
         givenAuthenticatedClub();
-        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
-                "정기 모임", "2026-08-01", "08-02", null, null);
 
-        assertThatThrownBy(() -> customCalendarEventService.create(user, request))
+        assertThatThrownBy(() -> customCalendarEventService.create(
+                user, request("2026/08/01", null, null, null, null, null)))
                 .isInstanceOf(RestApiException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_DATE_FORMAT);
@@ -176,28 +272,187 @@ class CustomCalendarEventServiceTest {
     @DisplayName("start가 end보다 이후면 예외가 발생한다")
     void create_startAfterEnd_throws() {
         givenAuthenticatedClub();
-        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
-                "정기 모임", "2026-08-02", "2026-08-01", null, null);
 
-        assertThatThrownBy(() -> customCalendarEventService.create(user, request))
+        assertThatThrownBy(() -> customCalendarEventService.create(
+                user, request("2026-08-02", "2026-08-01", null, null, null, null)))
                 .isInstanceOf(RestApiException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_DATE_RANGE);
     }
 
     @Test
-    @DisplayName("start와 end가 같은 날짜면 정상 생성된다")
-    void create_sameStartAndEnd_succeeds() {
+    @DisplayName("관리자 목록 조회는 전개하지 않고 원형을 반환한다")
+    void list_returnsRawEvents() {
         givenAuthenticatedClub();
-        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
-                "정기 모임", "2026-08-01", "2026-08-01", null, null);
-        when(customCalendarEventRepository.save(any(CustomCalendarEvent.class)))
-                .thenAnswer(invocation -> invocation.getArgument(0));
+        CustomEventRecurrence recurrence = new CustomEventRecurrence("WEEKLY", null, "2026-03-31", null);
+        when(customCalendarEventRepository.findByClubId(CLUB_ID))
+                .thenReturn(List.of(storedEvent("RECURRING", "2026-03-06", null, null, recurrence)));
 
-        ClubCalendarEventResult result = customCalendarEventService.create(user, request);
+        List<CustomCalendarEventResponse> results = customCalendarEventService.list(user);
 
-        assertThat(result.start()).isEqualTo("2026-08-01");
-        assertThat(result.end()).isEqualTo("2026-08-01");
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).id()).isEqualTo(EVENT_ID);
+        assertThat(results.get(0).start()).isEqualTo("2026-03-06");
+        assertThat(results.get(0).recurrence().frequency()).isEqualTo("WEEKLY");
+    }
+
+    @Test
+    @DisplayName("이벤트를 수정하면 확장 필드까지 갱신된다")
+    void update_updatesExtendedFields() {
+        givenAuthenticatedClub();
+        givenSaveReturnsArgument();
+        when(customCalendarEventRepository.findByIdAndClubId(EVENT_ID, CLUB_ID))
+                .thenReturn(Optional.of(storedEvent("SINGLE", "2026-08-01", null, null, null)));
+        List<String> dates = List.of("2026-09-01", "2026-09-02");
+
+        CustomCalendarEventResponse response = customCalendarEventService.update(
+                user, EVENT_ID, request("2026-09-01", null, "MULTI", "ORANGE", dates, null));
+
+        assertThat(response.eventType()).isEqualTo("MULTI");
+        assertThat(response.color()).isEqualTo("ORANGE");
+        assertThat(response.dates()).containsExactlyElementsOf(dates);
+    }
+
+    @Test
+    @DisplayName("다른 동아리의 이벤트를 수정하면 예외가 발생한다")
+    void update_otherClubEvent_throwsNotFound() {
+        givenAuthenticatedClub();
+        when(customCalendarEventRepository.findByIdAndClubId(EVENT_ID, CLUB_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> customCalendarEventService.update(
+                user, EVENT_ID, request("2026-08-01", null, null, null, null, null)))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("scope가 없으면 이벤트를 삭제한다")
+    void delete_withoutScope_deletesEvent() {
+        givenAuthenticatedClub();
+        CustomCalendarEvent event = storedEvent("SINGLE", "2026-08-01", null, null, null);
+        when(customCalendarEventRepository.findByIdAndClubId(EVENT_ID, CLUB_ID)).thenReturn(Optional.of(event));
+
+        customCalendarEventService.delete(user, EVENT_ID, null, null);
+
+        verify(customCalendarEventRepository).delete(event);
+    }
+
+    @Test
+    @DisplayName("THIS 스코프는 해당 발생일을 excludedDates에 추가한다")
+    void delete_thisScope_addsExcludedDate() {
+        givenAuthenticatedClub();
+        givenSaveReturnsArgument();
+        CustomEventRecurrence recurrence = new CustomEventRecurrence("WEEKLY", null, "2026-03-31", null);
+        CustomCalendarEvent event = storedEvent("RECURRING", "2026-03-06", null, null, recurrence);
+        when(customCalendarEventRepository.findByIdAndClubId(EVENT_ID, CLUB_ID)).thenReturn(Optional.of(event));
+
+        customCalendarEventService.delete(user, EVENT_ID, "THIS", "2026-03-13");
+
+        ArgumentCaptor<CustomCalendarEvent> captor = ArgumentCaptor.forClass(CustomCalendarEvent.class);
+        verify(customCalendarEventRepository).save(captor.capture());
+        verify(customCalendarEventRepository, never()).delete(any(CustomCalendarEvent.class));
+        assertThat(captor.getValue().getRecurrence().excludedDates()).containsExactly("2026-03-13");
+    }
+
+    @Test
+    @DisplayName("THIS_AND_FOLLOWING 스코프는 반복 종료일을 기준일 하루 전으로 당긴다")
+    void delete_thisAndFollowingScope_truncatesRecurrenceEnd() {
+        givenAuthenticatedClub();
+        givenSaveReturnsArgument();
+        CustomEventRecurrence recurrence = new CustomEventRecurrence("WEEKLY", null, "2026-03-31", null);
+        CustomCalendarEvent event = storedEvent("RECURRING", "2026-03-06", null, null, recurrence);
+        when(customCalendarEventRepository.findByIdAndClubId(EVENT_ID, CLUB_ID)).thenReturn(Optional.of(event));
+
+        customCalendarEventService.delete(user, EVENT_ID, "THIS_AND_FOLLOWING", "2026-03-20");
+
+        ArgumentCaptor<CustomCalendarEvent> captor = ArgumentCaptor.forClass(CustomCalendarEvent.class);
+        verify(customCalendarEventRepository).save(captor.capture());
+        assertThat(captor.getValue().getRecurrence().end()).isEqualTo("2026-03-19");
+    }
+
+    @Test
+    @DisplayName("THIS_AND_FOLLOWING 기준일이 시작일이면 이벤트를 삭제한다")
+    void delete_thisAndFollowingFromStart_deletesEvent() {
+        givenAuthenticatedClub();
+        CustomEventRecurrence recurrence = new CustomEventRecurrence("WEEKLY", null, "2026-03-31", null);
+        CustomCalendarEvent event = storedEvent("RECURRING", "2026-03-06", null, null, recurrence);
+        when(customCalendarEventRepository.findByIdAndClubId(EVENT_ID, CLUB_ID)).thenReturn(Optional.of(event));
+
+        customCalendarEventService.delete(user, EVENT_ID, "THIS_AND_FOLLOWING", "2026-03-06");
+
+        verify(customCalendarEventRepository).delete(event);
+        verify(customCalendarEventRepository, never()).save(any(CustomCalendarEvent.class));
+    }
+
+    @Test
+    @DisplayName("반복이 아닌 일정은 THIS 스코프여도 삭제한다")
+    void delete_nonRecurringWithScope_deletesEvent() {
+        givenAuthenticatedClub();
+        CustomCalendarEvent event = storedEvent("PERIOD", "2026-08-01", "2026-08-05", null, null);
+        when(customCalendarEventRepository.findByIdAndClubId(EVENT_ID, CLUB_ID)).thenReturn(Optional.of(event));
+
+        customCalendarEventService.delete(user, EVENT_ID, "THIS", "2026-08-03");
+
+        verify(customCalendarEventRepository).delete(event);
+    }
+
+    @Test
+    @DisplayName("허용되지 않은 삭제 스코프면 예외가 발생한다")
+    void delete_invalidScope_throws() {
+        givenAuthenticatedClub();
+
+        assertThatThrownBy(() -> customCalendarEventService.delete(user, EVENT_ID, "ONLY_ONE", "2026-08-01"))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_DELETE_SCOPE);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 이벤트를 삭제하면 예외가 발생한다")
+    void delete_notFound_throws() {
+        givenAuthenticatedClub();
+        when(customCalendarEventRepository.findByIdAndClubId(EVENT_ID, CLUB_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> customCalendarEventService.delete(user, EVENT_ID, null, null))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("공개 캘린더 조회는 발생일마다 하나씩 펼쳐서 반환한다")
+    void getClubCalendarEvents_expandsOccurrences() {
+        when(customCalendarEventRepository.findByClubId(CLUB_ID))
+                .thenReturn(List.of(storedEvent("PERIOD", "2026-08-01", "2026-08-03", null, null)));
+
+        List<ClubCalendarEventResult> results = customCalendarEventService.getClubCalendarEvents(CLUB_ID);
+
+        assertThat(results).hasSize(3);
+        assertThat(results).extracting(ClubCalendarEventResult::start)
+                .containsExactly("2026-08-01", "2026-08-02", "2026-08-03");
+        assertThat(results).extracting(ClubCalendarEventResult::id)
+                .containsExactly(EVENT_ID + ":2026-08-01", EVENT_ID + ":2026-08-02", EVENT_ID + ":2026-08-03");
+        assertThat(results).allSatisfy(result -> assertThat(result.source()).isEqualTo("CUSTOM"));
+    }
+
+    @Test
+    @DisplayName("발생일이 하나면 원래 id와 end를 유지한다")
+    void getClubCalendarEvents_singleOccurrenceKeepsId() {
+        when(customCalendarEventRepository.findByClubId(CLUB_ID))
+                .thenReturn(List.of(storedEvent("SINGLE", "2026-08-01", "2026-08-05", null, null)));
+
+        List<ClubCalendarEventResult> results = customCalendarEventService.getClubCalendarEvents(CLUB_ID);
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).id()).isEqualTo(EVENT_ID);
+        assertThat(results.get(0).end()).isEqualTo("2026-08-05");
+    }
+
+    @Test
+    @DisplayName("clubId가 비어있으면 빈 리스트를 반환한다")
+    void getClubCalendarEvents_blankClubId_returnsEmpty() {
+        assertThat(customCalendarEventService.getClubCalendarEvents(" ")).isEmpty();
     }
 
     @Test
@@ -205,10 +460,9 @@ class CustomCalendarEventServiceTest {
     void create_noClub_throws() {
         when(user.getId()).thenReturn(USER_ID);
         when(clubRepository.findClubByUserId(USER_ID)).thenReturn(Optional.empty());
-        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
-                "정기 모임", "2026-08-01", null, null, null);
 
-        assertThatThrownBy(() -> customCalendarEventService.create(user, request))
+        assertThatThrownBy(() -> customCalendarEventService.create(
+                user, request("2026-08-01", null, null, null, null, null)))
                 .isInstanceOf(RestApiException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.CUSTOM_EVENT_CLUB_NOT_FOUND);

--- a/backend/src/test/java/moadong/calendar/custom/service/CustomCalendarEventServiceTest.java
+++ b/backend/src/test/java/moadong/calendar/custom/service/CustomCalendarEventServiceTest.java
@@ -80,6 +80,7 @@ class CustomCalendarEventServiceTest {
                 .start(start)
                 .end(end)
                 .eventType(eventType)
+                .color("MINT")
                 .dates(dates)
                 .recurrence(recurrence)
                 .build();
@@ -463,17 +464,50 @@ class CustomCalendarEventServiceTest {
     @Test
     @DisplayName("공개 캘린더 조회는 발생일마다 하나씩 펼쳐서 반환한다")
     void getClubCalendarEvents_expandsOccurrences() {
+        List<String> dates = List.of("2026-08-01", "2026-08-02", "2026-08-03");
         when(customCalendarEventRepository.findByClubId(CLUB_ID))
-                .thenReturn(List.of(storedEvent("PERIOD", "2026-08-01", "2026-08-03", null, null)));
+                .thenReturn(List.of(storedEvent("MULTI", "2026-08-01", null, dates, null)));
 
         List<ClubCalendarEventResult> results = customCalendarEventService.getClubCalendarEvents(CLUB_ID);
 
         assertThat(results).hasSize(3);
         assertThat(results).extracting(ClubCalendarEventResult::start)
-                .containsExactly("2026-08-01", "2026-08-02", "2026-08-03");
+                .containsExactlyElementsOf(dates);
         assertThat(results).extracting(ClubCalendarEventResult::id)
                 .containsExactly(EVENT_ID + ":2026-08-01", EVENT_ID + ":2026-08-02", EVENT_ID + ":2026-08-03");
-        assertThat(results).allSatisfy(result -> assertThat(result.source()).isEqualTo("CUSTOM"));
+        assertThat(results).allSatisfy(result -> {
+            assertThat(result.source()).isEqualTo("CUSTOM");
+            assertThat(result.eventType()).isEqualTo("MULTI");
+            assertThat(result.color()).isEqualTo("MINT");
+        });
+    }
+
+    @Test
+    @DisplayName("PERIOD는 전개하지 않고 start/end를 가진 한 건으로 반환한다")
+    void getClubCalendarEvents_periodIsNotExpanded() {
+        when(customCalendarEventRepository.findByClubId(CLUB_ID))
+                .thenReturn(List.of(storedEvent("PERIOD", "2026-03-16", "2026-03-20", null, null)));
+
+        List<ClubCalendarEventResult> results = customCalendarEventService.getClubCalendarEvents(CLUB_ID);
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).id()).isEqualTo(EVENT_ID);
+        assertThat(results.get(0).start()).isEqualTo("2026-03-16");
+        assertThat(results.get(0).end()).isEqualTo("2026-03-20");
+        assertThat(results.get(0).eventType()).isEqualTo("PERIOD");
+        assertThat(results.get(0).color()).isEqualTo("MINT");
+    }
+
+    @Test
+    @DisplayName("eventType이 없는 이벤트는 SINGLE로 내려준다")
+    void getClubCalendarEvents_nullEventTypeDefaultsToSingle() {
+        when(customCalendarEventRepository.findByClubId(CLUB_ID))
+                .thenReturn(List.of(storedEvent(null, "2026-08-01", null, null, null)));
+
+        List<ClubCalendarEventResult> results = customCalendarEventService.getClubCalendarEvents(CLUB_ID);
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).eventType()).isEqualTo("SINGLE");
     }
 
     @Test

--- a/backend/src/test/java/moadong/calendar/custom/service/CustomCalendarEventServiceTest.java
+++ b/backend/src/test/java/moadong/calendar/custom/service/CustomCalendarEventServiceTest.java
@@ -1,0 +1,170 @@
+package moadong.calendar.custom.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import moadong.calendar.custom.entity.CustomCalendarEvent;
+import moadong.calendar.custom.payload.request.CustomCalendarEventRequest;
+import moadong.calendar.custom.repository.CustomCalendarEventRepository;
+import moadong.club.entity.Club;
+import moadong.club.payload.dto.ClubCalendarEventResult;
+import moadong.club.repository.ClubRepository;
+import moadong.global.exception.ErrorCode;
+import moadong.global.exception.RestApiException;
+import moadong.user.payload.CustomUserDetails;
+import moadong.util.annotations.UnitTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+@UnitTest
+class CustomCalendarEventServiceTest {
+
+    @Mock
+    private CustomCalendarEventRepository customCalendarEventRepository;
+
+    @Mock
+    private ClubRepository clubRepository;
+
+    @Mock
+    private CustomUserDetails user;
+
+    @Mock
+    private Club club;
+
+    private CustomCalendarEventService customCalendarEventService;
+
+    private static final String USER_ID = "test-user-id";
+    private static final String CLUB_ID = "test-club-id";
+    private static final String EVENT_ID = "test-event-id";
+
+    @BeforeEach
+    void setUp() {
+        customCalendarEventService = new CustomCalendarEventService(customCalendarEventRepository, clubRepository);
+    }
+
+    private void givenAuthenticatedClub() {
+        when(user.getId()).thenReturn(USER_ID);
+        when(club.getId()).thenReturn(CLUB_ID);
+        when(clubRepository.findClubByUserId(USER_ID)).thenReturn(Optional.of(club));
+    }
+
+    @Test
+    @DisplayName("커스텀 이벤트를 생성하면 source가 CUSTOM인 결과를 반환한다")
+    void create_returnsCustomResult() {
+        givenAuthenticatedClub();
+        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
+                "정기 모임", "2026-08-01", "2026-08-02", "https://example.com", "설명");
+        when(customCalendarEventRepository.save(any(CustomCalendarEvent.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        ClubCalendarEventResult result = customCalendarEventService.create(user, request);
+
+        assertThat(result.source()).isEqualTo("CUSTOM");
+        assertThat(result.title()).isEqualTo("정기 모임");
+        assertThat(result.start()).isEqualTo("2026-08-01");
+        assertThat(result.end()).isEqualTo("2026-08-02");
+    }
+
+    @Test
+    @DisplayName("clubId로 커스텀 이벤트 목록을 CUSTOM 결과로 매핑한다")
+    void getClubCalendarEvents_mapsToCustomResults() {
+        CustomCalendarEvent event = CustomCalendarEvent.builder()
+                .id(EVENT_ID)
+                .clubId(CLUB_ID)
+                .title("정기 모임")
+                .start("2026-08-01")
+                .build();
+        when(customCalendarEventRepository.findByClubId(CLUB_ID)).thenReturn(List.of(event));
+
+        List<ClubCalendarEventResult> results = customCalendarEventService.getClubCalendarEvents(CLUB_ID);
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).id()).isEqualTo(EVENT_ID);
+        assertThat(results.get(0).source()).isEqualTo("CUSTOM");
+    }
+
+    @Test
+    @DisplayName("clubId가 비어있으면 빈 리스트를 반환한다")
+    void getClubCalendarEvents_blankClubId_returnsEmpty() {
+        List<ClubCalendarEventResult> results = customCalendarEventService.getClubCalendarEvents(" ");
+
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    @DisplayName("다른 동아리의 이벤트를 수정하면 예외가 발생한다")
+    void update_otherClubEvent_throwsNotFound() {
+        givenAuthenticatedClub();
+        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
+                "수정", "2026-08-01", null, null, null);
+        when(customCalendarEventRepository.findByIdAndClubId(EVENT_ID, CLUB_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> customCalendarEventService.update(user, EVENT_ID, request))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("커스텀 이벤트를 수정하면 변경된 값이 반영된다")
+    void update_updatesFields() {
+        givenAuthenticatedClub();
+        CustomCalendarEvent event = CustomCalendarEvent.builder()
+                .id(EVENT_ID)
+                .clubId(CLUB_ID)
+                .title("이전 제목")
+                .start("2026-08-01")
+                .build();
+        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
+                "새 제목", "2026-09-01", null, null, null);
+        when(customCalendarEventRepository.findByIdAndClubId(EVENT_ID, CLUB_ID)).thenReturn(Optional.of(event));
+        when(customCalendarEventRepository.save(any(CustomCalendarEvent.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        ClubCalendarEventResult result = customCalendarEventService.update(user, EVENT_ID, request);
+
+        assertThat(result.title()).isEqualTo("새 제목");
+        assertThat(result.start()).isEqualTo("2026-09-01");
+        assertThat(result.source()).isEqualTo("CUSTOM");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 이벤트를 삭제하면 예외가 발생한다")
+    void delete_notFound_throws() {
+        givenAuthenticatedClub();
+        when(customCalendarEventRepository.deleteByIdAndClubId(EVENT_ID, CLUB_ID)).thenReturn(0L);
+
+        assertThatThrownBy(() -> customCalendarEventService.delete(user, EVENT_ID))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("인증된 사용자에게 동아리가 없으면 예외가 발생한다")
+    void create_noClub_throws() {
+        when(user.getId()).thenReturn(USER_ID);
+        when(clubRepository.findClubByUserId(USER_ID)).thenReturn(Optional.empty());
+        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
+                "정기 모임", "2026-08-01", null, null, null);
+
+        assertThatThrownBy(() -> customCalendarEventService.create(user, request))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_CLUB_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("이벤트가 존재하면 hasCalendarConnection이 true를 반환한다")
+    void hasCalendarConnection_eventsExist_returnsTrue() {
+        when(customCalendarEventRepository.existsByClubId(CLUB_ID)).thenReturn(true);
+
+        assertThat(customCalendarEventService.hasCalendarConnection(CLUB_ID)).isTrue();
+    }
+}

--- a/backend/src/test/java/moadong/calendar/custom/service/CustomEventOccurrenceExpanderTest.java
+++ b/backend/src/test/java/moadong/calendar/custom/service/CustomEventOccurrenceExpanderTest.java
@@ -165,6 +165,21 @@ class CustomEventOccurrenceExpanderTest {
     }
 
     @Test
+    @DisplayName("오래된 무기한 WEEKLY 반복도 미래 발생일을 포함한다")
+    void expand_unboundedPastWeeklyIncludesFutureOccurrences() {
+        LocalDate today = LocalDate.now();
+        CustomEventRecurrence recurrence = new CustomEventRecurrence("WEEKLY", null, null, null);
+
+        List<String> occurrences = expander.expand(event(
+                "RECURRING", today.minusYears(20).toString(), null, null, recurrence));
+
+        assertThat(occurrences).isNotEmpty();
+        assertThat(occurrences)
+                .anySatisfy(date -> assertThat(LocalDate.parse(date)).isAfter(today))
+                .allSatisfy(date -> assertThat(LocalDate.parse(date)).isBeforeOrEqualTo(today.plusYears(1)));
+    }
+
+    @Test
     @DisplayName("RECURRING인데 recurrence가 없으면 start 하루만 전개한다")
     void expand_recurringWithoutRecurrence() {
         assertThat(expander.expand(event("RECURRING", "2026-03-01", null, null, null)))

--- a/backend/src/test/java/moadong/calendar/custom/service/CustomEventOccurrenceExpanderTest.java
+++ b/backend/src/test/java/moadong/calendar/custom/service/CustomEventOccurrenceExpanderTest.java
@@ -1,0 +1,180 @@
+package moadong.calendar.custom.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.util.List;
+import moadong.calendar.custom.entity.CustomCalendarEvent;
+import moadong.calendar.custom.entity.CustomEventRecurrence;
+import moadong.util.annotations.UnitTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@UnitTest
+class CustomEventOccurrenceExpanderTest {
+
+    private CustomEventOccurrenceExpander expander;
+
+    @BeforeEach
+    void setUp() {
+        expander = new CustomEventOccurrenceExpander();
+    }
+
+    private CustomCalendarEvent event(String eventType, String start, String end,
+                                      List<String> dates, CustomEventRecurrence recurrence) {
+        return CustomCalendarEvent.builder()
+                .id("event-1")
+                .clubId("club-1")
+                .title("일정")
+                .start(start)
+                .end(end)
+                .eventType(eventType)
+                .dates(dates)
+                .recurrence(recurrence)
+                .build();
+    }
+
+    @Test
+    @DisplayName("SINGLE은 start 하루만 전개한다")
+    void expand_single() {
+        assertThat(expander.expand(event("SINGLE", "2026-03-01", null, null, null)))
+                .containsExactly("2026-03-01");
+    }
+
+    @Test
+    @DisplayName("eventType이 없으면 SINGLE로 취급한다")
+    void expand_nullEventType_treatedAsSingle() {
+        assertThat(expander.expand(event(null, "2026-03-01", "2026-03-05", null, null)))
+                .containsExactly("2026-03-01");
+    }
+
+    @Test
+    @DisplayName("PERIOD는 start부터 end까지 매일 전개한다")
+    void expand_period() {
+        assertThat(expander.expand(event("PERIOD", "2026-03-01", "2026-03-05", null, null)))
+                .containsExactly("2026-03-01", "2026-03-02", "2026-03-03", "2026-03-04", "2026-03-05");
+    }
+
+    @Test
+    @DisplayName("PERIOD에 end가 없으면 start 하루만 전개한다")
+    void expand_periodWithoutEnd() {
+        assertThat(expander.expand(event("PERIOD", "2026-03-01", null, null, null)))
+                .containsExactly("2026-03-01");
+    }
+
+    @Test
+    @DisplayName("MULTI는 dates의 각 날짜를 전개한다")
+    void expand_multi() {
+        List<String> dates = List.of("2026-03-01", "2026-03-10", "2026-03-20");
+
+        assertThat(expander.expand(event("MULTI", "2026-03-01", null, dates, null)))
+                .containsExactlyElementsOf(dates);
+    }
+
+    @Test
+    @DisplayName("MULTI에 dates가 비어있으면 start 하루만 전개한다")
+    void expand_multiWithoutDates() {
+        assertThat(expander.expand(event("MULTI", "2026-03-01", null, List.of(), null)))
+                .containsExactly("2026-03-01");
+    }
+
+    @Test
+    @DisplayName("WEEKLY는 지정한 요일마다 전개한다")
+    void expand_weeklyWithWeekdays() {
+        // 2026-03-06(금, 5), 2026-03-07(토, 6)
+        CustomEventRecurrence recurrence =
+                new CustomEventRecurrence("WEEKLY", List.of(5, 6), "2026-03-31", null);
+
+        assertThat(expander.expand(event("RECURRING", "2026-03-06", null, null, recurrence)))
+                .containsExactly("2026-03-06", "2026-03-07", "2026-03-13", "2026-03-14",
+                        "2026-03-20", "2026-03-21", "2026-03-27", "2026-03-28");
+    }
+
+    @Test
+    @DisplayName("WEEKLY에 weekdays가 없으면 start의 요일로 반복한다")
+    void expand_weeklyWithoutWeekdays() {
+        CustomEventRecurrence recurrence =
+                new CustomEventRecurrence("WEEKLY", null, "2026-03-31", null);
+
+        assertThat(expander.expand(event("RECURRING", "2026-03-06", null, null, recurrence)))
+                .containsExactly("2026-03-06", "2026-03-13", "2026-03-20", "2026-03-27");
+    }
+
+    @Test
+    @DisplayName("MONTHLY는 매월 start의 일자로 반복하고 없는 날짜는 건너뛴다")
+    void expand_monthlySkipsShortMonths() {
+        CustomEventRecurrence recurrence =
+                new CustomEventRecurrence("MONTHLY", null, "2026-06-30", null);
+
+        assertThat(expander.expand(event("RECURRING", "2026-01-31", null, null, recurrence)))
+                .containsExactly("2026-01-31", "2026-03-31", "2026-05-31");
+    }
+
+    @Test
+    @DisplayName("YEARLY는 매년 start의 월/일로 반복한다")
+    void expand_yearly() {
+        CustomEventRecurrence recurrence =
+                new CustomEventRecurrence("YEARLY", null, "2026-12-31", null);
+
+        assertThat(expander.expand(event("RECURRING", "2024-05-01", null, null, recurrence)))
+                .containsExactly("2024-05-01", "2025-05-01", "2026-05-01");
+    }
+
+    @Test
+    @DisplayName("YEARLY는 윤년이 아닌 해의 2월 29일을 건너뛴다")
+    void expand_yearlySkipsNonLeapYears() {
+        CustomEventRecurrence recurrence =
+                new CustomEventRecurrence("YEARLY", null, "2026-12-31", null);
+
+        assertThat(expander.expand(event("RECURRING", "2024-02-29", null, null, recurrence)))
+                .containsExactly("2024-02-29");
+    }
+
+    @Test
+    @DisplayName("excludedDates에 포함된 발생일은 제외한다")
+    void expand_excludesExcludedDates() {
+        CustomEventRecurrence recurrence = new CustomEventRecurrence(
+                "WEEKLY", null, "2026-03-31", List.of("2026-03-13"));
+
+        assertThat(expander.expand(event("RECURRING", "2026-03-06", null, null, recurrence)))
+                .containsExactly("2026-03-06", "2026-03-20", "2026-03-27");
+    }
+
+    @Test
+    @DisplayName("반복 종료일이 시작일보다 앞이면 발생일이 없다")
+    void expand_recurrenceEndBeforeStart() {
+        CustomEventRecurrence recurrence =
+                new CustomEventRecurrence("WEEKLY", null, "2026-02-28", null);
+
+        assertThat(expander.expand(event("RECURRING", "2026-03-06", null, null, recurrence)))
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("반복 종료일이 없으면 오늘 기준 1년까지만 전개한다")
+    void expand_unboundedRecurrenceStopsAtWindowLimit() {
+        CustomEventRecurrence recurrence = new CustomEventRecurrence("MONTHLY", null, null, null);
+        LocalDate windowLimit = LocalDate.now().plusYears(1);
+
+        List<String> occurrences = expander.expand(event("RECURRING", "2026-03-01", null, null, recurrence));
+
+        assertThat(occurrences).isNotEmpty();
+        assertThat(occurrences).allSatisfy(date ->
+                assertThat(LocalDate.parse(date)).isBeforeOrEqualTo(windowLimit));
+    }
+
+    @Test
+    @DisplayName("RECURRING인데 recurrence가 없으면 start 하루만 전개한다")
+    void expand_recurringWithoutRecurrence() {
+        assertThat(expander.expand(event("RECURRING", "2026-03-01", null, null, null)))
+                .containsExactly("2026-03-01");
+    }
+
+    @Test
+    @DisplayName("start가 없거나 형식이 잘못되면 발생일이 없다")
+    void expand_invalidStart() {
+        assertThat(expander.expand(event("SINGLE", "2026/03/01", null, null, null))).isEmpty();
+        assertThat(expander.expand(event("SINGLE", null, null, null, null))).isEmpty();
+    }
+}

--- a/backend/src/test/java/moadong/calendar/custom/service/CustomEventOccurrenceExpanderTest.java
+++ b/backend/src/test/java/moadong/calendar/custom/service/CustomEventOccurrenceExpanderTest.java
@@ -50,14 +50,14 @@ class CustomEventOccurrenceExpanderTest {
     }
 
     @Test
-    @DisplayName("PERIOD는 start부터 end까지 매일 전개한다")
+    @DisplayName("PERIOD는 여러 날에 걸친 하나의 일정이므로 전개하지 않고 start 한 건만 반환한다")
     void expand_period() {
         assertThat(expander.expand(event("PERIOD", "2026-03-01", "2026-03-05", null, null)))
-                .containsExactly("2026-03-01", "2026-03-02", "2026-03-03", "2026-03-04", "2026-03-05");
+                .containsExactly("2026-03-01");
     }
 
     @Test
-    @DisplayName("PERIOD에 end가 없으면 start 하루만 전개한다")
+    @DisplayName("PERIOD에 end가 없어도 start 한 건만 반환한다")
     void expand_periodWithoutEnd() {
         assertThat(expander.expand(event("PERIOD", "2026-03-01", null, null, null)))
                 .containsExactly("2026-03-01");

--- a/backend/src/test/java/moadong/calendar/hidden/service/HiddenCalendarEventServiceTest.java
+++ b/backend/src/test/java/moadong/calendar/hidden/service/HiddenCalendarEventServiceTest.java
@@ -1,0 +1,154 @@
+package moadong.calendar.hidden.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import moadong.calendar.hidden.entity.HiddenCalendarEvent;
+import moadong.calendar.hidden.payload.dto.HiddenCalendarEventResult;
+import moadong.calendar.hidden.repository.HiddenCalendarEventRepository;
+import moadong.club.entity.Club;
+import moadong.club.repository.ClubRepository;
+import moadong.global.exception.ErrorCode;
+import moadong.global.exception.RestApiException;
+import moadong.user.payload.CustomUserDetails;
+import moadong.util.annotations.UnitTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+@UnitTest
+class HiddenCalendarEventServiceTest {
+
+    @Mock
+    private HiddenCalendarEventRepository hiddenCalendarEventRepository;
+
+    @Mock
+    private ClubRepository clubRepository;
+
+    @Mock
+    private CustomUserDetails user;
+
+    @Mock
+    private Club club;
+
+    private HiddenCalendarEventService hiddenCalendarEventService;
+
+    private static final String USER_ID = "test-user-id";
+    private static final String CLUB_ID = "test-club-id";
+    private static final String EVENT_ID = "google-event-1";
+
+    @BeforeEach
+    void setUp() {
+        hiddenCalendarEventService = new HiddenCalendarEventService(hiddenCalendarEventRepository, clubRepository);
+    }
+
+    private void givenAuthenticatedClub() {
+        when(user.getId()).thenReturn(USER_ID);
+        when(club.getId()).thenReturn(CLUB_ID);
+        when(clubRepository.findClubByUserId(USER_ID)).thenReturn(Optional.of(club));
+    }
+
+    @Test
+    @DisplayName("GOOGLE 이벤트를 숨김 처리하면 저장된다")
+    void hide_savesHiddenEvent() {
+        givenAuthenticatedClub();
+        when(hiddenCalendarEventRepository.existsByClubIdAndSourceAndEventId(CLUB_ID, "GOOGLE", EVENT_ID))
+                .thenReturn(false);
+
+        hiddenCalendarEventService.hide(user, "GOOGLE", EVENT_ID);
+
+        verify(hiddenCalendarEventRepository).save(any(HiddenCalendarEvent.class));
+    }
+
+    @Test
+    @DisplayName("이미 숨김 처리된 이벤트는 다시 저장하지 않는다")
+    void hide_alreadyHidden_isIdempotent() {
+        givenAuthenticatedClub();
+        when(hiddenCalendarEventRepository.existsByClubIdAndSourceAndEventId(CLUB_ID, "GOOGLE", EVENT_ID))
+                .thenReturn(true);
+
+        hiddenCalendarEventService.hide(user, "GOOGLE", EVENT_ID);
+
+        verify(hiddenCalendarEventRepository, never()).save(any(HiddenCalendarEvent.class));
+    }
+
+    @Test
+    @DisplayName("GOOGLE/NOTION이 아닌 source는 예외가 발생한다")
+    void hide_invalidSource_throws() {
+        givenAuthenticatedClub();
+
+        assertThatThrownBy(() -> hiddenCalendarEventService.hide(user, "CUSTOM", EVENT_ID))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.HIDDEN_EVENT_INVALID_SOURCE);
+    }
+
+    @Test
+    @DisplayName("숨김 해제 시 삭제를 호출한다")
+    void unhide_deletesHiddenEvent() {
+        givenAuthenticatedClub();
+
+        hiddenCalendarEventService.unhide(user, "NOTION", EVENT_ID);
+
+        verify(hiddenCalendarEventRepository).deleteByClubIdAndSourceAndEventId(CLUB_ID, "NOTION", EVENT_ID);
+    }
+
+    @Test
+    @DisplayName("숨김 목록을 source:eventId 키 집합으로 반환한다")
+    void getHiddenKeys_returnsKeySet() {
+        HiddenCalendarEvent hidden = HiddenCalendarEvent.builder()
+                .clubId(CLUB_ID)
+                .source("GOOGLE")
+                .eventId(EVENT_ID)
+                .build();
+        when(hiddenCalendarEventRepository.findByClubId(CLUB_ID)).thenReturn(List.of(hidden));
+
+        Set<String> keys = hiddenCalendarEventService.getHiddenKeys(CLUB_ID);
+
+        assertThat(keys).containsExactly("GOOGLE:" + EVENT_ID);
+    }
+
+    @Test
+    @DisplayName("clubId가 비어있으면 빈 집합을 반환한다")
+    void getHiddenKeys_blankClubId_returnsEmpty() {
+        assertThat(hiddenCalendarEventService.getHiddenKeys(" ")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("숨김 목록 조회는 source/eventId 형태로 매핑된다")
+    void list_mapsToResults() {
+        givenAuthenticatedClub();
+        HiddenCalendarEvent hidden = HiddenCalendarEvent.builder()
+                .clubId(CLUB_ID)
+                .source("NOTION")
+                .eventId(EVENT_ID)
+                .build();
+        when(hiddenCalendarEventRepository.findByClubId(CLUB_ID)).thenReturn(List.of(hidden));
+
+        List<HiddenCalendarEventResult> results = hiddenCalendarEventService.list(user);
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).source()).isEqualTo("NOTION");
+        assertThat(results.get(0).eventId()).isEqualTo(EVENT_ID);
+    }
+
+    @Test
+    @DisplayName("인증된 사용자에게 동아리가 없으면 예외가 발생한다")
+    void hide_noClub_throws() {
+        when(user.getId()).thenReturn(USER_ID);
+        when(clubRepository.findClubByUserId(USER_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> hiddenCalendarEventService.hide(user, "GOOGLE", EVENT_ID))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.HIDDEN_EVENT_CLUB_NOT_FOUND);
+    }
+}

--- a/backend/src/test/java/moadong/calendar/hidden/service/HiddenCalendarEventServiceTest.java
+++ b/backend/src/test/java/moadong/calendar/hidden/service/HiddenCalendarEventServiceTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.springframework.dao.DuplicateKeyException;
 
 @UnitTest
 class HiddenCalendarEventServiceTest {
@@ -78,6 +79,20 @@ class HiddenCalendarEventServiceTest {
         hiddenCalendarEventService.hide(user, "GOOGLE", EVENT_ID);
 
         verify(hiddenCalendarEventRepository, never()).save(any(HiddenCalendarEvent.class));
+    }
+
+    @Test
+    @DisplayName("동시 요청으로 인한 중복 저장은 멱등적으로 처리한다")
+    void hide_duplicateKey_isIdempotent() {
+        givenAuthenticatedClub();
+        when(hiddenCalendarEventRepository.existsByClubIdAndSourceAndEventId(CLUB_ID, "GOOGLE", EVENT_ID))
+                .thenReturn(false);
+        when(hiddenCalendarEventRepository.save(any(HiddenCalendarEvent.class)))
+                .thenThrow(new DuplicateKeyException("duplicate"));
+
+        hiddenCalendarEventService.hide(user, "GOOGLE", EVENT_ID);
+
+        verify(hiddenCalendarEventRepository).save(any(HiddenCalendarEvent.class));
     }
 
     @Test

--- a/backend/src/test/java/moadong/calendar/service/CalendarAggregationServiceTest.java
+++ b/backend/src/test/java/moadong/calendar/service/CalendarAggregationServiceTest.java
@@ -97,7 +97,7 @@ class CalendarAggregationServiceTest {
         ClubCalendarEventResult googleEvent = ClubCalendarEventResult.ofGoogle(
                 "google-1", "Google 이벤트", "2026-04-01", null, null, null);
         ClubCalendarEventResult customEvent = ClubCalendarEventResult.ofCustom(
-                "custom-1", "커스텀 이벤트", "2026-04-02", null, null, null);
+                "custom-1", "커스텀 이벤트", "2026-04-02", null, null, null, "SINGLE", "MINT");
 
         when(notionOAuthService.getClubCalendarEvents(CLUB_ID)).thenReturn(List.of(notionEvent));
         when(googleOAuthService.getClubCalendarEvents(CLUB_ID)).thenReturn(List.of(googleEvent));
@@ -119,7 +119,7 @@ class CalendarAggregationServiceTest {
         ClubCalendarEventResult googleEvent = ClubCalendarEventResult.ofGoogle(
                 "google-1", "Google 이벤트", "2026-04-02", null, null, null);
         ClubCalendarEventResult customEvent = ClubCalendarEventResult.ofCustom(
-                "custom-1", "커스텀 이벤트", "2026-04-03", null, null, null);
+                "custom-1", "커스텀 이벤트", "2026-04-03", null, null, null, "SINGLE", "MINT");
 
         when(notionOAuthService.getClubCalendarEvents(CLUB_ID)).thenReturn(List.of(notionEvent));
         when(googleOAuthService.getClubCalendarEvents(CLUB_ID)).thenReturn(List.of(googleEvent));

--- a/backend/src/test/java/moadong/calendar/service/CalendarAggregationServiceTest.java
+++ b/backend/src/test/java/moadong/calendar/service/CalendarAggregationServiceTest.java
@@ -4,7 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Set;
+import moadong.calendar.custom.service.CustomCalendarEventService;
 import moadong.calendar.google.service.GoogleOAuthService;
+import moadong.calendar.hidden.service.HiddenCalendarEventService;
 import moadong.calendar.notion.service.NotionOAuthService;
 import moadong.club.payload.dto.ClubCalendarEventResult;
 import moadong.util.annotations.UnitTest;
@@ -22,13 +25,20 @@ class CalendarAggregationServiceTest {
     @Mock
     private GoogleOAuthService googleOAuthService;
 
+    @Mock
+    private CustomCalendarEventService customCalendarEventService;
+
+    @Mock
+    private HiddenCalendarEventService hiddenCalendarEventService;
+
     private CalendarAggregationService calendarAggregationService;
 
     private static final String CLUB_ID = "test-club-id";
 
     @BeforeEach
     void setUp() {
-        calendarAggregationService = new CalendarAggregationService(notionOAuthService, googleOAuthService);
+        calendarAggregationService = new CalendarAggregationService(
+                notionOAuthService, googleOAuthService, customCalendarEventService, hiddenCalendarEventService);
     }
 
     @Test
@@ -80,6 +90,65 @@ class CalendarAggregationServiceTest {
     }
 
     @Test
+    @DisplayName("커스텀 이벤트도 함께 병합하여 시작일 기준 정렬한다")
+    void getAggregatedEvents_includesCustomEvents() {
+        ClubCalendarEventResult notionEvent = ClubCalendarEventResult.ofNotion(
+                "notion-1", "Notion 이벤트", "2026-04-03", null, null, null);
+        ClubCalendarEventResult googleEvent = ClubCalendarEventResult.ofGoogle(
+                "google-1", "Google 이벤트", "2026-04-01", null, null, null);
+        ClubCalendarEventResult customEvent = ClubCalendarEventResult.ofCustom(
+                "custom-1", "커스텀 이벤트", "2026-04-02", null, null, null);
+
+        when(notionOAuthService.getClubCalendarEvents(CLUB_ID)).thenReturn(List.of(notionEvent));
+        when(googleOAuthService.getClubCalendarEvents(CLUB_ID)).thenReturn(List.of(googleEvent));
+        when(customCalendarEventService.getClubCalendarEvents(CLUB_ID)).thenReturn(List.of(customEvent));
+
+        List<ClubCalendarEventResult> results = calendarAggregationService.getAggregatedEvents(CLUB_ID);
+
+        assertThat(results).hasSize(3);
+        assertThat(results.get(0).source()).isEqualTo("GOOGLE");
+        assertThat(results.get(1).source()).isEqualTo("CUSTOM");
+        assertThat(results.get(2).source()).isEqualTo("NOTION");
+    }
+
+    @Test
+    @DisplayName("숨김 목록의 GOOGLE/NOTION 이벤트는 결과에서 제외된다")
+    void getAggregatedEvents_excludesHiddenEvents() {
+        ClubCalendarEventResult notionEvent = ClubCalendarEventResult.ofNotion(
+                "notion-1", "Notion 이벤트", "2026-04-01", null, null, null);
+        ClubCalendarEventResult googleEvent = ClubCalendarEventResult.ofGoogle(
+                "google-1", "Google 이벤트", "2026-04-02", null, null, null);
+        ClubCalendarEventResult customEvent = ClubCalendarEventResult.ofCustom(
+                "custom-1", "커스텀 이벤트", "2026-04-03", null, null, null);
+
+        when(notionOAuthService.getClubCalendarEvents(CLUB_ID)).thenReturn(List.of(notionEvent));
+        when(googleOAuthService.getClubCalendarEvents(CLUB_ID)).thenReturn(List.of(googleEvent));
+        when(customCalendarEventService.getClubCalendarEvents(CLUB_ID)).thenReturn(List.of(customEvent));
+        when(hiddenCalendarEventService.getHiddenKeys(CLUB_ID)).thenReturn(Set.of("GOOGLE:google-1"));
+
+        List<ClubCalendarEventResult> results = calendarAggregationService.getAggregatedEvents(CLUB_ID);
+
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0).source()).isEqualTo("NOTION");
+        assertThat(results.get(1).source()).isEqualTo("CUSTOM");
+    }
+
+    @Test
+    @DisplayName("숨김 목록 조회가 실패해도 이벤트는 그대로 반환된다")
+    void getAggregatedEvents_hiddenLookupFails_returnsAllEvents() {
+        ClubCalendarEventResult googleEvent = ClubCalendarEventResult.ofGoogle(
+                "google-1", "Google 이벤트", "2026-04-01", null, null, null);
+
+        when(googleOAuthService.getClubCalendarEvents(CLUB_ID)).thenReturn(List.of(googleEvent));
+        when(hiddenCalendarEventService.getHiddenKeys(CLUB_ID)).thenThrow(new RuntimeException("조회 오류"));
+
+        List<ClubCalendarEventResult> results = calendarAggregationService.getAggregatedEvents(CLUB_ID);
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).source()).isEqualTo("GOOGLE");
+    }
+
+    @Test
     @DisplayName("둘 다 실패 시 빈 리스트를 반환한다")
     void getAggregatedEvents_bothFail_returnsEmpty() {
         when(notionOAuthService.getClubCalendarEvents(CLUB_ID)).thenThrow(new RuntimeException("Notion 오류"));
@@ -106,6 +175,18 @@ class CalendarAggregationServiceTest {
     void hasAnyCalendarConnection_googleOnly_returnsTrue() {
         when(notionOAuthService.hasCalendarConnection(CLUB_ID)).thenReturn(false);
         when(googleOAuthService.hasCalendarConnection(CLUB_ID)).thenReturn(true);
+
+        boolean result = calendarAggregationService.hasAnyCalendarConnection(CLUB_ID);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("커스텀 이벤트만 있는 경우 true를 반환한다")
+    void hasAnyCalendarConnection_customOnly_returnsTrue() {
+        when(notionOAuthService.hasCalendarConnection(CLUB_ID)).thenReturn(false);
+        when(googleOAuthService.hasCalendarConnection(CLUB_ID)).thenReturn(false);
+        when(customCalendarEventService.hasCalendarConnection(CLUB_ID)).thenReturn(true);
 
         boolean result = calendarAggregationService.hasAnyCalendarConnection(CLUB_ID);
 


### PR DESCRIPTION
## 요약

관리자가 직접 입력한 일정(커스텀 이벤트)을 공개 캘린더에 표시하고, Google/Notion OAuth 이벤트를 공개 캘린더에서 숨길 수 있게 합니다.

> **21개 파일 +1981줄이지만 절반(998줄)이 테스트입니다.** 기존 동작을 건드리는 곳은 `CalendarAggregationService` 한 곳뿐이고, 나머지는 전부 신규 파일입니다.

## 리뷰 가이드

| | 파일 | 규모 | 봐주실 것 |
|---|---|---|---|
| **1** | `CustomEventOccurrenceExpander` | 191줄 (신규) | 날짜 전개 로직. 무한 루프·응답 폭증 가드가 여기 있습니다 |
| **2** | `CustomCalendarEventService` | 305줄 (신규) | 입력 검증 + 반복 일정 삭제 범위 |
| **3** | `CalendarAggregationService` | +31 / -3 | **유일하게 기존 동작을 건드리는 곳.** 병합·숨김 필터 |
| — | 나머지 14개 main 파일 | +456줄 | 엔티티 / DTO / 레포지토리 인터페이스 / 컨트롤러. 훑고 넘어가셔도 됩니다 |

## 설계 결정 3가지

맞고 틀리고가 아니라 **합의가 필요한 지점**입니다.

**① PERIOD는 발생일로 전개하지 않습니다**
기간 일정은 "여러 발생일"이 아니라 "여러 날에 걸친 하나의 일정"이라, `start`/`end`를 가진 한 건으로 내려갑니다. MT(3.16~3.20)가 5건으로 쪼개지지 않고 목록에도 "3.16 - 3.20" 한 줄로 표시됩니다.
Google도 `singleEvents=true`가 펼치는 건 *반복* 일정이고 여러 날에 걸친 이벤트는 `start`/`end` 단일 이벤트로 내려주므로, 전개하지 않는 쪽이 Google 의미론과 일치합니다. `RECURRING`/`MULTI`는 그대로 전개합니다.

**② 커스텀 이벤트는 숨김이 아니라 실삭제입니다**
숨김(`hidden`)은 GOOGLE/NOTION만 허용합니다. 커스텀 이벤트는 소유자가 실제로 지울 수 있으므로 숨김 대상에서 제외했습니다.
그래서 병합 필터가 `source + ":" + id` **복합키**입니다 — 저장 시 source가 GOOGLE/NOTION으로 강제되므로 CUSTOM 이벤트는 id 형태와 무관하게 필터에 걸리지 않습니다.

**③ 전개에 상한을 둡니다**
종료일 없는 반복은 **오늘 기준 +1년**까지만, 전체 발생일은 **최대 500건**까지만 전개합니다(도달 시 warn 로그). 무기한 반복이 응답을 무한정 부풀리는 것을 막기 위함입니다.

## 실패 시 동작

외부 연동이 죽어도 페이지가 죽지 않도록 각 소스를 독립적으로 감쌌습니다.

- Notion / Google / 커스텀 조회 실패 → 해당 소스만 빠지고 나머지는 정상 반환
- 숨김 목록 조회 실패 → **필터 없이** 기존 동작 유지 (숨긴 게 잠깐 보이는 편이 페이지가 죽는 것보다 낫다는 판단)
- 공개 피드는 읽기 경로라 저장된 `eventType`이 비어 있어도 예외 대신 `SINGLE`로 채웁니다 (검증기를 재사용하면 레거시 데이터 하나에 동아리 상세가 통째로 죽습니다)

<details>
<summary><b>API 스펙</b></summary>

### 커스텀 이벤트 `/api/integration/custom-events`
POST(생성) / GET(목록) / PUT `{eventId}`(전체 교체) / DELETE `{eventId}`
모든 작업은 `requireAuthenticatedClubId(user)`로 소유권 강제, 수정·삭제는 `findByIdAndClubId` 조합 조회로 타 동아리 접근 차단.

**이벤트 유형**

| 유형 | 의미 | 필요한 필드 |
|---|---|---|
| `SINGLE` (기본값) | 하루짜리 일정 | `start` |
| `PERIOD` | 기간 일정 | `start`, `end` |
| `MULTI` | 여러 날짜 선택 | `dates` (첫 원소 == `start`) |
| `RECURRING` | 반복 일정 | `recurrence` |

- `recurrence`: `frequency`(WEEKLY/MONTHLY/YEARLY), `weekdays`(0=일 ~ 6=토), `end`, `excludedDates`
- `color`: PINK / YELLOW / MINT / BLUE / PURPLE / ORANGE

**반복 일정 삭제 범위** — `DELETE .../{eventId}?scope=&date=`

| scope | 동작 |
|---|---|
| `ALL` (기본값) | 도큐먼트 삭제 |
| `THIS` | 해당 발생일을 `recurrence.excludedDates`에 추가 |
| `THIS_AND_FOLLOWING` | `recurrence.end`를 `date - 1일`로 축소 (시작일보다 앞서면 도큐먼트 삭제) |

반복 이벤트가 아니면 scope와 무관하게 삭제. `THIS`/`THIS_AND_FOLLOWING`은 `date` 필수.

### 숨김 `/api/integration/calendar-events/hidden`
POST(숨김) / DELETE(해제) / GET(목록). 멱등 보장 — 사전 `existsBy` 확인 + 동시 요청 대비 `DuplicateKeyException` 흡수.

### 공개 피드 `ClubCalendarEventResult`
`eventType`, `color` 필드 추가 — **CUSTOM만 값, Google/Notion은 `null`**.
발생일이 여러 개인 경우(RECURRING/MULTI) id는 `{eventId}:{date}`, 한 건이면 원래 `{eventId}`.
</details>

<details>
<summary><b>입력 검증 규칙</b></summary>

- 날짜: `YYYY-MM-DD` 파싱 실패 시 `970-3`, `start > end`면 `970-4`
- `eventType` / `color` / `frequency` 허용값, `weekdays` 0~6 범위, `MULTI`인데 `dates`가 비었거나 `dates[0] != start`면 `970-5`
- `RECURRING` ↔ `recurrence` 상호 필수 (한쪽만 있으면 `970-5`)
- `url`은 http/https 스킴만 허용
- 컬렉션(`dates`, `weekdays`, `excludedDates`) 최대 365건
- `ErrorCode` 970-1~970-6(커스텀), 971-1~971-2(숨김) 추가
</details>

<details>
<summary><b>데이터 모델</b></summary>

- `CustomCalendarEvent` — `custom_calendar_events` 컬렉션, `clubId` 인덱스, club당 N개
- `HiddenCalendarEvent` — `hidden_calendar_events` 컬렉션, `(clubId, source, eventId)` 복합 유니크 인덱스
- 둘 다 이 PR에서 신규 생성되는 컬렉션이라 마이그레이션 대상 없음
- `hasAnyCalendarConnection`은 커스텀 이벤트가 있으면 true 반환
</details>

<details>
<summary><b>테스트 (998줄, 72개)</b></summary>

- `CustomCalendarEventServiceTest` 35개 — 소유권 / 검증 / 삭제 범위(ALL·THIS·THIS_AND_FOLLOWING) / 발생일 전개 / PERIOD 단일 유지 / color·eventType 전달
- `CustomEventOccurrenceExpanderTest` 17개 — SINGLE·PERIOD·MULTI·WEEKLY·MONTHLY·YEARLY, 제외일, 500건 상한, +1년 윈도우
- `HiddenCalendarEventServiceTest` 9개 — 멱등 hide/unhide, 중복키 흡수, 잘못된 source
- `CalendarAggregationServiceTest` 11개 — CUSTOM 병합·정렬, 숨김 필터, 숨김 조회 실패 폴백
- `./gradlew unitTest` 전체 통과
</details>

## 프론트 영향

없습니다.

- **`color`·`eventType`**: `ClubCalendarEvent` 타입에 이미 optional로 선언돼 있어 백엔드가 채우면 프론트 수정 없이 동작합니다.
- **PERIOD id 형태 변경** (`{eventId}:{date}` × N → `{eventId}` × 1): 공개 피드 소비처는 `ClubScheduleCalendar` 하나뿐이고 id는 React 렌더 key로만 쓰입니다. id를 키로 하는 로컬 상태·딥링크·영속 데이터가 없습니다. 영속 쿼리 캐시에는 남지만 buster가 커밋 SHA라 배포 시 자동 폐기됩니다.
