### PR TITLE
[fix] 지원서 답변 입력창·객관식 선택지 폭 불일치 수정

### DIFF
--- a/frontend/src/components/common/CustomTextArea/CustomTextArea.styles.ts
+++ b/frontend/src/components/common/CustomTextArea/CustomTextArea.styles.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { media } from '@/styles/mediaQuery';
 import { colors } from '@/styles/theme/colors';
 
 //Todo : InputField 컴포넌트와 중복되는 부분이 많아 추후 리팩토링 검토
@@ -8,6 +9,10 @@ export const TextAreaContainer = styled.div<{ width: string }>`
   max-width: 100%;
   display: flex;
   flex-direction: column;
+
+  ${media.tablet} {
+    width: 100%;
+  }
 `;
 
 export const Label = styled.label`

--- a/frontend/src/pages/ApplicationFormPage/components/ChoiceItem/ChoiceItem.styles.ts
+++ b/frontend/src/pages/ApplicationFormPage/components/ChoiceItem/ChoiceItem.styles.ts
@@ -1,7 +1,9 @@
 import styled from 'styled-components';
+import { media } from '@/styles/mediaQuery';
 
 export const ItemWrapper = styled.div`
   flex: 1;
+  max-width: 60%;
   height: 45px;
   padding: 12px 18px;
   border: none;
@@ -18,6 +20,10 @@ export const ItemWrapper = styled.div`
   transition:
     background-color 0.2s,
     border-color 0.2s;
+
+  ${media.tablet} {
+    max-width: 100%;
+  }
 `;
 
 export const Label = styled.span`


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음 (배포본에서 발견한 UI 버그)

## 📝작업 내용

지원서 화면에서 **답변 입력창과 객관식 선택지의 폭이 서로 어긋나는** 문제를 수정했습니다. 원인이 다른 두 건이라 커밋을 나눴습니다.

### 1. `CustomTextArea` 모바일 폭 오버라이드 누락 (회귀)

`InputField.styles.ts`에는 `media.tablet`에서 `width: 100%`로 되돌리는 규칙이 있는데, `CustomTextArea.styles.ts`에는 없었습니다.

`7192f02cc`(main)에서 `SHORT_TEXT`를 `InputField` → `CustomTextArea`로 교체할 때 스타일 파일을 함께 손보지 않아, 모바일에서 `width={'60%'}`가 그대로 적용되고 있었습니다. 해당 커밋은 `ShortText.tsx`와 `QuestionAnswerer.tsx` 2개 파일만 변경했습니다.

### 2. `ChoiceItem` 폭 제한 없음

`flex: 1`만 있고 `max-width`가 없어 컨테이너 전체를 채웁니다. 답변 입력창(60%)과 어긋나 보입니다. 입력창과 동일하게 데스크탑 60% / tablet 이하 100%로 맞췄습니다.

## ✅ 검증

실제 API(`api.moadong.com`)를 붙여 "후라 26 신입 부원 지원서"로 확인했습니다. `getBoundingClientRect()` 실측값(px):

**객관식 폭**

| 뷰포트 | | 객관식 | 입력창 |
|---|---|---|---|
| 1280 | before | **1132** | 679 |
| 1280 | after | **679** | 679 |
| 390 | before | 342 / **390**(오버플로우) | 342 |
| 390 | after | **342** | 342 |

**모바일 textarea** — 이 브랜치엔 `multiline` 경로가 없어, main의 `ShortText.tsx`·`QuestionAnswerer.tsx`를 임시로 체크아웃해 머지 후 상태를 재현했습니다.

| 모바일 390 | textarea | 객관식 |
|---|---|---|
| 현재 main 그대로 | **205** (= 342 × 60%) | 342 |
| 이 PR 적용 | **342** | 342 |

그 외: `typecheck` / `jest` 30 suites 299 tests / `eslint` / `prettier --check` 모두 통과.

## 중점적으로 리뷰받고 싶은 부분(선택)

**객관식의 `60%`가 적절한 값인지** 봐주세요. "입력창과 맞춘다"로 해석해 `ShortText.tsx`의 `width={'60%'}`에 맞췄는데, 디자인 의도가 다르면 조정하겠습니다.

## 논의하고 싶은 부분(선택)

`60%`가 `ShortText.tsx`와 `ChoiceItem.styles.ts` 두 곳에 하드코딩돼 또 어긋날 여지가 있습니다. `src/constants/`로 뽑는 게 나을지 의견 주세요. 이번 PR 범위에서는 손대지 않았습니다.

## 🫡 참고사항

- 커밋 1은 develop-fe 기준으로는 **아직 눈에 보이지 않습니다.** `7192f02cc`가 main에만 있어 이 브랜치의 `ShortText`는 `InputField` 단일 경로이기 때문입니다. develop-fe가 릴리즈로 main과 만나는 시점에 효과가 납니다. 커밋 2는 즉시 반영됩니다.
- `CustomTextArea`의 다른 사용처(`LongText`, `ApplicationEditTab`, `ClubIntroEditTab`)는 모두 `width`를 생략(기본 100%)하거나 `'100%'`를 넘겨서 영향이 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 태블릿 화면에서 텍스트 입력 영역이 화면 너비에 맞게 확장됩니다.
  * 선택 항목이 태블릿 화면에서 전체 너비를 활용하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->