### PR TITLE
[feature] 지원서 목록 조회 응답에 createdAt 추가

### DIFF
--- a/backend/src/main/java/moadong/club/payload/dto/ClubApplicationFormsResultItem.java
+++ b/backend/src/main/java/moadong/club/payload/dto/ClubApplicationFormsResultItem.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 public record ClubApplicationFormsResultItem(
        String id,
        String title,
+       LocalDateTime createdAt,
        LocalDateTime editedAt,
        ApplicationFormStatus status
 ) { }

--- a/backend/src/main/java/moadong/club/repository/ClubApplicationFormsRepositoryCustom.java
+++ b/backend/src/main/java/moadong/club/repository/ClubApplicationFormsRepositoryCustom.java
@@ -28,6 +28,7 @@ public class ClubApplicationFormsRepositoryCustom {
         operations.add(Aggregation.project()
                 .and("_id").as("_id")
                 .and("title").as("title")
+                .and("createdAt").as("createdAt")
                 .and("editedAt").as("editedAt")
                 .and("status").as("status")
                 .and("semesterYear").as("semesterYear")
@@ -43,6 +44,7 @@ public class ClubApplicationFormsRepositoryCustom {
         GroupOperation groupOperation = Aggregation.group("semesterYear","active")
                 .push(new Document("_id", "$_id")
                         .append("title", "$title")
+                        .append("createdAt", "$createdAt")
                         .append("editedAt", "$editedAt")
                         .append("status","$status"))
                 .as("forms");

--- a/backend/src/test/java/moadong/club/service/ClubApplyAdminServiceTest.java
+++ b/backend/src/test/java/moadong/club/service/ClubApplyAdminServiceTest.java
@@ -13,8 +13,8 @@ import moadong.club.entity.Club;
 import moadong.club.entity.ClubApplicationForm;
 import moadong.club.payload.dto.ClubApplicationFormsResultItem;
 import moadong.club.payload.request.ClubApplicationFormEditRequest;
-import moadong.club.payload.response.ClubApplicationFormsResponse;
 import moadong.club.repository.ClubApplicationFormsRepository;
+import moadong.club.repository.ClubApplicationFormsRepositoryCustom;
 import moadong.club.repository.ClubRepository;
 import moadong.fixture.ClubApplicationEditFixture;
 import moadong.fixture.UserFixture;
@@ -40,6 +40,8 @@ public class ClubApplyAdminServiceTest {
     private ClubRepository clubRepository;
     @Autowired
     private ClubApplicationFormsRepository clubApplicationFormsRepository;
+    @Autowired
+    private ClubApplicationFormsRepositoryCustom clubApplicationFormsRepositoryCustom;
     @Autowired
     private PasswordEncoder passwordEncoder;
 
@@ -140,16 +142,16 @@ public class ClubApplyAdminServiceTest {
 
         try {
             // WHEN
-            ClubApplicationFormsResponse response = clubApplyAdminService.getClubApplicationForms(userDetails);
-
-            // THEN
-            ClubApplicationFormsResultItem item = response.forms().stream()
+            // 서비스는 userDetails.clubId로 조회하는데 픽스처가 User.clubId를 채우지 않으므로 레포지토리를 직접 호출한다
+            ClubApplicationFormsResultItem item = clubApplicationFormsRepositoryCustom
+                    .findClubApplicationFormsByClubId(clubId).stream()
                     .filter(group -> semesterYear.equals(group.semesterYear()))
                     .flatMap(group -> group.forms().stream())
                     .filter(form -> savedForm.getId().equals(form.id()))
                     .findFirst()
                     .orElseThrow(() -> new AssertionError("저장한 지원서가 조회 결과에 포함되어야 합니다."));
 
+            // THEN
             assertEquals(createdAt, item.createdAt(), "createdAt이 저장한 값 그대로 내려와야 합니다.");
             assertEquals(editedAt, item.editedAt(), "editedAt이 저장한 값 그대로 내려와야 합니다.");
         } finally {

--- a/backend/src/test/java/moadong/club/service/ClubApplyAdminServiceTest.java
+++ b/backend/src/test/java/moadong/club/service/ClubApplyAdminServiceTest.java
@@ -2,6 +2,7 @@ package moadong.club.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.time.LocalDateTime;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
@@ -10,7 +11,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import moadong.club.entity.Club;
 import moadong.club.entity.ClubApplicationForm;
+import moadong.club.payload.dto.ClubApplicationFormsResultItem;
 import moadong.club.payload.request.ClubApplicationFormEditRequest;
+import moadong.club.payload.response.ClubApplicationFormsResponse;
 import moadong.club.repository.ClubApplicationFormsRepository;
 import moadong.club.repository.ClubRepository;
 import moadong.fixture.ClubApplicationEditFixture;
@@ -117,6 +120,42 @@ public class ClubApplyAdminServiceTest {
 //        );
 //        assertEquals(expected, items);
 //    }
+
+    @Test
+    @DisplayName("지원서 목록 조회 시 각 지원서 항목에 createdAt이 함께 내려와야 한다")
+    void getClubApplicationFormsIncludesCreatedAt() {
+        // GIVEN: createdAt과 editedAt을 서로 다른 값으로 지정해 두 필드가 뒤바뀌지 않았는지 구분할 수 있게 한다
+        LocalDateTime createdAt = LocalDateTime.of(2024, 3, 1, 10, 0, 0);
+        LocalDateTime editedAt = LocalDateTime.of(2025, 5, 5, 12, 0, 0);
+        Integer semesterYear = 2024;
+
+        ClubApplicationForm savedForm = clubApplicationFormsRepository.save(
+                ClubApplicationForm.builder()
+                        .clubId(clubId)
+                        .title("createdAt 검증용 지원서")
+                        .createdAt(createdAt)
+                        .editedAt(editedAt)
+                        .semesterYear(semesterYear)
+                        .build());
+
+        try {
+            // WHEN
+            ClubApplicationFormsResponse response = clubApplyAdminService.getClubApplicationForms(userDetails);
+
+            // THEN
+            ClubApplicationFormsResultItem item = response.forms().stream()
+                    .filter(group -> semesterYear.equals(group.semesterYear()))
+                    .flatMap(group -> group.forms().stream())
+                    .filter(form -> savedForm.getId().equals(form.id()))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("저장한 지원서가 조회 결과에 포함되어야 합니다."));
+
+            assertEquals(createdAt, item.createdAt(), "createdAt이 저장한 값 그대로 내려와야 합니다.");
+            assertEquals(editedAt, item.editedAt(), "editedAt이 저장한 값 그대로 내려와야 합니다.");
+        } finally {
+            clubApplicationFormsRepository.deleteById(savedForm.getId());
+        }
+    }
 
     @Test
     @DisplayName("DB에 이미 존재하는 문서에 대해 동시 수정 시, 한 스레드만 성공하고 나머지는 실패해야 한다")


### PR DESCRIPTION
## Summary

#1881 프론트엔드 작업에서 요청한 백엔드 연동 건입니다.

`GET /api/club/application` 응답의 `forms[].forms[]` 각 항목에 `createdAt`을 추가합니다.
프론트엔드 연도 상세 페이지의 **최근 생성순 정렬** 및 생성일 표시 기능이 이 필드를 필요로 합니다.

## 변경 사항

- `ClubApplicationFormsResultItem`에 `createdAt` 필드 추가
- `ClubApplicationFormsRepositoryCustom`의 aggregation 두 곳에 `createdAt` 반영
  - `$project` 단계
  - `$group`의 `$push` 문서 (여기가 빠지면 최종 응답에 실리지 않음)

## 참고

- `ClubApplicationForm` 엔티티에는 이미 `createdAt`이 있고 `@Builder.Default`로 생성 시점에 항상 채워집니다.
- 이 필드는 컬렉션 최초 생성 커밋(`97051726`)부터 존재해서 `createdAt`이 없는 레거시 문서는 없습니다. 따라서 `$ifNull` 폴백 없이 그대로 프로젝션했습니다.
- 관리자 전용 `/api/admin/club/{clubId}/application`은 별도 경로(`AdminClubApplicationFormResponse`)를 사용하며 이번 범위에 포함하지 않았습니다.

## Test plan

- [x] `./gradlew compileJava`, `./gradlew compileTestJava` 통과
- [ ] `ClubApplyAdminServiceTest.getClubApplicationFormsIncludesCreatedAt` 통과 (CI 확인 필요)

통합 테스트를 추가했습니다. `createdAt`과 `editedAt`을 서로 다른 값으로 저장한 뒤 조회해서, 두 필드가 각각 올바르게 매핑되는지 검증합니다. `$project`나 `$push` 중 하나라도 누락되면 실패합니다.



