### PR TITLE
feat(dev-portal): 개발자용 임의 동아리 외부폼 연결 + 지원기간 관리

### DIFF
--- a/backend/src/main/java/moadong/club/controller/ClubApplicationAdminController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubApplicationAdminController.java
@@ -1,0 +1,68 @@
+package moadong.club.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import moadong.club.payload.request.AdminExternalFormConnectRequest;
+import moadong.club.service.ClubApplyAdminService;
+import moadong.global.payload.Response;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin")
+@AllArgsConstructor
+@Tag(name = "Club Application Admin", description = "동아리 지원폼 관리자 API (개발자 전용)")
+public class ClubApplicationAdminController {
+
+    private final ClubApplyAdminService clubApplyAdminService;
+
+    @GetMapping("/club/{clubId}/application")
+    @Operation(summary = "동아리 지원폼 목록 조회 (관리자)", description = "DEVELOPER 역할 필요.")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> getApplications(@PathVariable String clubId) {
+        return Response.ok(clubApplyAdminService.getApplicationFormsForClub(clubId));
+    }
+
+    @PostMapping("/club/{clubId}/application")
+    @Operation(summary = "동아리 외부 지원폼 연결 (관리자)",
+            description = "구글폼/네이버폼 등 외부 URL을 지정 동아리에 연결하고 게시(ACTIVE)합니다. DEVELOPER 역할 필요.")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> connectExternal(@PathVariable String clubId,
+                                             @RequestBody @Valid AdminExternalFormConnectRequest request) {
+        clubApplyAdminService.connectExternalApplicationFormForClub(clubId, request);
+        return Response.ok("success connect external application form");
+    }
+
+    @PatchMapping("/club/{clubId}/application/{formId}/status")
+    @Operation(summary = "동아리 지원폼 활성화/미게시 토글 (관리자)",
+            description = "active=true면 게시(ACTIVE), false면 미게시. DEVELOPER 역할 필요.")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> updateStatus(@PathVariable String clubId,
+                                          @PathVariable String formId,
+                                          @RequestBody StatusRequest request) {
+        clubApplyAdminService.setApplicationFormStatusForClub(clubId, formId, request.active());
+        return Response.ok("success update application status");
+    }
+
+    @DeleteMapping("/club/{clubId}/application/{formId}")
+    @Operation(summary = "동아리 지원폼 삭제 (관리자)", description = "DEVELOPER 역할 필요.")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> deleteApplication(@PathVariable String clubId,
+                                               @PathVariable String formId) {
+        clubApplyAdminService.deleteApplicationFormForClub(clubId, formId);
+        return Response.ok("success delete application");
+    }
+
+    public record StatusRequest(boolean active) {
+    }
+}

--- a/backend/src/main/java/moadong/club/controller/ClubApplicationAdminController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubApplicationAdminController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import moadong.club.payload.request.AdminExternalFormConnectRequest;
+import moadong.club.payload.request.ApplicationFormStatusUpdateRequest;
 import moadong.club.service.ClubApplyAdminService;
 import moadong.global.payload.Response;
 import org.springframework.http.ResponseEntity;
@@ -49,7 +50,7 @@ public class ClubApplicationAdminController {
     @SecurityRequirement(name = "BearerAuth")
     public ResponseEntity<?> updateStatus(@PathVariable String clubId,
                                           @PathVariable String formId,
-                                          @RequestBody StatusRequest request) {
+                                          @RequestBody ApplicationFormStatusUpdateRequest request) {
         clubApplyAdminService.setApplicationFormStatusForClub(clubId, formId, request.active());
         return Response.ok("success update application status");
     }
@@ -61,8 +62,5 @@ public class ClubApplicationAdminController {
                                                @PathVariable String formId) {
         clubApplyAdminService.deleteApplicationFormForClub(clubId, formId);
         return Response.ok("success delete application");
-    }
-
-    public record StatusRequest(boolean active) {
     }
 }

--- a/backend/src/main/java/moadong/club/payload/request/AdminExternalFormConnectRequest.java
+++ b/backend/src/main/java/moadong/club/payload/request/AdminExternalFormConnectRequest.java
@@ -1,0 +1,28 @@
+package moadong.club.payload.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import moadong.club.enums.SemesterTerm;
+
+public record AdminExternalFormConnectRequest(
+        @Size(max = 50)
+        String title,
+
+        @NotBlank
+        String externalApplicationUrl,
+
+        @NotNull
+        @Min(2000)
+        @Max(2999)
+        Integer semesterYear,
+
+        @NotNull
+        SemesterTerm semesterTerm
+) {
+    public String titleOrDefault() {
+        return (title == null || title.isBlank()) ? "외부 지원폼" : title;
+    }
+}

--- a/backend/src/main/java/moadong/club/payload/request/AdminExternalFormConnectRequest.java
+++ b/backend/src/main/java/moadong/club/payload/request/AdminExternalFormConnectRequest.java
@@ -5,7 +5,6 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import moadong.club.enums.SemesterTerm;
 
 public record AdminExternalFormConnectRequest(
         @Size(max = 50)
@@ -17,10 +16,7 @@ public record AdminExternalFormConnectRequest(
         @NotNull
         @Min(2000)
         @Max(2999)
-        Integer semesterYear,
-
-        @NotNull
-        SemesterTerm semesterTerm
+        Integer semesterYear
 ) {
     public String titleOrDefault() {
         return (title == null || title.isBlank()) ? "외부 지원폼" : title;

--- a/backend/src/main/java/moadong/club/payload/request/ApplicationFormStatusUpdateRequest.java
+++ b/backend/src/main/java/moadong/club/payload/request/ApplicationFormStatusUpdateRequest.java
@@ -1,0 +1,6 @@
+package moadong.club.payload.request;
+
+public record ApplicationFormStatusUpdateRequest(
+        boolean active
+) {
+}

--- a/backend/src/main/java/moadong/club/payload/response/AdminClubApplicationFormResponse.java
+++ b/backend/src/main/java/moadong/club/payload/response/AdminClubApplicationFormResponse.java
@@ -1,0 +1,30 @@
+package moadong.club.payload.response;
+
+import lombok.Builder;
+import moadong.club.entity.ClubApplicationForm;
+import moadong.club.enums.ApplicationFormMode;
+import moadong.club.enums.ApplicationFormStatus;
+import moadong.club.enums.SemesterTerm;
+
+@Builder
+public record AdminClubApplicationFormResponse(
+        String id,
+        String title,
+        ApplicationFormMode formMode,
+        ApplicationFormStatus status,
+        String externalApplicationUrl,
+        Integer semesterYear,
+        SemesterTerm semesterTerm
+) {
+    public static AdminClubApplicationFormResponse from(ClubApplicationForm form) {
+        return AdminClubApplicationFormResponse.builder()
+                .id(form.getId())
+                .title(form.getTitle())
+                .formMode(form.getFormMode())
+                .status(form.getStatus())
+                .externalApplicationUrl(form.getExternalApplicationUrl())
+                .semesterYear(form.getSemesterYear())
+                .semesterTerm(form.getSemesterTerm())
+                .build();
+    }
+}

--- a/backend/src/main/java/moadong/club/payload/response/AdminClubApplicationFormResponse.java
+++ b/backend/src/main/java/moadong/club/payload/response/AdminClubApplicationFormResponse.java
@@ -4,7 +4,6 @@ import lombok.Builder;
 import moadong.club.entity.ClubApplicationForm;
 import moadong.club.enums.ApplicationFormMode;
 import moadong.club.enums.ApplicationFormStatus;
-import moadong.club.enums.SemesterTerm;
 
 @Builder
 public record AdminClubApplicationFormResponse(
@@ -13,8 +12,7 @@ public record AdminClubApplicationFormResponse(
         ApplicationFormMode formMode,
         ApplicationFormStatus status,
         String externalApplicationUrl,
-        Integer semesterYear,
-        SemesterTerm semesterTerm
+        Integer semesterYear
 ) {
     public static AdminClubApplicationFormResponse from(ClubApplicationForm form) {
         return AdminClubApplicationFormResponse.builder()
@@ -24,7 +22,6 @@ public record AdminClubApplicationFormResponse(
                 .status(form.getStatus())
                 .externalApplicationUrl(form.getExternalApplicationUrl())
                 .semesterYear(form.getSemesterYear())
-                .semesterTerm(form.getSemesterTerm())
                 .build();
     }
 }

--- a/backend/src/main/java/moadong/club/service/ClubApplyAdminService.java
+++ b/backend/src/main/java/moadong/club/service/ClubApplyAdminService.java
@@ -259,14 +259,11 @@ public class ClubApplyAdminService {
     }
 
     public void connectExternalApplicationFormForClub(String clubId, AdminExternalFormConnectRequest request) {
-        validateSemester(request.semesterYear(), request.semesterTerm());
-
         ClubApplicationForm form = ClubApplicationForm.builder().clubId(clubId).build();
         form.updateFormTitle(request.titleOrDefault());
         form.updateFormMode(ApplicationFormMode.EXTERNAL);
         form.updateExternalApplicationUrl(request.externalApplicationUrl());
         form.updateSemesterYear(request.semesterYear());
-        form.updateSemesterTerm(request.semesterTerm());
         form.updateFormStatus(true); // ACTIVE (게시)
         clubApplicationFormsRepository.save(form);
     }

--- a/backend/src/main/java/moadong/club/service/ClubApplyAdminService.java
+++ b/backend/src/main/java/moadong/club/service/ClubApplyAdminService.java
@@ -7,6 +7,7 @@ import moadong.club.enums.ApplicationFormMode;
 import moadong.club.payload.dto.ApplicantStatusEvent;
 import moadong.club.payload.dto.ClubApplicantsResult;
 import moadong.club.payload.request.*;
+import moadong.club.payload.response.AdminClubApplicationFormResponse;
 import moadong.club.payload.response.ClubApplicationFormsResponse;
 import moadong.club.payload.response.ClubApplyInfoResponse;
 import moadong.club.repository.ClubApplicantsRepository;
@@ -249,5 +250,41 @@ public class ClubApplyAdminService {
         }
 
         return formQuestions;
+    }
+
+    public List<AdminClubApplicationFormResponse> getApplicationFormsForClub(String clubId) {
+        return clubApplicationFormsRepository.findByClubId(clubId).stream()
+                .map(AdminClubApplicationFormResponse::from)
+                .toList();
+    }
+
+    public void connectExternalApplicationFormForClub(String clubId, AdminExternalFormConnectRequest request) {
+        validateSemester(request.semesterYear(), request.semesterTerm());
+
+        ClubApplicationForm form = ClubApplicationForm.builder().clubId(clubId).build();
+        form.updateFormTitle(request.titleOrDefault());
+        form.updateFormMode(ApplicationFormMode.EXTERNAL);
+        form.updateExternalApplicationUrl(request.externalApplicationUrl());
+        form.updateSemesterYear(request.semesterYear());
+        form.updateSemesterTerm(request.semesterTerm());
+        form.updateFormStatus(true); // ACTIVE (게시)
+        clubApplicationFormsRepository.save(form);
+    }
+
+    @Transactional
+    public void setApplicationFormStatusForClub(String clubId, String formId, boolean active) {
+        ClubApplicationForm form = clubApplicationFormsRepository.findByClubIdAndId(clubId, formId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.APPLICATION_NOT_FOUND));
+        form.updateFormStatus(active);
+        form.updateEditedAt();
+        clubApplicationFormsRepository.save(form);
+    }
+
+    @Transactional
+    public void deleteApplicationFormForClub(String clubId, String formId) {
+        ClubApplicationForm form = clubApplicationFormsRepository.findByClubIdAndId(clubId, formId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.APPLICATION_NOT_FOUND));
+        clubApplicantsRepository.deleteAllByFormId(form.getId());
+        clubApplicationFormsRepository.delete(form);
     }
 }

--- a/backend/src/main/resources/static/dev/edit.html
+++ b/backend/src/main/resources/static/dev/edit.html
@@ -60,6 +60,23 @@
     </div>
     <button type="button" id="btnUpdateDescription">모집정보 저장</button>
     <div id="descResult" class="message-box hidden"></div>
+
+    <h2 style="font-size:1rem; margin-top:24px;">지원폼 연결 (외부)</h2>
+    <div id="formListState" class="loading">지원폼 불러오는 중...</div>
+    <table id="formList" style="width:100%; border-collapse:collapse; margin-bottom:12px; font-size:0.9rem;">
+      <thead>
+        <tr style="text-align:left; border-bottom:1px solid #e5e7eb;">
+          <th style="padding:6px 4px;">제목</th><th>모드</th><th>상태</th><th></th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+    <div class="form-row"><label for="newExternalUrl">외부 지원 URL (구글폼/네이버폼)</label>
+      <input type="text" id="newExternalUrl" placeholder="https://forms.gle/..."></div>
+    <div class="form-row"><label for="newFormTitle">제목 (선택)</label>
+      <input type="text" id="newFormTitle" placeholder="외부 지원폼"></div>
+    <button type="button" id="btnConnectExternal">외부폼 연결</button>
+    <div id="connectResult" class="message-box hidden"></div>
   </div>
 
   <script>
@@ -129,6 +146,7 @@
           document.getElementById('editRecruitmentEnd').value = toDatetimeLocal(club.recruitmentEnd);
           document.getElementById('loadState').classList.add('hidden');
           document.getElementById('editForm').classList.remove('hidden');
+          loadFormList();
         } catch (e) {
           document.getElementById('loadState').classList.add('hidden');
           document.getElementById('loadError').textContent = e.message || '요청 실패';
@@ -196,6 +214,103 @@
       } finally {
         btn.disabled = false;
         btn.textContent = '모집정보 저장';
+      }
+    };
+
+    function currentSemester() {
+      const now = new Date();
+      return {
+        semesterYear: now.getFullYear(),
+        semesterTerm: (now.getMonth() + 1) < 7 ? 'FIRST' : 'SECOND'
+      };
+    }
+
+    async function loadFormList() {
+      if (!clubId || !getToken()) return;
+      const stateEl = document.getElementById('formListState');
+      const tbody = document.getElementById('formList').querySelector('tbody');
+      stateEl.classList.remove('hidden');
+      try {
+        const res = await fetch(API_BASE + '/api/admin/club/' + clubId + '/application', { headers: headers() });
+        const data = await res.json();
+        if (!res.ok) { stateEl.textContent = data.message || ('HTTP ' + res.status); return; }
+        const forms = data.data || [];
+        tbody.innerHTML = '';
+        forms.forEach(function(f) {
+          const tr = document.createElement('tr');
+          tr.style.borderBottom = '1px solid #f3f4f6';
+          const active = f.status === 'ACTIVE';
+          tr.innerHTML =
+            '<td style="padding:6px 4px;">' + (f.title || '') + '</td>' +
+            '<td>' + (f.formMode || '') + '</td>' +
+            '<td>' + (f.status || '') + '</td>' +
+            '<td style="white-space:nowrap;"></td>';
+          const actionCell = tr.querySelector('td:last-child');
+          const toggleBtn = document.createElement('button');
+          toggleBtn.type = 'button';
+          toggleBtn.textContent = active ? '미게시로 변경' : '활성화';
+          toggleBtn.onclick = function() { toggleStatus(f.id, !active); };
+          const delBtn = document.createElement('button');
+          delBtn.type = 'button';
+          delBtn.textContent = '삭제';
+          delBtn.onclick = function() { deleteForm(f.id); };
+          actionCell.appendChild(toggleBtn);
+          actionCell.appendChild(delBtn);
+          tbody.appendChild(tr);
+        });
+        stateEl.textContent = forms.length ? '' : '연결된 지원폼이 없습니다.';
+        if (forms.length) stateEl.classList.add('hidden');
+      } catch (e) {
+        stateEl.textContent = e.message || '요청 실패';
+      }
+    }
+
+    async function toggleStatus(formId, active) {
+      try {
+        const res = await fetch(API_BASE + '/api/admin/club/' + clubId + '/application/' + formId + '/status',
+          { method: 'PATCH', headers: headers(), body: JSON.stringify({ active: active }) });
+        const data = await res.json();
+        showResult('connectResult', res.ok, res.ok ? '상태 변경됨' : (data.message || '요청 실패'));
+        if (res.ok) loadFormList();
+      } catch (e) { showResult('connectResult', false, e.message || '요청 실패'); }
+    }
+
+    async function deleteForm(formId) {
+      try {
+        const res = await fetch(API_BASE + '/api/admin/club/' + clubId + '/application/' + formId,
+          { method: 'DELETE', headers: headers() });
+        const data = await res.json();
+        showResult('connectResult', res.ok, res.ok ? '삭제됨' : (data.message || '요청 실패'));
+        if (res.ok) loadFormList();
+      } catch (e) { showResult('connectResult', false, e.message || '요청 실패'); }
+    }
+
+    document.getElementById('btnConnectExternal').onclick = async function() {
+      const btn = this;
+      const url = document.getElementById('newExternalUrl').value.trim();
+      if (!url) { showResult('connectResult', false, '외부 URL을 입력하세요.'); return; }
+      const sem = currentSemester();
+      const body = {
+        title: document.getElementById('newFormTitle').value.trim() || null,
+        externalApplicationUrl: url,
+        semesterYear: sem.semesterYear,
+        semesterTerm: sem.semesterTerm
+      };
+      btn.disabled = true; btn.textContent = '연결 중...';
+      try {
+        const res = await fetch(API_BASE + '/api/admin/club/' + clubId + '/application',
+          { method: 'POST', headers: headers(), body: JSON.stringify(body) });
+        const data = await res.json();
+        showResult('connectResult', res.ok, res.ok ? '연결됨' : (data.message || '요청 실패'));
+        if (res.ok) {
+          document.getElementById('newExternalUrl').value = '';
+          document.getElementById('newFormTitle').value = '';
+          loadFormList();
+        }
+      } catch (e) {
+        showResult('connectResult', false, e.message || '요청 실패');
+      } finally {
+        btn.disabled = false; btn.textContent = '외부폼 연결';
       }
     };
   </script>

--- a/backend/src/main/resources/static/dev/edit.html
+++ b/backend/src/main/resources/static/dev/edit.html
@@ -220,8 +220,7 @@
     function currentSemester() {
       const now = new Date();
       return {
-        semesterYear: now.getFullYear(),
-        semesterTerm: (now.getMonth() + 1) < 7 ? 'FIRST' : 'SECOND'
+        semesterYear: now.getFullYear()
       };
     }
 
@@ -293,8 +292,7 @@
       const body = {
         title: document.getElementById('newFormTitle').value.trim() || null,
         externalApplicationUrl: url,
-        semesterYear: sem.semesterYear,
-        semesterTerm: sem.semesterTerm
+        semesterYear: sem.semesterYear
       };
       btn.disabled = true; btn.textContent = '연결 중...';
       try {

--- a/backend/src/main/resources/static/dev/edit.html
+++ b/backend/src/main/resources/static/dev/edit.html
@@ -239,12 +239,17 @@
           const tr = document.createElement('tr');
           tr.style.borderBottom = '1px solid #f3f4f6';
           const active = f.status === 'ACTIVE';
-          tr.innerHTML =
-            '<td style="padding:6px 4px;">' + (f.title || '') + '</td>' +
-            '<td>' + (f.formMode || '') + '</td>' +
-            '<td>' + (f.status || '') + '</td>' +
-            '<td style="white-space:nowrap;"></td>';
-          const actionCell = tr.querySelector('td:last-child');
+
+          const tdTitle = document.createElement('td');
+          tdTitle.style.padding = '6px 4px';
+          tdTitle.textContent = f.title || '';
+          const tdMode = document.createElement('td');
+          tdMode.textContent = f.formMode || '';
+          const tdStatus = document.createElement('td');
+          tdStatus.textContent = f.status || '';
+          const actionCell = document.createElement('td');
+          actionCell.style.whiteSpace = 'nowrap';
+
           const toggleBtn = document.createElement('button');
           toggleBtn.type = 'button';
           toggleBtn.textContent = active ? '미게시로 변경' : '활성화';
@@ -255,6 +260,11 @@
           delBtn.onclick = function() { deleteForm(f.id); };
           actionCell.appendChild(toggleBtn);
           actionCell.appendChild(delBtn);
+
+          tr.appendChild(tdTitle);
+          tr.appendChild(tdMode);
+          tr.appendChild(tdStatus);
+          tr.appendChild(actionCell);
           tbody.appendChild(tr);
         });
         stateEl.textContent = forms.length ? '' : '연결된 지원폼이 없습니다.';

--- a/backend/src/test/java/moadong/club/service/ClubApplicationAdminServiceTest.java
+++ b/backend/src/test/java/moadong/club/service/ClubApplicationAdminServiceTest.java
@@ -1,0 +1,123 @@
+package moadong.club.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import moadong.club.entity.Club;
+import moadong.club.entity.ClubApplicationForm;
+import moadong.club.enums.ApplicationFormMode;
+import moadong.club.enums.ApplicationFormStatus;
+import moadong.club.enums.SemesterTerm;
+import moadong.club.payload.request.AdminExternalFormConnectRequest;
+import moadong.club.payload.response.AdminClubApplicationFormResponse;
+import moadong.club.repository.ClubApplicationFormsRepository;
+import moadong.club.repository.ClubRepository;
+import moadong.global.exception.RestApiException;
+import moadong.util.annotations.IntegrationTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@IntegrationTest
+public class ClubApplicationAdminServiceTest {
+
+    @Autowired
+    private ClubApplyAdminService clubApplyAdminService;
+    @Autowired
+    private ClubRepository clubRepository;
+    @Autowired
+    private ClubApplicationFormsRepository clubApplicationFormsRepository;
+
+    private String clubId;
+
+    private int currentSemesterYear() {
+        return java.time.ZonedDateTime.now(java.time.ZoneId.of("Asia/Seoul")).toLocalDate().getYear();
+    }
+
+    private SemesterTerm currentSemesterTerm() {
+        int month = java.time.ZonedDateTime.now(java.time.ZoneId.of("Asia/Seoul")).toLocalDate().getMonthValue();
+        return month < 7 ? SemesterTerm.FIRST : SemesterTerm.SECOND;
+    }
+
+    @BeforeEach
+    void setUp() {
+        Club club = new Club("dev-portal-test-user");
+        clubRepository.save(club);
+        this.clubId = club.getId();
+    }
+
+    @AfterEach
+    void tearDown() {
+        clubApplicationFormsRepository.findByClubId(clubId)
+                .forEach(clubApplicationFormsRepository::delete);
+        clubRepository.deleteById(clubId);
+    }
+
+    @Test
+    @DisplayName("외부폼 연결 시 EXTERNAL + ACTIVE 상태로 생성된다")
+    void connectExternalForm_createsActiveExternalForm() {
+        AdminExternalFormConnectRequest request = new AdminExternalFormConnectRequest(
+                "구글폼", "https://forms.gle/abcd", currentSemesterYear(), currentSemesterTerm());
+
+        clubApplyAdminService.connectExternalApplicationFormForClub(clubId, request);
+
+        List<ClubApplicationForm> forms = clubApplicationFormsRepository.findByClubId(clubId);
+        assertEquals(1, forms.size());
+        assertEquals(ApplicationFormMode.EXTERNAL, forms.get(0).getFormMode());
+        assertEquals(ApplicationFormStatus.ACTIVE, forms.get(0).getStatus());
+        assertEquals("https://forms.gle/abcd", forms.get(0).getExternalApplicationUrl());
+    }
+
+    @Test
+    @DisplayName("허용되지 않은 외부 URL이면 예외가 발생한다")
+    void connectExternalForm_rejectsNotAllowedUrl() {
+        AdminExternalFormConnectRequest request = new AdminExternalFormConnectRequest(
+                "잘못된폼", "https://evil.example.com/form", currentSemesterYear(), currentSemesterTerm());
+
+        assertThrows(RestApiException.class,
+                () -> clubApplyAdminService.connectExternalApplicationFormForClub(clubId, request));
+    }
+
+    @Test
+    @DisplayName("상태 토글: active=false면 ACTIVE에서 PUBLISHED로 내려가 지원 목록에서 빠진다")
+    void setStatus_deactivatesActiveForm() {
+        AdminExternalFormConnectRequest request = new AdminExternalFormConnectRequest(
+                "구글폼", "https://forms.gle/abcd", currentSemesterYear(), currentSemesterTerm());
+        clubApplyAdminService.connectExternalApplicationFormForClub(clubId, request);
+        String formId = clubApplicationFormsRepository.findByClubId(clubId).get(0).getId();
+
+        clubApplyAdminService.setApplicationFormStatusForClub(clubId, formId, false);
+
+        ClubApplicationForm form = clubApplicationFormsRepository.findByClubIdAndId(clubId, formId).orElseThrow();
+        assertEquals(ApplicationFormStatus.PUBLISHED, form.getStatus());
+    }
+
+    @Test
+    @DisplayName("목록 조회는 해당 동아리 폼을 반환한다")
+    void getForms_returnsClubForms() {
+        AdminExternalFormConnectRequest request = new AdminExternalFormConnectRequest(
+                "구글폼", "https://forms.gle/abcd", currentSemesterYear(), currentSemesterTerm());
+        clubApplyAdminService.connectExternalApplicationFormForClub(clubId, request);
+
+        List<AdminClubApplicationFormResponse> forms = clubApplyAdminService.getApplicationFormsForClub(clubId);
+        assertEquals(1, forms.size());
+        assertEquals("구글폼", forms.get(0).title());
+    }
+
+    @Test
+    @DisplayName("삭제하면 폼이 사라진다")
+    void deleteForm_removesForm() {
+        AdminExternalFormConnectRequest request = new AdminExternalFormConnectRequest(
+                "구글폼", "https://forms.gle/abcd", currentSemesterYear(), currentSemesterTerm());
+        clubApplyAdminService.connectExternalApplicationFormForClub(clubId, request);
+        String formId = clubApplicationFormsRepository.findByClubId(clubId).get(0).getId();
+
+        clubApplyAdminService.deleteApplicationFormForClub(clubId, formId);
+
+        assertTrue(clubApplicationFormsRepository.findByClubId(clubId).isEmpty());
+    }
+}

--- a/backend/src/test/java/moadong/club/service/ClubApplicationAdminServiceTest.java
+++ b/backend/src/test/java/moadong/club/service/ClubApplicationAdminServiceTest.java
@@ -9,7 +9,6 @@ import moadong.club.entity.Club;
 import moadong.club.entity.ClubApplicationForm;
 import moadong.club.enums.ApplicationFormMode;
 import moadong.club.enums.ApplicationFormStatus;
-import moadong.club.enums.SemesterTerm;
 import moadong.club.payload.request.AdminExternalFormConnectRequest;
 import moadong.club.payload.response.AdminClubApplicationFormResponse;
 import moadong.club.repository.ClubApplicationFormsRepository;
@@ -38,11 +37,6 @@ public class ClubApplicationAdminServiceTest {
         return java.time.ZonedDateTime.now(java.time.ZoneId.of("Asia/Seoul")).toLocalDate().getYear();
     }
 
-    private SemesterTerm currentSemesterTerm() {
-        int month = java.time.ZonedDateTime.now(java.time.ZoneId.of("Asia/Seoul")).toLocalDate().getMonthValue();
-        return month < 7 ? SemesterTerm.FIRST : SemesterTerm.SECOND;
-    }
-
     @BeforeEach
     void setUp() {
         Club club = new Club("dev-portal-test-user");
@@ -61,7 +55,7 @@ public class ClubApplicationAdminServiceTest {
     @DisplayName("외부폼 연결 시 EXTERNAL + ACTIVE 상태로 생성된다")
     void connectExternalForm_createsActiveExternalForm() {
         AdminExternalFormConnectRequest request = new AdminExternalFormConnectRequest(
-                "구글폼", "https://forms.gle/abcd", currentSemesterYear(), currentSemesterTerm());
+                "구글폼", "https://forms.gle/abcd", currentSemesterYear());
 
         clubApplyAdminService.connectExternalApplicationFormForClub(clubId, request);
 
@@ -76,31 +70,31 @@ public class ClubApplicationAdminServiceTest {
     @DisplayName("허용되지 않은 외부 URL이면 예외가 발생한다")
     void connectExternalForm_rejectsNotAllowedUrl() {
         AdminExternalFormConnectRequest request = new AdminExternalFormConnectRequest(
-                "잘못된폼", "https://evil.example.com/form", currentSemesterYear(), currentSemesterTerm());
+                "잘못된폼", "https://evil.example.com/form", currentSemesterYear());
 
         assertThrows(RestApiException.class,
                 () -> clubApplyAdminService.connectExternalApplicationFormForClub(clubId, request));
     }
 
     @Test
-    @DisplayName("상태 토글: active=false면 ACTIVE에서 PUBLISHED로 내려가 지원 목록에서 빠진다")
+    @DisplayName("상태 토글: active=false면 ACTIVE에서 INACTIVE로 내려가 지원 목록에서 빠진다")
     void setStatus_deactivatesActiveForm() {
         AdminExternalFormConnectRequest request = new AdminExternalFormConnectRequest(
-                "구글폼", "https://forms.gle/abcd", currentSemesterYear(), currentSemesterTerm());
+                "구글폼", "https://forms.gle/abcd", currentSemesterYear());
         clubApplyAdminService.connectExternalApplicationFormForClub(clubId, request);
         String formId = clubApplicationFormsRepository.findByClubId(clubId).get(0).getId();
 
         clubApplyAdminService.setApplicationFormStatusForClub(clubId, formId, false);
 
         ClubApplicationForm form = clubApplicationFormsRepository.findByClubIdAndId(clubId, formId).orElseThrow();
-        assertEquals(ApplicationFormStatus.PUBLISHED, form.getStatus());
+        assertEquals(ApplicationFormStatus.INACTIVE, form.getStatus());
     }
 
     @Test
     @DisplayName("목록 조회는 해당 동아리 폼을 반환한다")
     void getForms_returnsClubForms() {
         AdminExternalFormConnectRequest request = new AdminExternalFormConnectRequest(
-                "구글폼", "https://forms.gle/abcd", currentSemesterYear(), currentSemesterTerm());
+                "구글폼", "https://forms.gle/abcd", currentSemesterYear());
         clubApplyAdminService.connectExternalApplicationFormForClub(clubId, request);
 
         List<AdminClubApplicationFormResponse> forms = clubApplyAdminService.getApplicationFormsForClub(clubId);
@@ -112,7 +106,7 @@ public class ClubApplicationAdminServiceTest {
     @DisplayName("삭제하면 폼이 사라진다")
     void deleteForm_removesForm() {
         AdminExternalFormConnectRequest request = new AdminExternalFormConnectRequest(
-                "구글폼", "https://forms.gle/abcd", currentSemesterYear(), currentSemesterTerm());
+                "구글폼", "https://forms.gle/abcd", currentSemesterYear());
         clubApplyAdminService.connectExternalApplicationFormForClub(clubId, request);
         String formId = clubApplicationFormsRepository.findByClubId(clubId).get(0).getId();
 

--- a/docs/superpowers/plans/2026-07-21-dev-portal-external-form-and-recruit-period.md
+++ b/docs/superpowers/plans/2026-07-21-dev-portal-external-form-and-recruit-period.md
@@ -1,0 +1,619 @@
+# 개발자 포털 외부폼 연결 + 지원기간 설정 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 개발자 포털에서 임의 동아리의 외부 지원폼(구글/네이버) 연결·활성화/미게시 토글·삭제와 지원기간 설정을 할 수 있게 한다.
+
+**Architecture:** `/api/admin/**`(이미 `hasRole("DEVELOPER")` 보호) 아래에 clubId를 파라미터로 받는 지원폼 관리 엔드포인트를 새 컨트롤러로 추가하고, `ClubApplyAdminService`에 clubId를 명시적으로 받는 메서드를 추가한다(기존 본인-동아리 메서드는 건드리지 않음). 개발자 포털 정적 페이지 `dev/edit.html`에 UI 섹션을 추가한다. 지원기간은 기존 `PUT /api/admin/club/{clubId}/description`를 그대로 사용한다(신규 백엔드 없음).
+
+**Tech Stack:** Spring Boot 3.3.8 / Java 17 / MongoDB, 정적 HTML+바닐라 JS(dev portal).
+
+## Global Constraints
+
+- 백엔드 응답은 `moadong.global.payload.Response`(record) 래퍼 사용: `Response.ok(data)`.
+- DTO는 `payload/request`·`payload/response`에 Java `record`로 정의.
+- 서비스는 `@Service @AllArgsConstructor`, 필드 주입 방식(기존 `ClubApplyAdminService` 패턴).
+- 외부 URL 허용 도메인 검증은 엔티티 `ClubApplicationForm.updateExternalApplicationUrl`가 담당(위반 시 `ErrorCode.NOT_ALLOWED_EXTERNAL_URL`). 허용: `https://forms.gle`, `https://docs.google.com/forms`, `https://form.naver.com`, `https://naver.me`, `https://everytime.kr`.
+- 학기 검증은 기존 `ClubApplyAdminService.validateSemester(Integer, SemesterTerm)`(private, 같은 클래스에서 호출) — 현재+향후 2개 학기만 허용, 위반 시 `ErrorCode.APPLICATION_SEMESTER_INVALID`.
+- 폼 생성만 하면 status가 `UNPUBLISHED`라 지원 목록에 안 뜬다. 연결 시 반드시 `updateFormStatus(true)`로 `ACTIVE` 설정.
+- 통합 테스트는 `@moadong.util.annotations.IntegrationTest`(SpringBootTest, 실제 Mongo 필요) 사용. 로컬 실행 전 `./gradlew setupDev`로 시크릿 세팅 필요.
+- 커밋 메시지 마지막 줄: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+
+---
+
+## File Structure
+
+- Create `backend/.../club/payload/request/AdminExternalFormConnectRequest.java` — 외부폼 연결 요청 DTO
+- Create `backend/.../club/payload/response/AdminClubApplicationFormResponse.java` — 목록/응답 항목 DTO
+- Modify `backend/.../club/service/ClubApplyAdminService.java` — clubId 기반 메서드 4개 추가
+- Create `backend/.../club/controller/ClubApplicationAdminController.java` — `/api/admin` 엔드포인트 4개
+- Create `backend/.../test/java/moadong/club/service/ClubApplicationAdminServiceTest.java` — 서비스 통합 테스트
+- Modify `backend/src/main/resources/static/dev/edit.html` — "지원폼 연결(외부)" 섹션 + JS
+
+패키지 prefix: `backend/src/main/java/moadong`, 테스트 prefix: `backend/src/test/java/moadong`.
+
+---
+
+## Task 1: 백엔드 DTO + 서비스 메서드 (+ 통합 테스트)
+
+**Files:**
+- Create: `backend/src/main/java/moadong/club/payload/request/AdminExternalFormConnectRequest.java`
+- Create: `backend/src/main/java/moadong/club/payload/response/AdminClubApplicationFormResponse.java`
+- Modify: `backend/src/main/java/moadong/club/service/ClubApplyAdminService.java`
+- Test: `backend/src/test/java/moadong/club/service/ClubApplicationAdminServiceTest.java`
+
+**Interfaces:**
+- Produces (컨트롤러가 소비):
+  - `List<AdminClubApplicationFormResponse> ClubApplyAdminService.getApplicationFormsForClub(String clubId)`
+  - `void ClubApplyAdminService.connectExternalApplicationFormForClub(String clubId, AdminExternalFormConnectRequest request)`
+  - `void ClubApplyAdminService.setApplicationFormStatusForClub(String clubId, String formId, boolean active)`
+  - `void ClubApplyAdminService.deleteApplicationFormForClub(String clubId, String formId)`
+  - `record AdminExternalFormConnectRequest(String title, String externalApplicationUrl, Integer semesterYear, SemesterTerm semesterTerm)`
+  - `record AdminClubApplicationFormResponse(String id, String title, ApplicationFormMode formMode, ApplicationFormStatus status, String externalApplicationUrl, Integer semesterYear, SemesterTerm semesterTerm)`
+
+- [ ] **Step 1: 요청 DTO 생성**
+
+Create `AdminExternalFormConnectRequest.java`:
+
+```java
+package moadong.club.payload.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import moadong.club.enums.SemesterTerm;
+
+public record AdminExternalFormConnectRequest(
+        @Size(max = 50)
+        String title,
+
+        @NotBlank
+        String externalApplicationUrl,
+
+        @NotNull
+        @Min(2000)
+        @Max(2999)
+        Integer semesterYear,
+
+        @NotNull
+        SemesterTerm semesterTerm
+) {
+    public String titleOrDefault() {
+        return (title == null || title.isBlank()) ? "외부 지원폼" : title;
+    }
+}
+```
+
+- [ ] **Step 2: 응답 DTO 생성**
+
+Create `AdminClubApplicationFormResponse.java`:
+
+```java
+package moadong.club.payload.response;
+
+import lombok.Builder;
+import moadong.club.entity.ClubApplicationForm;
+import moadong.club.enums.ApplicationFormMode;
+import moadong.club.enums.ApplicationFormStatus;
+import moadong.club.enums.SemesterTerm;
+
+@Builder
+public record AdminClubApplicationFormResponse(
+        String id,
+        String title,
+        ApplicationFormMode formMode,
+        ApplicationFormStatus status,
+        String externalApplicationUrl,
+        Integer semesterYear,
+        SemesterTerm semesterTerm
+) {
+    public static AdminClubApplicationFormResponse from(ClubApplicationForm form) {
+        return AdminClubApplicationFormResponse.builder()
+                .id(form.getId())
+                .title(form.getTitle())
+                .formMode(form.getFormMode())
+                .status(form.getStatus())
+                .externalApplicationUrl(form.getExternalApplicationUrl())
+                .semesterYear(form.getSemesterYear())
+                .semesterTerm(form.getSemesterTerm())
+                .build();
+    }
+}
+```
+
+- [ ] **Step 3: 실패하는 테스트 작성**
+
+Create `ClubApplicationAdminServiceTest.java` (기존 `ClubApplyAdminServiceTest`의 setUp 패턴 복제):
+
+```java
+package moadong.club.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import moadong.club.entity.Club;
+import moadong.club.entity.ClubApplicationForm;
+import moadong.club.enums.ApplicationFormMode;
+import moadong.club.enums.ApplicationFormStatus;
+import moadong.club.enums.SemesterTerm;
+import moadong.club.payload.request.AdminExternalFormConnectRequest;
+import moadong.club.payload.response.AdminClubApplicationFormResponse;
+import moadong.club.repository.ClubApplicationFormsRepository;
+import moadong.club.repository.ClubRepository;
+import moadong.global.exception.RestApiException;
+import moadong.util.annotations.IntegrationTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@IntegrationTest
+public class ClubApplicationAdminServiceTest {
+
+    @Autowired
+    private ClubApplyAdminService clubApplyAdminService;
+    @Autowired
+    private ClubRepository clubRepository;
+    @Autowired
+    private ClubApplicationFormsRepository clubApplicationFormsRepository;
+
+    private String clubId;
+
+    private int currentSemesterYear() {
+        return java.time.ZonedDateTime.now(java.time.ZoneId.of("Asia/Seoul")).toLocalDate().getYear();
+    }
+
+    private SemesterTerm currentSemesterTerm() {
+        int month = java.time.ZonedDateTime.now(java.time.ZoneId.of("Asia/Seoul")).toLocalDate().getMonthValue();
+        return month < 7 ? SemesterTerm.FIRST : SemesterTerm.SECOND;
+    }
+
+    @BeforeEach
+    void setUp() {
+        Club club = new Club("dev-portal-test-user");
+        clubRepository.save(club);
+        this.clubId = club.getId();
+    }
+
+    @AfterEach
+    void tearDown() {
+        clubApplicationFormsRepository.findByClubId(clubId)
+                .forEach(clubApplicationFormsRepository::delete);
+        clubRepository.deleteById(clubId);
+    }
+
+    @Test
+    @DisplayName("외부폼 연결 시 EXTERNAL + ACTIVE 상태로 생성된다")
+    void connectExternalForm_createsActiveExternalForm() {
+        AdminExternalFormConnectRequest request = new AdminExternalFormConnectRequest(
+                "구글폼", "https://forms.gle/abcd", currentSemesterYear(), currentSemesterTerm());
+
+        clubApplyAdminService.connectExternalApplicationFormForClub(clubId, request);
+
+        List<ClubApplicationForm> forms = clubApplicationFormsRepository.findByClubId(clubId);
+        assertEquals(1, forms.size());
+        assertEquals(ApplicationFormMode.EXTERNAL, forms.get(0).getFormMode());
+        assertEquals(ApplicationFormStatus.ACTIVE, forms.get(0).getStatus());
+        assertEquals("https://forms.gle/abcd", forms.get(0).getExternalApplicationUrl());
+    }
+
+    @Test
+    @DisplayName("허용되지 않은 외부 URL이면 예외가 발생한다")
+    void connectExternalForm_rejectsNotAllowedUrl() {
+        AdminExternalFormConnectRequest request = new AdminExternalFormConnectRequest(
+                "잘못된폼", "https://evil.example.com/form", currentSemesterYear(), currentSemesterTerm());
+
+        assertThrows(RestApiException.class,
+                () -> clubApplyAdminService.connectExternalApplicationFormForClub(clubId, request));
+    }
+
+    @Test
+    @DisplayName("상태 토글: active=false면 ACTIVE에서 PUBLISHED로 내려가 지원 목록에서 빠진다")
+    void setStatus_deactivatesActiveForm() {
+        AdminExternalFormConnectRequest request = new AdminExternalFormConnectRequest(
+                "구글폼", "https://forms.gle/abcd", currentSemesterYear(), currentSemesterTerm());
+        clubApplyAdminService.connectExternalApplicationFormForClub(clubId, request);
+        String formId = clubApplicationFormsRepository.findByClubId(clubId).get(0).getId();
+
+        clubApplyAdminService.setApplicationFormStatusForClub(clubId, formId, false);
+
+        ClubApplicationForm form = clubApplicationFormsRepository.findByClubIdAndId(clubId, formId).orElseThrow();
+        assertEquals(ApplicationFormStatus.PUBLISHED, form.getStatus());
+    }
+
+    @Test
+    @DisplayName("목록 조회는 해당 동아리 폼을 반환한다")
+    void getForms_returnsClubForms() {
+        AdminExternalFormConnectRequest request = new AdminExternalFormConnectRequest(
+                "구글폼", "https://forms.gle/abcd", currentSemesterYear(), currentSemesterTerm());
+        clubApplyAdminService.connectExternalApplicationFormForClub(clubId, request);
+
+        List<AdminClubApplicationFormResponse> forms = clubApplyAdminService.getApplicationFormsForClub(clubId);
+        assertEquals(1, forms.size());
+        assertEquals("구글폼", forms.get(0).title());
+    }
+
+    @Test
+    @DisplayName("삭제하면 폼이 사라진다")
+    void deleteForm_removesForm() {
+        AdminExternalFormConnectRequest request = new AdminExternalFormConnectRequest(
+                "구글폼", "https://forms.gle/abcd", currentSemesterYear(), currentSemesterTerm());
+        clubApplyAdminService.connectExternalApplicationFormForClub(clubId, request);
+        String formId = clubApplicationFormsRepository.findByClubId(clubId).get(0).getId();
+
+        clubApplyAdminService.deleteApplicationFormForClub(clubId, formId);
+
+        assertTrue(clubApplicationFormsRepository.findByClubId(clubId).isEmpty());
+    }
+}
+```
+
+- [ ] **Step 4: 테스트가 컴파일 실패/실패하는지 확인**
+
+Run: `cd backend && ./gradlew integrationTest --tests "moadong.club.service.ClubApplicationAdminServiceTest"`
+Expected: 컴파일 실패 (메서드 `connectExternalApplicationFormForClub` 등 미정의).
+
+- [ ] **Step 5: 서비스 메서드 구현**
+
+Modify `ClubApplyAdminService.java`. 필요한 import 추가:
+
+```java
+import moadong.club.enums.ApplicationFormStatus;
+import moadong.club.payload.request.AdminExternalFormConnectRequest;
+import moadong.club.payload.response.AdminClubApplicationFormResponse;
+```
+
+클래스 안(기존 메서드들 옆)에 아래 4개 메서드 추가:
+
+```java
+public List<AdminClubApplicationFormResponse> getApplicationFormsForClub(String clubId) {
+    return clubApplicationFormsRepository.findByClubId(clubId).stream()
+            .map(AdminClubApplicationFormResponse::from)
+            .toList();
+}
+
+public void connectExternalApplicationFormForClub(String clubId, AdminExternalFormConnectRequest request) {
+    validateSemester(request.semesterYear(), request.semesterTerm());
+
+    ClubApplicationForm form = ClubApplicationForm.builder().clubId(clubId).build();
+    form.updateFormTitle(request.titleOrDefault());
+    form.updateFormMode(ApplicationFormMode.EXTERNAL);
+    form.updateExternalApplicationUrl(request.externalApplicationUrl());
+    form.updateSemesterYear(request.semesterYear());
+    form.updateSemesterTerm(request.semesterTerm());
+    form.updateFormStatus(true); // ACTIVE (게시)
+    clubApplicationFormsRepository.save(form);
+}
+
+@Transactional
+public void setApplicationFormStatusForClub(String clubId, String formId, boolean active) {
+    ClubApplicationForm form = clubApplicationFormsRepository.findByClubIdAndId(clubId, formId)
+            .orElseThrow(() -> new RestApiException(ErrorCode.APPLICATION_NOT_FOUND));
+    form.updateFormStatus(active);
+    form.updateEditedAt();
+    clubApplicationFormsRepository.save(form);
+}
+
+@Transactional
+public void deleteApplicationFormForClub(String clubId, String formId) {
+    ClubApplicationForm form = clubApplicationFormsRepository.findByClubIdAndId(clubId, formId)
+            .orElseThrow(() -> new RestApiException(ErrorCode.APPLICATION_NOT_FOUND));
+    clubApplicantsRepository.deleteAllByFormId(form.getId());
+    clubApplicationFormsRepository.delete(form);
+}
+```
+
+- [ ] **Step 6: 테스트 통과 확인**
+
+Run: `cd backend && ./gradlew integrationTest --tests "moadong.club.service.ClubApplicationAdminServiceTest"`
+Expected: 5개 테스트 PASS.
+
+- [ ] **Step 7: 커밋**
+
+```bash
+cd backend && git add src/main/java/moadong/club/payload/request/AdminExternalFormConnectRequest.java \
+  src/main/java/moadong/club/payload/response/AdminClubApplicationFormResponse.java \
+  src/main/java/moadong/club/service/ClubApplyAdminService.java \
+  src/test/java/moadong/club/service/ClubApplicationAdminServiceTest.java
+git commit -m "feat(admin): 개발자용 clubId 기반 외부폼 연결/토글/삭제 서비스 추가
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: 백엔드 컨트롤러 (`/api/admin` 엔드포인트 4개)
+
+**Files:**
+- Create: `backend/src/main/java/moadong/club/controller/ClubApplicationAdminController.java`
+
+**Interfaces:**
+- Consumes: Task 1의 `ClubApplyAdminService` 메서드 4개, DTO 2개.
+- Produces (프론트가 소비하는 HTTP 계약):
+  - `GET /api/admin/club/{clubId}/application` → `Response.ok(List<AdminClubApplicationFormResponse>)`
+  - `POST /api/admin/club/{clubId}/application` (body `AdminExternalFormConnectRequest`) → `Response.ok("success connect external application form")`
+  - `PATCH /api/admin/club/{clubId}/application/{formId}/status` (body `{ "active": boolean }`) → `Response.ok("success update application status")`
+  - `DELETE /api/admin/club/{clubId}/application/{formId}` → `Response.ok("success delete application")`
+
+- [ ] **Step 1: 컨트롤러 생성**
+
+Create `ClubApplicationAdminController.java`:
+
+```java
+package moadong.club.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import moadong.club.payload.request.AdminExternalFormConnectRequest;
+import moadong.club.service.ClubApplyAdminService;
+import moadong.global.payload.Response;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin")
+@AllArgsConstructor
+@Tag(name = "Club Application Admin", description = "동아리 지원폼 관리자 API (개발자 전용)")
+public class ClubApplicationAdminController {
+
+    private final ClubApplyAdminService clubApplyAdminService;
+
+    @GetMapping("/club/{clubId}/application")
+    @Operation(summary = "동아리 지원폼 목록 조회 (관리자)", description = "DEVELOPER 역할 필요.")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> getApplications(@PathVariable String clubId) {
+        return Response.ok(clubApplyAdminService.getApplicationFormsForClub(clubId));
+    }
+
+    @PostMapping("/club/{clubId}/application")
+    @Operation(summary = "동아리 외부 지원폼 연결 (관리자)",
+            description = "구글폼/네이버폼 등 외부 URL을 지정 동아리에 연결하고 게시(ACTIVE)합니다. DEVELOPER 역할 필요.")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> connectExternal(@PathVariable String clubId,
+                                             @RequestBody @Valid AdminExternalFormConnectRequest request) {
+        clubApplyAdminService.connectExternalApplicationFormForClub(clubId, request);
+        return Response.ok("success connect external application form");
+    }
+
+    @PatchMapping("/club/{clubId}/application/{formId}/status")
+    @Operation(summary = "동아리 지원폼 활성화/미게시 토글 (관리자)",
+            description = "active=true면 게시(ACTIVE), false면 미게시. DEVELOPER 역할 필요.")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> updateStatus(@PathVariable String clubId,
+                                          @PathVariable String formId,
+                                          @RequestBody StatusRequest request) {
+        clubApplyAdminService.setApplicationFormStatusForClub(clubId, formId, request.active());
+        return Response.ok("success update application status");
+    }
+
+    @DeleteMapping("/club/{clubId}/application/{formId}")
+    @Operation(summary = "동아리 지원폼 삭제 (관리자)", description = "DEVELOPER 역할 필요.")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> deleteApplication(@PathVariable String clubId,
+                                               @PathVariable String formId) {
+        clubApplyAdminService.deleteApplicationFormForClub(clubId, formId);
+        return Response.ok("success delete application");
+    }
+
+    public record StatusRequest(boolean active) {
+    }
+}
+```
+
+- [ ] **Step 2: 컴파일 확인**
+
+Run: `cd backend && ./gradlew compileJava`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: 커밋**
+
+```bash
+cd backend && git add src/main/java/moadong/club/controller/ClubApplicationAdminController.java
+git commit -m "feat(admin): 개발자 포털용 지원폼 관리 엔드포인트 추가
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: 개발자 포털 UI (`dev/edit.html` 확장)
+
+**Files:**
+- Modify: `backend/src/main/resources/static/dev/edit.html`
+
+**Interfaces:**
+- Consumes: Task 2의 4개 엔드포인트.
+- 기존 `getToken()`, `headers()`, `showResult(elId, ok, message)`, `clubId`, `API_BASE` 재사용.
+
+- [ ] **Step 1: HTML 섹션 추가**
+
+`edit.html`에서 "모집정보 수정" 섹션의 닫는 부분(현재 `<div id="descResult" ...></div>` 뒤, `editForm` div 닫기 전) 에 아래 블록 삽입:
+
+```html
+    <h2 style="font-size:1rem; margin-top:24px;">지원폼 연결 (외부)</h2>
+    <div id="formListState" class="loading">지원폼 불러오는 중...</div>
+    <table id="formList" style="width:100%; border-collapse:collapse; margin-bottom:12px; font-size:0.9rem;">
+      <thead>
+        <tr style="text-align:left; border-bottom:1px solid #e5e7eb;">
+          <th style="padding:6px 4px;">제목</th><th>모드</th><th>상태</th><th></th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+    <div class="form-row"><label for="newExternalUrl">외부 지원 URL (구글폼/네이버폼)</label>
+      <input type="text" id="newExternalUrl" placeholder="https://forms.gle/..."></div>
+    <div class="form-row"><label for="newFormTitle">제목 (선택)</label>
+      <input type="text" id="newFormTitle" placeholder="외부 지원폼"></div>
+    <button type="button" id="btnConnectExternal">외부폼 연결</button>
+    <div id="connectResult" class="message-box hidden"></div>
+```
+
+- [ ] **Step 2: JS 로직 추가**
+
+`edit.html`의 `<script>` 끝(마지막 `};` 뒤, `</script>` 앞)에 추가:
+
+```javascript
+    function currentSemester() {
+      const now = new Date();
+      return {
+        semesterYear: now.getFullYear(),
+        semesterTerm: (now.getMonth() + 1) < 7 ? 'FIRST' : 'SECOND'
+      };
+    }
+
+    async function loadFormList() {
+      if (!clubId || !getToken()) return;
+      const stateEl = document.getElementById('formListState');
+      const tbody = document.getElementById('formList').querySelector('tbody');
+      stateEl.classList.remove('hidden');
+      try {
+        const res = await fetch(API_BASE + '/api/admin/club/' + clubId + '/application', { headers: headers() });
+        const data = await res.json();
+        if (!res.ok) { stateEl.textContent = data.message || ('HTTP ' + res.status); return; }
+        const forms = data.data || [];
+        tbody.innerHTML = '';
+        forms.forEach(function(f) {
+          const tr = document.createElement('tr');
+          tr.style.borderBottom = '1px solid #f3f4f6';
+          const active = f.status === 'ACTIVE';
+          tr.innerHTML =
+            '<td style="padding:6px 4px;">' + (f.title || '') + '</td>' +
+            '<td>' + (f.formMode || '') + '</td>' +
+            '<td>' + (f.status || '') + '</td>' +
+            '<td style="white-space:nowrap;"></td>';
+          const actionCell = tr.querySelector('td:last-child');
+          const toggleBtn = document.createElement('button');
+          toggleBtn.type = 'button';
+          toggleBtn.textContent = active ? '미게시로 변경' : '활성화';
+          toggleBtn.onclick = function() { toggleStatus(f.id, !active); };
+          const delBtn = document.createElement('button');
+          delBtn.type = 'button';
+          delBtn.textContent = '삭제';
+          delBtn.onclick = function() { deleteForm(f.id); };
+          actionCell.appendChild(toggleBtn);
+          actionCell.appendChild(delBtn);
+          tbody.appendChild(tr);
+        });
+        stateEl.textContent = forms.length ? '' : '연결된 지원폼이 없습니다.';
+        if (forms.length) stateEl.classList.add('hidden');
+      } catch (e) {
+        stateEl.textContent = e.message || '요청 실패';
+      }
+    }
+
+    async function toggleStatus(formId, active) {
+      try {
+        const res = await fetch(API_BASE + '/api/admin/club/' + clubId + '/application/' + formId + '/status',
+          { method: 'PATCH', headers: headers(), body: JSON.stringify({ active: active }) });
+        const data = await res.json();
+        showResult('connectResult', res.ok, res.ok ? '상태 변경됨' : (data.message || '요청 실패'));
+        if (res.ok) loadFormList();
+      } catch (e) { showResult('connectResult', false, e.message || '요청 실패'); }
+    }
+
+    async function deleteForm(formId) {
+      try {
+        const res = await fetch(API_BASE + '/api/admin/club/' + clubId + '/application/' + formId,
+          { method: 'DELETE', headers: headers() });
+        const data = await res.json();
+        showResult('connectResult', res.ok, res.ok ? '삭제됨' : (data.message || '요청 실패'));
+        if (res.ok) loadFormList();
+      } catch (e) { showResult('connectResult', false, e.message || '요청 실패'); }
+    }
+
+    document.getElementById('btnConnectExternal').onclick = async function() {
+      const btn = this;
+      const url = document.getElementById('newExternalUrl').value.trim();
+      if (!url) { showResult('connectResult', false, '외부 URL을 입력하세요.'); return; }
+      const sem = currentSemester();
+      const body = {
+        title: document.getElementById('newFormTitle').value.trim() || null,
+        externalApplicationUrl: url,
+        semesterYear: sem.semesterYear,
+        semesterTerm: sem.semesterTerm
+      };
+      btn.disabled = true; btn.textContent = '연결 중...';
+      try {
+        const res = await fetch(API_BASE + '/api/admin/club/' + clubId + '/application',
+          { method: 'POST', headers: headers(), body: JSON.stringify(body) });
+        const data = await res.json();
+        showResult('connectResult', res.ok, res.ok ? '연결됨' : (data.message || '요청 실패'));
+        if (res.ok) {
+          document.getElementById('newExternalUrl').value = '';
+          document.getElementById('newFormTitle').value = '';
+          loadFormList();
+        }
+      } catch (e) {
+        showResult('connectResult', false, e.message || '요청 실패');
+      } finally {
+        btn.disabled = false; btn.textContent = '외부폼 연결';
+      }
+    };
+```
+
+- [ ] **Step 3: 최초 로드 시 목록 조회 연결**
+
+`edit.html`의 초기 클럽 로드 성공 블록(현재 `document.getElementById('editForm').classList.remove('hidden');` 직후)에 한 줄 추가:
+
+```javascript
+          document.getElementById('editForm').classList.remove('hidden');
+          loadFormList();
+```
+
+- [ ] **Step 4: 수동 검증 (지원폼 + 지원기간)**
+
+Run: `cd backend && ./gradlew bootRun` (Infisical dev 세팅 필요) — 또는 배포 환경.
+개발자 계정으로 `/dev` 로그인 → 동아리 관리 → 임의 동아리 클릭 → edit 팝업에서:
+1. "외부 지원 URL"에 `https://forms.gle/xxxx` 입력 → "외부폼 연결" → 목록에 ACTIVE로 추가되는지 확인.
+2. 해당 동아리 상세 페이지 "지원하기" 클릭 → 외부 URL로 이동하는지 확인.
+3. 목록에서 "미게시로 변경" → 상태 PUBLISHED, 지원 버튼에서 사라지는지 확인. "활성화"로 되돌려 확인.
+4. **지원기간:** "모집 시작/종료" 값 입력 → "모집정보 저장" → 팝업 새로고침 후 값이 유지되는지, 동아리 상세의 모집상태가 반영되는지 확인.
+
+Expected: 위 4개 모두 정상.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+cd backend && git add src/main/resources/static/dev/edit.html
+git commit -m "feat(dev): 개발자 포털 edit 페이지에 외부폼 연결/토글/삭제 UI 추가
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- 외부폼 연결(구글/네이버) → Task 1 `connectExternalApplicationFormForClub` + Task 2 POST + Task 3 UI. ✅
+- 생성 즉시 ACTIVE → Task 1 Step 5 `updateFormStatus(true)` + 테스트. ✅
+- 활성화/미게시 토글 → Task 1 `setApplicationFormStatusForClub` + Task 2 PATCH + Task 3 토글 버튼. ✅
+- 삭제 → Task 1 `deleteApplicationFormForClub` + Task 2 DELETE + Task 3 삭제 버튼. ✅
+- 목록 조회 → Task 1 `getApplicationFormsForClub` + Task 2 GET + Task 3 목록. ✅
+- 지원기간 설정 → 기존 `/api/admin/club/{clubId}/description` 유지 + Task 3 Step 4 수동 검증. ✅
+- DEVELOPER 권한 보호 → `/api/admin/**` 기존 SecurityConfig 규칙(신규 컨트롤러가 자동 상속). ✅
+- 허용 도메인/학기 검증 → 엔티티/기존 validateSemester 재사용 + Task 1 테스트. ✅
+
+**Placeholder scan:** 모든 코드 스텝에 실제 코드 포함. TODO/TBD 없음. ✅
+
+**Type consistency:** `AdminExternalFormConnectRequest`(title, externalApplicationUrl, semesterYear, semesterTerm), `AdminClubApplicationFormResponse`(id, title, formMode, status, externalApplicationUrl, semesterYear, semesterTerm), 서비스 4개 메서드 시그니처가 Task 1↔2↔3에서 일치. `StatusRequest(active)` ↔ 프론트 `{active}` 일치. ✅
+
+## 참고: 남은 미결(구현 중 판단)
+
+- `Club` 생성자 시그니처: 테스트에서 `new Club(userId)` 사용(기존 `ClubApplyAdminServiceTest`가 `new Club(user.getId())` 사용함을 확인). 다른 시그니처면 기존 테스트 패턴을 따를 것.
+- 여러 ACTIVE 폼 허용(자동 단일화 안 함) — 스펙의 의도된 동작. 지원 버튼은 ACTIVE가 2개 이상이면 선택 모달을 띄움(기존 동작).

--- a/docs/superpowers/plans/2026-07-21-dev-portal-external-form-and-recruit-period.md
+++ b/docs/superpowers/plans/2026-07-21-dev-portal-external-form-and-recruit-period.md
@@ -2,6 +2,8 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
+> **정정(develop/be 리베이스 반영):** 이 계획은 main 기준으로 작성됐다. 실제 구현은 develop/be로 리베이스되었고, develop/be는 `ApplicationFormStatus`를 `ACTIVE`/`INACTIVE` **2-state**로 축소하고 `ClubApplicationForm`에서 `semesterTerm`·`validateSemester`를 제거했다. 따라서 아래 코드/설명의 `semesterTerm`, `validateSemester`, `updateSemesterTerm`, `getSemesterTerm`, `PUBLISHED` 참조는 **실제 구현에서 제거/대체**되었다: 요청/응답 DTO에서 `semesterTerm` 필드 없음, connect는 `validateSemester`/`updateSemesterTerm` 호출 없이 `semesterYear`만 설정, 미게시(`active=false`)는 `PUBLISHED`가 아니라 `INACTIVE`로 처리. 최종 코드는 브랜치의 실제 파일을 기준으로 한다.
+
 **Goal:** 개발자 포털에서 임의 동아리의 외부 지원폼(구글/네이버) 연결·활성화/미게시 토글·삭제와 지원기간 설정을 할 수 있게 한다.
 
 **Architecture:** `/api/admin/**`(이미 `hasRole("DEVELOPER")` 보호) 아래에 clubId를 파라미터로 받는 지원폼 관리 엔드포인트를 새 컨트롤러로 추가하고, `ClubApplyAdminService`에 clubId를 명시적으로 받는 메서드를 추가한다(기존 본인-동아리 메서드는 건드리지 않음). 개발자 포털 정적 페이지 `dev/edit.html`에 UI 섹션을 추가한다. 지원기간은 기존 `PUT /api/admin/club/{clubId}/description`를 그대로 사용한다(신규 백엔드 없음).

--- a/docs/superpowers/specs/2026-07-21-dev-portal-external-form-and-recruit-period-design.md
+++ b/docs/superpowers/specs/2026-07-21-dev-portal-external-form-and-recruit-period-design.md
@@ -44,11 +44,15 @@
 |---|---|---|
 | GET | `/api/admin/club/{clubId}/application` | 해당 동아리의 지원폼 목록 조회 |
 | POST | `/api/admin/club/{clubId}/application` | 외부폼 연결 (생성 + 즉시 ACTIVE) |
+| PATCH | `/api/admin/club/{clubId}/application/{formId}/status` | 기존 지원폼 활성화/미게시 토글 |
 | DELETE | `/api/admin/club/{clubId}/application/{formId}` | 지원폼 삭제 |
 
 - POST 요청 바디: `{ title, externalApplicationUrl, semesterYear, semesterTerm }`
   - `formMode`는 서버에서 `EXTERNAL` 고정. `externalApplicationUrl` 필수(허용 도메인 검증은 엔티티 재사용).
   - `title` 기본값 허용(예: "외부 지원폼")으로 개발자 편의. semester 기본은 현재 학기(프론트에서 채워 보냄).
+- PATCH `.../status` 요청 바디: `{ active: true|false }`
+  - `active=true` → `ACTIVE`(게시, 지원 목록에 노출). `active=false` → `updateFormStatus(false)`로 ACTIVE였던 폼은 `PUBLISHED`로 내려가 지원 목록에서 빠짐(= 미게시/비활성).
+  - **외부폼뿐 아니라 기존 자체폼 등 모든 지원폼**에 적용 가능(상태만 변경).
 - 지원기간은 **기존** `PUT /api/admin/club/{clubId}/description` 재사용(신규 없음).
 
 ### 2) 서비스 계층
@@ -60,6 +64,7 @@
   - `ClubApplicationForm.builder().clubId(clubId).build()` → title/semester/externalApplicationUrl(허용검증)/formMode=EXTERNAL 세팅
   - **`updateFormStatus(true)`로 ACTIVE 설정** 후 save
 - `getApplicationFormsForClub(String clubId)`: `findClubApplicationFormsByClubId(clubId)` 재사용
+- `setApplicationFormStatusForClub(String clubId, String formId, boolean active)`: `findByClubIdAndId(clubId, formId)` → `updateFormStatus(active)` → save. 기존 자체폼 포함 모든 폼에 적용.
 - `deleteApplicationFormForClub(String clubId, String formId)`: `findByClubIdAndId(clubId, formId)` → 지원자 삭제 + 폼 삭제 (기존 delete 로직과 동일 패턴)
 
 리팩터링은 최소로: 기존 본인-동아리 메서드가 새 clubId 메서드를 호출하도록 위임할 수 있으면 위임, 아니면 신규 메서드만 추가.
@@ -74,7 +79,8 @@
 
 - 기존 "모집정보 수정" 섹션(모집 시작/종료 = 지원기간) **유지**. 로드/저장 실동작 검증.
 - 새 섹션 **"지원폼 연결 (외부)"** 추가:
-  - 현재 연결된 지원폼 목록 표시 (`GET /api/admin/club/{clubId}/application`): 제목/모드/상태/URL + 삭제 버튼
+  - 현재 연결된 지원폼 목록 표시 (`GET /api/admin/club/{clubId}/application`): 제목/모드/상태/URL + 각 행에 **활성화/미게시 토글 버튼**(→ `PATCH .../status`) + 삭제 버튼
+    - 상태에 따라 버튼 라벨 전환: `ACTIVE`이면 "미게시로 변경"(`active=false`), 아니면 "활성화"(`active=true`).
   - 입력: 외부 URL(구글폼/네이버폼), (선택) 제목 → "연결" 버튼 → `POST /api/admin/club/{clubId}/application`
   - 성공/실패 메시지는 기존 `showResult` 패턴 재사용. 허용 도메인 위반 시 서버 에러 메시지 표시.
 - 학기는 현재 학기를 기본으로 자동 세팅(프론트에서 계산해 전송).
@@ -87,7 +93,7 @@
 
 ## 테스트
 
-- 백엔드: `ClubApplyAdminService`의 새 clubId 메서드에 대한 유닛 테스트(생성 시 ACTIVE 확인, 허용도메인 위반 예외, 삭제). 컨트롤러는 DEVELOPER 권한 통합 테스트가 있으면 패턴 따라 추가.
+- 백엔드: `ClubApplyAdminService`의 새 clubId 메서드에 대한 유닛 테스트(생성 시 ACTIVE 확인, 허용도메인 위반 예외, 상태 토글 시 ACTIVE↔PUBLISHED 전이, 삭제). 컨트롤러는 DEVELOPER 권한 통합 테스트가 있으면 패턴 따라 추가.
 - 수동 검증: 개발자 포털에서 임의 동아리에 구글폼 URL 연결 → 해당 동아리 상세 페이지 "지원하기" → 외부 URL로 이동하는지 확인. 지원기간 저장 후 재조회로 반영 확인.
 
 ## 범위 밖 (YAGNI)

--- a/docs/superpowers/specs/2026-07-21-dev-portal-external-form-and-recruit-period-design.md
+++ b/docs/superpowers/specs/2026-07-21-dev-portal-external-form-and-recruit-period-design.md
@@ -1,0 +1,97 @@
+# 개발자 포털: 임의 동아리 외부폼 연결 + 지원기간 설정
+
+작성일: 2026-07-21
+브랜치: master-account-club-form-editor
+
+## 목표
+
+개발자(DEVELOPER) 계정으로 개발자 포털(`/dev`)에서 **임의 동아리**의:
+
+1. **지원기간 설정** — 모집 시작/종료 (`ClubRecruitmentInformation.recruitmentStart/End`)
+2. **외부 지원폼 연결** — 구글폼/네이버폼 등 외부 URL을 실제 지원 버튼에 연결
+
+을 할 수 있게 한다. **자체 지원폼(질문 빌더)은 범위 밖.** 외부 URL 연결만.
+
+## 배경 / 현황 (조사 결과)
+
+- 개발자 포털 = `backend/src/main/resources/static/dev/index.html`. "동아리 관리" 탭에서 동아리 클릭 시 `edit.html?clubId=...` 팝업이 열림.
+- `edit.html`은 이미 **모집 시작/종료(지원기간)**를 `PUT /api/admin/club/{clubId}/description` 로 저장한다. (동작함 — 구현 시 검증)
+- `edit.html`의 "외부 지원 URL" 필드는 `ClubRecruitmentInformation.externalApplicationUrl`에 저장되지만, **실제 지원 버튼은 이 값을 쓰지 않는다.** `ClubDetailedResult`에 노출만 될 뿐이다.
+- 실제 지원 버튼(`frontend .../ClubApplyButton.tsx`)은 **`ClubApplicationForm`**(status=ACTIVE)을 불러와, `formMode === EXTERNAL`이면 그 폼의 `externalApplicationUrl`로 이동한다.
+- `ClubApplicationForm` 관리 API(`/api/club/application/**`, `ClubApplyAdminController`)는 전부 `@PreAuthorize("isAuthenticated()")` + `user.getClubId()` — **로그인한 본인 동아리만** 대상. 개발자가 clubId를 지정해 다른 동아리 폼을 만드는 엔드포인트가 **없음**. → 이것이 진짜 갭.
+
+### 핵심 도메인 사실
+
+- `ApplicationFormStatus`: `ACTIVE`(게시 중) / `PUBLISHED`(게시된 적 있음) / `UNPUBLISHED`(게시된 적 없음).
+- **생성(`createApplicationForm`)은 status를 세팅하지 않아 기본 `UNPUBLISHED`** → 지원 버튼에 안 뜬다. 실제 연결하려면 생성 시 `ACTIVE`로 만들어야 한다.
+- 공개 지원 목록 쿼리: `{'clubId': ?0, 'status': 'ACTIVE'}` (`ClubApplicationFormsRepository.findClubActiveFormsByClubId`).
+- 외부 URL 허용 도메인은 엔티티(`ClubApplicationForm.updateExternalApplicationUrl`)에서 검증: `forms.gle`, `docs.google.com/forms`, `form.naver.com`, `naver.me`, `everytime.kr` → 구글폼·네이버폼 커버됨. 위반 시 `NOT_ALLOWED_EXTERNAL_URL`.
+- 학기 유효성(`validateSemester`): 현재 학기 + 향후 2개 학기만 허용.
+
+## 접근 방식: A (초경량)
+
+"이 동아리에 외부폼 URL을 연결한다" 중심. 새 폼 생성 시 즉시 `ACTIVE`. 최소 엔드포인트 3개(목록/연결/삭제)만 추가.
+
+- 이미 활성 폼이 여러 개면 지원 버튼에 선택 모달이 뜨는 것은 기존 동작 그대로 유지 (자동 비활성화하지 않음). 개발자가 목록에서 불필요한 폼을 삭제해 정리.
+
+## 백엔드 변경
+
+### 1) 새 관리자 엔드포인트 (DEVELOPER 전용, clubId 파라미터)
+
+`ClubAdminController` (`/api/admin`)에 추가. `/api/admin/**`는 `SecurityConfig`에서 이미 `hasRole("DEVELOPER")`로 보호됨.
+
+| 메서드 | 경로 | 설명 |
+|---|---|---|
+| GET | `/api/admin/club/{clubId}/application` | 해당 동아리의 지원폼 목록 조회 |
+| POST | `/api/admin/club/{clubId}/application` | 외부폼 연결 (생성 + 즉시 ACTIVE) |
+| DELETE | `/api/admin/club/{clubId}/application/{formId}` | 지원폼 삭제 |
+
+- POST 요청 바디: `{ title, externalApplicationUrl, semesterYear, semesterTerm }`
+  - `formMode`는 서버에서 `EXTERNAL` 고정. `externalApplicationUrl` 필수(허용 도메인 검증은 엔티티 재사용).
+  - `title` 기본값 허용(예: "외부 지원폼")으로 개발자 편의. semester 기본은 현재 학기(프론트에서 채워 보냄).
+- 지원기간은 **기존** `PUT /api/admin/club/{clubId}/description` 재사용(신규 없음).
+
+### 2) 서비스 계층
+
+`ClubApplyAdminService`에 **clubId를 명시적으로 받는** 메서드 추가(기존 `user.getClubId()` 메서드는 그대로 두고 오버로드/신규 추가):
+
+- `createExternalApplicationFormForClub(String clubId, request)`:
+  - `validateSemester(...)`
+  - `ClubApplicationForm.builder().clubId(clubId).build()` → title/semester/externalApplicationUrl(허용검증)/formMode=EXTERNAL 세팅
+  - **`updateFormStatus(true)`로 ACTIVE 설정** 후 save
+- `getApplicationFormsForClub(String clubId)`: `findClubApplicationFormsByClubId(clubId)` 재사용
+- `deleteApplicationFormForClub(String clubId, String formId)`: `findByClubIdAndId(clubId, formId)` → 지원자 삭제 + 폼 삭제 (기존 delete 로직과 동일 패턴)
+
+리팩터링은 최소로: 기존 본인-동아리 메서드가 새 clubId 메서드를 호출하도록 위임할 수 있으면 위임, 아니면 신규 메서드만 추가.
+
+### 3) 요청 DTO
+
+- 신규 `AdminExternalFormConnectRequest(String title, String externalApplicationUrl, Integer semesterYear, SemesterTerm semesterTerm)` 또는 기존 `ClubApplicationFormCreateRequest` 재사용(formMode 서버 고정). 재사용이 더 단순하면 재사용.
+
+## 프론트엔드 (개발자 포털 정적 페이지)
+
+`backend/src/main/resources/static/dev/edit.html` 확장:
+
+- 기존 "모집정보 수정" 섹션(모집 시작/종료 = 지원기간) **유지**. 로드/저장 실동작 검증.
+- 새 섹션 **"지원폼 연결 (외부)"** 추가:
+  - 현재 연결된 지원폼 목록 표시 (`GET /api/admin/club/{clubId}/application`): 제목/모드/상태/URL + 삭제 버튼
+  - 입력: 외부 URL(구글폼/네이버폼), (선택) 제목 → "연결" 버튼 → `POST /api/admin/club/{clubId}/application`
+  - 성공/실패 메시지는 기존 `showResult` 패턴 재사용. 허용 도메인 위반 시 서버 에러 메시지 표시.
+- 학기는 현재 학기를 기본으로 자동 세팅(프론트에서 계산해 전송).
+
+## 에러 처리
+
+- 허용되지 않은 URL → 서버 `NOT_ALLOWED_EXTERNAL_URL` → 팝업에 메시지.
+- 잘못된 학기 → `APPLICATION_SEMESTER_INVALID`.
+- 존재하지 않는 clubId/formId → `CLUB_NOT_FOUND` / `APPLICATION_NOT_FOUND`.
+
+## 테스트
+
+- 백엔드: `ClubApplyAdminService`의 새 clubId 메서드에 대한 유닛 테스트(생성 시 ACTIVE 확인, 허용도메인 위반 예외, 삭제). 컨트롤러는 DEVELOPER 권한 통합 테스트가 있으면 패턴 따라 추가.
+- 수동 검증: 개발자 포털에서 임의 동아리에 구글폼 URL 연결 → 해당 동아리 상세 페이지 "지원하기" → 외부 URL로 이동하는지 확인. 지원기간 저장 후 재조회로 반영 확인.
+
+## 범위 밖 (YAGNI)
+
+- 자체 지원폼(질문 빌더) 개발자 편집.
+- 활성 폼 자동 단일화(다른 폼 자동 비활성화).
+- `ClubRecruitmentInformation.externalApplicationUrl`(미사용 레거시 필드) 정리 — 건드리지 않음.

--- a/docs/superpowers/specs/2026-07-21-dev-portal-external-form-and-recruit-period-design.md
+++ b/docs/superpowers/specs/2026-07-21-dev-portal-external-form-and-recruit-period-design.md
@@ -32,7 +32,7 @@
 
 ## 접근 방식: A (초경량)
 
-"이 동아리에 외부폼 URL을 연결한다" 중심. 새 폼 생성 시 즉시 `ACTIVE`. 최소 엔드포인트 3개(목록/연결/삭제)만 추가.
+"이 동아리에 외부폼 URL을 연결한다" 중심. 새 폼 생성 시 즉시 `ACTIVE`. 엔드포인트 4개(목록/연결/상태토글/삭제)만 추가.
 
 - 이미 활성 폼이 여러 개면 지원 버튼에 선택 모달이 뜨는 것은 기존 동작 그대로 유지 (자동 비활성화하지 않음). 개발자가 목록에서 불필요한 폼을 삭제해 정리.
 
@@ -40,7 +40,7 @@
 
 ### 1) 새 관리자 엔드포인트 (DEVELOPER 전용, clubId 파라미터)
 
-`ClubAdminController` (`/api/admin`)에 추가. `/api/admin/**`는 `SecurityConfig`에서 이미 `hasRole("DEVELOPER")`로 보호됨.
+신규 컨트롤러 `ClubApplicationAdminController` (`/api/admin`)에 추가. `/api/admin/**`는 `SecurityConfig`에서 이미 `hasRole("DEVELOPER")`로 보호됨.
 
 | 메서드 | 경로 | 설명 |
 |---|---|---|
@@ -61,11 +61,11 @@
 
 `ClubApplyAdminService`에 **clubId를 명시적으로 받는** 메서드 추가(기존 `user.getClubId()` 메서드는 그대로 두고 오버로드/신규 추가):
 
-- `createExternalApplicationFormForClub(String clubId, request)`:
+- `connectExternalApplicationFormForClub(String clubId, request)`:
   - `validateSemester(...)`
   - `ClubApplicationForm.builder().clubId(clubId).build()` → title/semester/externalApplicationUrl(허용검증)/formMode=EXTERNAL 세팅
   - **`updateFormStatus(true)`로 ACTIVE 설정** 후 save
-- `getApplicationFormsForClub(String clubId)`: `findClubApplicationFormsByClubId(clubId)` 재사용
+- `getApplicationFormsForClub(String clubId)`: `clubApplicationFormsRepository.findByClubId(clubId)` → `AdminClubApplicationFormResponse`로 매핑
 - `setApplicationFormStatusForClub(String clubId, String formId, boolean active)`: `findByClubIdAndId(clubId, formId)` → `updateFormStatus(active)` → save. 기존 자체폼 포함 모든 폼에 적용.
 - `deleteApplicationFormForClub(String clubId, String formId)`: `findByClubIdAndId(clubId, formId)` → 지원자 삭제 + 폼 삭제 (기존 delete 로직과 동일 패턴)
 

--- a/docs/superpowers/specs/2026-07-21-dev-portal-external-form-and-recruit-period-design.md
+++ b/docs/superpowers/specs/2026-07-21-dev-portal-external-form-and-recruit-period-design.md
@@ -22,8 +22,10 @@
 
 ### 핵심 도메인 사실
 
-- `ApplicationFormStatus`: `ACTIVE`(게시 중) / `PUBLISHED`(게시된 적 있음) / `UNPUBLISHED`(게시된 적 없음).
-- **생성(`createApplicationForm`)은 status를 세팅하지 않아 기본 `UNPUBLISHED`** → 지원 버튼에 안 뜬다. 실제 연결하려면 생성 시 `ACTIVE`로 만들어야 한다.
+> **정정(develop/be 리베이스 반영):** develop/be는 `ApplicationFormStatus`를 `ACTIVE`/`INACTIVE` **2-state**로 축소하고, `ClubApplicationForm`에서 `semesterTerm`·`validateSemester`를 제거했다. 따라서 아래 본문의 `PUBLISHED`/`UNPUBLISHED`, `semesterTerm` 언급은 실제 구현에서는 각각 `INACTIVE`(미게시) 및 "없음"으로 대체되었다.
+
+- `ApplicationFormStatus`: `ACTIVE`(게시 중) / `INACTIVE`(미게시).
+- **생성 시 status 기본값은 `INACTIVE`** → 지원 버튼에 안 뜬다. 실제 연결하려면 생성 시 `updateFormStatus(true)`로 `ACTIVE`로 만들어야 한다.
 - 공개 지원 목록 쿼리: `{'clubId': ?0, 'status': 'ACTIVE'}` (`ClubApplicationFormsRepository.findClubActiveFormsByClubId`).
 - 외부 URL 허용 도메인은 엔티티(`ClubApplicationForm.updateExternalApplicationUrl`)에서 검증: `forms.gle`, `docs.google.com/forms`, `form.naver.com`, `naver.me`, `everytime.kr` → 구글폼·네이버폼 커버됨. 위반 시 `NOT_ALLOWED_EXTERNAL_URL`.
 - 학기 유효성(`validateSemester`): 현재 학기 + 향후 2개 학기만 허용.
@@ -47,11 +49,11 @@
 | PATCH | `/api/admin/club/{clubId}/application/{formId}/status` | 기존 지원폼 활성화/미게시 토글 |
 | DELETE | `/api/admin/club/{clubId}/application/{formId}` | 지원폼 삭제 |
 
-- POST 요청 바디: `{ title, externalApplicationUrl, semesterYear, semesterTerm }`
+- POST 요청 바디: `{ title, externalApplicationUrl, semesterYear }`
   - `formMode`는 서버에서 `EXTERNAL` 고정. `externalApplicationUrl` 필수(허용 도메인 검증은 엔티티 재사용).
   - `title` 기본값 허용(예: "외부 지원폼")으로 개발자 편의. semester 기본은 현재 학기(프론트에서 채워 보냄).
 - PATCH `.../status` 요청 바디: `{ active: true|false }`
-  - `active=true` → `ACTIVE`(게시, 지원 목록에 노출). `active=false` → `updateFormStatus(false)`로 ACTIVE였던 폼은 `PUBLISHED`로 내려가 지원 목록에서 빠짐(= 미게시/비활성).
+  - `active=true` → `ACTIVE`(게시, 지원 목록에 노출). `active=false` → `updateFormStatus(false)`로 `INACTIVE`가 되어 지원 목록에서 빠짐(= 미게시/비활성).
   - **외부폼뿐 아니라 기존 자체폼 등 모든 지원폼**에 적용 가능(상태만 변경).
 - 지원기간은 **기존** `PUT /api/admin/club/{clubId}/description` 재사용(신규 없음).
 
@@ -71,7 +73,7 @@
 
 ### 3) 요청 DTO
 
-- 신규 `AdminExternalFormConnectRequest(String title, String externalApplicationUrl, Integer semesterYear, SemesterTerm semesterTerm)` 또는 기존 `ClubApplicationFormCreateRequest` 재사용(formMode 서버 고정). 재사용이 더 단순하면 재사용.
+- 신규 `AdminExternalFormConnectRequest(String title, String externalApplicationUrl, Integer semesterYear)` 또는 기존 `ClubApplicationFormCreateRequest` 재사용(formMode 서버 고정). 재사용이 더 단순하면 재사용.
 
 ## 프론트엔드 (개발자 포털 정적 페이지)
 
@@ -93,7 +95,7 @@
 
 ## 테스트
 
-- 백엔드: `ClubApplyAdminService`의 새 clubId 메서드에 대한 유닛 테스트(생성 시 ACTIVE 확인, 허용도메인 위반 예외, 상태 토글 시 ACTIVE↔PUBLISHED 전이, 삭제). 컨트롤러는 DEVELOPER 권한 통합 테스트가 있으면 패턴 따라 추가.
+- 백엔드: `ClubApplyAdminService`의 새 clubId 메서드에 대한 유닛 테스트(생성 시 ACTIVE 확인, 허용도메인 위반 예외, 상태 토글 시 ACTIVE↔INACTIVE 전이, 삭제). 컨트롤러는 DEVELOPER 권한 통합 테스트가 있으면 패턴 따라 추가.
 - 수동 검증: 개발자 포털에서 임의 동아리에 구글폼 URL 연결 → 해당 동아리 상세 페이지 "지원하기" → 외부 URL로 이동하는지 확인. 지원기간 저장 후 재조회로 반영 확인.
 
 ## 범위 밖 (YAGNI)


### PR DESCRIPTION
## 개요
개발자(DEVELOPER) 마스터 계정이 **개발자 포털(`/dev`)에서 임의 동아리**의 지원폼 연결·지원기간을 관리할 수 있게 합니다.

- **외부 지원폼 연결**: 구글폼/네이버폼 URL을 임의 동아리에 연결(생성 즉시 게시=ACTIVE) → 해당 동아리 "지원하기" 버튼이 그 URL로 이동
- **활성화/미게시 토글**: 기존 지원폼을 게시(ACTIVE)/미게시(INACTIVE) 전환
- **삭제**: 잘못 만든 폼 제거
- **지원기간(모집 시작/종료)**: 기존 `edit.html`의 모집정보 저장 기능 유지

기존엔 지원폼(`ClubApplicationForm`) 관리 API가 전부 본인 동아리(`user.getClubId()`) 전용이라 개발자가 다른 동아리 걸 건드릴 수 없었습니다.

## 변경 사항
- `ClubApplicationAdminController` (`/api/admin`, `hasRole("DEVELOPER")` 자동 보호) 엔드포인트 4개:
  - `GET /api/admin/club/{clubId}/application` 목록
  - `POST /api/admin/club/{clubId}/application` 외부폼 연결(ACTIVE)
  - `PATCH /api/admin/club/{clubId}/application/{formId}/status` `{active}` 토글
  - `DELETE /api/admin/club/{clubId}/application/{formId}` 삭제
- `ClubApplyAdminService`에 clubId 기반 메서드 4개 추가(기존 본인-동아리 메서드 불변)
- DTO: `AdminExternalFormConnectRequest`, `AdminClubApplicationFormResponse`
- 개발자 포털 `dev/edit.html`에 "지원폼 연결(외부)" 섹션(목록/연결/토글/삭제)
- 외부 URL 허용 도메인 검증은 기존 엔티티(`ClubApplicationForm.updateExternalApplicationUrl`) 재사용 — forms.gle / docs.google.com/forms / form.naver.com / naver.me / everytime.kr

## develop/be 모델 대응
이 브랜치는 main에서 시작했으나 develop/be로 리베이스했고, develop/be의 변경(지원서 상태 `ACTIVE/INACTIVE` 2-state 축소, `semesterTerm`/`validateSemester` 제거)에 맞춰 코드를 조정했습니다. "미게시"는 `INACTIVE`로 처리됩니다.

## 테스트 / 검증
- `ClubApplicationAdminServiceTest` 통합 테스트 5개 추가(연결→ACTIVE·EXTERNAL, 허용도메인 위반 예외, 토글 ACTIVE→INACTIVE, 목록, 삭제)
- ⚠️ 통합 테스트는 시크릿(Infisical/Mongo/Firebase)이 없는 작업 환경에서 **실행하지 못했고 컴파일까지만 검증**했습니다. CI 또는 시크릿이 설정된 로컬에서 `./gradlew integrationTest --tests "moadong.club.service.ClubApplicationAdminServiceTest"` 실행 및 개발자 포털 브라우저 수동 확인이 필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 동아리별 외부 지원폼을 연결하고 목록을 확인할 수 있습니다.
  * 지원폼을 활성화하거나 미게시 상태로 전환할 수 있습니다.
  * 연결된 지원폼을 삭제할 수 있습니다.
  * 개발자 포털에서 외부 URL, 제목, 학년도를 입력해 지원폼을 관리할 수 있습니다.

* **개선 사항**
  * 외부 지원폼 관리 작업의 성공 및 실패 결과와 로딩 상태를 화면에 표시합니다.

* **테스트**
  * 외부 지원폼 연결, 상태 변경, 조회, 삭제 및 URL 검증 시나리오를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->