### PR TITLE
[feature] AI 초안 생성 월 3회 제한 - 한도 초과 처리

### DIFF
--- a/frontend/src/apis/application.test.ts
+++ b/frontend/src/apis/application.test.ts
@@ -1,6 +1,7 @@
 import fetchMock from 'jest-fetch-mock';
-import { ApplicationDraft } from '@/types/application';
-import { generateApplicationDraft } from './application';
+import { ApiError } from '@/errors';
+import { AiDraftQuota, ApplicationDraft } from '@/types/application';
+import { generateApplicationDraft, getAiDraftQuota } from './application';
 
 jest.mock('@/constants/api', () => ({
   __esModule: true,
@@ -55,6 +56,39 @@ describe('generateApplicationDraft', () => {
     );
   });
 
+  it('응답에 remaining이 포함되면 그대로 반환한다', async () => {
+    const draft: ApplicationDraft = {
+      title: '매니아 신입 부원 모집 지원서',
+      description: '안녕하세요',
+      aiGenerated: true,
+      questions: [],
+      remaining: 2,
+    };
+    fetchMock.mockResponseOnce(JSON.stringify({ data: draft }), {
+      headers: { 'content-type': 'application/json' },
+    });
+
+    const result = await generateApplicationDraft();
+
+    expect(result?.remaining).toBe(2);
+  });
+
+  it('한도 초과(429) 시 status 429를 담은 ApiError를 던진다', async () => {
+    fetchMock.mockResponseOnce(
+      JSON.stringify({
+        statuscode: '600-17',
+        message: '이번 달 AI 초안 생성 횟수(3회)를 모두 사용했습니다.',
+        data: null,
+      }),
+      { status: 429, headers: { 'content-type': 'application/json' } },
+    );
+
+    const error = await generateApplicationDraft().catch((e) => e);
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error.status).toBe(429);
+  });
+
   it('서버 오류 시 에러를 던진다', async () => {
     fetchMock.mockResponseOnce(JSON.stringify({ message: 'fail' }), {
       status: 500,
@@ -62,5 +96,27 @@ describe('generateApplicationDraft', () => {
     });
 
     await expect(generateApplicationDraft()).rejects.toThrow();
+  });
+});
+
+describe('getAiDraftQuota', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks();
+    localStorage.setItem('accessToken', 'mock-token');
+  });
+
+  it('응답의 data를 unwrap하여 남은 횟수 정보를 반환한다', async () => {
+    const quota: AiDraftQuota = { limit: 3, used: 2, remaining: 1 };
+    fetchMock.mockResponseOnce(JSON.stringify({ data: quota }), {
+      headers: { 'content-type': 'application/json' },
+    });
+
+    const result = await getAiDraftQuota();
+
+    expect(result).toEqual(quota);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:3000/api/club/application/ai-draft/quota',
+      expect.anything(),
+    );
   });
 });

--- a/frontend/src/apis/application.ts
+++ b/frontend/src/apis/application.ts
@@ -1,6 +1,7 @@
 import API_BASE_URL from '@/constants/api';
 import { UpdateApplicantParams } from '@/types/applicants';
 import {
+  AiDraftQuota,
   AnswerItem,
   ApplicationDraft,
   ApplicationForm,
@@ -175,5 +176,15 @@ export const generateApplicationDraft = async () => {
   return handleResponse<ApplicationDraft>(
     response,
     '지원서 초안 생성에 실패했습니다.',
+  );
+};
+
+export const getAiDraftQuota = async () => {
+  const response = await secureFetch(
+    `${API_BASE_URL}/api/club/application/ai-draft/quota`,
+  );
+  return handleResponse<AiDraftQuota>(
+    response,
+    'AI 초안 생성 가능 횟수를 불러오지 못했습니다.',
   );
 };

--- a/frontend/src/constants/queryKeys.ts
+++ b/frontend/src/constants/queryKeys.ts
@@ -14,6 +14,8 @@ export const queryKeys = {
     all: ['applicationForm'] as const,
     detail: (clubId: string, applicationFormId: string) =>
       ['applicationForm', clubId, applicationFormId] as const,
+    aiDraftQuota: (clubId: string) =>
+      ['applicationForm', 'aiDraftQuota', clubId] as const,
   },
   club: {
     all: ['clubs'] as const,

--- a/frontend/src/hooks/Queries/useApplication.ts
+++ b/frontend/src/hooks/Queries/useApplication.ts
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   deleteApplication,
   duplicateApplication,
+  getAiDraftQuota,
   getAllApplicationForms,
   getApplication,
   updateApplicationStatus,
@@ -27,6 +28,18 @@ export const useGetApplicationList = () => {
   return useQuery({
     queryKey: queryKeys.application.all,
     queryFn: () => getAllApplicationForms(),
+  });
+};
+
+export const useAiDraftQuota = (
+  clubId: string | undefined,
+  enabled: boolean = true,
+) => {
+  return useQuery({
+    queryKey: queryKeys.application.aiDraftQuota(clubId || 'unknown'),
+    queryFn: () => getAiDraftQuota(),
+    enabled: !!clubId && enabled,
+    staleTime: 60 * 1000,
   });
 };
 

--- a/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.styles.ts
+++ b/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.styles.ts
@@ -192,7 +192,7 @@ export const AiDraftActions = styled.div`
 
 export const AiDraftRemaining = styled.span`
   font-size: 12px;
-  color: #787878;
+  color: ${colors.gray[700]};
   white-space: nowrap;
 `;
 

--- a/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.styles.ts
+++ b/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.styles.ts
@@ -184,6 +184,18 @@ export const AiLoadingText = styled.p`
   color: ${colors.base.white};
 `;
 
+export const AiDraftActions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+export const AiDraftRemaining = styled.span`
+  font-size: 12px;
+  color: #787878;
+  white-space: nowrap;
+`;
+
 export const AiDraftButton = styled.button`
   display: inline-flex;
   align-items: center;

--- a/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.tsx
@@ -68,14 +68,7 @@ const ApplicationEditTab = () => {
   const setRemaining = (nextRemaining: number) =>
     queryClient.setQueryData<AiDraftQuota>(
       queryKeys.application.aiDraftQuota(clubId ?? 'unknown'),
-      (old) =>
-        old
-          ? {
-              ...old,
-              used: old.limit - nextRemaining,
-              remaining: nextRemaining,
-            }
-          : old,
+      (old) => (old ? { ...old, remaining: nextRemaining } : old),
     );
 
   useEffect(() => {

--- a/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.tsx
@@ -12,7 +12,11 @@ import Spinner from '@/components/common/Spinner/Spinner';
 import { APPLICATION_FORM } from '@/constants/applicationForm';
 import INITIAL_FORM_DATA from '@/constants/initialFormData';
 import { queryKeys } from '@/constants/queryKeys';
-import { useGetApplication } from '@/hooks/Queries/useApplication';
+import { ApiError } from '@/errors';
+import {
+  useAiDraftQuota,
+  useGetApplication,
+} from '@/hooks/Queries/useApplication';
 import QuestionBuilder from '@/pages/AdminPage/components/QuestionBuilder/QuestionBuilder';
 import {
   hasErrors,
@@ -21,6 +25,7 @@ import {
 import { useAdminClubId } from '@/store/useAdminClubStore';
 import { PageContainer } from '@/styles/PageContainer.styles';
 import {
+  AiDraftQuota,
   ApplicationFormData,
   ApplicationFormMode,
   Question,
@@ -50,6 +55,24 @@ const ApplicationEditTab = () => {
   const [applicationFormMode, setApplicationFormMode] =
     useState<ApplicationFormMode>(ApplicationFormMode.INTERNAL);
   const [externalApplicationUrl, setExternalApplicationUrl] = useState('');
+
+  const isDraftButtonVisible =
+    !formId && applicationFormMode === ApplicationFormMode.INTERNAL;
+  const { data: draftQuota } = useAiDraftQuota(
+    clubId ?? undefined,
+    isDraftButtonVisible,
+  );
+  const remaining = draftQuota?.remaining;
+  const isDraftLimitReached = remaining === 0;
+
+  const setRemaining = (nextRemaining: number) =>
+    queryClient.setQueryData<AiDraftQuota>(
+      queryKeys.application.aiDraftQuota(clubId ?? 'unknown'),
+      (old) =>
+        old
+          ? { ...old, used: old.limit - nextRemaining, remaining: nextRemaining }
+          : old,
+    );
 
   useEffect(() => {
     if (!existingFormData) return;
@@ -119,14 +142,23 @@ const ApplicationEditTab = () => {
         questions: [nameQuestion, ...draftQuestions],
       }));
       setNextId(draftQuestions.length + 2);
+      if (typeof draft.remaining === 'number') {
+        setRemaining(draft.remaining);
+      }
       if (!draft.aiGenerated) {
         alert(
           'AI 생성에 실패해 기본 템플릿을 제공했어요. 질문을 직접 다듬어주세요.',
         );
       }
     },
-    onError: (err: Error) =>
-      alert(`지원서 초안 생성에 실패했습니다: ${err.message}`),
+    onError: (err: Error) => {
+      if (err instanceof ApiError && err.status === 429) {
+        setRemaining(0);
+        alert('이번 달 AI 초안 생성 횟수(3회)를 모두 사용했어요.');
+        return;
+      }
+      alert(`지원서 초안 생성에 실패했습니다: ${err.message}`);
+    },
   });
 
   const handleGenerateDraft = () => {
@@ -237,13 +269,25 @@ const ApplicationEditTab = () => {
               외부지원서
             </Styled.ApplicationFormChangeButton>
           </Styled.ChangeButtonWrapper>
-          {!formId && applicationFormMode === ApplicationFormMode.INTERNAL && (
-            <Styled.AiDraftButton
-              onClick={handleGenerateDraft}
-              disabled={isGenerating}
-            >
-              ✨ AI로 초안 생성
-            </Styled.AiDraftButton>
+          {isDraftButtonVisible && (
+            <Styled.AiDraftActions>
+              {typeof remaining === 'number' && (
+                <Styled.AiDraftRemaining>
+                  이번 달 {remaining}회 남음
+                </Styled.AiDraftRemaining>
+              )}
+              <Styled.AiDraftButton
+                onClick={handleGenerateDraft}
+                disabled={isGenerating || isDraftLimitReached}
+                title={
+                  isDraftLimitReached
+                    ? '이번 달 AI 초안 생성 횟수(3회)를 모두 사용했어요.'
+                    : undefined
+                }
+              >
+                ✨ AI로 초안 생성
+              </Styled.AiDraftButton>
+            </Styled.AiDraftActions>
           )}
         </Styled.HeaderContainer>
         <Styled.FormTitle

--- a/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.tsx
@@ -25,7 +25,6 @@ import {
 import { useAdminClubId } from '@/store/useAdminClubStore';
 import { PageContainer } from '@/styles/PageContainer.styles';
 import {
-  AiDraftQuota,
   ApplicationFormData,
   ApplicationFormMode,
   Question,
@@ -62,14 +61,10 @@ const ApplicationEditTab = () => {
     clubId ?? undefined,
     isDraftButtonVisible,
   );
-  const remaining = draftQuota?.remaining;
+  // 생성 성공/429로 갱신된 값을 즉시 반영 (quota 조회 전·실패 시에도 동작)
+  const [remainingOverride, setRemainingOverride] = useState<number>();
+  const remaining = remainingOverride ?? draftQuota?.remaining;
   const isDraftLimitReached = remaining === 0;
-
-  const setRemaining = (nextRemaining: number) =>
-    queryClient.setQueryData<AiDraftQuota>(
-      queryKeys.application.aiDraftQuota(clubId ?? 'unknown'),
-      (old) => (old ? { ...old, remaining: nextRemaining } : old),
-    );
 
   useEffect(() => {
     if (!existingFormData) return;
@@ -140,7 +135,7 @@ const ApplicationEditTab = () => {
       }));
       setNextId(draftQuestions.length + 2);
       if (typeof draft.remaining === 'number') {
-        setRemaining(draft.remaining);
+        setRemainingOverride(draft.remaining);
       }
       if (!draft.aiGenerated) {
         alert(
@@ -150,7 +145,7 @@ const ApplicationEditTab = () => {
     },
     onError: (err: Error) => {
       if (err instanceof ApiError && err.status === 429) {
-        setRemaining(0);
+        setRemainingOverride(0);
         alert('이번 달 AI 초안 생성 횟수(3회)를 모두 사용했어요.');
         return;
       }

--- a/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicationEditTab/ApplicationEditTab.tsx
@@ -70,7 +70,11 @@ const ApplicationEditTab = () => {
       queryKeys.application.aiDraftQuota(clubId ?? 'unknown'),
       (old) =>
         old
-          ? { ...old, used: old.limit - nextRemaining, remaining: nextRemaining }
+          ? {
+              ...old,
+              used: old.limit - nextRemaining,
+              remaining: nextRemaining,
+            }
           : old,
     );
 

--- a/frontend/src/types/application.ts
+++ b/frontend/src/types/application.ts
@@ -94,4 +94,11 @@ export interface ApplicationDraft {
   description: string;
   questions: Question[];
   aiGenerated: boolean;
+  remaining?: number;
+}
+
+export interface AiDraftQuota {
+  limit: number;
+  used: number;
+  remaining: number;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#1857

## 📝작업 내용

백엔드 월 3회 제한(429 + `remaining`)에 대응하는 프론트 처리를 추가했습니다.

- **한도 초과(429) 안내**: `generateApplicationDraft` 실패가 429면 전용 문구("이번 달 AI 초안 생성 횟수(3회)를 모두 사용했어요.")를 띄우고, 그 외 오류는 기존 제네릭 문구를 유지합니다. 구분은 `ApiError.status === 429`로 판정합니다.
- **남은 횟수 표시**: 성공 응답의 `remaining`과 신규 `GET /api/club/application/ai-draft/quota` 조회로 버튼 근처에 "이번 달 N회 남음"을 표시하고, `remaining === 0`이면 버튼을 비활성화(툴팁 안내)합니다.
- 진입 시 quota를 조회해 버튼 상태를 선반영하고, 생성 성공/429 시 캐시(`setQueryData`)로 갱신합니다.
- 타입 추가: `ApplicationDraft.remaining?`, `AiDraftQuota`. 기존 인라인 `useMutation` 구조는 그대로 두었습니다(리팩터 없음).

## 중점적으로 리뷰받고 싶은 부분(선택)

- 한도 구분을 body 코드가 아닌 **HTTP 429**로 판정한 점. BE 에러 body는 필드명이 `errorCode`가 아니라 `statuscode`("600-17")라, 프론트 `handleResponse`가 채우는 `ApiError.errorCode`는 undefined입니다. 그래서 transport-level 429로 구분했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 요약
* **새로운 기능**
  * AI 지원서 초안의 월간 쿼터(한도)와 남은 횟수를 조회해 표시합니다.
  * 남은 횟수에 따라 초안 생성 버튼 활성/비활성 및 안내 문구를 제공합니다.
  * 초안 생성 성공 시 남은 횟수를 즉시 갱신합니다.
* **버그 수정**
  * 한도 초과(429) 시 “모두 소진” 안내로 정확히 처리합니다.
* **테스트**
  * 초안 생성/쿼터 조회 응답 처리 및 성공·실패 케이스 검증을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->