### PR TITLE
[fix] 외부 지원서 링크 허용 목록을 백엔드 기준으로 맞춤

### DIFF
--- a/frontend/src/pages/AdminPage/validation/validateApplicationForm.ts
+++ b/frontend/src/pages/AdminPage/validation/validateApplicationForm.ts
@@ -5,7 +5,10 @@ const ALLOWED_EXTERNAL_URLS = [
   'https://docs.google.com/forms/',
   'https://form.naver.com/',
   'https://naver.me/',
+  'https://m.site.naver.com/',
   'https://everytime.kr/',
+  'https://cafe.daum.net/',
+  'https://open.kakao.com/',
 ];
 
 export interface ApplicationFormErrors {
@@ -62,7 +65,7 @@ export const validateApplicationForm = (
       !ALLOWED_EXTERNAL_URLS.some((url) => externalUrl.startsWith(url))
     ) {
       errors.externalUrl =
-        'Google Forms, Naver Form 또는 Everytime 링크여야 합니다.';
+        'Google Forms, 네이버 폼, 에브리타임, 다음 카페, 카카오 오픈채팅 링크만 등록할 수 있습니다.';
     }
   }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

어드민 외부 지원서 링크 허용 목록이 백엔드와 어긋나 있어, **백엔드는 통과하는 URL이 프론트 검증에서 저장 전에 막히던 문제**를 수정했습니다.

백엔드 source of truth (`ClubApplicationForm.java:32` `externalApplicationUrlAllowedHosts`) 기준으로 3개 호스트가 프론트에 빠져 있었습니다.

- `ALLOWED_EXTERNAL_URLS`에 `m.site.naver.com`, `cafe.daum.net`, `open.kakao.com` 추가
- 에러 메시지가 실제 허용 범위와 안 맞아 교정
  - before: `Google Forms, Naver Form 또는 Everytime 링크여야 합니다.`
  - after: `Google Forms, 네이버 폼, 에브리타임, 다음 카페, 카카오 오픈채팅 링크만 등록할 수 있습니다.`

변경 파일은 `validateApplicationForm.ts` 하나입니다.

### 검증

임시 테스트로 `validateApplicationForm`을 직접 호출해 11 케이스 확인 후 테스트 파일은 삭제했습니다.

- 통과: `m.site.naver.com/2djWG`, `forms.gle/…`, `docs.google.com/forms/d/e/…`, `form.naver.com/…`, `naver.me/…`, `everytime.kr/…`, `cafe.daum.net/…`, `open.kakao.com/o/…`
- 차단: `evil.example/abcd`, `docs.google.com/document/d/abcd`(Docs 문서는 여전히 차단), `http://forms.gle/abcd`(https 아님)

`npm run typecheck` 통과. `ApplicationEditTab.tsx`에서 이 validator가 `createMutate`/`updateMutate` 앞의 유일한 게이트라 통과 = 저장 요청 발신입니다.

## 중점적으로 리뷰받고 싶은 부분(선택)

검증 방식은 기존 `startsWith` 접두사 매칭을 그대로 뒀습니다. 실제 보안 검증은 백엔드가 URI host 파싱 + userinfo/scheme 체크로 하고 있고 프론트는 UX용 사전 체크라 판단했는데, 이 선택이 괜찮은지 봐주시면 좋겠습니다.

## 🫡 참고사항

- 백엔드는 `docs.google.com`을 경로가 `/forms`로 시작할 때만 허용하는데, 프론트의 `https://docs.google.com/forms/` 접두사 매칭이 이미 같은 효과라 별도 처리는 넣지 않았습니다.
- 백엔드 쪽 대응은 `develop/be`에 이미 반영되어 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 외부 지원서 링크에 네이버 폼, 다음 카페, 카카오 오픈채팅 URL을 사용할 수 있도록 허용 목록을 확대했습니다.
  * 허용되지 않은 링크 안내 문구에 지원 가능한 서비스가 명확히 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->