### PR TITLE
fix(club): AI 초안 폴백 시 월 횟수 환불 및 Anthropic 타임아웃 45초 단축

### DIFF
--- a/backend/src/main/java/moadong/club/service/AiApplicationDraftService.java
+++ b/backend/src/main/java/moadong/club/service/AiApplicationDraftService.java
@@ -77,6 +77,10 @@ public class AiApplicationDraftService {
         }
 
         boolean aiGenerated = !aiQuestions.isEmpty();
+        if (!aiGenerated && used > 0) {
+            // AI 결과를 주지 못한 경우(실패·타임아웃·전량 필터) 소모한 횟수를 환불한다.
+            used = refundMonthlyUsage(club.getId(), used);
+        }
         List<QuestionDto> questions = assemble(aiQuestions);
         int remaining = (int) Math.max(0, MONTHLY_LIMIT - used);
         return new ClubApplicationDraftResponse(
@@ -108,6 +112,18 @@ public class AiApplicationDraftService {
         } catch (Exception e) {
             log.warn("AI 초안 생성 카운트 실패, 제한 없이 통과. clubId={}", clubId, e);
             return 0L;
+        }
+    }
+
+    // aiGenerated=false로 결과를 주지 못한 경우 증가분을 되돌리고(DECR) 남은 사용 횟수를 반환한다.
+    // Redis 장애 시에는 차감을 유지하고 로그만 남긴다.
+    private long refundMonthlyUsage(String clubId, long currentUsed) {
+        try {
+            Long count = stringRedisTemplate.opsForValue().decrement(monthlyKey(clubId));
+            return count == null ? currentUsed : count;
+        } catch (Exception e) {
+            log.warn("AI 초안 생성 카운트 환불 실패, 차감 유지. clubId={}", clubId, e);
+            return currentUsed;
         }
     }
 

--- a/backend/src/main/java/moadong/global/config/AnthropicConfig.java
+++ b/backend/src/main/java/moadong/global/config/AnthropicConfig.java
@@ -14,7 +14,7 @@ public class AnthropicConfig {
     public AnthropicClient anthropicClient(AnthropicProperties anthropicProperties) {
         return AnthropicOkHttpClient.builder()
                 .apiKey(anthropicProperties.apiKey())
-                .timeout(Duration.ofSeconds(60))
+                .timeout(Duration.ofSeconds(45))
                 .build();
     }
 }

--- a/backend/src/test/java/moadong/club/service/AiApplicationDraftServiceTest.java
+++ b/backend/src/test/java/moadong/club/service/AiApplicationDraftServiceTest.java
@@ -40,6 +40,7 @@ class AiApplicationDraftServiceTest {
     private ClubRepository clubRepository;
     private AnthropicQuestionGenerator generator;
     private StringRedisTemplate stringRedisTemplate;
+    private ValueOperations<String, String> valueOps;
     private AiApplicationDraftService service;
     private CustomUserDetails user;
     private Club club;
@@ -61,6 +62,11 @@ class AiApplicationDraftServiceTest {
         // 기본: 한도 이내(첫 호출) 로 통과
         lenient().when(stringRedisTemplate.execute(any(RedisScript.class), anyList(), anyString()))
                 .thenReturn(1L);
+
+        // 폴백 환불(DECR)용 기본 스텁
+        valueOps = mock(ValueOperations.class);
+        lenient().when(stringRedisTemplate.opsForValue()).thenReturn(valueOps);
+        lenient().when(valueOps.decrement(anyString())).thenReturn(0L);
     }
 
     private DraftQuestion validQuestion(String title) {
@@ -83,6 +89,7 @@ class AiApplicationDraftServiceTest {
         assertThat(response.questions()).extracting("id").containsExactly(1L, 2L, 3L, 4L, 5L);
         assertThat(response.title()).contains("매니아");
         assertThat(response.remaining()).isEqualTo(2); // 3 - 1회 사용
+        verify(valueOps, times(0)).decrement(anyString()); // 성공 시 환불 없음
     }
 
     @Test
@@ -196,15 +203,35 @@ class AiApplicationDraftServiceTest {
     }
 
     @Test
-    @DisplayName("Anthropic 실패로 폴백이 나가도 카운트는 1회 증가한다")
-    void generateDraft_countsEvenOnFallback() {
+    @DisplayName("Anthropic 실패로 폴백이 나가면 소모한 횟수를 환불한다(DECR)")
+    void generateDraft_refundsOnFallback() {
+        when(generator.generate(anyString(), anyString()))
+                .thenThrow(new IllegalStateException("api down"));
+        String key = "ai-draft:count:club-1:" + YearMonth.now(ZoneId.of("Asia/Seoul"));
+        when(valueOps.decrement(key)).thenReturn(0L);
+
+        ClubApplicationDraftResponse response = service.generateDraft(user);
+
+        assertThat(response.aiGenerated()).isFalse();
+        // 증가는 1회(원자적 한도 방어), 이후 환불로 소모 0
+        verify(stringRedisTemplate, times(1)).execute(any(RedisScript.class), anyList(), anyString());
+        verify(valueOps, times(1)).decrement(key);
+        assertThat(response.remaining()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("Redis 장애로 카운트가 통과된 상태에서 폴백이 나가도 환불 DECR을 호출하지 않는다")
+    void generateDraft_noRefundWhenCountBypassed() {
+        when(stringRedisTemplate.execute(any(RedisScript.class), anyList(), anyString()))
+                .thenThrow(new RuntimeException("redis down"));
         when(generator.generate(anyString(), anyString()))
                 .thenThrow(new IllegalStateException("api down"));
 
         ClubApplicationDraftResponse response = service.generateDraft(user);
 
         assertThat(response.aiGenerated()).isFalse();
-        verify(stringRedisTemplate, times(1)).execute(any(RedisScript.class), anyList(), anyString());
+        verify(valueOps, times(0)).decrement(anyString());
+        assertThat(response.remaining()).isEqualTo(3);
     }
 
     @Test


### PR DESCRIPTION
## 배경
프론트에서 "AI 초안 생성이 타임아웃되면 월 3회 횟수는 차감되고 기능은 실패"하는 버그가 보고됨. 프론트는 타임아웃을 60초로 늘려 배포 예정이며, 아래는 백엔드 측 보완.

## 변경 사항

### 1. 폴백 시 카운트 환불 (`AiApplicationDraftService`)
- 기존: 카운트를 AI 호출 **전** 증가시키고 롤백이 없어, AI 실패·타임아웃으로 `aiGenerated=false` 템플릿 폴백이 나가도 월 횟수를 소모함.
- 변경: `aiGenerated=false && used>0`이면 `DECR`로 **환불**. 동시 요청에 대한 원자적 한도 방어를 위해 **증가-선행 구조는 유지**하고, 결과 미제공 시에만 되돌림.
- Redis 장애로 카운트가 우회된 경우(`used=0`)에는 환불하지 않아 음수 키 생성을 방지.

### 2. Anthropic 타임아웃 단축 (`AnthropicConfig`)
- `60s → 45s`. 프론트(60초) abort 이전에 백엔드가 성공 또는 템플릿 폴백(200)으로 **항상 응답**하도록 보장.

### 3. 테스트 (`AiApplicationDraftServiceTest`)
- 구 "폴백해도 차감" 테스트를 "폴백 시 환불(DECR)" 검증으로 교체.
- Redis 우회 시 환불하지 않는 엣지 케이스 추가.
- 성공 시 환불이 호출되지 않음을 검증하는 가드 추가.

## 검증
- `./gradlew unitTest --tests "moadong.club.service.AiApplicationDraftServiceTest"` → BUILD SUCCESSFUL

## 프론트 연계
- 이제 백엔드는 `aiGenerated=false`면 차감하지 않으므로, 프론트 카운터도 `aiGenerated===true`일 때만 차감(또는 응답의 `remaining` 값 신뢰)하도록 맞추면 정책이 일치함.
- 참고: quota 기능(GET `/api/club/application/ai-draft/quota`, 429)은 이 브랜치의 베이스인 `develop/be`에 이미 존재하나 `main` 미배포 상태.
