### PR TITLE
[fix] 상세페이지 알림 버튼 구독 이벤트 트래킹 누락 수정

### DIFF
--- a/frontend/src/constants/eventName.ts
+++ b/frontend/src/constants/eventName.ts
@@ -152,4 +152,7 @@ export const PAGE_NAME = {
   WEBVIEW_MAIN: 'webview-main',
   INTRODUCE: 'introduce',
   SUBSCRIPTIONS: 'subscriptions',
+  CLUB_DETAIL: 'club-detail',
 } as const;
+
+export type PageName = (typeof PAGE_NAME)[keyof typeof PAGE_NAME];

--- a/frontend/src/hooks/useWebviewSubscribe.ts
+++ b/frontend/src/hooks/useWebviewSubscribe.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { USER_EVENT } from '@/constants/eventName';
+import { USER_EVENT, type PageName } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import {
   AppToWebMessage,
@@ -57,11 +57,12 @@ const useWebviewSubscribe = () => {
   }, []);
 
   const toggleSubscribe = useCallback(
-    (clubId: string, subscribed: boolean) => {
+    (clubId: string, subscribed: boolean, source: PageName) => {
       requestSubscribeToggle(clubId);
       trackEvent(USER_EVENT.WEBVIEW_SUBSCRIBE_TOGGLED, {
         club_id: clubId,
         subscribed: !subscribed,
+        source,
       });
     },
     [trackEvent],

--- a/frontend/src/pages/ClubDetailPage/components/ClubDetailTopBar/ClubDetailTopBar.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubDetailTopBar/ClubDetailTopBar.tsx
@@ -4,7 +4,7 @@ import { useTheme } from 'styled-components';
 import NotificationIcon from '@/assets/images/icons/notification_icon.svg?react';
 import PrevButtonIcon from '@/assets/images/icons/prev_button_icon.svg?react';
 import Spinner from '@/components/common/Spinner/Spinner';
-import { USER_EVENT } from '@/constants/eventName';
+import { PAGE_NAME, USER_EVENT } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import { useScrollTrigger } from '@/hooks/Scroll/useScrollTrigger';
 import useOpenAppFromKakao from '@/hooks/useOpenAppFromKakao';
@@ -94,6 +94,11 @@ const ClubDetailTopBar = ({
 
   const handleNotificationClick = () => {
     requestSubscribeToggle(clubId);
+    trackEvent(USER_EVENT.WEBVIEW_SUBSCRIBE_TOGGLED, {
+      club_id: clubId,
+      subscribed: !isNotificationActive,
+      source: PAGE_NAME.CLUB_DETAIL,
+    });
   };
 
   return (

--- a/frontend/src/pages/MainPage/MainPage.tsx
+++ b/frontend/src/pages/MainPage/MainPage.tsx
@@ -76,7 +76,11 @@ const MainPage = () => {
           <SubscribeButton
             subscribed={subscribedClubIds.has(club.id)}
             onToggle={() =>
-              toggleSubscribe(club.id, subscribedClubIds.has(club.id))
+              toggleSubscribe(
+                club.id,
+                subscribedClubIds.has(club.id),
+                PAGE_NAME.WEBVIEW_MAIN,
+              )
             }
           />
         )}

--- a/frontend/src/pages/SubscriptionsPage/SubscriptionsPage.tsx
+++ b/frontend/src/pages/SubscriptionsPage/SubscriptionsPage.tsx
@@ -65,7 +65,11 @@ const SubscribedClubs = () => {
               <SubscribeButton
                 subscribed={subscribedClubIds.has(club.id)}
                 onToggle={() =>
-                  toggleSubscribe(club.id, subscribedClubIds.has(club.id))
+                  toggleSubscribe(
+                    club.id,
+                    subscribedClubIds.has(club.id),
+                    PAGE_NAME.SUBSCRIPTIONS,
+                  )
                 }
               />
             </ClubCard>


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

동아리 상세페이지 상단바의 **알림(구독) 버튼 클릭이 Mixpanel에 전혀 잡히지 않던 문제**를 수정했습니다.

### 원인

메인·구독 목록의 구독 토글은 `useWebviewSubscribe`의 `toggleSubscribe`를 거치고, 트래킹은 이 훅 안에 있습니다.

```ts
// useWebviewSubscribe.ts
const toggleSubscribe = useCallback((clubId, subscribed) => {
  requestSubscribeToggle(clubId);
  trackEvent(USER_EVENT.WEBVIEW_SUBSCRIBE_TOGGLED, { ... });
}, [trackEvent]);
```

그런데 `ClubDetailTopBar`는 자체 `isNotificationActive` 상태를 들고 있어서 훅을 쓰지 않고 `requestSubscribeToggle(clubId)`를 **직접** 호출합니다. 구독 동작 자체는 정상이지만 트래킹만 우회돼서, `Webview Subscribe Toggled` 이벤트에 상세페이지 유입분이 통째로 빠져 있었습니다. (같은 파일의 뒤로가기 버튼은 `BACK_BUTTON_CLICKED`를 보내고 있어 `useMixpanelTrack`은 이미 붙어 있는 상태였습니다.)

### 변경 내용

1. `ClubDetailTopBar.handleNotificationClick`에 트래킹 추가
2. 진입 지점을 구분할 수 있도록 `Webview Subscribe Toggled`에 `source` 프로퍼티 추가
   - `toggleSubscribe(clubId, subscribed, source)` — **필수 인자**로 둬서 앞으로 새 호출부가 생겨도 source 누락이 타입 에러로 잡히게 했습니다
   - 값은 새로 만들지 않고 기존 `PAGE_NAME`을 재사용 (ClubCard `page` 프로퍼티·스크롤 트래킹과 같은 체계). `CLUB_DETAIL: 'club-detail'`만 추가

최종 이벤트 스키마 — `club_id`, `subscribed`(토글 후 상태), `source`

| source | 위치 |
| --- | --- |
| `club-detail` | 상세페이지 상단바 알림 버튼 (**신규**) |
| `webview-main` | 웹뷰 메인 클럽카드 구독 버튼 |
| `subscriptions` | 구독 목록 페이지 |

### 검증

- `npm run typecheck` 통과
- `npx eslint` 변경 파일 5개 — 에러 0
  - MainPage의 `navigate` exhaustive-deps 경고 1건은 HEAD 버전에서도 동일하게 나오는 기존 경고라 손대지 않았습니다
- `npx jest --testPathPattern \"(ClubDetail|MainPage|Subscription|Mixpanel|Webview)\"` — 5 suites / 56 tests 통과

## 중점적으로 리뷰받고 싶은 부분(선택)

이벤트를 쪼개지 않고 `source` 프로퍼티로 구분하는 방식을 택했습니다. 전체 구독 전환 수를 볼 때 매번 여러 이벤트를 합산하지 않아도 되고, 진입 지점별 분해도 가능해서인데 이 판단이 괜찮은지 봐주시면 좋겠습니다.

`ClubDetailTopBar`를 `useWebviewSubscribe`로 통합하는 방향도 있었지만, 이 컴포넌트는 `initialIsSubscribed` prop + 자체 message 리스너로 단일 동아리 상태만 관리하고 있어서 훅(전체 구독 목록 Set 관리 + 마운트 시 `REQUEST_SUBSCRIBE_STATE` 발신)으로 갈아끼우는 건 트래킹 수정 범위를 넘어선다고 봤습니다.

## 🫡 참고사항

- `source`는 이번 배포 이후 데이터부터 붙습니다. 기존 `Webview Subscribe Toggled` 이벤트에는 이 프로퍼티가 비어 있으니 Mixpanel에서 진입 지점별로 비교할 때는 **배포 시점 이후로 기간을 잡아야** 합니다.
- 알림 버튼은 `isInApp`일 때만 렌더되므로 이번 누락은 앱 웹뷰 한정이었습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 동아리 구독 토글 이벤트에 출처 페이지 정보가 포함됩니다.
  * 동아리 상세 페이지, 메인 페이지, 구독 페이지에서 구독 활동을 보다 정확하게 추적할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->