### PR TITLE
ci(test): 테스트 실행 시 RabbitMQ 리스너 자동 기동 비활성화

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -83,6 +83,12 @@ dependencies {
 
 apply from: 'gradle/infisical.gradle'
 
+// 테스트 환경에는 RabbitMQ 브로커가 없다.
+// 리스너 컨테이너가 기동되면 SpringBootTest 컨텍스트마다 연결 타임아웃으로 약 2분씩 대기하므로 꺼둔다.
+tasks.withType(Test).configureEach {
+    systemProperty 'spring.rabbitmq.listener.simple.auto-startup', 'false'
+}
+
 //전체 테스트
 tasks.named('test') {
     description = 'Runs the total tests.'


### PR DESCRIPTION
## 배경

BE CI(`PR Test`)가 비정상적으로 느립니다. [run 29886821513](https://github.com/Moadong/moadong/actions/runs/29886821513) 기준 `./gradlew test` 단계가 **8분 41초**입니다.

로그를 보면 SpringBootTest 컨텍스트마다 RabbitMQ 연결 타임아웃으로 대기하고 있습니다.

```
o.s.a.r.l.SimpleMessageListenerContainer : Broker not available; cannot force queue declarations during start
org.springframework.amqp.AmqpIOException: java.net.SocketTimeoutException: Connect timed out
	at ...AbstractMessageListenerContainer.attemptDeclarations
	at ...SimpleMessageListenerContainer$AsyncMessageProcessingConsumer.run
```

컨텍스트별 기동 시간:

| 테스트 | 기동 시간 |
|---|---|
| `MoadongApplicationTests` | 138.9s |
| `ClubProfileServiceTest` | 132.0s |
| `FcmServiceTest` | 130.9s |

각 컨텍스트에서 약 2분이 순수 브로커 연결 대기입니다.

## 변경

테스트 태스크에만 시스템 프로퍼티로 리스너 자동 기동을 끕니다.

```gradle
tasks.withType(Test).configureEach {
    systemProperty 'spring.rabbitmq.listener.simple.auto-startup', 'false'
}
```

- 연결을 강제하는 주체는 `SimpleMessageListenerContainer` 기동 경로입니다. `RabbitTemplate` 빈 생성 자체는 커넥션을 열지 않으므로 리스너만 막으면 연결 시도가 사라집니다.
- JVM 시스템 프로퍼티는 Spring Environment에서 `application.properties`보다 우선순위가 높아 **프로덕션 설정 파일은 건드리지 않습니다.**
- `test` / `unitTest` / `integrationTest` 세 태스크 모두 적용됩니다.

## 검증

- [x] `./gradlew unitTest` BUILD SUCCESSFUL
- [x] `spring.rabbitmq.listener.simple.auto-startup` 키가 spring-boot-autoconfigure 3.3.8 메타데이터에 존재함을 확인
- [x] **CI run 확인 완료** — [run 29895082601](https://github.com/Moadong/moadong/actions/runs/29895082601) success. `test` job 9분 03초 → **2분 23초**, Gradle 8m 41s → **1m 45s**. 로그에서 `Connect timed out` / `Broker not available` 0건. 상세는 [코멘트](https://github.com/Moadong/moadong/pull/1855#issuecomment-5042415268) 참고.

## 참고 (이 PR 범위 밖)

운영에서 RabbitMQ 브로커를 더 이상 쓰지 않는다고 확인했습니다. 그렇다면 `ClubApplyPublicService:95` → `ApplicantIdMessageConsumer` 로 이어지는 지원서 AI 요약 경로는 이미 동작하지 않는 코드입니다. 별도 PR에서 정리가 필요해 보입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 테스트 환경에서 RabbitMQ 브로커가 없어도 불필요한 연결 대기 없이 테스트가 실행되도록 개선했습니다.
  * 테스트 시작 시 메시지 리스너가 자동으로 실행되지 않도록 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
