### PR TITLE
[feature] 지원서 외부폼 허용 목록에 카카오톡 오픈채팅 호스트 추가

### DIFF
--- a/backend/src/main/java/moadong/club/entity/ClubApplicationForm.java
+++ b/backend/src/main/java/moadong/club/entity/ClubApplicationForm.java
@@ -29,7 +29,7 @@ import java.util.Set;
 @Getter
 @Builder(toBuilder = true)
 public class ClubApplicationForm implements Persistable<String> {
-    private static final Set<String> externalApplicationUrlAllowedHosts = Set.of("forms.gle", "docs.google.com", "form.naver.com", "naver.me", "everytime.kr", "cafe.daum.net");
+    private static final Set<String> externalApplicationUrlAllowedHosts = Set.of("forms.gle", "docs.google.com", "form.naver.com", "naver.me", "everytime.kr", "cafe.daum.net", "open.kakao.com");
     private static final String GOOGLE_DOCS_HOST = "docs.google.com";
     private static final String GOOGLE_FORMS_PATH_PREFIX = "/forms";
 

--- a/backend/src/test/java/moadong/club/entity/ClubApplicationFormTest.java
+++ b/backend/src/test/java/moadong/club/entity/ClubApplicationFormTest.java
@@ -19,7 +19,8 @@ class ClubApplicationFormTest {
             "https://form.naver.com/response/abcd",
             "https://naver.me/xyz",
             "https://everytime.kr/board/1",
-            "https://cafe.daum.net/pknusic/OMPr/43"
+            "https://cafe.daum.net/pknusic/OMPr/43",
+            "https://open.kakao.com/o/gFWZdlFi"
     })
     void 허용된_외부폼_호스트는_저장된다(String url) {
         ClubApplicationForm form = ClubApplicationForm.builder().build();


### PR DESCRIPTION
## 개요
지원서 외부폼 URL로 카카오톡 오픈채팅 링크(`https://open.kakao.com/o/...`)를 저장할 수 있도록 허용합니다.

## 문제
외부폼 URL은 `ClubApplicationForm.updateExternalApplicationUrl` → `isAllowedExternalUrl`에서 호스트 화이트리스트로 검증되는데, `open.kakao.com`이 목록에 없어 `NOT_ALLOWED_EXTERNAL_URL` 예외로 저장이 막혔습니다. 어드민 편집/생성 경로와 개발자 포털의 외부폼 연결(`connectExternalApplicationFormForClub`) 모두 동일한 검증을 탑니다.

## 변경 사항
- `ClubApplicationForm.externalApplicationUrlAllowedHosts`에 `open.kakao.com` 추가
- 허용 케이스 테스트에 `https://open.kakao.com/o/gFWZdlFi` 추가

## 비고
- 기존 SSRF 방어 로직(https 강제, userinfo 위장 차단, host suffix 위장 차단)은 그대로 유지되며 오픈채팅 링크도 정확한 host 매칭으로 통과합니다.
- 입력 시 `https://` 스킴은 필수입니다.

## 테스트
- `ClubApplicationFormTest` 전체 통과 확인 (BUILD SUCCESSFUL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)