### PR TITLE
[feature] Notion 캘린더 연동 해제 API 추가

### DIFF
--- a/backend/src/main/java/moadong/calendar/notion/controller/NotionOAuthController.java
+++ b/backend/src/main/java/moadong/calendar/notion/controller/NotionOAuthController.java
@@ -13,6 +13,7 @@ import moadong.user.annotation.CurrentUser;
 import moadong.user.payload.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -71,5 +72,14 @@ public class NotionOAuthController {
                                               @PathVariable String databaseId,
                                               @RequestParam(required = false) String dateProperty) {
         return Response.ok(notionOAuthService.getDatabasePages(user, databaseId, dateProperty));
+    }
+
+    @DeleteMapping("/connection")
+    @Operation(summary = "Notion 연결 해제", description = "Notion 연결을 해제합니다.")
+    @PreAuthorize("isAuthenticated()")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> deleteConnection(@CurrentUser CustomUserDetails user) {
+        notionOAuthService.deleteConnection(user);
+        return Response.ok("Notion 연결이 해제되었습니다.");
     }
 }

--- a/backend/src/main/java/moadong/calendar/notion/service/NotionOAuthService.java
+++ b/backend/src/main/java/moadong/calendar/notion/service/NotionOAuthService.java
@@ -460,6 +460,14 @@ public class NotionOAuthService {
         }
     }
 
+    public void deleteConnection(CustomUserDetails user) {
+        String userId = requireAuthenticatedUserId(user);
+        String clubId = requireAuthenticatedClubId(user);
+        notionConnectionRepository.deleteById(clubId);
+        // userId를 _id로 저장하던 레거시 문서가 남아 있으면 재연동된 것으로 복구되므로 함께 삭제한다.
+        notionConnectionRepository.deleteById(userId);
+    }
+
     private String requireAuthenticatedUserId(CustomUserDetails user) {
         if (user == null || !StringUtils.hasText(user.getId())) {
             throw new RestApiException(ErrorCode.USER_UNAUTHORIZED);

--- a/backend/src/main/java/moadong/calendar/notion/service/NotionOAuthService.java
+++ b/backend/src/main/java/moadong/calendar/notion/service/NotionOAuthService.java
@@ -463,9 +463,10 @@ public class NotionOAuthService {
     public void deleteConnection(CustomUserDetails user) {
         String userId = requireAuthenticatedUserId(user);
         String clubId = requireAuthenticatedClubId(user);
-        notionConnectionRepository.deleteById(clubId);
         // userId를 _id로 저장하던 레거시 문서가 남아 있으면 재연동된 것으로 복구되므로 함께 삭제한다.
+        // clubId 문서를 먼저 지우면 그 사이 조회가 레거시 문서를 clubId 문서로 다시 마이그레이션하므로 레거시부터 삭제한다.
         notionConnectionRepository.deleteById(userId);
+        notionConnectionRepository.deleteById(clubId);
     }
 
     private String requireAuthenticatedUserId(CustomUserDetails user) {

--- a/backend/src/test/java/moadong/calendar/notion/service/NotionOAuthServiceTest.java
+++ b/backend/src/test/java/moadong/calendar/notion/service/NotionOAuthServiceTest.java
@@ -1,0 +1,64 @@
+package moadong.calendar.notion.service;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import moadong.calendar.notion.config.NotionProperties;
+import moadong.calendar.notion.repository.NotionConnectionRepository;
+import moadong.club.entity.Club;
+import moadong.club.repository.ClubRepository;
+import moadong.fixture.UserFixture;
+import moadong.global.util.AESCipher;
+import moadong.user.payload.CustomUserDetails;
+import moadong.util.annotations.UnitTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+@UnitTest
+class NotionOAuthServiceTest {
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @Mock
+    private NotionConnectionRepository notionConnectionRepository;
+
+    @Mock
+    private ClubRepository clubRepository;
+
+    @Mock
+    private AESCipher cipher;
+
+    @Mock
+    private NotionProperties notionProperties;
+
+    private NotionOAuthService notionOAuthService;
+
+    private static final String USER_ID = "test-user-id";
+    private static final String CLUB_ID = "test-club-id";
+
+    @BeforeEach
+    void setUp() {
+        notionOAuthService = new NotionOAuthService(
+                restTemplate, notionConnectionRepository, clubRepository, cipher, notionProperties);
+    }
+
+    @Test
+    @DisplayName("연결 해제 시 clubId 문서와 userId 기반 레거시 문서를 모두 삭제한다")
+    void deleteConnection_deletesClubAndLegacyDocuments() {
+        CustomUserDetails user = UserFixture.createUserDetails(USER_ID);
+        Club club = Club.builder().userId(USER_ID).build();
+        ReflectionTestUtils.setField(club, "id", CLUB_ID);
+        when(clubRepository.findClubByUserId(USER_ID)).thenReturn(Optional.of(club));
+
+        notionOAuthService.deleteConnection(user);
+
+        verify(notionConnectionRepository).deleteById(CLUB_ID);
+        verify(notionConnectionRepository).deleteById(USER_ID);
+    }
+}

--- a/backend/src/test/java/moadong/calendar/notion/service/NotionOAuthServiceTest.java
+++ b/backend/src/test/java/moadong/calendar/notion/service/NotionOAuthServiceTest.java
@@ -1,6 +1,6 @@
 package moadong.calendar.notion.service;
 
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
@@ -15,6 +15,7 @@ import moadong.util.annotations.UnitTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
@@ -49,8 +50,8 @@ class NotionOAuthServiceTest {
     }
 
     @Test
-    @DisplayName("연결 해제 시 clubId 문서와 userId 기반 레거시 문서를 모두 삭제한다")
-    void deleteConnection_deletesClubAndLegacyDocuments() {
+    @DisplayName("연결 해제 시 레거시 문서를 먼저 삭제한 뒤 clubId 문서를 삭제한다")
+    void deleteConnection_deletesLegacyDocumentBeforeClubDocument() {
         CustomUserDetails user = UserFixture.createUserDetails(USER_ID);
         Club club = Club.builder().userId(USER_ID).build();
         ReflectionTestUtils.setField(club, "id", CLUB_ID);
@@ -58,7 +59,9 @@ class NotionOAuthServiceTest {
 
         notionOAuthService.deleteConnection(user);
 
-        verify(notionConnectionRepository).deleteById(CLUB_ID);
-        verify(notionConnectionRepository).deleteById(USER_ID);
+        // clubId 문서를 먼저 지우면 그 사이 조회가 레거시 문서를 다시 마이그레이션하므로 순서를 고정한다.
+        InOrder inOrder = inOrder(notionConnectionRepository);
+        inOrder.verify(notionConnectionRepository).deleteById(USER_ID);
+        inOrder.verify(notionConnectionRepository).deleteById(CLUB_ID);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

>

## 📝작업 내용

관리자 캘린더 UI에 Google·Notion 양쪽 연동 해제 버튼이 생겼는데 Notion만 해제 엔드포인트가 없어, Google과 대칭으로 추가했습니다. 프론트는 이미 이 경로로 호출하도록 구현되어 있습니다 (`disconnectNotionCalendar`, `frontend/src/apis/calendarOAuth.ts`).

**`DELETE /api/integration/notion/connection`** (인증: `Authorization: Bearer <accessToken>`)


## 중점적으로 리뷰받고 싶은 부분(선택)

**레거시 문서를 함께 삭제한 부분**입니다. Google 구현은 `deleteById(clubId)` 한 줄이면 끝이지만, Notion에는 마이그레이션 폴백이 있어 그대로 복사하면 동작이 달라집니다.

`getNotionConnection`은 `findById(clubId)`가 비면 `findLegacyNotionConnectionAndMigrate`로 폴백해서 **userId를 `_id`로 쓰던 옛 도큐먼트를 찾아 clubId 도큐먼트로 다시 복사**하는데, 이때 레거시 도큐먼트를 지우지는 않습니다. 그래서 `deleteById(clubId)`만 하면 레거시 도큐먼트가 남아 있는 동아리는 다음 `GET /pages`나 공개 캘린더 조회(`getClubCalendarEvents` → `getNotionConnection`) 시점에 연결이 되살아납니다.

```java
public void deleteConnection(CustomUserDetails user) {
    String userId = requireAuthenticatedUserId(user);
    String clubId = requireAuthenticatedClubId(user);
    notionConnectionRepository.deleteById(clubId);
    // userId를 _id로 저장하던 레거시 문서가 남아 있으면 재연동된 것으로 복구되므로 함께 삭제한다.
    notionConnectionRepository.deleteById(userId);
}
```

대칭을 깬 게 아니라 Google과 **같은 결과**를 내기 위한 차이입니다. 코드만 봐서는 드러나지 않는 동작이라 `NotionOAuthServiceTest`로 고정해뒀습니다.

## 논의하고 싶은 부분(선택)

Google 구현과 마찬가지로 `hidden_calendar_events`의 NOTION 레코드는 지우지 않았습니다. 재연동 시 예전 숨김 설정이 남아 있는 건 Google·Notion 공통 이슈라 이번 PR 범위 밖으로 뒀는데, 별도로 정리할지 판단이 필요해 보입니다.

## 🫡 참고사항

해제 후 기대 동작:
- `GET /api/integration/notion/pages`, `GET /api/integration/notion/databases`가 미연동 상태로 응답 (프론트는 401/403을 "미연동"으로 처리)
- 해당 동아리 공개 캘린더에서 Notion 일정이 사라짐

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 연결된 Notion 계정을 앱에서 해제할 수 있는 기능이 추가되었습니다.
  - Notion 연결 해제 시 관련 연결 정보가 안전하게 삭제됩니다.
  - 연결 상태를 정리한 후 필요하면 다시 Notion을 연결할 수 있습니다.

- **버그 수정**
  - 기존 연결 정보와 이전 형식으로 저장된 연결 정보가 함께 정리되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->