### PR TITLE
[fix] AI 초안 생성 요청 60초 타임아웃 적용해 조기 abort 방지

### DIFF
--- a/frontend/src/apis/application.test.ts
+++ b/frontend/src/apis/application.test.ts
@@ -2,6 +2,7 @@ import fetchMock from 'jest-fetch-mock';
 import { ApiError } from '@/errors';
 import { AiDraftQuota, ApplicationDraft } from '@/types/application';
 import { generateApplicationDraft, getAiDraftQuota } from './application';
+import { secureFetch } from './auth/secureFetch';
 
 jest.mock('@/constants/api', () => ({
   __esModule: true,
@@ -96,6 +97,20 @@ describe('generateApplicationDraft', () => {
     });
 
     await expect(generateApplicationDraft()).rejects.toThrow();
+  });
+
+  it('LLM 생성이 느려도 조기 abort되지 않도록 60초 타임아웃을 전달한다', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ data: null }), {
+      headers: { 'content-type': 'application/json' },
+    });
+
+    await generateApplicationDraft();
+
+    expect(secureFetch).toHaveBeenCalledWith(
+      'http://localhost:3000/api/club/application/ai-draft',
+      expect.objectContaining({ method: 'POST' }),
+      60_000,
+    );
   });
 });
 

--- a/frontend/src/apis/application.ts
+++ b/frontend/src/apis/application.ts
@@ -166,12 +166,17 @@ export const updateApplicationStatus = async (
   return handleResponse(response, '지원서 상태 수정에 실패했습니다.');
 };
 
+// LLM 초안 생성은 기본 10초 타임아웃을 넘기기 쉬워, 조기 abort로 인한
+// "실패했는데 횟수만 차감" 문제를 막기 위해 별도의 넉넉한 타임아웃을 준다.
+const AI_DRAFT_TIMEOUT_MS = 60_000;
+
 export const generateApplicationDraft = async () => {
   const response = await secureFetch(
     `${API_BASE_URL}/api/club/application/ai-draft`,
     {
       method: 'POST',
     },
+    AI_DRAFT_TIMEOUT_MS,
   );
   return handleResponse<ApplicationDraft>(
     response,

--- a/frontend/src/apis/auth/secureFetch.ts
+++ b/frontend/src/apis/auth/secureFetch.ts
@@ -4,18 +4,23 @@ import { fetchWithTimeout } from '@/apis/utils/fetchWithTimeout';
 export const secureFetch = async (
   input: RequestInfo,
   init?: RequestInit,
+  timeoutMs?: number,
 ): Promise<Response> => {
   const accessToken = localStorage.getItem('accessToken');
 
   // 1차 요청 시도
-  let response = await fetchWithTimeout(input, {
-    ...init,
-    headers: {
-      ...(init?.headers || {}),
-      Authorization: `Bearer ${accessToken}`,
+  let response = await fetchWithTimeout(
+    input,
+    {
+      ...init,
+      headers: {
+        ...(init?.headers || {}),
+        Authorization: `Bearer ${accessToken}`,
+      },
+      credentials: 'include',
     },
-    credentials: 'include',
-  });
+    timeoutMs,
+  );
 
   // accessToken 만료 시 → refresh 시도
   if (response.status === 401) {
@@ -23,15 +28,19 @@ export const secureFetch = async (
       const newAccessToken = await refreshAccessToken();
       localStorage.setItem('accessToken', newAccessToken);
 
-      response = await fetchWithTimeout(input, {
-        ...init,
-        headers: {
-          ...(init?.headers || {}),
-          Authorization: `Bearer ${newAccessToken}`,
-          'Content-Type': 'application/json',
+      response = await fetchWithTimeout(
+        input,
+        {
+          ...init,
+          headers: {
+            ...(init?.headers || {}),
+            Authorization: `Bearer ${newAccessToken}`,
+            'Content-Type': 'application/json',
+          },
+          credentials: 'include',
         },
-        credentials: 'include',
-      });
+        timeoutMs,
+      );
     } catch (err) {
       // refresh도 실패한 경우
       throw new Error(`REFRESH_FAILED: ${(err as Error).message}`);


### PR DESCRIPTION
## 문제
AI 지원서 초안 생성이 기본 10초 타임아웃(`fetchWithTimeout`)을 넘기면 프론트가 요청을 abort → 화면엔 "실패"로 보이지만, 백엔드는 이미 요청을 처리하며 월 3회 횟수를 차감한다. → **"실패했는데 횟수만 깎임".**

## 원인
`generateApplicationDraft` → `secureFetch` → `fetchWithTimeout`의 기본 10초 타임아웃이 LLM 생성(통상 10초 초과)에 그대로 적용돼 조기 abort.

## 수정 (프론트 전용)
- `secureFetch`에 선택적 `timeoutMs` 파라미터 추가 → 두 `fetchWithTimeout` 호출에 전달 (기존 호출부는 하위 호환).
- 초안 생성 호출에만 `AI_DRAFT_TIMEOUT_MS = 60_000` 전달 → LLM 생성이 끝날 때까지 기다려 조기 abort 방지. 사용자가 차감된 횟수만큼 실제 초안을 받게 됨.
- 60초 타임아웃 전달 검증 테스트 추가.

## 검증
- `application.test.ts` 6/6 통과, `tsc --noEmit` 통과.

## 백엔드 연계 (별도 처리)
- 백엔드는 `aiGenerated=false` 시 횟수를 환불(롤백)하도록 반영됨. 프론트는 응답의 `remaining`을 그대로 신뢰(로컬 차감 없음)하므로 정책 일치.
- ⚠️ quota/429는 현재 `develop/be`에만 있고 main 미배포 — 프론트·백엔드 배포 타이밍 정렬 필요.
