### PR TITLE
feat(be): 외부 지원폼 허용 호스트에 cafe.daum.net 추가

### DIFF
--- a/backend/src/main/java/moadong/club/entity/ClubApplicationForm.java
+++ b/backend/src/main/java/moadong/club/entity/ClubApplicationForm.java
@@ -29,7 +29,7 @@ import java.util.Set;
 @Getter
 @Builder(toBuilder = true)
 public class ClubApplicationForm implements Persistable<String> {
-    private static final Set<String> externalApplicationUrlAllowedHosts = Set.of("forms.gle", "docs.google.com", "form.naver.com", "naver.me", "everytime.kr");
+    private static final Set<String> externalApplicationUrlAllowedHosts = Set.of("forms.gle", "docs.google.com", "form.naver.com", "naver.me", "everytime.kr", "cafe.daum.net");
     private static final String GOOGLE_DOCS_HOST = "docs.google.com";
     private static final String GOOGLE_FORMS_PATH_PREFIX = "/forms";
 

--- a/backend/src/test/java/moadong/club/entity/ClubApplicationFormTest.java
+++ b/backend/src/test/java/moadong/club/entity/ClubApplicationFormTest.java
@@ -18,7 +18,8 @@ class ClubApplicationFormTest {
             "https://docs.google.com/forms/d/e/1FAIpQL/viewform",
             "https://form.naver.com/response/abcd",
             "https://naver.me/xyz",
-            "https://everytime.kr/board/1"
+            "https://everytime.kr/board/1",
+            "https://cafe.daum.net/pknusic/OMPr/43"
     })
     void 허용된_외부폼_호스트는_저장된다(String url) {
         ClubApplicationForm form = ClubApplicationForm.builder().build();
@@ -33,6 +34,7 @@ class ClubApplicationFormTest {
             "https://forms.gle@evil.example/abcd",           // userinfo로 host 위장
             "https://forms.gle.evil.example/abcd",           // suffix 로 host 위장
             "https://everytime.kr.evil.example/board/1",
+            "https://cafe.daum.net.evil.example/pknusic/OMPr/43",
             "https://evil.example/abcd",
             "http://forms.gle/abcd",                         // https 아님
             "https://docs.google.com/document/d/1/edit",     // 구글 문서(폼 아님)


### PR DESCRIPTION
## 개요

외부 지원폼 허용 호스트에 `cafe.daum.net`을 추가합니다. 다음 카페 게시글을 지원 경로로 사용하는 동아리가 있어 필요합니다.

예: `https://cafe.daum.net/pknusic/OMPr/43`

#1852 에서 도입한 host 정확 매칭 검증 위에 올라가는 한 줄 변경입니다.

## 변경 내용

```diff
- Set.of("forms.gle", "docs.google.com", "form.naver.com", "naver.me", "everytime.kr")
+ Set.of("forms.gle", "docs.google.com", "form.naver.com", "naver.me", "everytime.kr", "cafe.daum.net")
```

경로 제약이 필요한 `docs.google.com`(`/forms` 하위만 허용)과 달리, 다음 카페는 게시글 경로가 자유로워 host 매칭만으로 충분합니다. 별도 분기를 두지 않았습니다.

## 테스트

`ClubApplicationFormTest`에 두 케이스를 추가했습니다.

| 구분 | 입력 | 기대 |
| --- | --- | --- |
| 허용 | `https://cafe.daum.net/pknusic/OMPr/43` | 저장됨 |
| 차단 | `https://cafe.daum.net.evil.example/pknusic/OMPr/43` | `NOT_ALLOWED_EXTERNAL_URL` |

suffix 위장(`cafe.daum.net.evil.example`)이 차단되는지 함께 검증해, 호스트 하나를 늘리면서 우회 경로가 생기지 않는 것을 확인했습니다.

전체 유닛 테스트 **129건 통과** (`./gradlew unitTest`), `ClubApplicationFormTest` 16건.

## 참고

`https://forms.gle/nw3KQtB4nQZo4Mff7` 도 함께 확인 요청이 있었는데, `forms.gle`는 기존부터 허용 목록에 있어 실제 구현에 통과시켜 본 결과 정상 동작합니다. 별도 수정이 필요하지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENCF69f9DxuUygFsXSdar8
