### PR TITLE
[refactor] 지원서 목록 년도별 그룹핑 및 UI 텍스트 통일

### DIFF
--- a/frontend/docs/features/admin/application/desktop.md
+++ b/frontend/docs/features/admin/application/desktop.md
@@ -1,0 +1,44 @@
+# ApplicationFormList 년도별 그룹핑
+
+지원서 목록 화면에서 지원서를 년도별로 분류해 표시하는 구조.
+
+## 구조
+
+- **게시된 지원서 섹션**: `status === 'ACTIVE'`인 지원서만 모아 상단에 핀 고정
+- **년도 그룹 섹션**: `semesterYear` 기준으로 그룹핑, 활성/비활성 전부 표시
+
+## API 응답 구조와 프론트 처리
+
+API는 `ApplicationFormGroup[]`를 내려주는데, 같은 `semesterYear`라도 `active: true / false`로 분리된 두 그룹이 올 수 있다.
+
+```ts
+// API 응답 예시
+[
+  { semesterYear: 2026, active: true,  forms: [...] },
+  { semesterYear: 2026, active: false, forms: [...] },
+]
+```
+
+프론트에서 `Map<number, ApplicationFormItem[]>`으로 머지해 같은 년도를 하나의 그룹으로 합친다.
+`Number()` 변환으로 타입 불일치(`string` vs `number`) 방어.
+
+```ts
+const yearMap = new Map<number, ApplicationFormItem[]>();
+formGroups.forEach((group) => {
+  const year = Number(group.semesterYear);
+  const existing = yearMap.get(year) ?? [];
+  yearMap.set(year, [...existing, ...group.forms]);
+});
+```
+
+## UI 텍스트 규칙
+
+- "게시/미게시" 대신 "활성화/비활성화" 용어 사용 (모바일 디자인 통일)
+- 컨텍스트 메뉴: `지원서 활성화` / `지원서 비활성화`
+
+## 관련 코드
+
+- `src/pages/AdminPage/components/ApplicationFormList/ApplicationFormList.tsx` — 목록 렌더링, 년도별 머지 로직
+- `src/pages/AdminPage/tabs/ApplicationListTab/ApplicationMenu.tsx` — ... 메뉴 텍스트
+- `src/pages/AdminPage/tabs/ApplicationListTab/ApplicationListTab.styles.ts` — 스타일
+- `src/hooks/Queries/useApplication.ts` — `useGetApplicationList`, 상태 변경 뮤테이션

--- a/frontend/src/pages/AdminPage/components/ApplicationFormList/ApplicationFormList.tsx
+++ b/frontend/src/pages/AdminPage/components/ApplicationFormList/ApplicationFormList.tsx
@@ -166,13 +166,13 @@ const ApplicationFormList = ({
 
   const yearMap = new Map<number, ApplicationFormItem[]>();
   formGroups.forEach((group) => {
-    const year = Number(group.semesterYear);
-    const existing = yearMap.get(year) ?? [];
-    yearMap.set(year, [...existing, ...group.forms]);
+    const year = group.semesterYear;
+    if (!yearMap.has(year)) yearMap.set(year, []);
+    yearMap.get(year)!.push(...group.forms);
   });
-  const groupedByYear = Array.from(yearMap.entries()).map(
-    ([semesterYear, forms]) => ({ semesterYear, forms }),
-  );
+  const groupedByYear = Array.from(yearMap.entries())
+    .map(([semesterYear, forms]) => ({ semesterYear, forms }))
+    .sort((a, b) => b.semesterYear - a.semesterYear);
 
   const formsToDisplay = isExpanded
     ? activeForms

--- a/frontend/src/pages/AdminPage/components/ApplicationFormList/ApplicationFormList.tsx
+++ b/frontend/src/pages/AdminPage/components/ApplicationFormList/ApplicationFormList.tsx
@@ -221,10 +221,10 @@ const ApplicationFormList = ({
           <ActiveListBody>
             <Styled.MessageContainer>
               <Styled.NoActiveFormsMessage>
-                게시된 지원서 없음
+                활성화된 지원서 없음
               </Styled.NoActiveFormsMessage>
               <Styled.SuggestionText>
-                지원서 카드 우측 메뉴에서 지원서 게시를 선택해 보세요.
+                지원서 카드 우측 메뉴에서 지원서 활성화를 선택해 보세요.
               </Styled.SuggestionText>
             </Styled.MessageContainer>
           </ActiveListBody>

--- a/frontend/src/pages/AdminPage/components/ApplicationFormList/ApplicationFormList.tsx
+++ b/frontend/src/pages/AdminPage/components/ApplicationFormList/ApplicationFormList.tsx
@@ -47,7 +47,7 @@ interface ApplicationFormListProps {
 }
 
 /**
- * 지원서 목록 화면(게시된 지원서 핀 섹션 + 미게시 섹션).
+ * 지원서 목록 화면(게시된 지원서 핀 섹션 + 년도별 전체 그룹 섹션).
  * ApplicationListTab·ApplicantsListTab이 동일한 로직/렌더를 쓰므로 공유한다.
  * 탭별 차이(이동 대상·메시지·복제 동작·hover색)만 props로 받는다.
  */
@@ -164,9 +164,15 @@ const ApplicationFormList = ({
     .flatMap((group) => group.forms)
     .filter((form) => form.status === 'ACTIVE');
 
-  const inactiveForms = formGroups
-    .flatMap((group) => group.forms)
-    .filter((form) => form.status !== 'ACTIVE');
+  const yearMap = new Map<number, ApplicationFormItem[]>();
+  formGroups.forEach((group) => {
+    const year = Number(group.semesterYear);
+    const existing = yearMap.get(year) ?? [];
+    yearMap.set(year, [...existing, ...group.forms]);
+  });
+  const groupedByYear = Array.from(yearMap.entries()).map(
+    ([semesterYear, forms]) => ({ semesterYear, forms }),
+  );
 
   const formsToDisplay = isExpanded
     ? activeForms
@@ -229,21 +235,23 @@ const ApplicationFormList = ({
           새 양식 만들기 <Styled.PlusIcon src={Plus} />{' '}
         </Styled.AddButton>
       </Styled.Header>
-      {inactiveForms.length > 0 && (
-        <Styled.ApplicationList>
+      {groupedByYear.map((group) => (
+        <Styled.ApplicationList key={group.semesterYear}>
           <Styled.ListHeader>
-            <Styled.SemesterTitle>미게시</Styled.SemesterTitle>
+            <Styled.SemesterTitle>
+              {group.semesterYear}년도
+            </Styled.SemesterTitle>
             <Styled.DateHeader>
               <Styled.Separation_Bar />
               최종 수정 날짜
             </Styled.DateHeader>
           </Styled.ListHeader>
-          {inactiveForms.map((application: ApplicationFormItem) => (
+          {group.forms.map((application: ApplicationFormItem) => (
             <ApplicationRowItem
               key={application.id}
               application={application}
-              isActive={false}
-              uniqueKeyPrefix='inactivelist'
+              isActive={application.status === 'ACTIVE'}
+              uniqueKeyPrefix={`yeargroup-${group.semesterYear}`}
               openMenuId={openMenuId}
               menuRef={menuRef}
               onEdit={onEdit}
@@ -254,7 +262,7 @@ const ApplicationFormList = ({
             />
           ))}
         </Styled.ApplicationList>
-      )}
+      ))}
     </Styled.Container>
   );
 };

--- a/frontend/src/pages/AdminPage/tabs/ApplicationListTab/ApplicationMenu.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicationListTab/ApplicationMenu.tsx
@@ -5,8 +5,8 @@ import Pencil from '@/assets/images/icons/pencil_icon_3.svg';
 import * as Styled from './ApplicationListTab.styles';
 
 const TOGGLE_BUTTON_TEXT = {
-  ACTIVE: '지원서 게시 취소',
-  INACTIVE: '지원서 게시',
+  ACTIVE: '지원서 비활성화',
+  INACTIVE: '지원서 활성화',
 } as const;
 
 interface ApplicationMenuProps {


### PR DESCRIPTION
## #️⃣연관된 이슈

#1843

## 📝작업 내용

### 지원서 목록 년도별 그룹핑

기존 ACTIVE/INACTIVE 단일 분류 방식을 `semesterYear` 기준 년도별 그룹핑으로 변경했습니다.

**화면 구조**
```
게시된 지원서 (ACTIVE only, 핀 섹션)
────────────────────────────────────
2026년도 (활성 + 비활성 전부)
2025년도
2024년도
...
```

**API 응답 처리**

API가 같은 `semesterYear`를 `active: true / false`로 분리해서 내려주기 때문에, 프론트에서 `Map<number, ApplicationFormItem[]>`으로 병합합니다. `Number()` 변환으로 타입 불일치(`string` vs `number`) 방어.

### UI 텍스트 모바일 디자인 통일

- `게시된 지원서 없음` → `활성화된 지원서 없음`
- 컨텍스트 메뉴: `지원서 게시` / `지원서 게시 취소` → `지원서 활성화` / `지원서 비활성화`

## 🫡 참고사항

- 활성/비활성 토글 시 `editedAt`이 갱신되는 현상은 백엔드 이슈로 별도 처리 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 문서
- 지원서 목록의 연도별 그룹화 및 활성화된 지원서 상단 고정 방식을 안내합니다.
- 지원서 상태 처리와 “활성화/비활성화” 용어 기준을 문서화했습니다.

## 개선 사항
- 지원서 목록을 연도별로 확인할 수 있도록 개선했습니다.
- 연도별 지원서를 활성화 상태에 따라 함께 표시합니다.
- 활성화된 지원서가 없을 때 안내 문구를 개선했습니다.
- 메뉴의 상태 변경 문구를 “지원서 활성화/비활성화”로 명확히 변경했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->