### PR TITLE
[feature] 지원서 작성 상태 저장 안내 토스트 및 전역 Toast 컴포넌트 추가

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -83,7 +83,7 @@ npm run generate:sitemap # sitemap.xml 생성
 - `src/hooks/Queries/` ★ - API를 래핑하는 React Query 훅 + 캐싱 전략
 - `src/store/` - Zustand 스토어 (useCategoryStore, useSearchStore, useAdminClubStore)
 - `src/pages/` - 라우트 기반 페이지 컴포넌트
-- `src/components/` - 공용 UI 컴포넌트
+- `src/components/` ★ - 공용 UI 컴포넌트
 - `src/layouts/` ★ - 웹/웹뷰 통합 라우팅 레이아웃
 - `src/experiments/` ★ - A/B 테스트 실험 정의 및 관리
 - `src/styles/` ★ - 전역 스타일·테마·브레이크포인트
@@ -143,6 +143,7 @@ Agent 사용 시 해당 문서를 참조하여 일관된 패턴 유지.
 | --- | --- |
 | API 레이어·인증·SSE | [`src/apis/CLAUDE.md`](src/apis/CLAUDE.md) |
 | React Query 훅·캐싱 전략 | [`src/hooks/Queries/CLAUDE.md`](src/hooks/Queries/CLAUDE.md) |
+| 공용 UI 컴포넌트·오버레이·Toast | [`src/components/CLAUDE.md`](src/components/CLAUDE.md) |
 | 상수 관리 | [`src/constants/CLAUDE.md`](src/constants/CLAUDE.md) |
 | UI·테마·브레이크포인트·날짜 | [`src/styles/CLAUDE.md`](src/styles/CLAUDE.md) |
 | A/B 테스트 실험 | [`src/experiments/CLAUDE.md`](src/experiments/CLAUDE.md) |

--- a/frontend/src/components/CLAUDE.md
+++ b/frontend/src/components/CLAUDE.md
@@ -1,0 +1,78 @@
+# components — 공용 UI 컴포넌트
+
+- `common/` - 페이지 무관 범용 컴포넌트 (Header, Modal, Toast, Button, Portal 등)
+- `application/` - 지원서 관련 공용 컴포넌트
+- `map/` - 지도 화면 전용 컴포넌트
+- `ClubStateBox/`, `ClubTag/` - 동아리 상태·태그 표시
+
+## 파일 구성
+
+컴포넌트 하나당 같은 이름의 디렉토리를 만들고 그 안에 파일을 둔다.
+
+```
+common/Toast/
+  Toast.tsx          # 로직 + 마크업
+  Toast.styles.ts    # styled-components (스타일은 반드시 분리)
+  Toast.stories.tsx  # Storybook (common 컴포넌트는 작성 권장)
+```
+
+- 스타일은 `* as Styled`로 import: `import * as Styled from './Toast.styles'`
+- styled-components에 넘기는 커스텀 prop은 **`$` 접두사(transient prop)**. DOM에 새어나가지 않는다. 예: `$isActive`, `$duration`
+- `src/components/`에는 테스트 파일이 없다. 검증은 Storybook + `npm run typecheck`로 한다 (루트 `CLAUDE.md`의 Storybook 가이드 참고)
+
+## 스타일 하드룰
+
+값을 직접 쓰지 말고 토큰을 쓴다.
+
+| 대상 | 토큰 |
+| --- | --- |
+| 색상 | `colors` (`@/styles/theme/colors`) |
+| 타이포 | `setTypography(typography.xxx)` (`@/styles/theme/typography`) |
+| 트랜지션 | `transitions.duration.*`, `transitions.easing.*` |
+| z-index | `Z_INDEX` (`@/styles/zIndex`) |
+| 반응형 | `media.*` (`@/styles/mediaQuery`) |
+| 헤더 높이 | `HEADER_HEIGHT` (`common/Header/Header.styles`) |
+
+- 반투명 색상은 예외다. 알파 색상 토큰이나 변환 유틸이 없어서 `rgba()` 리터럴을 그대로 쓴다 (`Modal`, `Toast` 동일).
+- 브레이크포인트는 **max-width 기준**이라 데스크탑 스타일을 먼저 쓰고 `media.tablet` → `media.mobile` 순으로 좁혀간다.
+
+## 오버레이 컴포넌트 (Modal, Toast)
+
+화면 위에 띄우는 컴포넌트는 아래 규약을 공유한다.
+
+- **제어형**: `isOpen` + `onClose`를 받고 상태는 호출부가 소유한다. 컴포넌트가 스스로 열림 상태를 들지 않는다.
+- **Portal**: `common/Portal/Portal.tsx`로 `#modal-root`(`index.html`)에 렌더한다. 조상의 `transform`·`overflow`로 인한 stacking context 문제를 피한다. Storybook에서는 `.storybook/preview.tsx`가 `#modal-root`를 만들어 준다.
+- **z-index**: `Z_INDEX`에 정의된 값만 사용 (`overlay: 1100` < `modal: 1200` < `toast: 1300`).
+
+## Toast
+
+전역 토스트. 문구·색상·노출시간을 호출부에서 지정한다.
+
+```tsx
+const [isOpen, setIsOpen] = useState(true);
+
+<Toast
+  isOpen={isOpen}
+  onClose={() => setIsOpen(false)}
+  message='같은 기기에서 작성 상태는 저장돼요.'
+  backgroundColor={colors.primary[900]}
+/>;
+```
+
+| prop | 필수 | 기본값 | 설명 |
+| --- | --- | --- | --- |
+| `isOpen` | ✅ | - | 노출 여부 |
+| `onClose` | ✅ | - | `duration` 경과 시 호출. 호출부가 `isOpen`을 내린다 |
+| `message` | ✅ | - | 표시할 문구 |
+| `backgroundColor` | | `rgba(17,17,17,0.85)` | 배경색 |
+| `color` | | `colors.base.white` | 글자색 |
+| `duration` | | `3500` | 노출 시간(ms) |
+
+- **위치가 브레이크포인트별로 다르다.**
+  - 701px 초과: 헤더 아래 (`top: HEADER_HEIGHT.desktop + 16px`), 위에서 내려오는 애니메이션
+  - 700px 이하: 화면 하단 (`bottom: 24px`), 아래에서 올라오는 애니메이션
+  - 헤더를 숨기는 화면(`<Header showOn={['desktop', 'laptop']} />`)이 많아 좁은 화면에서 상단에 두면 제목·본문을 가린다. 그래서 하단으로 붙인다.
+  - ⚠️ `AppLayout` 하위 페이지(`/`, `/promotions`, `/subscriptions`, `/menu` 등)는 바텀네비가 있어 좁은 화면에서 겹친다. 해당 페이지에서 토스트를 쓰게 되면 오프셋 처리가 필요하다.
+- `pointer-events: none`이라 사용자 입력을 가리지 않고, `role="status"`로 스크린리더에 읽힌다.
+- 애니메이션은 `duration` 하나로 페이드인·유지·페이드아웃을 모두 처리한다. `duration` 전에 호출부가 강제로 닫으면 퇴장 애니메이션 없이 사라진다.
+- 상태를 호출부의 `useState`로 들고 있어서 **언마운트·페이지 이동 시 사라진다.** 컴포넌트 밖(훅, react-query `onError`)에서 띄우거나 `navigate` 이후까지 유지해야 하면 전역 스토어(`src/store/`)가 필요하다.

--- a/frontend/src/components/common/Toast/Toast.stories.tsx
+++ b/frontend/src/components/common/Toast/Toast.stories.tsx
@@ -1,0 +1,80 @@
+import { ComponentProps, useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { colors } from '@/styles/theme/colors';
+import Button from '../Button/Button';
+import Toast from './Toast';
+
+const meta = {
+  title: 'Components/Common/Toast',
+  component: Toast,
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    isOpen: {
+      control: 'boolean',
+      description: '토스트의 노출 여부를 제어합니다.',
+    },
+    onClose: {
+      action: 'closed',
+      description: 'duration이 지나 토스트가 사라질 때 호출되는 함수입니다.',
+    },
+    message: {
+      control: 'text',
+      description: '토스트에 표시할 문구입니다.',
+    },
+    backgroundColor: {
+      control: 'color',
+      description: '토스트 배경색입니다. 기본값은 반투명 검정입니다.',
+    },
+    color: {
+      control: 'color',
+      description: '토스트 글자색입니다. 기본값은 흰색입니다.',
+    },
+    duration: {
+      control: 'number',
+      description: '토스트가 유지되는 시간(ms)입니다.',
+    },
+  },
+} satisfies Meta<typeof Toast>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const ToastTrigger = (args: ComponentProps<typeof Toast>) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleClose = () => {
+    setIsOpen(false);
+    args.onClose();
+  };
+
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)}>토스트 띄우기</Button>
+      <Toast {...args} isOpen={isOpen} onClose={handleClose} />
+    </>
+  );
+};
+
+// 기본 토스트(반투명 검정 배경 + 흰 글자)
+export const Default: Story = {
+  args: {
+    isOpen: false,
+    onClose: () => {},
+    message: '같은 기기에서 작성 상태는 저장돼요.',
+  },
+  render: (args) => <ToastTrigger {...args} />,
+};
+
+// 호출부에서 색상을 지정한 케이스
+export const CustomColor: Story = {
+  args: {
+    isOpen: false,
+    onClose: () => {},
+    message: '지원서가 제출되었어요.',
+    backgroundColor: colors.primary[900],
+    color: colors.base.white,
+  },
+  render: (args) => <ToastTrigger {...args} />,
+};

--- a/frontend/src/components/common/Toast/Toast.styles.ts
+++ b/frontend/src/components/common/Toast/Toast.styles.ts
@@ -1,0 +1,47 @@
+import styled, { keyframes } from 'styled-components';
+import { HEADER_HEIGHT } from '@/components/common/Header/Header.styles';
+import { media } from '@/styles/mediaQuery';
+import { transitions } from '@/styles/theme/transitions';
+import { setTypography, typography } from '@/styles/theme/typography';
+import { Z_INDEX } from '@/styles/zIndex';
+
+// 헤더 아래에 노출되므로 위에서 내려왔다가 위로 사라진다.
+const fadeInOut = keyframes`
+  0% { opacity: 0; transform: translate(-50%, -12px); }
+  10% { opacity: 1; transform: translate(-50%, 0); }
+  85% { opacity: 1; transform: translate(-50%, 0); }
+  100% { opacity: 0; transform: translate(-50%, -8px); }
+`;
+
+const GAP_BELOW_HEADER = 16;
+
+export const ToastMessage = styled.div<{
+  $backgroundColor: string;
+  $color: string;
+  $duration: number;
+}>`
+  position: fixed;
+  left: 50%;
+  top: ${HEADER_HEIGHT.desktop + GAP_BELOW_HEADER}px;
+  z-index: ${Z_INDEX.toast};
+  max-width: calc(100% - 40px);
+  padding: 12px 20px;
+  border-radius: 999px;
+  background-color: ${({ $backgroundColor }) => $backgroundColor};
+  color: ${({ $color }) => $color};
+  ${setTypography(typography.paragraph.p5)};
+  letter-spacing: -0.2px;
+  text-align: center;
+  pointer-events: none;
+  animation: ${fadeInOut} ${({ $duration }) => $duration}ms
+    ${transitions.easing.easeInOut} forwards;
+
+  ${media.tablet} {
+    top: ${HEADER_HEIGHT.tablet + GAP_BELOW_HEADER}px;
+  }
+
+  ${media.mobile} {
+    top: ${HEADER_HEIGHT.mobile + GAP_BELOW_HEADER}px;
+    padding: 10px 16px;
+  }
+`;

--- a/frontend/src/components/common/Toast/Toast.styles.ts
+++ b/frontend/src/components/common/Toast/Toast.styles.ts
@@ -5,15 +5,24 @@ import { transitions } from '@/styles/theme/transitions';
 import { setTypography, typography } from '@/styles/theme/typography';
 import { Z_INDEX } from '@/styles/zIndex';
 
-// 헤더 아래에 노출되므로 위에서 내려왔다가 위로 사라진다.
-const fadeInOut = keyframes`
+// 헤더 아래(상단 고정)에서는 위에서 내려왔다가 위로 사라진다.
+const fadeInOutFromTop = keyframes`
   0% { opacity: 0; transform: translate(-50%, -12px); }
   10% { opacity: 1; transform: translate(-50%, 0); }
   85% { opacity: 1; transform: translate(-50%, 0); }
   100% { opacity: 0; transform: translate(-50%, -8px); }
 `;
 
+// 하단 고정에서는 반대로 아래에서 올라왔다가 아래로 사라진다.
+const fadeInOutFromBottom = keyframes`
+  0% { opacity: 0; transform: translate(-50%, 12px); }
+  10% { opacity: 1; transform: translate(-50%, 0); }
+  85% { opacity: 1; transform: translate(-50%, 0); }
+  100% { opacity: 0; transform: translate(-50%, 8px); }
+`;
+
 const GAP_BELOW_HEADER = 16;
+const GAP_FROM_BOTTOM = 24;
 
 export const ToastMessage = styled.div<{
   $backgroundColor: string;
@@ -33,15 +42,17 @@ export const ToastMessage = styled.div<{
   letter-spacing: -0.2px;
   text-align: center;
   pointer-events: none;
-  animation: ${fadeInOut} ${({ $duration }) => $duration}ms
+  animation: ${fadeInOutFromTop} ${({ $duration }) => $duration}ms
     ${transitions.easing.easeInOut} forwards;
 
+  /* 헤더를 숨기는 화면이 많아 상단에 두면 콘텐츠를 가린다. 하단으로 붙인다. */
   ${media.tablet} {
-    top: ${HEADER_HEIGHT.tablet + GAP_BELOW_HEADER}px;
+    top: auto;
+    bottom: ${GAP_FROM_BOTTOM}px;
+    animation-name: ${fadeInOutFromBottom};
   }
 
   ${media.mobile} {
-    top: ${HEADER_HEIGHT.mobile + GAP_BELOW_HEADER}px;
     padding: 10px 16px;
   }
 `;

--- a/frontend/src/components/common/Toast/Toast.tsx
+++ b/frontend/src/components/common/Toast/Toast.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useRef } from 'react';
+import { colors } from '@/styles/theme/colors';
+import Portal from '../Portal/Portal';
+import * as Styled from './Toast.styles';
+
+const DEFAULT_DURATION = 3500;
+const DEFAULT_BACKGROUND_COLOR = 'rgba(17, 17, 17, 0.85)';
+
+interface ToastProps {
+  isOpen: boolean;
+  onClose: () => void;
+  message: string;
+  backgroundColor?: string;
+  color?: string;
+  duration?: number;
+}
+
+const Toast = ({
+  isOpen,
+  onClose,
+  message,
+  backgroundColor = DEFAULT_BACKGROUND_COLOR,
+  color = colors.base.white,
+  duration = DEFAULT_DURATION,
+}: ToastProps) => {
+  const onCloseRef = useRef(onClose);
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const timer = setTimeout(() => onCloseRef.current(), duration);
+    return () => clearTimeout(timer);
+  }, [isOpen, duration]);
+
+  if (!isOpen) return null;
+
+  return (
+    <Portal>
+      <Styled.ToastMessage
+        role='status'
+        $backgroundColor={backgroundColor}
+        $color={color}
+        $duration={duration}
+      >
+        {message}
+      </Styled.ToastMessage>
+    </Portal>
+  );
+};
+
+export default Toast;

--- a/frontend/src/pages/ApplicationFormPage/ApplicationFormPage.tsx
+++ b/frontend/src/pages/ApplicationFormPage/ApplicationFormPage.tsx
@@ -4,6 +4,7 @@ import { applyToClub } from '@/apis/application';
 import Footer from '@/components/common/Footer/Footer';
 import Header from '@/components/common/Header/Header';
 import Spinner from '@/components/common/Spinner/Spinner';
+import Toast from '@/components/common/Toast/Toast';
 import { PAGE_VIEW, USER_EVENT } from '@/constants/eventName';
 import { useAnswers } from '@/hooks/Application/useAnswers';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
@@ -13,6 +14,7 @@ import { useGetClubDetail } from '@/hooks/Queries/useClub';
 import QuestionAnswerer from '@/pages/ApplicationFormPage/components/QuestionAnswerer/QuestionAnswerer';
 import QuestionContainer from '@/pages/ApplicationFormPage/components/QuestionContainer/QuestionContainer';
 import { PageContainer } from '@/styles/PageContainer.styles';
+import { colors } from '@/styles/theme/colors';
 import { Question } from '@/types/application';
 import { linkifyText } from '@/utils/linkifyText';
 import { validateAnswers } from '@/utils/useValidateAnswers';
@@ -26,6 +28,7 @@ const ApplicationFormPage = () => {
   const navigate = useNavigate();
   const questionRefs = useRef<Array<HTMLDivElement | null>>([]);
   const [invalidQuestionIds, setInvalidQuestionIds] = useState<number[]>([]);
+  const [isSaveNoticeOpen, setIsSaveNoticeOpen] = useState(true);
   const trackEvent = useMixpanelTrack();
 
   const { data: clubDetail, error: clubError } = useGetClubDetail(clubId ?? '');
@@ -166,6 +169,12 @@ const ApplicationFormPage = () => {
           </Styled.SubmitButton>
         </Styled.ButtonWrapper>
       </PageContainer>
+      <Toast
+        isOpen={isSaveNoticeOpen}
+        onClose={() => setIsSaveNoticeOpen(false)}
+        message='같은 기기에서 작성 상태는 저장돼요.'
+        backgroundColor={colors.primary[900]}
+      />
       <Footer />
     </>
   );

--- a/frontend/src/styles/zIndex.ts
+++ b/frontend/src/styles/zIndex.ts
@@ -5,4 +5,5 @@ export const Z_INDEX = {
   floatingButton: 1050, // 플로팅 버튼
   overlay: 1100, // 모달 오버레이
   modal: 1200, // 모달 컨테이너
+  toast: 1300, // 토스트 메시지
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

지원서 작성 페이지는 `localStorage`에 작성 상태를 저장하고 있지만 사용자가 이를 알 방법이 없었습니다. 폼 진입 시 안내 토스트를 노출합니다.

**문구**: `같은 기기에서 작성 상태는 저장돼요.` (brand 컬러, 3.5초 후 자동 소멸)

레포에 토스트 컴포넌트/라이브러리가 없어서 `components/common/Toast/`에 전역 컴포넌트로 추가했습니다. `Modal`의 기존 관례를 그대로 따랐습니다.

- 제어형 `isOpen` / `onClose` + `Portal`(`#modal-root`)
- 색상(`backgroundColor`, `color`)·문구(`message`)·노출시간(`duration`)을 호출부에서 지정
- `role="status"`로 스크린리더 알림, `pointer-events: none`으로 입력 비간섭

### 노출 위치

브레이크포인트에 따라 앵커가 다릅니다.

| 화면 | 위치 | 애니메이션 |
| --- | --- | --- |
| 701px 초과 | 헤더 아래 (`top: HEADER_HEIGHT.desktop + 16px`) | 위에서 내려옴 |
| 700px 이하 | 화면 하단 (`bottom: 24px`) | 아래에서 올라옴 |

처음엔 전 구간 "헤더 아래"로 뒀는데, 지원서 페이지가 `<Header showOn={['desktop', 'laptop']} />`라 **701px 미만에서는 헤더가 없어서** 토스트가 제목과 설명을 그대로 덮었습니다.

콘텐츠 사이에 토스트를 끼울 안전한 틈이 없어서(`FormDescription`이 옵셔널이고 길이도 가변) 좁은 화면은 하단 고정으로 바꿨습니다.

### 사용한 토큰

| 항목 | 토큰 |
| --- | --- |
| 타이포 | `typography.paragraph.p5` (14px/500/140%) |
| 이징 | `transitions.easing.easeInOut` |
| 위치 | `HEADER_HEIGHT.desktop` |
| z-index | `Z_INDEX.toast` (신규 추가, 1300) |
| 지원서 배경색 | `colors.primary[900]` |

### 문서

`src/components/`에 폴더 문서가 없어서 새로 작성하고 루트 `CLAUDE.md` 인덱스에 등록했습니다. 컴포넌트 40개를 나열하는 카탈로그 대신, 실제 코드에서 확인한 **공통 규약**과 신규 `Toast` 사용법만 담았습니다.

- 파일 구성 (`Xxx/{Xxx.tsx, Xxx.styles.ts, Xxx.stories.tsx}`, `* as Styled`, `$` transient prop)
- 스타일 토큰 하드룰
- 오버레이 규약 (제어형 `isOpen`/`onClose`, Portal → `#modal-root`, z-index 서열)
- `Toast` props 표와 주의사항

## 중점적으로 리뷰받고 싶은 부분(선택)

**1. 반투명 배경색이 리터럴입니다**

기본 배경 `rgba(17, 17, 17, 0.85)`가 토큰이 아닙니다. 레포에 알파 색상 토큰이나 `hexToRgba` 류 유틸이 전혀 없고(`Modal.styles.ts`도 `rgba(0,0,0,0.6)` 리터럴), 유틸을 새로 만드는 건 없던 관례를 만드는 거라 선례를 따랐습니다. 토큰화가 필요하면 별도로 논의하면 좋겠습니다.

**2. 바텀네비와 겹칠 여지 (지금은 해당 없음)**

좁은 화면에서 하단 고정이라, `AppLayout` 하위 페이지(`/`, `/promotions`, `/subscriptions`, `/menu` 등)에서 토스트를 쓰면 바텀네비와 겹칩니다. 지원서 페이지는 `AppLayout` 밖이라 현재는 문제없고, 문서에 주의사항으로 남겨뒀습니다. 지금 오프셋 처리를 미리 넣을지 의견 주시면 좋겠습니다.

## 논의하고 싶은 부분(선택)

**토스트 상태를 zustand로 올릴지**

이번엔 호출부가 1곳이라 로컬 `useState`로 뒀습니다. 다만 레포에 `alert()`가 **68곳**(`ApplicationEditTab` 8, `useClubInfoEdit` 6, `LoginTab` 5 등 AdminPage 집중) 있어서, 이걸 토스트로 걷어낼 계획이라면 전역 스토어가 필요해집니다.

- 훅·유틸(`useShare`, `useLogout`, react-query `onError`)처럼 컴포넌트 밖에서는 로컬 state로 토스트를 띄울 수 없음
- `handleSubmit`처럼 `navigate` 직후 토스트를 유지해야 하는 경우 언마운트되며 사라짐

지금 `Toast`는 순수 프레젠테이션 컴포넌트라, 나중에 `useToastStore`를 얹어도 이 코드를 버리지 않고 그대로 재사용할 수 있습니다.

## 🫡 참고사항

- 테스트: 기존 스위트 전체 통과 (29 suites / 295 tests). 신규 테스트는 없습니다 — 스타일·표시 로직이라 Storybook + 브라우저 실측으로 대체했습니다
- `typecheck`, `eslint`, `prettier` 통과
- Storybook 스토리 추가 (`Default`, `CustomColor`)
- Playwright 실측 검증
  - 1200px → `top: 108px` / 상단용 애니메이션
  - 680px → `bottom: 24px` / 하단용 애니메이션
  - 390px → `bottom: 24px` / 하단용 애니메이션
  - 배경 `rgb(255,84,20)`, `duration` 경과 후 자동 제거 확인