### PR TITLE
[fix] 단답형 답변 입력폭 초과 시 세로로 자동 확장

### DIFF
--- a/frontend/src/components/application/questionTypes/ShortText.tsx
+++ b/frontend/src/components/application/questionTypes/ShortText.tsx
@@ -1,8 +1,14 @@
 import QuestionDescription from '@/components/application/QuestionDescription/QuestionDescription';
 import QuestionTitle from '@/components/application/QuestionTitle/QuestionTitle';
+import CustomTextArea from '@/components/common/CustomTextArea/CustomTextArea';
 import InputField from '@/components/common/InputField/InputField';
 import { APPLICATION_FORM } from '@/constants/applicationForm';
 import { TextProps } from '@/types/application';
+
+interface ShortTextProps extends TextProps {
+  /** 답변이 입력폭을 넘으면 잘리지 않고 세로로 늘어나도록 textarea로 렌더링한다. */
+  multiline?: boolean;
+}
 
 const ShortText = ({
   id,
@@ -14,7 +20,8 @@ const ShortText = ({
   onAnswerChange,
   onTitleChange,
   onDescriptionChange,
-}: TextProps) => {
+  multiline = false,
+}: ShortTextProps) => {
   return (
     <>
       <QuestionTitle
@@ -29,18 +36,32 @@ const ShortText = ({
         mode={mode}
         onDescriptionChange={onDescriptionChange}
       />
-      <InputField
-        value={answer}
-        onChange={(e) => onAnswerChange?.(e.target.value)}
-        onClear={() => onAnswerChange?.('')}
-        placeholder={APPLICATION_FORM.SHORT_TEXT.placeholder}
-        disabled={mode === 'builder'}
-        readOnly={mode === 'builder'}
-        showMaxChar={mode === 'answer'}
-        maxLength={APPLICATION_FORM.SHORT_TEXT.maxLength}
-        showClearButton={mode === 'answer'}
-        width={'60%'}
-      />
+      {multiline ? (
+        <CustomTextArea
+          value={answer}
+          onChange={(e) => onAnswerChange?.(e.target.value)}
+          onClear={() => onAnswerChange?.('')}
+          placeholder={APPLICATION_FORM.SHORT_TEXT.placeholder}
+          disabled={mode === 'builder'}
+          showMaxChar={mode === 'answer'}
+          maxLength={APPLICATION_FORM.SHORT_TEXT.maxLength}
+          showClearButton={mode === 'answer'}
+          width={'60%'}
+        />
+      ) : (
+        <InputField
+          value={answer}
+          onChange={(e) => onAnswerChange?.(e.target.value)}
+          onClear={() => onAnswerChange?.('')}
+          placeholder={APPLICATION_FORM.SHORT_TEXT.placeholder}
+          disabled={mode === 'builder'}
+          readOnly={mode === 'builder'}
+          showMaxChar={mode === 'answer'}
+          maxLength={APPLICATION_FORM.SHORT_TEXT.maxLength}
+          showClearButton={mode === 'answer'}
+          width={'60%'}
+        />
+      )}
     </>
   );
 };

--- a/frontend/src/pages/ApplicationFormPage/components/QuestionAnswerer/QuestionAnswerer.tsx
+++ b/frontend/src/pages/ApplicationFormPage/components/QuestionAnswerer/QuestionAnswerer.tsx
@@ -23,10 +23,19 @@ const QuestionAnswerer = ({
   };
 
   switch (question.type) {
+    case 'SHORT_TEXT':
+      return (
+        <ShortText
+          {...baseProps}
+          multiline
+          answer={selectedAnswers[0] ?? ''}
+          onAnswerChange={(value) => onChange(question.id, value)}
+        />
+      );
+
     case 'NAME':
     case 'EMAIL':
     case 'PHONE_NUMBER':
-    case 'SHORT_TEXT':
       return (
         <ShortText
           {...baseProps}


### PR DESCRIPTION
## 문제
지원서 응답 화면에서 **단답형(SHORT_TEXT)** 답변이 고정 높이 단일 라인 `<input>`이라, 입력이 가로 폭을 넘으면 텍스트가 잘려 보이지 않았다.

## 변경
- `ShortText`에 `multiline` prop 추가 → 설정 시 기존 `useAutoGrow` 기반 `CustomTextArea`(장문형과 동일)로 렌더링해 폭 초과 시 세로로 늘어난다. placeholder·100자 제한·삭제 버튼·글자수 카운터 동일.
- `QuestionAnswerer`에서 `SHORT_TEXT` 케이스만 `multiline`을 넘긴다.

## 범위
- **이름/이메일/전화번호(NAME/EMAIL/PHONE_NUMBER)** 전용 타입은 단일 값 필드라 단일 라인 유지.
- 관리자 **빌더 미리보기**(`mode='builder'`)는 `multiline` 기본값 `false`라 기존과 동일.
- 변경 파일 2개뿐.

## 확인
- 동아리 지원 폼에서 단답형 질문에 폭을 넘겨 입력 → 세로 확장 확인
- 타입 체크 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 짧은 텍스트 답변 입력에서 여러 줄 입력을 지원합니다.
  - 일반 텍스트 답변은 기존 한 줄 입력 방식으로 유지됩니다.
  - 이름, 이메일, 전화번호 입력은 기존 입력 방식으로 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->