### PR TITLE
feat(club): AI 지원서 초안 생성 동아리당 월 3회 제한

### DIFF
--- a/backend/src/main/java/moadong/club/controller/ClubApplyAdminController.java
+++ b/backend/src/main/java/moadong/club/controller/ClubApplyAdminController.java
@@ -103,6 +103,16 @@ public class ClubApplyAdminController {
         return Response.ok(aiApplicationDraftService.generateDraft(user));
     }
 
+    @GetMapping("/application/ai-draft/quota")
+    @Operation(summary = "AI 지원서 초안 생성 잔여 횟수 조회",
+            description = "이번 달 AI 초안 생성 한도(limit)와 사용(used)·잔여(remaining) 횟수를 조회합니다.<br>"
+                    + "카운트를 증가시키지 않는 읽기 전용 조회입니다.")
+    @PreAuthorize("isAuthenticated()")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> getApplicationDraftQuota(@CurrentUser CustomUserDetails user) {
+        return Response.ok(aiApplicationDraftService.getQuota(user));
+    }
+
     @GetMapping("/apply/info/{applicationFormId}")
     @Operation(summary = "클럽 지원자 현황", description = "클럽 지원자 현황을 불러옵니다")
     @PreAuthorize("isAuthenticated()")

--- a/backend/src/main/java/moadong/club/payload/response/ClubAiDraftQuotaResponse.java
+++ b/backend/src/main/java/moadong/club/payload/response/ClubAiDraftQuotaResponse.java
@@ -1,0 +1,8 @@
+package moadong.club.payload.response;
+
+public record ClubAiDraftQuotaResponse(
+        int limit,
+        int used,
+        int remaining
+) {
+}

--- a/backend/src/main/java/moadong/club/payload/response/ClubApplicationDraftResponse.java
+++ b/backend/src/main/java/moadong/club/payload/response/ClubApplicationDraftResponse.java
@@ -6,7 +6,8 @@ public record ClubApplicationDraftResponse(
         String title,
         String description,
         List<QuestionDto> questions,
-        boolean aiGenerated
+        boolean aiGenerated,
+        int remaining
 ) {
     public record QuestionDto(
             long id,

--- a/backend/src/main/java/moadong/club/service/AiApplicationDraftService.java
+++ b/backend/src/main/java/moadong/club/service/AiApplicationDraftService.java
@@ -1,5 +1,8 @@
 package moadong.club.service;
 
+import java.time.Duration;
+import java.time.YearMonth;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -8,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import moadong.anthropic.dto.DraftQuestion;
 import moadong.anthropic.service.AnthropicQuestionGenerator;
 import moadong.club.entity.Club;
+import moadong.club.payload.response.ClubAiDraftQuotaResponse;
 import moadong.club.payload.response.ClubApplicationDraftResponse;
 import moadong.club.payload.response.ClubApplicationDraftResponse.ItemDto;
 import moadong.club.payload.response.ClubApplicationDraftResponse.OptionsDto;
@@ -16,6 +20,8 @@ import moadong.club.repository.ClubRepository;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
 import moadong.user.payload.CustomUserDetails;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -30,12 +36,35 @@ public class AiApplicationDraftService {
     private static final int MAX_DESCRIPTION = 300;
     private static final int MAX_ITEM = 20;
 
+    // 동아리당 월 AI 초안 생성 한도 (Anthropic API 비용 방어)
+    private static final int MONTHLY_LIMIT = 3;
+    // 오래된 월별 카운터 키 자동 청소용 TTL (정확한 월말 계산 불필요)
+    private static final Duration KEY_TTL = Duration.ofDays(62);
+    private static final String COUNT_KEY_PREFIX = "ai-draft:count:";
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    // INCR + 첫 증가 시 조건부 EXPIRE를 원자적으로 수행 (TTL 누락 방지)
+    private static final RedisScript<Long> COUNT_SCRIPT = RedisScript.of(
+            "local c = redis.call('INCR', KEYS[1])\n" +
+            "if c == 1 then redis.call('EXPIRE', KEYS[1], ARGV[1]) end\n" +
+            "return c",
+            Long.class
+    );
+
     private final ClubRepository clubRepository;
     private final AnthropicQuestionGenerator generator;
+    private final StringRedisTemplate stringRedisTemplate;
 
     public ClubApplicationDraftResponse generateDraft(CustomUserDetails user) {
         Club club = clubRepository.findClubByUserId(user.getId())
                 .orElseThrow(() -> new RestApiException(ErrorCode.CLUB_NOT_FOUND));
+
+        long used = incrementMonthlyUsage(club.getId());
+        if (used > MONTHLY_LIMIT) {
+            log.warn("AI 초안 생성 월 한도({}회) 초과로 차단. clubId={}, used={}",
+                    MONTHLY_LIMIT, club.getId(), used);
+            throw new RestApiException(ErrorCode.AI_DRAFT_LIMIT_EXCEEDED);
+        }
 
         List<DraftQuestion> aiQuestions = List.of();
         try {
@@ -49,8 +78,49 @@ public class AiApplicationDraftService {
 
         boolean aiGenerated = !aiQuestions.isEmpty();
         List<QuestionDto> questions = assemble(aiQuestions);
+        int remaining = (int) Math.max(0, MONTHLY_LIMIT - used);
         return new ClubApplicationDraftResponse(
-                buildTitle(club), buildDescription(club), questions, aiGenerated);
+                buildTitle(club), buildDescription(club), questions, aiGenerated, remaining);
+    }
+
+    public ClubAiDraftQuotaResponse getQuota(CustomUserDetails user) {
+        Club club = clubRepository.findClubByUserId(user.getId())
+                .orElseThrow(() -> new RestApiException(ErrorCode.CLUB_NOT_FOUND));
+
+        long used = readMonthlyUsage(club.getId());
+        int remaining = (int) Math.max(0, MONTHLY_LIMIT - used);
+        return new ClubAiDraftQuotaResponse(MONTHLY_LIMIT, (int) used, remaining);
+    }
+
+    private String monthlyKey(String clubId) {
+        return COUNT_KEY_PREFIX + clubId + ":" + YearMonth.now(KST);
+    }
+
+    // 월별 카운터를 원자적으로 1 증가시키고 증가 후 값을 반환한다.
+    // Redis 장애 시에는 가용성을 우선해 로그만 남기고 0을 반환하여 제한 없이 통과시킨다.
+    private long incrementMonthlyUsage(String clubId) {
+        try {
+            Long count = stringRedisTemplate.execute(
+                    COUNT_SCRIPT,
+                    List.of(monthlyKey(clubId)),
+                    String.valueOf(KEY_TTL.getSeconds()));
+            return count == null ? 0L : count;
+        } catch (Exception e) {
+            log.warn("AI 초안 생성 카운트 실패, 제한 없이 통과. clubId={}", clubId, e);
+            return 0L;
+        }
+    }
+
+    // 카운터를 증가시키지 않고 현재 사용 횟수만 읽는다 (quota 조회용).
+    // Redis 장애 시에는 0으로 처리하여 조회가 실패하지 않도록 한다.
+    private long readMonthlyUsage(String clubId) {
+        try {
+            String value = stringRedisTemplate.opsForValue().get(monthlyKey(clubId));
+            return value == null ? 0L : Long.parseLong(value);
+        } catch (Exception e) {
+            log.warn("AI 초안 quota 조회 실패, 0으로 처리. clubId={}", clubId, e);
+            return 0L;
+        }
     }
 
     private boolean isValid(DraftQuestion q) {

--- a/backend/src/main/java/moadong/global/exception/ErrorCode.java
+++ b/backend/src/main/java/moadong/global/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     CLICK_RATE_LIMITED(HttpStatus.TOO_MANY_REQUESTS, "600-14", "비정상적인 요청이 감지되었습니다. 30초 후 다시 시도해주세요."),
     CLICK_TIMESTAMP_INVALID(HttpStatus.BAD_REQUEST, "600-15", "클릭 시각이 유효하지 않습니다."),
     CLICK_GAME_ENDED(HttpStatus.GONE, "600-16", "클릭 이벤트가 종료되었습니다."),
+    AI_DRAFT_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "600-17", "이번 달 AI 초안 생성 횟수(3회)를 모두 사용했습니다."),
 
     // 601xx: 파일/미디어 관련 오류
     IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "601-1", "이미지 업로드에 실패하였습니다."),

--- a/backend/src/test/java/moadong/club/service/AiApplicationDraftServiceTest.java
+++ b/backend/src/test/java/moadong/club/service/AiApplicationDraftServiceTest.java
@@ -2,44 +2,65 @@ package moadong.club.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Duration;
+import java.time.YearMonth;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 import moadong.anthropic.dto.DraftQuestion;
 import moadong.anthropic.service.AnthropicQuestionGenerator;
 import moadong.club.entity.Club;
+import moadong.club.payload.response.ClubAiDraftQuotaResponse;
 import moadong.club.payload.response.ClubApplicationDraftResponse;
 import moadong.club.repository.ClubRepository;
+import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
 import moadong.user.payload.CustomUserDetails;
 import moadong.util.annotations.UnitTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.script.RedisScript;
 
 @UnitTest
 class AiApplicationDraftServiceTest {
 
     private ClubRepository clubRepository;
     private AnthropicQuestionGenerator generator;
+    private StringRedisTemplate stringRedisTemplate;
     private AiApplicationDraftService service;
     private CustomUserDetails user;
+    private Club club;
 
     @BeforeEach
     void setUp() {
         clubRepository = mock(ClubRepository.class);
         generator = mock(AnthropicQuestionGenerator.class);
-        service = new AiApplicationDraftService(clubRepository, generator);
+        stringRedisTemplate = mock(StringRedisTemplate.class);
+        service = new AiApplicationDraftService(clubRepository, generator, stringRedisTemplate);
 
         user = mock(CustomUserDetails.class);
-        Club club = mock(Club.class);
+        club = mock(Club.class);
         lenient().when(club.getName()).thenReturn("매니아");
+        lenient().when(club.getId()).thenReturn("club-1");
         when(user.getId()).thenReturn("user-1");
         lenient().when(clubRepository.findClubByUserId("user-1")).thenReturn(Optional.of(club));
+
+        // 기본: 한도 이내(첫 호출) 로 통과
+        lenient().when(stringRedisTemplate.execute(any(RedisScript.class), anyList(), anyString()))
+                .thenReturn(1L);
     }
 
     private DraftQuestion validQuestion(String title) {
@@ -47,7 +68,7 @@ class AiApplicationDraftServiceTest {
     }
 
     @Test
-    @DisplayName("AI 생성 성공 시 템플릿 2문항 + AI 문항이 순번 id로 조립된다")
+    @DisplayName("AI 생성 성공 시 템플릿 2문항 + AI 문항이 순번 id로 조립되고 남은 횟수를 내려준다")
     void generateDraft_success() {
         when(generator.generate(anyString(), anyString())).thenReturn(List.of(
                 validQuestion("지원 동기를 알려주세요"),
@@ -61,6 +82,7 @@ class AiApplicationDraftServiceTest {
         assertThat(response.questions().get(0).type()).isEqualTo("PHONE_NUMBER");
         assertThat(response.questions()).extracting("id").containsExactly(1L, 2L, 3L, 4L, 5L);
         assertThat(response.title()).contains("매니아");
+        assertThat(response.remaining()).isEqualTo(2); // 3 - 1회 사용
     }
 
     @Test
@@ -103,11 +125,137 @@ class AiApplicationDraftServiceTest {
     }
 
     @Test
-    @DisplayName("동아리가 없으면 RestApiException")
+    @DisplayName("동아리가 없으면 카운트 증가 전에 RestApiException")
     void generateDraft_clubNotFound() {
         when(clubRepository.findClubByUserId("user-1")).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.generateDraft(user))
+                .isInstanceOf(RestApiException.class);
+
+        verify(stringRedisTemplate, times(0)).execute(any(RedisScript.class), anyList(), anyString());
+    }
+
+    @Test
+    @DisplayName("월 한도(3회)를 넘어선 4번째 요청은 429로 차단되고 Anthropic을 호출하지 않는다")
+    void generateDraft_blocksAndSkipsAnthropicWhenLimitExceeded() {
+        when(generator.generate(anyString(), anyString())).thenReturn(List.of(validQuestion("질문")));
+        when(stringRedisTemplate.execute(any(RedisScript.class), anyList(), anyString()))
+                .thenReturn(1L, 2L, 3L, 4L);
+
+        for (int i = 0; i < 3; i++) {
+            assertThat(service.generateDraft(user)).isNotNull();
+        }
+
+        assertThatThrownBy(() -> service.generateDraft(user))
+                .isInstanceOf(RestApiException.class)
+                .satisfies(e -> assertThat(((RestApiException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.AI_DRAFT_LIMIT_EXCEEDED));
+
+        // 4번째 요청에서는 실제 Anthropic 호출이 없어야 한다 (비용 방어)
+        verify(generator, times(3)).generate(anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("카운터 키는 clubId와 연월을 포함하고 62일 TTL 인자로 증가시킨다")
+    void generateDraft_incrementsClubScopedMonthlyKeyWithTtl() {
+        when(generator.generate(anyString(), anyString())).thenReturn(List.of(validQuestion("질문")));
+
+        service.generateDraft(user);
+
+        ArgumentCaptor<List> keys = ArgumentCaptor.forClass(List.class);
+        ArgumentCaptor<String> ttl = ArgumentCaptor.forClass(String.class);
+        verify(stringRedisTemplate).execute(any(RedisScript.class), keys.capture(), ttl.capture());
+
+        String expectedKey = "ai-draft:count:club-1:" + YearMonth.now(ZoneId.of("Asia/Seoul"));
+        assertThat(keys.getValue()).containsExactly(expectedKey);
+        assertThat(ttl.getValue()).isEqualTo(String.valueOf(Duration.ofDays(62).getSeconds()));
+    }
+
+    @Test
+    @DisplayName("서로 다른 동아리는 독립된 카운터 키를 사용한다")
+    void generateDraft_usesIndependentKeyPerClub() {
+        when(generator.generate(anyString(), anyString())).thenReturn(List.of(validQuestion("질문")));
+
+        CustomUserDetails otherUser = mock(CustomUserDetails.class);
+        Club otherClub = mock(Club.class);
+        when(otherUser.getId()).thenReturn("user-2");
+        lenient().when(otherClub.getName()).thenReturn("다른동아리");
+        when(otherClub.getId()).thenReturn("club-2");
+        when(clubRepository.findClubByUserId("user-2")).thenReturn(Optional.of(otherClub));
+
+        service.generateDraft(user);
+        service.generateDraft(otherUser);
+
+        ArgumentCaptor<List> keys = ArgumentCaptor.forClass(List.class);
+        verify(stringRedisTemplate, times(2))
+                .execute(any(RedisScript.class), keys.capture(), anyString());
+
+        String month = YearMonth.now(ZoneId.of("Asia/Seoul")).toString();
+        assertThat(keys.getAllValues().get(0)).containsExactly("ai-draft:count:club-1:" + month);
+        assertThat(keys.getAllValues().get(1)).containsExactly("ai-draft:count:club-2:" + month);
+    }
+
+    @Test
+    @DisplayName("Anthropic 실패로 폴백이 나가도 카운트는 1회 증가한다")
+    void generateDraft_countsEvenOnFallback() {
+        when(generator.generate(anyString(), anyString()))
+                .thenThrow(new IllegalStateException("api down"));
+
+        ClubApplicationDraftResponse response = service.generateDraft(user);
+
+        assertThat(response.aiGenerated()).isFalse();
+        verify(stringRedisTemplate, times(1)).execute(any(RedisScript.class), anyList(), anyString());
+    }
+
+    @Test
+    @DisplayName("Redis 장애 시 제한을 무시하고 생성을 통과시킨다 (가용성 우선)")
+    void generateDraft_passesThroughOnRedisFailure() {
+        when(generator.generate(anyString(), anyString())).thenReturn(List.of(validQuestion("질문")));
+        when(stringRedisTemplate.execute(any(RedisScript.class), anyList(), anyString()))
+                .thenThrow(new RuntimeException("redis down"));
+
+        ClubApplicationDraftResponse response = service.generateDraft(user);
+
+        assertThat(response.aiGenerated()).isTrue();
+        assertThat(response.remaining()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("quota 조회 시 저장된 사용 횟수로 limit/used/remaining을 계산하고 카운트를 증가시키지 않는다")
+    void getQuota_returnsUsageWithoutIncrementing() {
+        ValueOperations<String, String> valueOps = mock(ValueOperations.class);
+        when(stringRedisTemplate.opsForValue()).thenReturn(valueOps);
+        String key = "ai-draft:count:club-1:" + YearMonth.now(ZoneId.of("Asia/Seoul"));
+        when(valueOps.get(key)).thenReturn("2");
+
+        ClubAiDraftQuotaResponse quota = service.getQuota(user);
+
+        assertThat(quota.limit()).isEqualTo(3);
+        assertThat(quota.used()).isEqualTo(2);
+        assertThat(quota.remaining()).isEqualTo(1);
+        // 조회는 INCR 스크립트를 호출하지 않아야 한다
+        verify(stringRedisTemplate, times(0)).execute(any(RedisScript.class), anyList(), anyString());
+    }
+
+    @Test
+    @DisplayName("quota 조회 시 키가 없으면 used=0, remaining=limit")
+    void getQuota_defaultsToFullQuotaWhenNoKey() {
+        ValueOperations<String, String> valueOps = mock(ValueOperations.class);
+        when(stringRedisTemplate.opsForValue()).thenReturn(valueOps);
+        when(valueOps.get(anyString())).thenReturn(null);
+
+        ClubAiDraftQuotaResponse quota = service.getQuota(user);
+
+        assertThat(quota.used()).isEqualTo(0);
+        assertThat(quota.remaining()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("quota 조회 시 동아리가 없으면 RestApiException")
+    void getQuota_clubNotFound() {
+        when(clubRepository.findClubByUserId("user-1")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getQuota(user))
                 .isInstanceOf(RestApiException.class);
     }
 }


### PR DESCRIPTION
## 배경

`POST /api/club/application/ai-draft`(AI 초안 생성)가 무제한 호출 가능해 Anthropic API 비용 방어가 필요했습니다. 동아리당 매월 3회로 제한하고, 매월 1일 자동 리셋되도록 구현했습니다. (closes #1856)

## 구현

기존 `ClubClickService`의 Redis 카운터 + TTL 패턴을 그대로 따랐습니다.

- **카운트 & 제한**: `ai-draft:count:{clubId}:{yyyy-MM}` 키로 원자적 `INCR`(Lua) 수행. 키에 연월(KST)을 포함해 매월 자동으로 새 키가 되므로 리셋 배치 불필요. 첫 증가 시에만 62일 TTL 설정(오래된 키 자동 청소).
- **한도 초과**: 월 3회 초과 시 실제 Anthropic 호출 없이 `429 AI_DRAFT_LIMIT_EXCEEDED`(코드 `600-17`) 예외. 차단 시 clubId 로그.
- **폴백 차감 정책**: 호출 전 `INCR` → Anthropic 실패로 템플릿 폴백이 나가도 1회 차감 (기존 `ClubClickService` 컨벤션과 일치).
- **Redis 장애 정책**: 예외를 잡아 로그만 남기고 통과 (가용성 우선).
- **남은 횟수 노출**: 생성 응답에 `remaining` 필드 추가.
- **quota 조회**: `GET /api/club/application/ai-draft/quota` → `{ limit, used, remaining }` 읽기 전용 엔드포인트(카운트 미증가).

### 상수화 (비기능 요구)
- 한도 3회, TTL 62일을 상수로 분리.

## 결정 사항 (이슈 확인 항목)
- **폴백도 1회 차감** (성공만 세지 않음)
- **Redis 장애 시 통과** (차단 아님, 가용성 우선)

## 테스트 (완료 기준)
- 같은 club 4회 연속 → 1~3 정상, 4번째 429 `AI_DRAFT_LIMIT_EXCEEDED`
- 4번째에서 Anthropic 미호출 검증 (비용 방어)
- 서로 다른 두 club의 독립 카운터 키 검증
- 키에 clubId·연월 포함 + 62일 TTL 인자 검증
- Anthropic 강제 실패 시 폴백이지만 카운트 1 증가 검증
- Redis 장애 시 통과 검증
- quota 조회: 저장 카운트 기반 계산 + INCR 미호출, 키 없을 때 기본값, club 미존재 예외

`./gradlew test --tests "moadong.club.service.AiApplicationDraftServiceTest"` 전체 통과.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - AI 지원서 초안의 이번 달 쿼터(한도/사용/잔여)를 조회할 수 있는 API가 추가되었습니다.
  - 초안 생성 응답에 이번 달 잔여 횟수가 함께 표시됩니다.
- **버그 수정**
  - AI 초안 생성 쿼터를 동아리별·월별로 정확히 관리하며, 한도 초과 시 429로 차단합니다.
  - 외부 AI 서비스 오류 시에도 대체 응답이 제공되고, 조회/집계 오류 상황에서는 시스템 장애 없이 동작하도록 처리됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->