### PR TITLE
[feature] 지원서 외부폼 허용 목록에 네이버 단축링크 호스트 추가

### DIFF
--- a/backend/src/main/java/moadong/club/entity/ClubApplicationForm.java
+++ b/backend/src/main/java/moadong/club/entity/ClubApplicationForm.java
@@ -29,7 +29,7 @@ import java.util.Set;
 @Getter
 @Builder(toBuilder = true)
 public class ClubApplicationForm implements Persistable<String> {
-    private static final Set<String> externalApplicationUrlAllowedHosts = Set.of("forms.gle", "docs.google.com", "form.naver.com", "naver.me", "everytime.kr", "cafe.daum.net", "open.kakao.com");
+    private static final Set<String> externalApplicationUrlAllowedHosts = Set.of("forms.gle", "docs.google.com", "form.naver.com", "naver.me", "m.site.naver.com", "everytime.kr", "cafe.daum.net", "open.kakao.com");
     private static final String GOOGLE_DOCS_HOST = "docs.google.com";
     private static final String GOOGLE_FORMS_PATH_PREFIX = "/forms";
 

--- a/backend/src/test/java/moadong/club/entity/ClubApplicationFormTest.java
+++ b/backend/src/test/java/moadong/club/entity/ClubApplicationFormTest.java
@@ -18,6 +18,7 @@ class ClubApplicationFormTest {
             "https://docs.google.com/forms/d/e/1FAIpQL/viewform",
             "https://form.naver.com/response/abcd",
             "https://naver.me/xyz",
+            "https://m.site.naver.com/2djWG",
             "https://everytime.kr/board/1",
             "https://cafe.daum.net/pknusic/OMPr/43",
             "https://open.kakao.com/o/gFWZdlFi"
@@ -35,6 +36,7 @@ class ClubApplicationFormTest {
             "https://forms.gle@evil.example/abcd",           // userinfo로 host 위장
             "https://forms.gle.evil.example/abcd",           // suffix 로 host 위장
             "https://everytime.kr.evil.example/board/1",
+            "https://m.site.naver.com.evil.example/2djWG",
             "https://cafe.daum.net.evil.example/pknusic/OMPr/43",
             "https://evil.example/abcd",
             "http://forms.gle/abcd",                         // https 아님


### PR DESCRIPTION
## 개요
지원서 외부폼 URL로 네이버 단축링크(`https://m.site.naver.com/...`)를 저장할 수 있도록 허용합니다.

## 문제
외부폼 URL은 `ClubApplicationForm.updateExternalApplicationUrl` → `isAllowedExternalUrl`에서 호스트 화이트리스트로 검증되는데, `m.site.naver.com`이 목록에 없어 `NOT_ALLOWED_EXTERNAL_URL` 예외로 저장이 막혔습니다. 기존에 허용된 네이버 계열 호스트는 `form.naver.com`, `naver.me` 뿐입니다.

## 변경 사항
- `ClubApplicationForm.externalApplicationUrlAllowedHosts`에 `m.site.naver.com` 추가
- 허용 케이스 테스트에 `https://m.site.naver.com/2djWG` 추가
- 차단 케이스 테스트에 host suffix 위장(`https://m.site.naver.com.evil.example/2djWG`) 추가

## 비고
- 기존 SSRF 방어 로직(https 강제, userinfo 위장 차단, host suffix 위장 차단)은 그대로 유지되며 네이버 단축링크도 정확한 host 매칭으로 통과합니다.
- `m.site.naver.com`은 `naver.me`와 같은 네이버 소유 단축링크 도메인이라 동일한 신뢰 수준으로 판단했습니다.
- **프론트엔드 후속 작업 필요**: `frontend/src/pages/AdminPage/validation/validateApplicationForm.ts`에 별도 허용 목록이 있고 `m.site.naver.com`, `cafe.daum.net`, `open.kakao.com`이 빠져 있어 어드민 UI에서는 여전히 저장 전에 막힙니다. 별도 PR로 처리 예정입니다.

## 테스트
- `ClubApplicationFormTest` 전체 통과 확인 (BUILD SUCCESSFUL)
