### PR TITLE
Develop/be

### DIFF
--- a/backend/src/main/java/moadong/analytics/controller/ClubDetailDurationController.java
+++ b/backend/src/main/java/moadong/analytics/controller/ClubDetailDurationController.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import moadong.analytics.payload.request.ClubDetailDurationRecordRequest;
 import moadong.analytics.service.ClubDetailDurationService;
+import moadong.global.payload.Response;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,22 +19,29 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Analytics", description = "사용자 행동 통계 수집 API")
 public class ClubDetailDurationController {
 
+    /** IPv6 최대 표기 길이. */
+    private static final int MAX_IP_LENGTH = 45;
+
     private final ClubDetailDurationService clubDetailDurationService;
 
     @PostMapping("/duration")
     @Operation(summary = "동아리 상세 페이지 체류 시간 기록")
-    public ResponseEntity<Void> recordDuration(
+    public ResponseEntity<?> recordDuration(
             @RequestBody ClubDetailDurationRecordRequest request,
             HttpServletRequest httpServletRequest
     ) {
         clubDetailDurationService.record(request, clientIp(httpServletRequest));
-        return ResponseEntity.noContent().build();
+        return Response.ok("체류 시간이 기록되었습니다.");
     }
 
     private String clientIp(HttpServletRequest request) {
         String forwardedFor = request.getHeader("X-Forwarded-For");
         if (forwardedFor != null && !forwardedFor.isBlank()) {
-            return forwardedFor.split(",")[0].trim();
+            String candidate = forwardedFor.split(",")[0].trim();
+            // 헤더는 호출자가 조작할 수 있으므로 IP 길이를 벗어난 값은 요청 제한 키로 쓰지 않는다.
+            if (!candidate.isEmpty() && candidate.length() <= MAX_IP_LENGTH) {
+                return candidate;
+            }
         }
         return request.getRemoteAddr();
     }

--- a/backend/src/main/java/moadong/analytics/controller/ClubDetailDurationController.java
+++ b/backend/src/main/java/moadong/analytics/controller/ClubDetailDurationController.java
@@ -1,0 +1,40 @@
+package moadong.analytics.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import moadong.analytics.payload.request.ClubDetailDurationRecordRequest;
+import moadong.analytics.service.ClubDetailDurationService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/analytics/club-detail")
+@RequiredArgsConstructor
+@Tag(name = "Analytics", description = "사용자 행동 통계 수집 API")
+public class ClubDetailDurationController {
+
+    private final ClubDetailDurationService clubDetailDurationService;
+
+    @PostMapping("/duration")
+    @Operation(summary = "동아리 상세 페이지 체류 시간 기록")
+    public ResponseEntity<Void> recordDuration(
+            @RequestBody ClubDetailDurationRecordRequest request,
+            HttpServletRequest httpServletRequest
+    ) {
+        clubDetailDurationService.record(request, clientIp(httpServletRequest));
+        return ResponseEntity.noContent().build();
+    }
+
+    private String clientIp(HttpServletRequest request) {
+        String forwardedFor = request.getHeader("X-Forwarded-For");
+        if (forwardedFor != null && !forwardedFor.isBlank()) {
+            return forwardedFor.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+}

--- a/backend/src/main/java/moadong/analytics/entity/ClubDetailDurationSession.java
+++ b/backend/src/main/java/moadong/analytics/entity/ClubDetailDurationSession.java
@@ -9,33 +9,39 @@ import org.springframework.data.mongodb.core.index.CompoundIndex;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-@Document("club_analytics_daily")
-@CompoundIndex(name = "date_club_unique", def = "{'date': 1, 'clubId': 1}", unique = true)
+@Document("club_detail_duration_sessions")
+@CompoundIndex(name = "session_club_unique", def = "{'sessionId': 1, 'clubId': 1}", unique = true)
 @CompoundIndex(name = "club_date_idx", def = "{'clubId': 1, 'date': 1}")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class ClubAnalyticsDaily {
+public class ClubDetailDurationSession {
 
     @Id
     private String id;
 
     @Indexed
-    private LocalDate date;
+    private String sessionId;
+
+    @Indexed
+    private String visitorId;
 
     @Indexed
     private String clubId;
 
     private String clubName;
 
-    private long detailViewCount;
-    private long detailDurationSumSeconds;
-    private long detailDurationCount;
+    @Indexed
+    private LocalDate date;
+
+    private Instant enteredAt;
+    private Instant leftAt;
+    private long durationSeconds;
 
     private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
 }

--- a/backend/src/main/java/moadong/analytics/entity/ClubDetailVisitorDaily.java
+++ b/backend/src/main/java/moadong/analytics/entity/ClubDetailVisitorDaily.java
@@ -12,14 +12,13 @@ import org.springframework.data.mongodb.core.mapping.Document;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-@Document("club_analytics_daily")
-@CompoundIndex(name = "date_club_unique", def = "{'date': 1, 'clubId': 1}", unique = true)
-@CompoundIndex(name = "club_date_idx", def = "{'clubId': 1, 'date': 1}")
+@Document("club_detail_visitor_daily")
+@CompoundIndex(name = "club_date_visitor_unique", def = "{'clubId': 1, 'date': 1, 'visitorId': 1}", unique = true)
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class ClubAnalyticsDaily {
+public class ClubDetailVisitorDaily {
 
     @Id
     private String id;
@@ -30,11 +29,11 @@ public class ClubAnalyticsDaily {
     @Indexed
     private String clubId;
 
-    private String clubName;
+    @Indexed
+    private String visitorId;
 
-    private long detailViewCount;
-    private long detailDurationSumSeconds;
-    private long detailDurationCount;
+    private long durationSumSeconds;
+    private long sessionCount;
 
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;

--- a/backend/src/main/java/moadong/analytics/payload/request/ClubDetailDurationRecordRequest.java
+++ b/backend/src/main/java/moadong/analytics/payload/request/ClubDetailDurationRecordRequest.java
@@ -1,0 +1,14 @@
+package moadong.analytics.payload.request;
+
+import java.time.Instant;
+
+public record ClubDetailDurationRecordRequest(
+        String clubId,
+        String clubName,
+        String sessionId,
+        String visitorId,
+        Instant enteredAt,
+        Instant leftAt,
+        Long durationSeconds
+) {
+}

--- a/backend/src/main/java/moadong/analytics/payload/response/ClubStatisticsOverviewResponse.java
+++ b/backend/src/main/java/moadong/analytics/payload/response/ClubStatisticsOverviewResponse.java
@@ -9,6 +9,8 @@ public record ClubStatisticsOverviewResponse(
         LocalDate to,
         long totalDetailViews,
         long averageDetailDurationSeconds,
+        long uniqueDetailVisitors,
+        long averageDetailDurationSecondsPerVisitor,
         long totalApplicants
 ) {
 }

--- a/backend/src/main/java/moadong/analytics/repository/ClubDetailDurationSessionRepository.java
+++ b/backend/src/main/java/moadong/analytics/repository/ClubDetailDurationSessionRepository.java
@@ -1,0 +1,7 @@
+package moadong.analytics.repository;
+
+import moadong.analytics.entity.ClubDetailDurationSession;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface ClubDetailDurationSessionRepository extends MongoRepository<ClubDetailDurationSession, String> {
+}

--- a/backend/src/main/java/moadong/analytics/repository/ClubDetailVisitorDailyRepository.java
+++ b/backend/src/main/java/moadong/analytics/repository/ClubDetailVisitorDailyRepository.java
@@ -1,0 +1,7 @@
+package moadong.analytics.repository;
+
+import moadong.analytics.entity.ClubDetailVisitorDaily;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface ClubDetailVisitorDailyRepository extends MongoRepository<ClubDetailVisitorDaily, String> {
+}

--- a/backend/src/main/java/moadong/analytics/service/ClubAnalyticsRecordService.java
+++ b/backend/src/main/java/moadong/analytics/service/ClubAnalyticsRecordService.java
@@ -45,6 +45,10 @@ public class ClubAnalyticsRecordService {
         }
     }
 
+    public void recordDetailDuration(String clubId, String clubName, LocalDate date, long durationSeconds) {
+        incrementClubDailyWithoutExistenceCheck(clubId, clubName, date, 0, durationSeconds, 1);
+    }
+
     public void incrementClubDaily(
             String clubId,
             String clubName,

--- a/backend/src/main/java/moadong/analytics/service/ClubDetailDurationService.java
+++ b/backend/src/main/java/moadong/analytics/service/ClubDetailDurationService.java
@@ -1,0 +1,153 @@
+package moadong.analytics.service;
+
+import com.mongodb.client.result.UpdateResult;
+import lombok.RequiredArgsConstructor;
+import moadong.analytics.payload.request.ClubDetailDurationRecordRequest;
+import moadong.analytics.support.AnalyticsTime;
+import moadong.club.entity.Club;
+import moadong.club.repository.ClubRepository;
+import moadong.global.exception.ErrorCode;
+import moadong.global.exception.RestApiException;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ClubDetailDurationService {
+
+    private static final long MIN_DURATION_SECONDS = 1L;
+    private static final long MAX_DURATION_SECONDS = 3600L;
+    private static final String RATE_LIMIT_KEY_PREFIX = "analytics:club-detail-duration:ratelimit:";
+    private static final long RATE_LIMIT_WINDOW_SECONDS = 60L;
+    private static final long RATE_LIMIT_MAX_REQUESTS = 120L;
+    private static final RedisScript<Long> RATE_LIMIT_SCRIPT = RedisScript.of(
+            "local c = redis.call('INCR', KEYS[1])\n" +
+                    "if c == 1 then redis.call('EXPIRE', KEYS[1], ARGV[1]) end\n" +
+                    "return c",
+            Long.class
+    );
+
+    private final ClubAnalyticsRecordService clubAnalyticsRecordService;
+    private final ClubRepository clubRepository;
+    private final MongoTemplate mongoTemplate;
+    private final StringRedisTemplate stringRedisTemplate;
+
+    @Transactional
+    public void record(ClubDetailDurationRecordRequest request, String clientIp) {
+        validate(request);
+        validateRateLimit(request.clubId(), clientIp);
+        Club club = clubRepository.findById(request.clubId())
+                .orElseThrow(() -> new RestApiException(ErrorCode.CLUB_NOT_FOUND));
+
+        LocalDate eventDate = eventDate(request.leftAt());
+        LocalDateTime now = LocalDateTime.now(AnalyticsTime.KST);
+
+        if (!insertSession(request, club, eventDate, now)) {
+            return;
+        }
+
+        clubAnalyticsRecordService.recordDetailDuration(club.getId(), club.getName(), eventDate, request.durationSeconds());
+        incrementVisitorDaily(club.getId(), request.visitorId(), eventDate, request.durationSeconds(), now);
+    }
+
+    private void validate(ClubDetailDurationRecordRequest request) {
+        if (request == null
+                || isBlank(request.clubId())
+                || isBlank(request.sessionId())
+                || isBlank(request.visitorId())
+                || request.durationSeconds() == null
+                || request.durationSeconds() < MIN_DURATION_SECONDS
+                || request.durationSeconds() > MAX_DURATION_SECONDS) {
+            throw new RestApiException(ErrorCode.STATISTICS_EVENT_INVALID);
+        }
+        if (request.enteredAt() != null
+                && request.leftAt() != null
+                && request.leftAt().isBefore(request.enteredAt())) {
+            throw new RestApiException(ErrorCode.STATISTICS_EVENT_INVALID);
+        }
+    }
+
+    private void validateRateLimit(String clubId, String clientIp) {
+        Long requestCount = stringRedisTemplate.execute(
+                RATE_LIMIT_SCRIPT,
+                List.of(rateLimitKey(clubId, clientIp)),
+                String.valueOf(RATE_LIMIT_WINDOW_SECONDS)
+        );
+        if (requestCount != null && requestCount > RATE_LIMIT_MAX_REQUESTS) {
+            throw new RestApiException(ErrorCode.STATISTICS_EVENT_RATE_LIMITED);
+        }
+    }
+
+    private String rateLimitKey(String clubId, String clientIp) {
+        return RATE_LIMIT_KEY_PREFIX + clubId + ":" + (clientIp == null || clientIp.isBlank() ? "unknown" : clientIp);
+    }
+
+    private boolean insertSession(
+            ClubDetailDurationRecordRequest request,
+            Club club,
+            LocalDate eventDate,
+            LocalDateTime now
+    ) {
+        Query query = Query.query(
+                Criteria.where("sessionId").is(request.sessionId())
+                        .and("clubId").is(club.getId())
+        );
+        Update update = new Update()
+                .setOnInsert("sessionId", request.sessionId())
+                .setOnInsert("visitorId", request.visitorId())
+                .setOnInsert("clubId", club.getId())
+                .setOnInsert("clubName", club.getName())
+                .setOnInsert("date", eventDate)
+                .setOnInsert("enteredAt", request.enteredAt())
+                .setOnInsert("leftAt", request.leftAt())
+                .setOnInsert("durationSeconds", request.durationSeconds())
+                .setOnInsert("createdAt", now);
+        UpdateResult result = mongoTemplate.upsert(query, update, "club_detail_duration_sessions");
+        return result.getUpsertedId() != null;
+    }
+
+    private void incrementVisitorDaily(
+            String clubId,
+            String visitorId,
+            LocalDate date,
+            long durationSeconds,
+            LocalDateTime now
+    ) {
+        Query query = Query.query(
+                Criteria.where("clubId").is(clubId)
+                        .and("date").is(date)
+                        .and("visitorId").is(visitorId)
+        );
+        Update update = new Update()
+                .inc("durationSumSeconds", durationSeconds)
+                .inc("sessionCount", 1)
+                .set("updatedAt", now)
+                .setOnInsert("clubId", clubId)
+                .setOnInsert("date", date)
+                .setOnInsert("visitorId", visitorId)
+                .setOnInsert("createdAt", now);
+        mongoTemplate.upsert(query, update, "club_detail_visitor_daily");
+    }
+
+    private LocalDate eventDate(Instant leftAt) {
+        if (leftAt == null) {
+            return AnalyticsTime.todayKst();
+        }
+        return leftAt.atZone(AnalyticsTime.KST).toLocalDate();
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/backend/src/main/java/moadong/analytics/service/ClubDetailDurationService.java
+++ b/backend/src/main/java/moadong/analytics/service/ClubDetailDurationService.java
@@ -28,6 +28,8 @@ public class ClubDetailDurationService {
 
     private static final long MIN_DURATION_SECONDS = 1L;
     private static final long MAX_DURATION_SECONDS = 3600L;
+    /** clubId는 24자 Mongo id, sessionId/visitorId는 36자 UUID이므로 64자면 충분하다. */
+    private static final int MAX_ID_LENGTH = 64;
     private static final String RATE_LIMIT_KEY_PREFIX = "analytics:club-detail-duration:ratelimit:";
     private static final long RATE_LIMIT_WINDOW_SECONDS = 60L;
     private static final long RATE_LIMIT_MAX_REQUESTS = 120L;
@@ -63,9 +65,9 @@ public class ClubDetailDurationService {
 
     private void validate(ClubDetailDurationRecordRequest request) {
         if (request == null
-                || isBlank(request.clubId())
-                || isBlank(request.sessionId())
-                || isBlank(request.visitorId())
+                || isInvalidId(request.clubId())
+                || isInvalidId(request.sessionId())
+                || isInvalidId(request.visitorId())
                 || request.durationSeconds() == null
                 || request.durationSeconds() < MIN_DURATION_SECONDS
                 || request.durationSeconds() > MAX_DURATION_SECONDS) {
@@ -147,7 +149,10 @@ public class ClubDetailDurationService {
         return leftAt.atZone(AnalyticsTime.KST).toLocalDate();
     }
 
-    private boolean isBlank(String value) {
-        return value == null || value.isBlank();
+    /**
+     * 인증 없는 공개 API이므로 식별자 길이를 제한해 Redis 키와 Mongo 질의에 임의 길이 값이 들어가지 않게 한다.
+     */
+    private boolean isInvalidId(String value) {
+        return value == null || value.isBlank() || value.length() > MAX_ID_LENGTH;
     }
 }

--- a/backend/src/main/java/moadong/analytics/service/ClubStatisticsAdminService.java
+++ b/backend/src/main/java/moadong/analytics/service/ClubStatisticsAdminService.java
@@ -17,6 +17,7 @@ import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.aggregation.AggregationResults;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.stereotype.Service;
+import org.bson.Document;
 
 import java.time.LocalDate;
 import java.util.*;
@@ -42,6 +43,7 @@ public class ClubStatisticsAdminService {
         long totalDetailViews = dailyStats.stream().mapToLong(ClubAnalyticsDaily::getDetailViewCount).sum();
         long durationSum = dailyStats.stream().mapToLong(ClubAnalyticsDaily::getDetailDurationSumSeconds).sum();
         long durationCount = dailyStats.stream().mapToLong(ClubAnalyticsDaily::getDetailDurationCount).sum();
+        VisitorDurationSummary visitorDurationSummary = getVisitorDurationSummary(clubId, from, to);
         long totalApplicants = applicantCounts.values().stream().mapToLong(Long::longValue).sum();
 
         return new ClubStatisticsOverviewResponse(
@@ -51,6 +53,8 @@ public class ClubStatisticsAdminService {
                 to,
                 totalDetailViews,
                 average(durationSum, durationCount),
+                visitorDurationSummary.uniqueVisitors(),
+                average(visitorDurationSummary.durationSumSeconds(), visitorDurationSummary.uniqueVisitors()),
                 totalApplicants
         );
     }
@@ -118,5 +122,36 @@ public class ClubStatisticsAdminService {
 
     private long average(long sum, long count) {
         return count == 0 ? 0 : Math.round((double) sum / count);
+    }
+
+    private VisitorDurationSummary getVisitorDurationSummary(String clubId, LocalDate from, LocalDate to) {
+        Aggregation aggregation = Aggregation.newAggregation(
+                Aggregation.match(Criteria.where("clubId").is(clubId).and("date").gte(from).lte(to)),
+                Aggregation.group("visitorId").sum("durationSumSeconds").as("visitorDurationSeconds"),
+                Aggregation.group()
+                        .count().as("uniqueVisitors")
+                        .sum("visitorDurationSeconds").as("durationSumSeconds")
+        );
+
+        AggregationResults<Document> results = mongoTemplate.aggregate(
+                aggregation,
+                "club_detail_visitor_daily",
+                Document.class
+        );
+        Document summary = results.getUniqueMappedResult();
+        if (summary == null) {
+            return new VisitorDurationSummary(0, 0);
+        }
+        return new VisitorDurationSummary(
+                longValue(summary.get("uniqueVisitors")),
+                longValue(summary.get("durationSumSeconds"))
+        );
+    }
+
+    private long longValue(Object value) {
+        return value instanceof Number number ? number.longValue() : 0;
+    }
+
+    private record VisitorDurationSummary(long uniqueVisitors, long durationSumSeconds) {
     }
 }

--- a/backend/src/main/java/moadong/calendar/custom/controller/CustomCalendarEventController.java
+++ b/backend/src/main/java/moadong/calendar/custom/controller/CustomCalendarEventController.java
@@ -1,0 +1,68 @@
+package moadong.calendar.custom.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import moadong.calendar.custom.payload.request.CustomCalendarEventRequest;
+import moadong.calendar.custom.service.CustomCalendarEventService;
+import moadong.global.payload.Response;
+import moadong.user.annotation.CurrentUser;
+import moadong.user.payload.CustomUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/integration/custom-events")
+@RequiredArgsConstructor
+@Tag(name = "Custom Calendar Events", description = "커스텀 캘린더 이벤트 관리 API")
+public class CustomCalendarEventController {
+
+    private final CustomCalendarEventService customCalendarEventService;
+
+    @PostMapping
+    @Operation(summary = "커스텀 캘린더 이벤트 생성", description = "관리자가 직접 입력한 캘린더 이벤트를 생성합니다.")
+    @PreAuthorize("isAuthenticated()")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> createEvent(@CurrentUser CustomUserDetails user,
+                                         @RequestBody @Valid CustomCalendarEventRequest request) {
+        return Response.ok(customCalendarEventService.create(user, request));
+    }
+
+    @GetMapping
+    @Operation(summary = "커스텀 캘린더 이벤트 목록 조회", description = "동아리의 커스텀 캘린더 이벤트 목록을 조회합니다.")
+    @PreAuthorize("isAuthenticated()")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> getEvents(@CurrentUser CustomUserDetails user) {
+        return Response.ok(customCalendarEventService.list(user));
+    }
+
+    @PutMapping("/{eventId}")
+    @Operation(summary = "커스텀 캘린더 이벤트 수정", description = "커스텀 캘린더 이벤트를 수정합니다.")
+    @PreAuthorize("isAuthenticated()")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> updateEvent(@CurrentUser CustomUserDetails user,
+                                         @PathVariable String eventId,
+                                         @RequestBody @Valid CustomCalendarEventRequest request) {
+        return Response.ok(customCalendarEventService.update(user, eventId, request));
+    }
+
+    @DeleteMapping("/{eventId}")
+    @Operation(summary = "커스텀 캘린더 이벤트 삭제", description = "커스텀 캘린더 이벤트를 삭제합니다.")
+    @PreAuthorize("isAuthenticated()")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> deleteEvent(@CurrentUser CustomUserDetails user,
+                                         @PathVariable String eventId) {
+        customCalendarEventService.delete(user, eventId);
+        return Response.ok("커스텀 캘린더 이벤트가 삭제되었습니다.");
+    }
+}

--- a/backend/src/main/java/moadong/calendar/custom/controller/CustomCalendarEventController.java
+++ b/backend/src/main/java/moadong/calendar/custom/controller/CustomCalendarEventController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -57,12 +58,15 @@ public class CustomCalendarEventController {
     }
 
     @DeleteMapping("/{eventId}")
-    @Operation(summary = "커스텀 캘린더 이벤트 삭제", description = "커스텀 캘린더 이벤트를 삭제합니다.")
+    @Operation(summary = "커스텀 캘린더 이벤트 삭제",
+            description = "커스텀 캘린더 이벤트를 삭제합니다. 반복 일정은 scope(ALL/THIS/THIS_AND_FOLLOWING)와 기준 발생일 date로 삭제 범위를 지정합니다.")
     @PreAuthorize("isAuthenticated()")
     @SecurityRequirement(name = "BearerAuth")
     public ResponseEntity<?> deleteEvent(@CurrentUser CustomUserDetails user,
-                                         @PathVariable String eventId) {
-        customCalendarEventService.delete(user, eventId);
+                                         @PathVariable String eventId,
+                                         @RequestParam(required = false) String scope,
+                                         @RequestParam(required = false) String date) {
+        customCalendarEventService.delete(user, eventId, scope, date);
         return Response.ok("커스텀 캘린더 이벤트가 삭제되었습니다.");
     }
 }

--- a/backend/src/main/java/moadong/calendar/custom/entity/CustomCalendarEvent.java
+++ b/backend/src/main/java/moadong/calendar/custom/entity/CustomCalendarEvent.java
@@ -1,0 +1,45 @@
+package moadong.calendar.custom.entity;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document("custom_calendar_events")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CustomCalendarEvent {
+
+    @Id
+    private String id;
+
+    @Indexed
+    private String clubId;
+
+    private String title;
+
+    private String start;
+
+    private String end;
+
+    private String url;
+
+    private String description;
+
+    private LocalDateTime updatedAt;
+
+    public void update(String title, String start, String end, String url, String description) {
+        this.title = title;
+        this.start = start;
+        this.end = end;
+        this.url = url;
+        this.description = description;
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/moadong/calendar/custom/entity/CustomCalendarEvent.java
+++ b/backend/src/main/java/moadong/calendar/custom/entity/CustomCalendarEvent.java
@@ -1,6 +1,7 @@
 package moadong.calendar.custom.entity;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -32,14 +33,43 @@ public class CustomCalendarEvent {
 
     private String description;
 
+    private String eventType;
+
+    private String color;
+
+    private List<String> dates;
+
+    private CustomEventRecurrence recurrence;
+
     private LocalDateTime updatedAt;
 
-    public void update(String title, String start, String end, String url, String description) {
+    public void update(String title, String start, String end, String url, String description,
+                       String eventType, String color, List<String> dates, CustomEventRecurrence recurrence) {
         this.title = title;
         this.start = start;
         this.end = end;
         this.url = url;
         this.description = description;
+        this.eventType = eventType;
+        this.color = color;
+        this.dates = dates;
+        this.recurrence = recurrence;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void excludeDate(String date) {
+        if (recurrence == null) {
+            return;
+        }
+        this.recurrence = recurrence.withExcludedDate(date);
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updateRecurrenceEnd(String recurrenceEnd) {
+        if (recurrence == null) {
+            return;
+        }
+        this.recurrence = recurrence.withEnd(recurrenceEnd);
         this.updatedAt = LocalDateTime.now();
     }
 }

--- a/backend/src/main/java/moadong/calendar/custom/entity/CustomCalendarEvent.java
+++ b/backend/src/main/java/moadong/calendar/custom/entity/CustomCalendarEvent.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import moadong.calendar.custom.payload.request.CustomCalendarEventRequest;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -43,17 +44,16 @@ public class CustomCalendarEvent {
 
     private LocalDateTime updatedAt;
 
-    public void update(String title, String start, String end, String url, String description,
-                       String eventType, String color, List<String> dates, CustomEventRecurrence recurrence) {
-        this.title = title;
-        this.start = start;
-        this.end = end;
-        this.url = url;
-        this.description = description;
+    public void update(CustomCalendarEventRequest request, String eventType) {
+        this.title = request.title();
+        this.start = request.start();
+        this.end = request.end();
+        this.url = request.url();
+        this.description = request.description();
         this.eventType = eventType;
-        this.color = color;
-        this.dates = dates;
-        this.recurrence = recurrence;
+        this.color = request.color();
+        this.dates = request.dates();
+        this.recurrence = request.recurrence();
         this.updatedAt = LocalDateTime.now();
     }
 

--- a/backend/src/main/java/moadong/calendar/custom/entity/CustomEventRecurrence.java
+++ b/backend/src/main/java/moadong/calendar/custom/entity/CustomEventRecurrence.java
@@ -1,0 +1,23 @@
+package moadong.calendar.custom.entity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public record CustomEventRecurrence(
+        String frequency,
+        List<Integer> weekdays,
+        String end,
+        List<String> excludedDates
+) {
+    public CustomEventRecurrence withExcludedDate(String date) {
+        List<String> updated = excludedDates == null ? new ArrayList<>() : new ArrayList<>(excludedDates);
+        if (!updated.contains(date)) {
+            updated.add(date);
+        }
+        return new CustomEventRecurrence(frequency, weekdays, end, updated);
+    }
+
+    public CustomEventRecurrence withEnd(String newEnd) {
+        return new CustomEventRecurrence(frequency, weekdays, newEnd, excludedDates);
+    }
+}

--- a/backend/src/main/java/moadong/calendar/custom/payload/request/CustomCalendarEventRequest.java
+++ b/backend/src/main/java/moadong/calendar/custom/payload/request/CustomCalendarEventRequest.java
@@ -1,0 +1,12 @@
+package moadong.calendar.custom.payload.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CustomCalendarEventRequest(
+        @NotBlank String title,
+        @NotBlank String start,
+        String end,
+        String url,
+        String description
+) {
+}

--- a/backend/src/main/java/moadong/calendar/custom/payload/request/CustomCalendarEventRequest.java
+++ b/backend/src/main/java/moadong/calendar/custom/payload/request/CustomCalendarEventRequest.java
@@ -1,12 +1,18 @@
 package moadong.calendar.custom.payload.request;
 
 import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+import moadong.calendar.custom.entity.CustomEventRecurrence;
 
 public record CustomCalendarEventRequest(
         @NotBlank String title,
         @NotBlank String start,
         String end,
         String url,
-        String description
+        String description,
+        String eventType,
+        String color,
+        List<String> dates,
+        CustomEventRecurrence recurrence
 ) {
 }

--- a/backend/src/main/java/moadong/calendar/custom/payload/response/CustomCalendarEventResponse.java
+++ b/backend/src/main/java/moadong/calendar/custom/payload/response/CustomCalendarEventResponse.java
@@ -1,0 +1,35 @@
+package moadong.calendar.custom.payload.response;
+
+import java.util.List;
+import moadong.calendar.custom.entity.CustomCalendarEvent;
+import moadong.calendar.custom.entity.CustomEventRecurrence;
+
+public record CustomCalendarEventResponse(
+        String id,
+        String title,
+        String start,
+        String end,
+        String url,
+        String description,
+        String source,
+        String eventType,
+        String color,
+        List<String> dates,
+        CustomEventRecurrence recurrence
+) {
+    public static CustomCalendarEventResponse from(CustomCalendarEvent event) {
+        return new CustomCalendarEventResponse(
+                event.getId(),
+                event.getTitle(),
+                event.getStart(),
+                event.getEnd(),
+                event.getUrl(),
+                event.getDescription(),
+                "CUSTOM",
+                event.getEventType() == null ? "SINGLE" : event.getEventType(),
+                event.getColor(),
+                event.getDates(),
+                event.getRecurrence()
+        );
+    }
+}

--- a/backend/src/main/java/moadong/calendar/custom/repository/CustomCalendarEventRepository.java
+++ b/backend/src/main/java/moadong/calendar/custom/repository/CustomCalendarEventRepository.java
@@ -1,0 +1,17 @@
+package moadong.calendar.custom.repository;
+
+import java.util.List;
+import java.util.Optional;
+import moadong.calendar.custom.entity.CustomCalendarEvent;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface CustomCalendarEventRepository extends MongoRepository<CustomCalendarEvent, String> {
+
+    List<CustomCalendarEvent> findByClubId(String clubId);
+
+    Optional<CustomCalendarEvent> findByIdAndClubId(String id, String clubId);
+
+    long deleteByIdAndClubId(String id, String clubId);
+
+    boolean existsByClubId(String clubId);
+}

--- a/backend/src/main/java/moadong/calendar/custom/repository/CustomCalendarEventRepository.java
+++ b/backend/src/main/java/moadong/calendar/custom/repository/CustomCalendarEventRepository.java
@@ -11,7 +11,5 @@ public interface CustomCalendarEventRepository extends MongoRepository<CustomCal
 
     Optional<CustomCalendarEvent> findByIdAndClubId(String id, String clubId);
 
-    long deleteByIdAndClubId(String id, String clubId);
-
     boolean existsByClubId(String clubId);
 }

--- a/backend/src/main/java/moadong/calendar/custom/service/CustomCalendarEventService.java
+++ b/backend/src/main/java/moadong/calendar/custom/service/CustomCalendarEventService.java
@@ -1,0 +1,107 @@
+package moadong.calendar.custom.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import moadong.calendar.custom.entity.CustomCalendarEvent;
+import moadong.calendar.custom.payload.request.CustomCalendarEventRequest;
+import moadong.calendar.custom.repository.CustomCalendarEventRepository;
+import moadong.club.entity.Club;
+import moadong.club.payload.dto.ClubCalendarEventResult;
+import moadong.club.repository.ClubRepository;
+import moadong.global.exception.ErrorCode;
+import moadong.global.exception.RestApiException;
+import moadong.user.payload.CustomUserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+public class CustomCalendarEventService {
+
+    private final CustomCalendarEventRepository customCalendarEventRepository;
+    private final ClubRepository clubRepository;
+
+    public ClubCalendarEventResult create(CustomUserDetails user, CustomCalendarEventRequest request) {
+        String clubId = requireAuthenticatedClubId(user);
+
+        CustomCalendarEvent event = CustomCalendarEvent.builder()
+                .clubId(clubId)
+                .title(request.title())
+                .start(request.start())
+                .end(request.end())
+                .url(request.url())
+                .description(request.description())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        return toResult(customCalendarEventRepository.save(event));
+    }
+
+    public List<ClubCalendarEventResult> list(CustomUserDetails user) {
+        String clubId = requireAuthenticatedClubId(user);
+        return getClubCalendarEvents(clubId);
+    }
+
+    public ClubCalendarEventResult update(CustomUserDetails user, String eventId, CustomCalendarEventRequest request) {
+        String clubId = requireAuthenticatedClubId(user);
+
+        CustomCalendarEvent event = customCalendarEventRepository.findByIdAndClubId(eventId, clubId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.CUSTOM_EVENT_NOT_FOUND));
+
+        event.update(request.title(), request.start(), request.end(), request.url(), request.description());
+
+        return toResult(customCalendarEventRepository.save(event));
+    }
+
+    public void delete(CustomUserDetails user, String eventId) {
+        String clubId = requireAuthenticatedClubId(user);
+
+        long deletedCount = customCalendarEventRepository.deleteByIdAndClubId(eventId, clubId);
+        if (deletedCount == 0) {
+            throw new RestApiException(ErrorCode.CUSTOM_EVENT_NOT_FOUND);
+        }
+    }
+
+    public List<ClubCalendarEventResult> getClubCalendarEvents(String clubId) {
+        if (!StringUtils.hasText(clubId)) {
+            return List.of();
+        }
+
+        return customCalendarEventRepository.findByClubId(clubId).stream()
+                .map(this::toResult)
+                .toList();
+    }
+
+    public boolean hasCalendarConnection(String clubId) {
+        if (!StringUtils.hasText(clubId)) {
+            return false;
+        }
+        return customCalendarEventRepository.existsByClubId(clubId);
+    }
+
+    private ClubCalendarEventResult toResult(CustomCalendarEvent event) {
+        return ClubCalendarEventResult.ofCustom(
+                event.getId(),
+                event.getTitle(),
+                event.getStart(),
+                event.getEnd(),
+                event.getUrl(),
+                event.getDescription()
+        );
+    }
+
+    private String requireAuthenticatedClubId(CustomUserDetails user) {
+        if (user == null || !StringUtils.hasText(user.getId())) {
+            throw new RestApiException(ErrorCode.USER_UNAUTHORIZED);
+        }
+
+        Club club = clubRepository.findClubByUserId(user.getId())
+                .orElseThrow(() -> new RestApiException(ErrorCode.CUSTOM_EVENT_CLUB_NOT_FOUND));
+
+        if (!StringUtils.hasText(club.getId())) {
+            throw new RestApiException(ErrorCode.CUSTOM_EVENT_CLUB_NOT_FOUND);
+        }
+        return club.getId();
+    }
+}

--- a/backend/src/main/java/moadong/calendar/custom/service/CustomCalendarEventService.java
+++ b/backend/src/main/java/moadong/calendar/custom/service/CustomCalendarEventService.java
@@ -126,6 +126,7 @@ public class CustomCalendarEventService {
 
     /**
      * 공개 캘린더는 발생일마다 하나씩 펼쳐 내려준다.
+     * 단, PERIOD는 start/end를 가진 한 건으로 유지해 프론트가 연속 막대로 그릴 수 있게 한다.
      * 발생일이 여러 개면 프론트에서 구분할 수 있도록 id에 날짜를 덧붙인다.
      */
     private List<ClubCalendarEventResult> toPublicResults(CustomCalendarEvent event) {
@@ -135,6 +136,8 @@ public class CustomCalendarEventService {
             return List.of();
         }
 
+        String eventType = StringUtils.hasText(event.getEventType()) ? event.getEventType() : "SINGLE";
+
         if (occurrences.size() == 1) {
             return List.of(ClubCalendarEventResult.ofCustom(
                     event.getId(),
@@ -142,7 +145,9 @@ public class CustomCalendarEventService {
                     occurrences.get(0),
                     event.getEnd(),
                     event.getUrl(),
-                    event.getDescription()
+                    event.getDescription(),
+                    eventType,
+                    event.getColor()
             ));
         }
 
@@ -153,7 +158,9 @@ public class CustomCalendarEventService {
                         date,
                         null,
                         event.getUrl(),
-                        event.getDescription()
+                        event.getDescription(),
+                        eventType,
+                        event.getColor()
                 ))
                 .toList();
     }

--- a/backend/src/main/java/moadong/calendar/custom/service/CustomCalendarEventService.java
+++ b/backend/src/main/java/moadong/calendar/custom/service/CustomCalendarEventService.java
@@ -97,7 +97,7 @@ public class CustomCalendarEventService {
             return;
         }
 
-        LocalDate newRecurrenceEnd = targetDate.minusDays(1);
+        LocalDate newRecurrenceEnd = earlierOfExistingEnd(event, targetDate.minusDays(1));
         if (newRecurrenceEnd.isBefore(parseRequiredDate(event.getStart()))) {
             customCalendarEventRepository.delete(event);
             return;
@@ -163,6 +163,19 @@ public class CustomCalendarEventService {
                         event.getColor()
                 ))
                 .toList();
+    }
+
+    /**
+     * THIS_AND_FOLLOWING 삭제는 종료일을 앞당기기만 해야 한다.
+     * 기준일이 기존 종료일보다 뒤면 종료일을 그대로 두어 발생일이 늘어나지 않게 한다.
+     */
+    private LocalDate earlierOfExistingEnd(CustomCalendarEvent event, LocalDate newRecurrenceEnd) {
+        String existingEnd = event.getRecurrence().end();
+        if (!StringUtils.hasText(existingEnd)) {
+            return newRecurrenceEnd;
+        }
+        LocalDate parsedExistingEnd = parseRequiredDate(existingEnd);
+        return parsedExistingEnd.isBefore(newRecurrenceEnd) ? parsedExistingEnd : newRecurrenceEnd;
     }
 
     private boolean isRecurring(CustomCalendarEvent event) {

--- a/backend/src/main/java/moadong/calendar/custom/service/CustomCalendarEventService.java
+++ b/backend/src/main/java/moadong/calendar/custom/service/CustomCalendarEventService.java
@@ -1,5 +1,7 @@
 package moadong.calendar.custom.service;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -27,6 +29,7 @@ public class CustomCalendarEventService {
     private static final Set<String> COLORS = Set.of("PINK", "YELLOW", "MINT", "BLUE", "PURPLE", "ORANGE");
     private static final Set<String> FREQUENCIES = Set.of("WEEKLY", "MONTHLY", "YEARLY");
     private static final Set<String> DELETE_SCOPES = Set.of("ALL", "THIS", "THIS_AND_FOLLOWING");
+    private static final int MAX_EVENT_DATES = 365;
 
     private final CustomCalendarEventRepository customCalendarEventRepository;
     private final ClubRepository clubRepository;
@@ -69,8 +72,7 @@ public class CustomCalendarEventService {
         CustomCalendarEvent event = customCalendarEventRepository.findByIdAndClubId(eventId, clubId)
                 .orElseThrow(() -> new RestApiException(ErrorCode.CUSTOM_EVENT_NOT_FOUND));
 
-        event.update(request.title(), request.start(), request.end(), request.url(), request.description(),
-                eventType, request.color(), request.dates(), request.recurrence());
+        event.update(request, eventType);
 
         return CustomCalendarEventResponse.from(customCalendarEventRepository.save(event));
     }
@@ -174,7 +176,12 @@ public class CustomCalendarEventService {
         LocalDate start = validateDates(request.start(), request.end());
         String eventType = resolveEventType(request.eventType());
         validateAllowedValue(request.color(), COLORS);
+        validateUrl(request.url());
 
+        validateCollectionSize(request.dates());
+        if ("MULTI".equals(eventType) && (request.dates() == null || request.dates().isEmpty())) {
+            throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
+        }
         if (request.dates() != null) {
             request.dates().forEach(this::parseRequiredDate);
             if (!request.dates().isEmpty() && !request.start().equals(request.dates().get(0))) {
@@ -195,6 +202,7 @@ public class CustomCalendarEventService {
         }
 
         validateRequiredAllowedValue(recurrence.frequency(), FREQUENCIES);
+        validateCollectionSize(recurrence.weekdays());
         validateWeekdays(recurrence.weekdays());
 
         if (StringUtils.hasText(recurrence.end())) {
@@ -204,6 +212,7 @@ public class CustomCalendarEventService {
             }
         }
         if (recurrence.excludedDates() != null) {
+            validateCollectionSize(recurrence.excludedDates());
             recurrence.excludedDates().forEach(this::parseRequiredDate);
         }
         return eventType;
@@ -235,6 +244,26 @@ public class CustomCalendarEventService {
         }
         boolean hasInvalidWeekday = weekdays.stream().anyMatch(weekday -> weekday == null || weekday < 0 || weekday > 6);
         if (hasInvalidWeekday) {
+            throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
+        }
+    }
+
+    private void validateCollectionSize(List<?> values) {
+        if (values != null && values.size() > MAX_EVENT_DATES) {
+            throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
+        }
+    }
+
+    private void validateUrl(String url) {
+        if (!StringUtils.hasText(url)) {
+            return;
+        }
+        try {
+            String scheme = new URI(url).getScheme();
+            if (!"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme)) {
+                throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
+            }
+        } catch (URISyntaxException e) {
             throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
         }
     }

--- a/backend/src/main/java/moadong/calendar/custom/service/CustomCalendarEventService.java
+++ b/backend/src/main/java/moadong/calendar/custom/service/CustomCalendarEventService.java
@@ -3,9 +3,12 @@ package moadong.calendar.custom.service;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import moadong.calendar.custom.entity.CustomCalendarEvent;
+import moadong.calendar.custom.entity.CustomEventRecurrence;
 import moadong.calendar.custom.payload.request.CustomCalendarEventRequest;
+import moadong.calendar.custom.payload.response.CustomCalendarEventResponse;
 import moadong.calendar.custom.repository.CustomCalendarEventRepository;
 import moadong.club.entity.Club;
 import moadong.club.payload.dto.ClubCalendarEventResult;
@@ -20,12 +23,18 @@ import org.springframework.util.StringUtils;
 @RequiredArgsConstructor
 public class CustomCalendarEventService {
 
+    private static final Set<String> EVENT_TYPES = Set.of("SINGLE", "PERIOD", "RECURRING", "MULTI");
+    private static final Set<String> COLORS = Set.of("PINK", "YELLOW", "MINT", "BLUE", "PURPLE", "ORANGE");
+    private static final Set<String> FREQUENCIES = Set.of("WEEKLY", "MONTHLY", "YEARLY");
+    private static final Set<String> DELETE_SCOPES = Set.of("ALL", "THIS", "THIS_AND_FOLLOWING");
+
     private final CustomCalendarEventRepository customCalendarEventRepository;
     private final ClubRepository clubRepository;
+    private final CustomEventOccurrenceExpander occurrenceExpander;
 
-    public ClubCalendarEventResult create(CustomUserDetails user, CustomCalendarEventRequest request) {
+    public CustomCalendarEventResponse create(CustomUserDetails user, CustomCalendarEventRequest request) {
         String clubId = requireAuthenticatedClubId(user);
-        validateDates(request.start(), request.end());
+        String eventType = validateRequest(request);
 
         CustomCalendarEvent event = CustomCalendarEvent.builder()
                 .clubId(clubId)
@@ -34,36 +43,66 @@ public class CustomCalendarEventService {
                 .end(request.end())
                 .url(request.url())
                 .description(request.description())
+                .eventType(eventType)
+                .color(request.color())
+                .dates(request.dates())
+                .recurrence(request.recurrence())
                 .updatedAt(LocalDateTime.now())
                 .build();
 
-        return toResult(customCalendarEventRepository.save(event));
+        return CustomCalendarEventResponse.from(customCalendarEventRepository.save(event));
     }
 
-    public List<ClubCalendarEventResult> list(CustomUserDetails user) {
+    public List<CustomCalendarEventResponse> list(CustomUserDetails user) {
         String clubId = requireAuthenticatedClubId(user);
-        return getClubCalendarEvents(clubId);
+
+        return customCalendarEventRepository.findByClubId(clubId).stream()
+                .map(CustomCalendarEventResponse::from)
+                .toList();
     }
 
-    public ClubCalendarEventResult update(CustomUserDetails user, String eventId, CustomCalendarEventRequest request) {
+    public CustomCalendarEventResponse update(CustomUserDetails user, String eventId,
+                                              CustomCalendarEventRequest request) {
         String clubId = requireAuthenticatedClubId(user);
-        validateDates(request.start(), request.end());
+        String eventType = validateRequest(request);
 
         CustomCalendarEvent event = customCalendarEventRepository.findByIdAndClubId(eventId, clubId)
                 .orElseThrow(() -> new RestApiException(ErrorCode.CUSTOM_EVENT_NOT_FOUND));
 
-        event.update(request.title(), request.start(), request.end(), request.url(), request.description());
+        event.update(request.title(), request.start(), request.end(), request.url(), request.description(),
+                eventType, request.color(), request.dates(), request.recurrence());
 
-        return toResult(customCalendarEventRepository.save(event));
+        return CustomCalendarEventResponse.from(customCalendarEventRepository.save(event));
     }
 
-    public void delete(CustomUserDetails user, String eventId) {
+    public void delete(CustomUserDetails user, String eventId, String scope, String date) {
         String clubId = requireAuthenticatedClubId(user);
+        String resolvedScope = resolveDeleteScope(scope);
 
-        long deletedCount = customCalendarEventRepository.deleteByIdAndClubId(eventId, clubId);
-        if (deletedCount == 0) {
-            throw new RestApiException(ErrorCode.CUSTOM_EVENT_NOT_FOUND);
+        CustomCalendarEvent event = customCalendarEventRepository.findByIdAndClubId(eventId, clubId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.CUSTOM_EVENT_NOT_FOUND));
+
+        if ("ALL".equals(resolvedScope) || !isRecurring(event)) {
+            customCalendarEventRepository.delete(event);
+            return;
         }
+
+        LocalDate targetDate = parseRequiredDate(date);
+
+        if ("THIS".equals(resolvedScope)) {
+            event.excludeDate(targetDate.toString());
+            customCalendarEventRepository.save(event);
+            return;
+        }
+
+        LocalDate newRecurrenceEnd = targetDate.minusDays(1);
+        if (newRecurrenceEnd.isBefore(parseRequiredDate(event.getStart()))) {
+            customCalendarEventRepository.delete(event);
+            return;
+        }
+
+        event.updateRecurrenceEnd(newRecurrenceEnd.toString());
+        customCalendarEventRepository.save(event);
     }
 
     public List<ClubCalendarEventResult> getClubCalendarEvents(String clubId) {
@@ -72,7 +111,7 @@ public class CustomCalendarEventService {
         }
 
         return customCalendarEventRepository.findByClubId(clubId).stream()
-                .map(this::toResult)
+                .flatMap(event -> toPublicResults(event).stream())
                 .toList();
     }
 
@@ -83,39 +122,142 @@ public class CustomCalendarEventService {
         return customCalendarEventRepository.existsByClubId(clubId);
     }
 
-    private void validateDates(String start, String end) {
-        LocalDate parsedStart;
-        try {
-            parsedStart = LocalDate.parse(start);
-        } catch (Exception e) {
-            throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_DATE_FORMAT);
+    /**
+     * 공개 캘린더는 발생일마다 하나씩 펼쳐 내려준다.
+     * 발생일이 여러 개면 프론트에서 구분할 수 있도록 id에 날짜를 덧붙인다.
+     */
+    private List<ClubCalendarEventResult> toPublicResults(CustomCalendarEvent event) {
+        List<String> occurrences = occurrenceExpander.expand(event);
+
+        if (occurrences.isEmpty()) {
+            return List.of();
         }
 
-        if (!StringUtils.hasText(end)) {
-            return;
+        if (occurrences.size() == 1) {
+            return List.of(ClubCalendarEventResult.ofCustom(
+                    event.getId(),
+                    event.getTitle(),
+                    occurrences.get(0),
+                    event.getEnd(),
+                    event.getUrl(),
+                    event.getDescription()
+            ));
         }
 
-        LocalDate parsedEnd;
-        try {
-            parsedEnd = LocalDate.parse(end);
-        } catch (Exception e) {
-            throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_DATE_FORMAT);
+        return occurrences.stream()
+                .map(date -> ClubCalendarEventResult.ofCustom(
+                        event.getId() + ":" + date,
+                        event.getTitle(),
+                        date,
+                        null,
+                        event.getUrl(),
+                        event.getDescription()
+                ))
+                .toList();
+    }
+
+    private boolean isRecurring(CustomCalendarEvent event) {
+        return "RECURRING".equals(event.getEventType()) && event.getRecurrence() != null;
+    }
+
+    private String resolveDeleteScope(String scope) {
+        if (!StringUtils.hasText(scope)) {
+            return "ALL";
+        }
+        if (!DELETE_SCOPES.contains(scope)) {
+            throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_DELETE_SCOPE);
+        }
+        return scope;
+    }
+
+    private String validateRequest(CustomCalendarEventRequest request) {
+        LocalDate start = validateDates(request.start(), request.end());
+        String eventType = resolveEventType(request.eventType());
+        validateAllowedValue(request.color(), COLORS);
+
+        if (request.dates() != null) {
+            request.dates().forEach(this::parseRequiredDate);
+            if (!request.dates().isEmpty() && !request.start().equals(request.dates().get(0))) {
+                throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
+            }
         }
 
-        if (parsedStart.isAfter(parsedEnd)) {
-            throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_DATE_RANGE);
+        CustomEventRecurrence recurrence = request.recurrence();
+        if (recurrence == null) {
+            if ("RECURRING".equals(eventType)) {
+                throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
+            }
+            return eventType;
+        }
+
+        if (!"RECURRING".equals(eventType)) {
+            throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
+        }
+
+        validateRequiredAllowedValue(recurrence.frequency(), FREQUENCIES);
+        validateWeekdays(recurrence.weekdays());
+
+        if (StringUtils.hasText(recurrence.end())) {
+            LocalDate recurrenceEnd = parseRequiredDate(recurrence.end());
+            if (start.isAfter(recurrenceEnd)) {
+                throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_DATE_RANGE);
+            }
+        }
+        if (recurrence.excludedDates() != null) {
+            recurrence.excludedDates().forEach(this::parseRequiredDate);
+        }
+        return eventType;
+    }
+
+    private String resolveEventType(String eventType) {
+        if (!StringUtils.hasText(eventType)) {
+            return "SINGLE";
+        }
+        validateAllowedValue(eventType, EVENT_TYPES);
+        return eventType;
+    }
+
+    private void validateAllowedValue(String value, Set<String> allowedValues) {
+        if (StringUtils.hasText(value) && !allowedValues.contains(value)) {
+            throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
         }
     }
 
-    private ClubCalendarEventResult toResult(CustomCalendarEvent event) {
-        return ClubCalendarEventResult.ofCustom(
-                event.getId(),
-                event.getTitle(),
-                event.getStart(),
-                event.getEnd(),
-                event.getUrl(),
-                event.getDescription()
-        );
+    private void validateRequiredAllowedValue(String value, Set<String> allowedValues) {
+        if (!StringUtils.hasText(value) || !allowedValues.contains(value)) {
+            throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
+        }
+    }
+
+    private void validateWeekdays(List<Integer> weekdays) {
+        if (weekdays == null) {
+            return;
+        }
+        boolean hasInvalidWeekday = weekdays.stream().anyMatch(weekday -> weekday == null || weekday < 0 || weekday > 6);
+        if (hasInvalidWeekday) {
+            throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
+        }
+    }
+
+    private LocalDate validateDates(String start, String end) {
+        LocalDate parsedStart = parseRequiredDate(start);
+
+        if (!StringUtils.hasText(end)) {
+            return parsedStart;
+        }
+
+        if (parsedStart.isAfter(parseRequiredDate(end))) {
+            throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_DATE_RANGE);
+        }
+        return parsedStart;
+    }
+
+    private LocalDate parseRequiredDate(String value) {
+        try {
+            return LocalDate.parse(value);
+        } catch (Exception e) {
+            throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_DATE_FORMAT);
+        }
     }
 
     private String requireAuthenticatedClubId(CustomUserDetails user) {

--- a/backend/src/main/java/moadong/calendar/custom/service/CustomCalendarEventService.java
+++ b/backend/src/main/java/moadong/calendar/custom/service/CustomCalendarEventService.java
@@ -1,5 +1,6 @@
 package moadong.calendar.custom.service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +25,7 @@ public class CustomCalendarEventService {
 
     public ClubCalendarEventResult create(CustomUserDetails user, CustomCalendarEventRequest request) {
         String clubId = requireAuthenticatedClubId(user);
+        validateDates(request.start(), request.end());
 
         CustomCalendarEvent event = CustomCalendarEvent.builder()
                 .clubId(clubId)
@@ -45,6 +47,7 @@ public class CustomCalendarEventService {
 
     public ClubCalendarEventResult update(CustomUserDetails user, String eventId, CustomCalendarEventRequest request) {
         String clubId = requireAuthenticatedClubId(user);
+        validateDates(request.start(), request.end());
 
         CustomCalendarEvent event = customCalendarEventRepository.findByIdAndClubId(eventId, clubId)
                 .orElseThrow(() -> new RestApiException(ErrorCode.CUSTOM_EVENT_NOT_FOUND));
@@ -78,6 +81,30 @@ public class CustomCalendarEventService {
             return false;
         }
         return customCalendarEventRepository.existsByClubId(clubId);
+    }
+
+    private void validateDates(String start, String end) {
+        LocalDate parsedStart;
+        try {
+            parsedStart = LocalDate.parse(start);
+        } catch (Exception e) {
+            throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_DATE_FORMAT);
+        }
+
+        if (!StringUtils.hasText(end)) {
+            return;
+        }
+
+        LocalDate parsedEnd;
+        try {
+            parsedEnd = LocalDate.parse(end);
+        } catch (Exception e) {
+            throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_DATE_FORMAT);
+        }
+
+        if (parsedStart.isAfter(parsedEnd)) {
+            throw new RestApiException(ErrorCode.CUSTOM_EVENT_INVALID_DATE_RANGE);
+        }
     }
 
     private ClubCalendarEventResult toResult(CustomCalendarEvent event) {

--- a/backend/src/main/java/moadong/calendar/custom/service/CustomEventOccurrenceExpander.java
+++ b/backend/src/main/java/moadong/calendar/custom/service/CustomEventOccurrenceExpander.java
@@ -58,13 +58,14 @@ public class CustomEventOccurrenceExpander {
             return List.of(start.toString());
         }
 
-        LocalDate windowLimit = LocalDate.now().plusYears(FUTURE_WINDOW_YEARS);
+        LocalDate today = LocalDate.now();
+        LocalDate windowLimit = today.plusYears(FUTURE_WINDOW_YEARS);
         LocalDate recurrenceEnd = parseOrNull(recurrence.end());
         LocalDate windowEnd = (recurrenceEnd != null && recurrenceEnd.isBefore(windowLimit))
                 ? recurrenceEnd
                 : windowLimit;
-        LocalDate visibleStart = recurrenceEnd == null && start.isBefore(LocalDate.now())
-                ? LocalDate.now()
+        LocalDate visibleStart = recurrenceEnd == null && start.isBefore(today)
+                ? today
                 : start;
 
         if (windowEnd.isBefore(visibleStart)) {

--- a/backend/src/main/java/moadong/calendar/custom/service/CustomEventOccurrenceExpander.java
+++ b/backend/src/main/java/moadong/calendar/custom/service/CustomEventOccurrenceExpander.java
@@ -14,6 +14,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * 커스텀 이벤트 원형을 공개 캘린더에 표시할 발생일 목록으로 전개한다.
+ * PERIOD는 여러 날에 걸친 하나의 일정이므로 전개하지 않고 start 한 건만 반환한다(end는 호출부가 그대로 유지한다).
  * 무기한 반복은 오늘 기준 1년까지만 전개하고, 전체 발생일은 최대 500건으로 제한한다.
  */
 @Component
@@ -32,26 +33,10 @@ public class CustomEventOccurrenceExpander {
         String eventType = StringUtils.hasText(event.getEventType()) ? event.getEventType() : "SINGLE";
 
         return switch (eventType) {
-            case "PERIOD" -> expandPeriod(start, parseOrNull(event.getEnd()));
             case "MULTI" -> expandMulti(event.getDates(), start);
             case "RECURRING" -> expandRecurring(event.getRecurrence(), start);
             default -> List.of(start.toString());
         };
-    }
-
-    private List<String> expandPeriod(LocalDate start, LocalDate end) {
-        if (end == null || end.isBefore(start)) {
-            return List.of(start.toString());
-        }
-
-        List<String> occurrences = new ArrayList<>();
-        for (LocalDate date = start; !date.isAfter(end); date = date.plusDays(1)) {
-            if (isFull(occurrences, start)) {
-                break;
-            }
-            occurrences.add(date.toString());
-        }
-        return occurrences;
     }
 
     private List<String> expandMulti(List<String> dates, LocalDate start) {

--- a/backend/src/main/java/moadong/calendar/custom/service/CustomEventOccurrenceExpander.java
+++ b/backend/src/main/java/moadong/calendar/custom/service/CustomEventOccurrenceExpander.java
@@ -1,0 +1,185 @@
+package moadong.calendar.custom.service;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import moadong.calendar.custom.entity.CustomCalendarEvent;
+import moadong.calendar.custom.entity.CustomEventRecurrence;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * 커스텀 이벤트 원형을 공개 캘린더에 표시할 발생일 목록으로 전개한다.
+ * 무기한 반복은 오늘 기준 1년까지만 전개하고, 전체 발생일은 최대 500건으로 제한한다.
+ */
+@Component
+@Slf4j
+public class CustomEventOccurrenceExpander {
+
+    private static final int MAX_OCCURRENCES = 500;
+    private static final int FUTURE_WINDOW_YEARS = 1;
+
+    public List<String> expand(CustomCalendarEvent event) {
+        LocalDate start = parseOrNull(event.getStart());
+        if (start == null) {
+            return List.of();
+        }
+
+        String eventType = StringUtils.hasText(event.getEventType()) ? event.getEventType() : "SINGLE";
+
+        return switch (eventType) {
+            case "PERIOD" -> expandPeriod(start, parseOrNull(event.getEnd()));
+            case "MULTI" -> expandMulti(event.getDates(), start);
+            case "RECURRING" -> expandRecurring(event.getRecurrence(), start);
+            default -> List.of(start.toString());
+        };
+    }
+
+    private List<String> expandPeriod(LocalDate start, LocalDate end) {
+        if (end == null || end.isBefore(start)) {
+            return List.of(start.toString());
+        }
+
+        List<String> occurrences = new ArrayList<>();
+        for (LocalDate date = start; !date.isAfter(end); date = date.plusDays(1)) {
+            if (isFull(occurrences, start)) {
+                break;
+            }
+            occurrences.add(date.toString());
+        }
+        return occurrences;
+    }
+
+    private List<String> expandMulti(List<String> dates, LocalDate start) {
+        if (dates == null || dates.isEmpty()) {
+            return List.of(start.toString());
+        }
+
+        Set<String> occurrences = new LinkedHashSet<>();
+        for (String date : dates) {
+            if (parseOrNull(date) != null) {
+                occurrences.add(date);
+            }
+        }
+        return occurrences.isEmpty() ? List.of(start.toString()) : List.copyOf(occurrences);
+    }
+
+    private List<String> expandRecurring(CustomEventRecurrence recurrence, LocalDate start) {
+        if (recurrence == null || !StringUtils.hasText(recurrence.frequency())) {
+            return List.of(start.toString());
+        }
+
+        LocalDate windowLimit = LocalDate.now().plusYears(FUTURE_WINDOW_YEARS);
+        LocalDate recurrenceEnd = parseOrNull(recurrence.end());
+        LocalDate windowEnd = (recurrenceEnd != null && recurrenceEnd.isBefore(windowLimit))
+                ? recurrenceEnd
+                : windowLimit;
+
+        if (windowEnd.isBefore(start)) {
+            return List.of();
+        }
+
+        Set<String> excludedDates = recurrence.excludedDates() == null
+                ? Set.of()
+                : Set.copyOf(recurrence.excludedDates());
+
+        return switch (recurrence.frequency()) {
+            case "WEEKLY" -> expandWeekly(recurrence.weekdays(), start, windowEnd, excludedDates);
+            case "MONTHLY" -> expandMonthly(start, windowEnd, excludedDates);
+            case "YEARLY" -> expandYearly(start, windowEnd, excludedDates);
+            default -> List.of(start.toString());
+        };
+    }
+
+    private List<String> expandWeekly(List<Integer> weekdays, LocalDate start, LocalDate windowEnd,
+                                      Set<String> excludedDates) {
+        Set<Integer> targetWeekdays = (weekdays == null || weekdays.isEmpty())
+                ? Set.of(toWeekdayIndex(start))
+                : Set.copyOf(weekdays);
+
+        List<String> occurrences = new ArrayList<>();
+        for (LocalDate date = start; !date.isAfter(windowEnd); date = date.plusDays(1)) {
+            if (isFull(occurrences, start)) {
+                break;
+            }
+            if (targetWeekdays.contains(toWeekdayIndex(date))) {
+                addUnlessExcluded(occurrences, date, excludedDates);
+            }
+        }
+        return occurrences;
+    }
+
+    private List<String> expandMonthly(LocalDate start, LocalDate windowEnd, Set<String> excludedDates) {
+        int dayOfMonth = start.getDayOfMonth();
+
+        List<String> occurrences = new ArrayList<>();
+        for (YearMonth month = YearMonth.from(start); !month.atDay(1).isAfter(windowEnd); month = month.plusMonths(1)) {
+            if (isFull(occurrences, start)) {
+                break;
+            }
+            if (dayOfMonth > month.lengthOfMonth()) {
+                continue;
+            }
+            LocalDate date = month.atDay(dayOfMonth);
+            if (!date.isBefore(start) && !date.isAfter(windowEnd)) {
+                addUnlessExcluded(occurrences, date, excludedDates);
+            }
+        }
+        return occurrences;
+    }
+
+    private List<String> expandYearly(LocalDate start, LocalDate windowEnd, Set<String> excludedDates) {
+        List<String> occurrences = new ArrayList<>();
+        for (int year = start.getYear(); year <= windowEnd.getYear(); year++) {
+            if (isFull(occurrences, start)) {
+                break;
+            }
+            YearMonth month = YearMonth.of(year, start.getMonth());
+            if (start.getDayOfMonth() > month.lengthOfMonth()) {
+                continue;
+            }
+            LocalDate date = month.atDay(start.getDayOfMonth());
+            if (!date.isBefore(start) && !date.isAfter(windowEnd)) {
+                addUnlessExcluded(occurrences, date, excludedDates);
+            }
+        }
+        return occurrences;
+    }
+
+    private void addUnlessExcluded(List<String> occurrences, LocalDate date, Set<String> excludedDates) {
+        String value = date.toString();
+        if (!excludedDates.contains(value)) {
+            occurrences.add(value);
+        }
+    }
+
+    private boolean isFull(List<String> occurrences, LocalDate start) {
+        if (occurrences.size() < MAX_OCCURRENCES) {
+            return false;
+        }
+        log.warn("커스텀 이벤트 발생일 전개 상한 도달. start={}, max={}", start, MAX_OCCURRENCES);
+        return true;
+    }
+
+    /**
+     * 프론트 계약(0=일 ~ 6=토)에 맞춰 요일 인덱스를 변환한다.
+     */
+    private int toWeekdayIndex(LocalDate date) {
+        return date.getDayOfWeek().getValue() % 7;
+    }
+
+    private LocalDate parseOrNull(String value) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        try {
+            return LocalDate.parse(value);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/backend/src/main/java/moadong/calendar/custom/service/CustomEventOccurrenceExpander.java
+++ b/backend/src/main/java/moadong/calendar/custom/service/CustomEventOccurrenceExpander.java
@@ -78,8 +78,11 @@ public class CustomEventOccurrenceExpander {
         LocalDate windowEnd = (recurrenceEnd != null && recurrenceEnd.isBefore(windowLimit))
                 ? recurrenceEnd
                 : windowLimit;
+        LocalDate visibleStart = recurrenceEnd == null && start.isBefore(LocalDate.now())
+                ? LocalDate.now()
+                : start;
 
-        if (windowEnd.isBefore(start)) {
+        if (windowEnd.isBefore(visibleStart)) {
             return List.of();
         }
 
@@ -88,21 +91,22 @@ public class CustomEventOccurrenceExpander {
                 : Set.copyOf(recurrence.excludedDates());
 
         return switch (recurrence.frequency()) {
-            case "WEEKLY" -> expandWeekly(recurrence.weekdays(), start, windowEnd, excludedDates);
-            case "MONTHLY" -> expandMonthly(start, windowEnd, excludedDates);
-            case "YEARLY" -> expandYearly(start, windowEnd, excludedDates);
+            case "WEEKLY" -> expandWeekly(recurrence.weekdays(), start, visibleStart, windowEnd, excludedDates);
+            case "MONTHLY" -> expandMonthly(start, visibleStart, windowEnd, excludedDates);
+            case "YEARLY" -> expandYearly(start, visibleStart, windowEnd, excludedDates);
             default -> List.of(start.toString());
         };
     }
 
-    private List<String> expandWeekly(List<Integer> weekdays, LocalDate start, LocalDate windowEnd,
+    private List<String> expandWeekly(List<Integer> weekdays, LocalDate start, LocalDate visibleStart,
+                                      LocalDate windowEnd,
                                       Set<String> excludedDates) {
         Set<Integer> targetWeekdays = (weekdays == null || weekdays.isEmpty())
                 ? Set.of(toWeekdayIndex(start))
                 : Set.copyOf(weekdays);
 
         List<String> occurrences = new ArrayList<>();
-        for (LocalDate date = start; !date.isAfter(windowEnd); date = date.plusDays(1)) {
+        for (LocalDate date = visibleStart; !date.isAfter(windowEnd); date = date.plusDays(1)) {
             if (isFull(occurrences, start)) {
                 break;
             }
@@ -113,11 +117,12 @@ public class CustomEventOccurrenceExpander {
         return occurrences;
     }
 
-    private List<String> expandMonthly(LocalDate start, LocalDate windowEnd, Set<String> excludedDates) {
+    private List<String> expandMonthly(LocalDate start, LocalDate visibleStart, LocalDate windowEnd,
+                                       Set<String> excludedDates) {
         int dayOfMonth = start.getDayOfMonth();
 
         List<String> occurrences = new ArrayList<>();
-        for (YearMonth month = YearMonth.from(start); !month.atDay(1).isAfter(windowEnd); month = month.plusMonths(1)) {
+        for (YearMonth month = YearMonth.from(visibleStart); !month.atDay(1).isAfter(windowEnd); month = month.plusMonths(1)) {
             if (isFull(occurrences, start)) {
                 break;
             }
@@ -125,16 +130,17 @@ public class CustomEventOccurrenceExpander {
                 continue;
             }
             LocalDate date = month.atDay(dayOfMonth);
-            if (!date.isBefore(start) && !date.isAfter(windowEnd)) {
+            if (!date.isBefore(visibleStart) && !date.isAfter(windowEnd)) {
                 addUnlessExcluded(occurrences, date, excludedDates);
             }
         }
         return occurrences;
     }
 
-    private List<String> expandYearly(LocalDate start, LocalDate windowEnd, Set<String> excludedDates) {
+    private List<String> expandYearly(LocalDate start, LocalDate visibleStart, LocalDate windowEnd,
+                                      Set<String> excludedDates) {
         List<String> occurrences = new ArrayList<>();
-        for (int year = start.getYear(); year <= windowEnd.getYear(); year++) {
+        for (int year = visibleStart.getYear(); year <= windowEnd.getYear(); year++) {
             if (isFull(occurrences, start)) {
                 break;
             }
@@ -143,7 +149,7 @@ public class CustomEventOccurrenceExpander {
                 continue;
             }
             LocalDate date = month.atDay(start.getDayOfMonth());
-            if (!date.isBefore(start) && !date.isAfter(windowEnd)) {
+            if (!date.isBefore(visibleStart) && !date.isAfter(windowEnd)) {
                 addUnlessExcluded(occurrences, date, excludedDates);
             }
         }

--- a/backend/src/main/java/moadong/calendar/hidden/controller/HiddenCalendarEventController.java
+++ b/backend/src/main/java/moadong/calendar/hidden/controller/HiddenCalendarEventController.java
@@ -1,0 +1,57 @@
+package moadong.calendar.hidden.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import moadong.calendar.hidden.payload.request.HiddenCalendarEventRequest;
+import moadong.calendar.hidden.service.HiddenCalendarEventService;
+import moadong.global.payload.Response;
+import moadong.user.annotation.CurrentUser;
+import moadong.user.payload.CustomUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/integration/calendar-events/hidden")
+@RequiredArgsConstructor
+@Tag(name = "Hidden Calendar Events", description = "OAuth 캘린더 이벤트 숨김 관리 API")
+public class HiddenCalendarEventController {
+
+    private final HiddenCalendarEventService hiddenCalendarEventService;
+
+    @PostMapping
+    @Operation(summary = "캘린더 이벤트 숨김", description = "Google/Notion 캘린더 이벤트를 공개 캘린더에서 숨깁니다.")
+    @PreAuthorize("isAuthenticated()")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> hideEvent(@CurrentUser CustomUserDetails user,
+                                       @RequestBody @Valid HiddenCalendarEventRequest request) {
+        hiddenCalendarEventService.hide(user, request.source(), request.eventId());
+        return Response.ok("이벤트가 숨김 처리되었습니다.");
+    }
+
+    @DeleteMapping
+    @Operation(summary = "캘린더 이벤트 숨김 해제", description = "숨김 처리된 Google/Notion 캘린더 이벤트를 다시 표시합니다.")
+    @PreAuthorize("isAuthenticated()")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> unhideEvent(@CurrentUser CustomUserDetails user,
+                                         @RequestBody @Valid HiddenCalendarEventRequest request) {
+        hiddenCalendarEventService.unhide(user, request.source(), request.eventId());
+        return Response.ok("이벤트 숨김이 해제되었습니다.");
+    }
+
+    @GetMapping
+    @Operation(summary = "숨김 이벤트 목록 조회", description = "숨김 처리된 캘린더 이벤트 목록을 조회합니다.")
+    @PreAuthorize("isAuthenticated()")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> getHiddenEvents(@CurrentUser CustomUserDetails user) {
+        return Response.ok(hiddenCalendarEventService.list(user));
+    }
+}

--- a/backend/src/main/java/moadong/calendar/hidden/entity/HiddenCalendarEvent.java
+++ b/backend/src/main/java/moadong/calendar/hidden/entity/HiddenCalendarEvent.java
@@ -1,0 +1,27 @@
+package moadong.calendar.hidden.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document("hidden_calendar_events")
+@CompoundIndex(name = "club_source_event_idx", def = "{'clubId': 1, 'source': 1, 'eventId': 1}", unique = true)
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HiddenCalendarEvent {
+
+    @Id
+    private String id;
+
+    private String clubId;
+
+    private String source;
+
+    private String eventId;
+}

--- a/backend/src/main/java/moadong/calendar/hidden/payload/dto/HiddenCalendarEventResult.java
+++ b/backend/src/main/java/moadong/calendar/hidden/payload/dto/HiddenCalendarEventResult.java
@@ -1,0 +1,7 @@
+package moadong.calendar.hidden.payload.dto;
+
+public record HiddenCalendarEventResult(
+        String source,
+        String eventId
+) {
+}

--- a/backend/src/main/java/moadong/calendar/hidden/payload/request/HiddenCalendarEventRequest.java
+++ b/backend/src/main/java/moadong/calendar/hidden/payload/request/HiddenCalendarEventRequest.java
@@ -1,0 +1,9 @@
+package moadong.calendar.hidden.payload.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record HiddenCalendarEventRequest(
+        @NotBlank String source,
+        @NotBlank String eventId
+) {
+}

--- a/backend/src/main/java/moadong/calendar/hidden/repository/HiddenCalendarEventRepository.java
+++ b/backend/src/main/java/moadong/calendar/hidden/repository/HiddenCalendarEventRepository.java
@@ -1,0 +1,14 @@
+package moadong.calendar.hidden.repository;
+
+import java.util.List;
+import moadong.calendar.hidden.entity.HiddenCalendarEvent;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface HiddenCalendarEventRepository extends MongoRepository<HiddenCalendarEvent, String> {
+
+    List<HiddenCalendarEvent> findByClubId(String clubId);
+
+    boolean existsByClubIdAndSourceAndEventId(String clubId, String source, String eventId);
+
+    long deleteByClubIdAndSourceAndEventId(String clubId, String source, String eventId);
+}

--- a/backend/src/main/java/moadong/calendar/hidden/service/HiddenCalendarEventService.java
+++ b/backend/src/main/java/moadong/calendar/hidden/service/HiddenCalendarEventService.java
@@ -1,0 +1,86 @@
+package moadong.calendar.hidden.service;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import moadong.calendar.hidden.entity.HiddenCalendarEvent;
+import moadong.calendar.hidden.payload.dto.HiddenCalendarEventResult;
+import moadong.calendar.hidden.repository.HiddenCalendarEventRepository;
+import moadong.club.entity.Club;
+import moadong.club.repository.ClubRepository;
+import moadong.global.exception.ErrorCode;
+import moadong.global.exception.RestApiException;
+import moadong.user.payload.CustomUserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+public class HiddenCalendarEventService {
+
+    private static final Set<String> HIDEABLE_SOURCES = Set.of("GOOGLE", "NOTION");
+
+    private final HiddenCalendarEventRepository hiddenCalendarEventRepository;
+    private final ClubRepository clubRepository;
+
+    public void hide(CustomUserDetails user, String source, String eventId) {
+        String clubId = requireAuthenticatedClubId(user);
+        validateSource(source);
+
+        if (hiddenCalendarEventRepository.existsByClubIdAndSourceAndEventId(clubId, source, eventId)) {
+            return;
+        }
+
+        hiddenCalendarEventRepository.save(HiddenCalendarEvent.builder()
+                .clubId(clubId)
+                .source(source)
+                .eventId(eventId)
+                .build());
+    }
+
+    public void unhide(CustomUserDetails user, String source, String eventId) {
+        String clubId = requireAuthenticatedClubId(user);
+        validateSource(source);
+
+        hiddenCalendarEventRepository.deleteByClubIdAndSourceAndEventId(clubId, source, eventId);
+    }
+
+    public List<HiddenCalendarEventResult> list(CustomUserDetails user) {
+        String clubId = requireAuthenticatedClubId(user);
+
+        return hiddenCalendarEventRepository.findByClubId(clubId).stream()
+                .map(hidden -> new HiddenCalendarEventResult(hidden.getSource(), hidden.getEventId()))
+                .toList();
+    }
+
+    public Set<String> getHiddenKeys(String clubId) {
+        if (!StringUtils.hasText(clubId)) {
+            return Set.of();
+        }
+
+        return hiddenCalendarEventRepository.findByClubId(clubId).stream()
+                .map(hidden -> hidden.getSource() + ":" + hidden.getEventId())
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private void validateSource(String source) {
+        if (!HIDEABLE_SOURCES.contains(source)) {
+            throw new RestApiException(ErrorCode.HIDDEN_EVENT_INVALID_SOURCE);
+        }
+    }
+
+    private String requireAuthenticatedClubId(CustomUserDetails user) {
+        if (user == null || !StringUtils.hasText(user.getId())) {
+            throw new RestApiException(ErrorCode.USER_UNAUTHORIZED);
+        }
+
+        Club club = clubRepository.findClubByUserId(user.getId())
+                .orElseThrow(() -> new RestApiException(ErrorCode.HIDDEN_EVENT_CLUB_NOT_FOUND));
+
+        if (!StringUtils.hasText(club.getId())) {
+            throw new RestApiException(ErrorCode.HIDDEN_EVENT_CLUB_NOT_FOUND);
+        }
+        return club.getId();
+    }
+}

--- a/backend/src/main/java/moadong/calendar/hidden/service/HiddenCalendarEventService.java
+++ b/backend/src/main/java/moadong/calendar/hidden/service/HiddenCalendarEventService.java
@@ -12,6 +12,7 @@ import moadong.club.repository.ClubRepository;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
 import moadong.user.payload.CustomUserDetails;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
@@ -32,11 +33,15 @@ public class HiddenCalendarEventService {
             return;
         }
 
-        hiddenCalendarEventRepository.save(HiddenCalendarEvent.builder()
-                .clubId(clubId)
-                .source(source)
-                .eventId(eventId)
-                .build());
+        try {
+            hiddenCalendarEventRepository.save(HiddenCalendarEvent.builder()
+                    .clubId(clubId)
+                    .source(source)
+                    .eventId(eventId)
+                    .build());
+        } catch (DuplicateKeyException ignored) {
+            // 동시에 동일 이벤트를 숨긴 요청도 멱등적으로 처리한다.
+        }
     }
 
     public void unhide(CustomUserDetails user, String source, String eventId) {

--- a/backend/src/main/java/moadong/calendar/hidden/service/HiddenCalendarEventService.java
+++ b/backend/src/main/java/moadong/calendar/hidden/service/HiddenCalendarEventService.java
@@ -65,7 +65,7 @@ public class HiddenCalendarEventService {
     }
 
     private void validateSource(String source) {
-        if (!HIDEABLE_SOURCES.contains(source)) {
+        if (source == null || !HIDEABLE_SOURCES.contains(source)) {
             throw new RestApiException(ErrorCode.HIDDEN_EVENT_INVALID_SOURCE);
         }
     }

--- a/backend/src/main/java/moadong/calendar/notion/controller/NotionOAuthController.java
+++ b/backend/src/main/java/moadong/calendar/notion/controller/NotionOAuthController.java
@@ -13,6 +13,7 @@ import moadong.user.annotation.CurrentUser;
 import moadong.user.payload.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -71,5 +72,14 @@ public class NotionOAuthController {
                                               @PathVariable String databaseId,
                                               @RequestParam(required = false) String dateProperty) {
         return Response.ok(notionOAuthService.getDatabasePages(user, databaseId, dateProperty));
+    }
+
+    @DeleteMapping("/connection")
+    @Operation(summary = "Notion 연결 해제", description = "Notion 연결을 해제합니다.")
+    @PreAuthorize("isAuthenticated()")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> deleteConnection(@CurrentUser CustomUserDetails user) {
+        notionOAuthService.deleteConnection(user);
+        return Response.ok("Notion 연결이 해제되었습니다.");
     }
 }

--- a/backend/src/main/java/moadong/calendar/notion/service/NotionOAuthService.java
+++ b/backend/src/main/java/moadong/calendar/notion/service/NotionOAuthService.java
@@ -460,6 +460,14 @@ public class NotionOAuthService {
         }
     }
 
+    public void deleteConnection(CustomUserDetails user) {
+        String userId = requireAuthenticatedUserId(user);
+        String clubId = requireAuthenticatedClubId(user);
+        notionConnectionRepository.deleteById(clubId);
+        // userId를 _id로 저장하던 레거시 문서가 남아 있으면 재연동된 것으로 복구되므로 함께 삭제한다.
+        notionConnectionRepository.deleteById(userId);
+    }
+
     private String requireAuthenticatedUserId(CustomUserDetails user) {
         if (user == null || !StringUtils.hasText(user.getId())) {
             throw new RestApiException(ErrorCode.USER_UNAUTHORIZED);

--- a/backend/src/main/java/moadong/calendar/notion/service/NotionOAuthService.java
+++ b/backend/src/main/java/moadong/calendar/notion/service/NotionOAuthService.java
@@ -463,9 +463,10 @@ public class NotionOAuthService {
     public void deleteConnection(CustomUserDetails user) {
         String userId = requireAuthenticatedUserId(user);
         String clubId = requireAuthenticatedClubId(user);
-        notionConnectionRepository.deleteById(clubId);
         // userId를 _id로 저장하던 레거시 문서가 남아 있으면 재연동된 것으로 복구되므로 함께 삭제한다.
+        // clubId 문서를 먼저 지우면 그 사이 조회가 레거시 문서를 clubId 문서로 다시 마이그레이션하므로 레거시부터 삭제한다.
         notionConnectionRepository.deleteById(userId);
+        notionConnectionRepository.deleteById(clubId);
     }
 
     private String requireAuthenticatedUserId(CustomUserDetails user) {

--- a/backend/src/main/java/moadong/calendar/service/CalendarAggregationService.java
+++ b/backend/src/main/java/moadong/calendar/service/CalendarAggregationService.java
@@ -3,8 +3,11 @@ package moadong.calendar.service;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import moadong.calendar.custom.service.CustomCalendarEventService;
+import moadong.calendar.hidden.service.HiddenCalendarEventService;
 import moadong.calendar.google.service.GoogleOAuthService;
 import moadong.calendar.notion.service.NotionOAuthService;
 import moadong.club.payload.dto.ClubCalendarEventResult;
@@ -18,6 +21,8 @@ public class CalendarAggregationService {
 
     private final NotionOAuthService notionOAuthService;
     private final GoogleOAuthService googleOAuthService;
+    private final CustomCalendarEventService customCalendarEventService;
+    private final HiddenCalendarEventService hiddenCalendarEventService;
 
     public List<ClubCalendarEventResult> getAggregatedEvents(String clubId) {
         List<ClubCalendarEventResult> allEvents = new ArrayList<>();
@@ -38,7 +43,24 @@ public class CalendarAggregationService {
             log.warn("Google 이벤트 조회 실패. clubId={}, message={}", clubId, e.getMessage());
         }
 
+        try {
+            List<ClubCalendarEventResult> customEvents = customCalendarEventService.getClubCalendarEvents(clubId);
+            allEvents.addAll(customEvents);
+            log.debug("커스텀 이벤트 조회 성공. clubId={}, count={}", clubId, customEvents.size());
+        } catch (Exception e) {
+            log.warn("커스텀 이벤트 조회 실패. clubId={}, message={}", clubId, e.getMessage());
+        }
+
+        Set<String> hiddenKeys = Set.of();
+        try {
+            hiddenKeys = hiddenCalendarEventService.getHiddenKeys(clubId);
+        } catch (Exception e) {
+            log.warn("숨김 이벤트 목록 조회 실패. clubId={}, message={}", clubId, e.getMessage());
+        }
+        final Set<String> resolvedHiddenKeys = hiddenKeys;
+
         return allEvents.stream()
+                .filter(event -> !resolvedHiddenKeys.contains(event.source() + ":" + event.id()))
                 .sorted(Comparator.comparing(
                         ClubCalendarEventResult::start,
                         Comparator.nullsLast(String::compareTo)
@@ -53,6 +75,7 @@ public class CalendarAggregationService {
 
         boolean hasNotion = false;
         boolean hasGoogle = false;
+        boolean hasCustom = false;
 
         try {
             hasNotion = notionOAuthService.hasCalendarConnection(clubId);
@@ -66,6 +89,12 @@ public class CalendarAggregationService {
             log.debug("Google 연결 상태 확인 실패. clubId={}", clubId);
         }
 
-        return hasNotion || hasGoogle;
+        try {
+            hasCustom = customCalendarEventService.hasCalendarConnection(clubId);
+        } catch (Exception e) {
+            log.debug("커스텀 이벤트 상태 확인 실패. clubId={}", clubId);
+        }
+
+        return hasNotion || hasGoogle || hasCustom;
     }
 }

--- a/backend/src/main/java/moadong/club/entity/ClubApplicationForm.java
+++ b/backend/src/main/java/moadong/club/entity/ClubApplicationForm.java
@@ -29,7 +29,7 @@ import java.util.Set;
 @Getter
 @Builder(toBuilder = true)
 public class ClubApplicationForm implements Persistable<String> {
-    private static final Set<String> externalApplicationUrlAllowedHosts = Set.of("forms.gle", "docs.google.com", "form.naver.com", "naver.me", "everytime.kr", "cafe.daum.net", "open.kakao.com");
+    private static final Set<String> externalApplicationUrlAllowedHosts = Set.of("forms.gle", "docs.google.com", "form.naver.com", "naver.me", "m.site.naver.com", "everytime.kr", "cafe.daum.net", "open.kakao.com");
     private static final String GOOGLE_DOCS_HOST = "docs.google.com";
     private static final String GOOGLE_FORMS_PATH_PREFIX = "/forms";
 

--- a/backend/src/main/java/moadong/club/payload/dto/ClubApplicationFormsResultItem.java
+++ b/backend/src/main/java/moadong/club/payload/dto/ClubApplicationFormsResultItem.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 public record ClubApplicationFormsResultItem(
        String id,
        String title,
+       LocalDateTime createdAt,
        LocalDateTime editedAt,
        ApplicationFormStatus status
 ) { }

--- a/backend/src/main/java/moadong/club/payload/dto/ClubCalendarEventResult.java
+++ b/backend/src/main/java/moadong/club/payload/dto/ClubCalendarEventResult.java
@@ -7,20 +7,23 @@ public record ClubCalendarEventResult(
         String end,
         String url,
         String description,
-        String source
+        String source,
+        String eventType,
+        String color
 ) {
     public static ClubCalendarEventResult ofNotion(
             String id, String title, String start, String end, String url, String description) {
-        return new ClubCalendarEventResult(id, title, start, end, url, description, "NOTION");
+        return new ClubCalendarEventResult(id, title, start, end, url, description, "NOTION", null, null);
     }
 
     public static ClubCalendarEventResult ofGoogle(
             String id, String title, String start, String end, String url, String description) {
-        return new ClubCalendarEventResult(id, title, start, end, url, description, "GOOGLE");
+        return new ClubCalendarEventResult(id, title, start, end, url, description, "GOOGLE", null, null);
     }
 
     public static ClubCalendarEventResult ofCustom(
-            String id, String title, String start, String end, String url, String description) {
-        return new ClubCalendarEventResult(id, title, start, end, url, description, "CUSTOM");
+            String id, String title, String start, String end, String url, String description,
+            String eventType, String color) {
+        return new ClubCalendarEventResult(id, title, start, end, url, description, "CUSTOM", eventType, color);
     }
 }

--- a/backend/src/main/java/moadong/club/payload/dto/ClubCalendarEventResult.java
+++ b/backend/src/main/java/moadong/club/payload/dto/ClubCalendarEventResult.java
@@ -18,4 +18,9 @@ public record ClubCalendarEventResult(
             String id, String title, String start, String end, String url, String description) {
         return new ClubCalendarEventResult(id, title, start, end, url, description, "GOOGLE");
     }
+
+    public static ClubCalendarEventResult ofCustom(
+            String id, String title, String start, String end, String url, String description) {
+        return new ClubCalendarEventResult(id, title, start, end, url, description, "CUSTOM");
+    }
 }

--- a/backend/src/main/java/moadong/club/repository/ClubApplicationFormsRepositoryCustom.java
+++ b/backend/src/main/java/moadong/club/repository/ClubApplicationFormsRepositoryCustom.java
@@ -28,6 +28,7 @@ public class ClubApplicationFormsRepositoryCustom {
         operations.add(Aggregation.project()
                 .and("_id").as("_id")
                 .and("title").as("title")
+                .and("createdAt").as("createdAt")
                 .and("editedAt").as("editedAt")
                 .and("status").as("status")
                 .and("semesterYear").as("semesterYear")
@@ -43,6 +44,7 @@ public class ClubApplicationFormsRepositoryCustom {
         GroupOperation groupOperation = Aggregation.group("semesterYear","active")
                 .push(new Document("_id", "$_id")
                         .append("title", "$title")
+                        .append("createdAt", "$createdAt")
                         .append("editedAt", "$editedAt")
                         .append("status","$status"))
                 .as("forms");

--- a/backend/src/main/java/moadong/global/exception/ErrorCode.java
+++ b/backend/src/main/java/moadong/global/exception/ErrorCode.java
@@ -86,6 +86,8 @@ public enum ErrorCode {
     MIXPANEL_EXPORT_FAILED(HttpStatus.BAD_GATEWAY, "903-1", "Mixpanel 데이터 조회에 실패했습니다."),
     STATISTICS_DATE_RANGE_INVALID(HttpStatus.BAD_REQUEST, "903-2", "통계 조회 기간이 올바르지 않습니다."),
     STATISTICS_BACKFILL_RANGE_TOO_LONG(HttpStatus.BAD_REQUEST, "903-3", "통계 백필 기간이 너무 깁니다."),
+    STATISTICS_EVENT_INVALID(HttpStatus.BAD_REQUEST, "903-4", "통계 이벤트 요청이 올바르지 않습니다."),
+    STATISTICS_EVENT_RATE_LIMITED(HttpStatus.TOO_MANY_REQUESTS, "903-5", "통계 이벤트 요청이 너무 많습니다."),
 
     // 950xx: Notion 연동 오류
     NOTION_CONFIG_MISSING(HttpStatus.INTERNAL_SERVER_ERROR, "950-1", "Notion 서버 환경변수가 설정되지 않았습니다."),

--- a/backend/src/main/java/moadong/global/exception/ErrorCode.java
+++ b/backend/src/main/java/moadong/global/exception/ErrorCode.java
@@ -109,6 +109,8 @@ public enum ErrorCode {
     CUSTOM_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "970-2", "커스텀 캘린더 이벤트를 찾을 수 없습니다."),
     CUSTOM_EVENT_INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "970-3", "날짜 형식이 올바르지 않습니다. YYYY-MM-DD 형식을 사용해주세요."),
     CUSTOM_EVENT_INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "970-4", "시작일은 종료일보다 이전이거나 같아야 합니다."),
+    CUSTOM_EVENT_INVALID_FIELD_VALUE(HttpStatus.BAD_REQUEST, "970-5", "이벤트 유형, 색상 또는 반복 주기 값이 올바르지 않습니다."),
+    CUSTOM_EVENT_INVALID_DELETE_SCOPE(HttpStatus.BAD_REQUEST, "970-6", "삭제 범위 값이 올바르지 않습니다."),
 
     HIDDEN_EVENT_CLUB_NOT_FOUND(HttpStatus.BAD_REQUEST, "971-1", "동아리 정보를 찾을 수 없습니다."),
     HIDDEN_EVENT_INVALID_SOURCE(HttpStatus.BAD_REQUEST, "971-2", "숨김 처리할 수 없는 이벤트 소스입니다.")

--- a/backend/src/main/java/moadong/global/exception/ErrorCode.java
+++ b/backend/src/main/java/moadong/global/exception/ErrorCode.java
@@ -107,6 +107,8 @@ public enum ErrorCode {
 
     CUSTOM_EVENT_CLUB_NOT_FOUND(HttpStatus.BAD_REQUEST, "970-1", "동아리 정보를 찾을 수 없습니다."),
     CUSTOM_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "970-2", "커스텀 캘린더 이벤트를 찾을 수 없습니다."),
+    CUSTOM_EVENT_INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "970-3", "날짜 형식이 올바르지 않습니다. YYYY-MM-DD 형식을 사용해주세요."),
+    CUSTOM_EVENT_INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "970-4", "시작일은 종료일보다 이전이거나 같아야 합니다."),
 
     HIDDEN_EVENT_CLUB_NOT_FOUND(HttpStatus.BAD_REQUEST, "971-1", "동아리 정보를 찾을 수 없습니다."),
     HIDDEN_EVENT_INVALID_SOURCE(HttpStatus.BAD_REQUEST, "971-2", "숨김 처리할 수 없는 이벤트 소스입니다.")

--- a/backend/src/main/java/moadong/global/exception/ErrorCode.java
+++ b/backend/src/main/java/moadong/global/exception/ErrorCode.java
@@ -103,7 +103,13 @@ public enum ErrorCode {
     GOOGLE_API_FAILED(HttpStatus.BAD_GATEWAY, "960-6", "Google API 호출에 실패했습니다."),
     GOOGLE_CLUB_NOT_FOUND(HttpStatus.BAD_REQUEST, "960-7", "연동할 동아리 정보를 찾을 수 없습니다."),
     GOOGLE_INVALID_TIME_FORMAT(HttpStatus.BAD_REQUEST, "960-8", "시간 형식이 올바르지 않습니다. RFC3339 형식을 사용해주세요."),
-    GOOGLE_INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST, "960-9", "시작 시간은 종료 시간보다 이전이어야 합니다.")
+    GOOGLE_INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST, "960-9", "시작 시간은 종료 시간보다 이전이어야 합니다."),
+
+    CUSTOM_EVENT_CLUB_NOT_FOUND(HttpStatus.BAD_REQUEST, "970-1", "동아리 정보를 찾을 수 없습니다."),
+    CUSTOM_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "970-2", "커스텀 캘린더 이벤트를 찾을 수 없습니다."),
+
+    HIDDEN_EVENT_CLUB_NOT_FOUND(HttpStatus.BAD_REQUEST, "971-1", "동아리 정보를 찾을 수 없습니다."),
+    HIDDEN_EVENT_INVALID_SOURCE(HttpStatus.BAD_REQUEST, "971-2", "숨김 처리할 수 없는 이벤트 소스입니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/backend/src/test/java/moadong/analytics/controller/ClubDetailDurationControllerTest.java
+++ b/backend/src/test/java/moadong/analytics/controller/ClubDetailDurationControllerTest.java
@@ -3,6 +3,7 @@ package moadong.analytics.controller;
 import jakarta.servlet.http.HttpServletRequest;
 import moadong.analytics.payload.request.ClubDetailDurationRecordRequest;
 import moadong.analytics.service.ClubDetailDurationService;
+import moadong.global.payload.Response;
 import moadong.util.annotations.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -28,7 +29,7 @@ class ClubDetailDurationControllerTest {
     private ClubDetailDurationController clubDetailDurationController;
 
     @Test
-    void 체류_시간_기록_요청은_204를_반환한다() {
+    void 체류_시간_기록_요청은_200과_공통_응답을_반환한다() {
         // given
         ClubDetailDurationRecordRequest request = new ClubDetailDurationRecordRequest(
                 "club-id",
@@ -42,10 +43,33 @@ class ClubDetailDurationControllerTest {
         when(httpServletRequest.getHeader("X-Forwarded-For")).thenReturn("203.0.113.1, 10.0.0.1");
 
         // when
-        ResponseEntity<Void> response = clubDetailDurationController.recordDuration(request, httpServletRequest);
+        ResponseEntity<?> response = clubDetailDurationController.recordDuration(request, httpServletRequest);
 
         // then
-        assertEquals(204, response.getStatusCode().value());
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals("200", ((Response<?>) response.getBody()).statuscode());
         verify(clubDetailDurationService).record(request, "203.0.113.1");
+    }
+
+    @Test
+    void 비정상적으로_긴_X_Forwarded_For_값은_무시하고_remoteAddr을_사용한다() {
+        // given
+        ClubDetailDurationRecordRequest request = new ClubDetailDurationRecordRequest(
+                "club-id",
+                "테스트동아리",
+                "session-id",
+                "visitor-id",
+                Instant.parse("2026-08-06T01:00:00Z"),
+                Instant.parse("2026-08-06T01:00:10Z"),
+                10L
+        );
+        when(httpServletRequest.getHeader("X-Forwarded-For")).thenReturn("x".repeat(500));
+        when(httpServletRequest.getRemoteAddr()).thenReturn("10.0.0.1");
+
+        // when
+        clubDetailDurationController.recordDuration(request, httpServletRequest);
+
+        // then
+        verify(clubDetailDurationService).record(request, "10.0.0.1");
     }
 }

--- a/backend/src/test/java/moadong/analytics/controller/ClubDetailDurationControllerTest.java
+++ b/backend/src/test/java/moadong/analytics/controller/ClubDetailDurationControllerTest.java
@@ -1,0 +1,51 @@
+package moadong.analytics.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import moadong.analytics.payload.request.ClubDetailDurationRecordRequest;
+import moadong.analytics.service.ClubDetailDurationService;
+import moadong.util.annotations.UnitTest;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.http.ResponseEntity;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@UnitTest
+class ClubDetailDurationControllerTest {
+
+    @Mock
+    private ClubDetailDurationService clubDetailDurationService;
+
+    @Mock
+    private HttpServletRequest httpServletRequest;
+
+    @InjectMocks
+    private ClubDetailDurationController clubDetailDurationController;
+
+    @Test
+    void 체류_시간_기록_요청은_204를_반환한다() {
+        // given
+        ClubDetailDurationRecordRequest request = new ClubDetailDurationRecordRequest(
+                "club-id",
+                "테스트동아리",
+                "session-id",
+                "visitor-id",
+                Instant.parse("2026-08-06T01:00:00Z"),
+                Instant.parse("2026-08-06T01:00:10Z"),
+                10L
+        );
+        when(httpServletRequest.getHeader("X-Forwarded-For")).thenReturn("203.0.113.1, 10.0.0.1");
+
+        // when
+        ResponseEntity<Void> response = clubDetailDurationController.recordDuration(request, httpServletRequest);
+
+        // then
+        assertEquals(204, response.getStatusCode().value());
+        verify(clubDetailDurationService).record(request, "203.0.113.1");
+    }
+}

--- a/backend/src/test/java/moadong/analytics/service/ClubDetailDurationServiceTest.java
+++ b/backend/src/test/java/moadong/analytics/service/ClubDetailDurationServiceTest.java
@@ -1,0 +1,225 @@
+package moadong.analytics.service;
+
+import com.mongodb.client.result.UpdateResult;
+import moadong.analytics.payload.request.ClubDetailDurationRecordRequest;
+import moadong.club.entity.Club;
+import moadong.club.repository.ClubRepository;
+import moadong.global.exception.ErrorCode;
+import moadong.global.exception.RestApiException;
+import moadong.util.annotations.UnitTest;
+import org.bson.BsonString;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@UnitTest
+class ClubDetailDurationServiceTest {
+
+    @Mock
+    private ClubAnalyticsRecordService clubAnalyticsRecordService;
+
+    @Mock
+    private ClubRepository clubRepository;
+
+    @Mock
+    private MongoTemplate mongoTemplate;
+
+    @Mock
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Test
+    void 정상_요청이면_세션을_저장하고_daily와_visitor_집계를_증가시킨다() {
+        // given
+        ClubDetailDurationService service = service();
+        ClubDetailDurationRecordRequest request = request(35);
+        passRateLimit();
+        sessionInserted();
+        visitorDailyUpdated();
+        Club club = mock(Club.class);
+        when(club.getId()).thenReturn("club-id");
+        when(club.getName()).thenReturn("테스트동아리");
+        when(clubRepository.findById("club-id")).thenReturn(Optional.of(club));
+
+        // when
+        service.record(request, "127.0.0.1");
+
+        // then
+        verify(clubAnalyticsRecordService).recordDetailDuration(
+                "club-id",
+                "테스트동아리",
+                LocalDate.of(2026, 8, 6),
+                35
+        );
+        verify(mongoTemplate).upsert(any(Query.class), any(Update.class), eq("club_detail_duration_sessions"));
+        verify(mongoTemplate).upsert(any(Query.class), any(Update.class), eq("club_detail_visitor_daily"));
+    }
+
+    @Test
+    void 중복_세션이면_daily_집계를_증가시키지_않는다() {
+        // given
+        ClubDetailDurationService service = service();
+        ClubDetailDurationRecordRequest request = request(10);
+        passRateLimit();
+        sessionDuplicated();
+        Club club = mock(Club.class);
+        when(club.getId()).thenReturn("club-id");
+        when(clubRepository.findById("club-id")).thenReturn(Optional.of(club));
+
+        // when
+        service.record(request, "127.0.0.1");
+
+        // then
+        verifyNoInteractions(clubAnalyticsRecordService);
+        verify(mongoTemplate).upsert(any(Query.class), any(Update.class), eq("club_detail_duration_sessions"));
+        verify(mongoTemplate, never()).upsert(any(Query.class), any(Update.class), eq("club_detail_visitor_daily"));
+    }
+
+    @Test
+    void daily_집계_실패_시_트랜잭션에_예외를_전파한다() {
+        // given
+        ClubDetailDurationService service = service();
+        ClubDetailDurationRecordRequest request = request(10);
+        passRateLimit();
+        sessionInserted();
+        Club club = mock(Club.class);
+        when(club.getId()).thenReturn("club-id");
+        when(club.getName()).thenReturn("테스트동아리");
+        when(clubRepository.findById("club-id")).thenReturn(Optional.of(club));
+        doThrow(new RuntimeException("mongo error"))
+                .when(clubAnalyticsRecordService)
+                .recordDetailDuration(any(), any(), any(), anyLong());
+
+        // when & then
+        assertThrows(RuntimeException.class, () -> service.record(request, "127.0.0.1"));
+        verify(mongoTemplate, never()).upsert(any(Query.class), any(Update.class), eq("club_detail_visitor_daily"));
+    }
+
+    @Test
+    void visitor_집계_실패_시_트랜잭션에_예외를_전파한다() {
+        // given
+        ClubDetailDurationService service = service();
+        ClubDetailDurationRecordRequest request = request(10);
+        passRateLimit();
+        sessionInserted();
+        Club club = mock(Club.class);
+        when(club.getId()).thenReturn("club-id");
+        when(club.getName()).thenReturn("테스트동아리");
+        when(clubRepository.findById("club-id")).thenReturn(Optional.of(club));
+        when(mongoTemplate.upsert(any(Query.class), any(Update.class), eq("club_detail_visitor_daily")))
+                .thenThrow(new RuntimeException("mongo error"));
+
+        // when & then
+        assertThrows(RuntimeException.class, () -> service.record(request, "127.0.0.1"));
+        verify(clubAnalyticsRecordService).recordDetailDuration(
+                "club-id",
+                "테스트동아리",
+                LocalDate.of(2026, 8, 6),
+                10
+        );
+    }
+
+    @Test
+    void 요청_제한을_초과하면_429_예외가_발생한다() {
+        // given
+        ClubDetailDurationService service = service();
+        when(stringRedisTemplate.execute(any(RedisScript.class), anyList(), anyString()))
+                .thenReturn(121L);
+
+        // when & then
+        RestApiException exception = assertThrows(
+                RestApiException.class,
+                () -> service.record(request(10), "127.0.0.1")
+        );
+        assertEquals(ErrorCode.STATISTICS_EVENT_RATE_LIMITED, exception.getErrorCode());
+        verifyNoInteractions(clubRepository);
+    }
+
+    @Test
+    void duration이_범위를_벗어나면_실패한다() {
+        // given
+        ClubDetailDurationService service = service();
+
+        // when & then
+        assertThrows(RestApiException.class, () -> service.record(request(0), "127.0.0.1"));
+        assertThrows(RestApiException.class, () -> service.record(request(3601), "127.0.0.1"));
+        verifyNoInteractions(clubRepository);
+        verifyNoInteractions(stringRedisTemplate);
+    }
+
+    @Test
+    void leftAt이_enteredAt보다_이전이면_실패한다() {
+        // given
+        ClubDetailDurationService service = service();
+        ClubDetailDurationRecordRequest request = new ClubDetailDurationRecordRequest(
+                "club-id",
+                "테스트동아리",
+                "session-id",
+                "visitor-id",
+                Instant.parse("2026-08-06T01:00:10Z"),
+                Instant.parse("2026-08-06T01:00:00Z"),
+                10L
+        );
+
+        // when & then
+        assertThrows(RestApiException.class, () -> service.record(request, "127.0.0.1"));
+        verifyNoInteractions(clubRepository);
+        verifyNoInteractions(stringRedisTemplate);
+    }
+
+    private ClubDetailDurationService service() {
+        return new ClubDetailDurationService(
+                clubAnalyticsRecordService,
+                clubRepository,
+                mongoTemplate,
+                stringRedisTemplate
+        );
+    }
+
+    private void passRateLimit() {
+        when(stringRedisTemplate.execute(any(RedisScript.class), anyList(), anyString()))
+                .thenReturn(1L);
+    }
+
+    private void sessionInserted() {
+        when(mongoTemplate.upsert(any(Query.class), any(Update.class), eq("club_detail_duration_sessions")))
+                .thenReturn(UpdateResult.acknowledged(0L, 0L, new BsonString("session-doc-id")));
+    }
+
+    private void sessionDuplicated() {
+        when(mongoTemplate.upsert(any(Query.class), any(Update.class), eq("club_detail_duration_sessions")))
+                .thenReturn(UpdateResult.acknowledged(1L, 0L, null));
+    }
+
+    private void visitorDailyUpdated() {
+        when(mongoTemplate.upsert(any(Query.class), any(Update.class), eq("club_detail_visitor_daily")))
+                .thenReturn(UpdateResult.acknowledged(1L, 1L, null));
+    }
+
+    private ClubDetailDurationRecordRequest request(long durationSeconds) {
+        return new ClubDetailDurationRecordRequest(
+                "club-id",
+                "테스트동아리",
+                "session-id",
+                "visitor-id",
+                Instant.parse("2026-08-06T01:00:00Z"),
+                Instant.parse("2026-08-06T01:00:35Z"),
+                durationSeconds
+        );
+    }
+}

--- a/backend/src/test/java/moadong/analytics/service/ClubStatisticsAdminServiceTest.java
+++ b/backend/src/test/java/moadong/analytics/service/ClubStatisticsAdminServiceTest.java
@@ -1,0 +1,93 @@
+package moadong.analytics.service;
+
+import moadong.analytics.entity.ClubAnalyticsDaily;
+import moadong.analytics.repository.ClubAnalyticsDailyRepository;
+import moadong.analytics.payload.response.ClubStatisticsOverviewResponse;
+import moadong.club.entity.Club;
+import moadong.club.repository.ClubRepository;
+import moadong.util.annotations.UnitTest;
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.AggregationResults;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@UnitTest
+class ClubStatisticsAdminServiceTest {
+
+    @Mock
+    private ClubAnalyticsDailyRepository clubAnalyticsDailyRepository;
+
+    @Mock
+    private ClubApplicantStatisticsService clubApplicantStatisticsService;
+
+    @Mock
+    private ClubRepository clubRepository;
+
+    @Mock
+    private MongoTemplate mongoTemplate;
+
+    @Test
+    void overview는_방문_세션_평균과_인당_평균_체류_시간을_계산한다() {
+        // given
+        ClubStatisticsAdminService service = service();
+        LocalDate from = LocalDate.of(2026, 8, 1);
+        LocalDate to = LocalDate.of(2026, 8, 2);
+        Club club = mock(Club.class);
+        when(club.getName()).thenReturn("테스트동아리");
+        when(clubRepository.findById("club-id")).thenReturn(Optional.of(club));
+        when(clubAnalyticsDailyRepository.findByClubIdAndDateBetweenOrderByDateAsc("club-id", from, to))
+                .thenReturn(List.of(
+                        daily(from, 10, 30, 2),
+                        daily(to, 5, 90, 3)
+                ));
+        when(clubApplicantStatisticsService.countApplicantsByDate("club-id", from, to))
+                .thenReturn(Map.of(from, 2L, to, 1L));
+        Document visitorSummary = new Document()
+                .append("uniqueVisitors", 3L)
+                .append("durationSumSeconds", 120L);
+        when(mongoTemplate.aggregate(any(Aggregation.class), eq("club_detail_visitor_daily"), eq(Document.class)))
+                .thenReturn(new AggregationResults<>(List.of(visitorSummary), new Document()));
+
+        // when
+        ClubStatisticsOverviewResponse response = service.getOverview("club-id", from, to);
+
+        // then
+        assertEquals(15, response.totalDetailViews());
+        assertEquals(24, response.averageDetailDurationSeconds());
+        assertEquals(3, response.uniqueDetailVisitors());
+        assertEquals(40, response.averageDetailDurationSecondsPerVisitor());
+        assertEquals(3, response.totalApplicants());
+    }
+
+    private ClubStatisticsAdminService service() {
+        return new ClubStatisticsAdminService(
+                clubAnalyticsDailyRepository,
+                clubApplicantStatisticsService,
+                clubRepository,
+                mongoTemplate
+        );
+    }
+
+    private ClubAnalyticsDaily daily(LocalDate date, long views, long durationSum, long durationCount) {
+        return ClubAnalyticsDaily.builder()
+                .date(date)
+                .clubId("club-id")
+                .detailViewCount(views)
+                .detailDurationSumSeconds(durationSum)
+                .detailDurationCount(durationCount)
+                .build();
+    }
+}

--- a/backend/src/test/java/moadong/calendar/custom/service/CustomCalendarEventServiceTest.java
+++ b/backend/src/test/java/moadong/calendar/custom/service/CustomCalendarEventServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Collections;
 import java.util.Optional;
 import moadong.calendar.custom.entity.CustomCalendarEvent;
 import moadong.calendar.custom.entity.CustomEventRecurrence;
@@ -239,6 +240,45 @@ class CustomCalendarEventServiceTest {
 
         assertThatThrownBy(() -> customCalendarEventService.create(
                 user, request("2026-08-01", null, "MULTI", null, List.of("2026-08-02"), null)))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
+    }
+
+    @Test
+    @DisplayName("MULTI 일정에 dates가 없으면 예외가 발생한다")
+    void create_multiWithoutDates_throws() {
+        givenAuthenticatedClub();
+
+        assertThatThrownBy(() -> customCalendarEventService.create(
+                user, request("2026-08-01", null, "MULTI", null, null, null)))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
+    }
+
+    @Test
+    @DisplayName("위험한 URL 스킴은 예외가 발생한다")
+    void create_unsafeUrl_throws() {
+        givenAuthenticatedClub();
+        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
+                "정기 모임", "2026-08-01", null, "javascript:alert(1)", null,
+                "SINGLE", null, null, null);
+
+        assertThatThrownBy(() -> customCalendarEventService.create(user, request))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
+    }
+
+    @Test
+    @DisplayName("날짜 배열이 365개를 초과하면 예외가 발생한다")
+    void create_tooManyDates_throws() {
+        givenAuthenticatedClub();
+
+        assertThatThrownBy(() -> customCalendarEventService.create(
+                user, request("2026-08-01", null, "MULTI", null,
+                        Collections.nCopies(366, "2026-08-01"), null)))
                 .isInstanceOf(RestApiException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);

--- a/backend/src/test/java/moadong/calendar/custom/service/CustomCalendarEventServiceTest.java
+++ b/backend/src/test/java/moadong/calendar/custom/service/CustomCalendarEventServiceTest.java
@@ -147,6 +147,60 @@ class CustomCalendarEventServiceTest {
     }
 
     @Test
+    @DisplayName("start가 YYYY-MM-DD 형식이 아니면 예외가 발생한다")
+    void create_invalidStartFormat_throws() {
+        givenAuthenticatedClub();
+        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
+                "정기 모임", "2026/08/01", null, null, null);
+
+        assertThatThrownBy(() -> customCalendarEventService.create(user, request))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_DATE_FORMAT);
+    }
+
+    @Test
+    @DisplayName("end가 YYYY-MM-DD 형식이 아니면 예외가 발생한다")
+    void create_invalidEndFormat_throws() {
+        givenAuthenticatedClub();
+        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
+                "정기 모임", "2026-08-01", "08-02", null, null);
+
+        assertThatThrownBy(() -> customCalendarEventService.create(user, request))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_DATE_FORMAT);
+    }
+
+    @Test
+    @DisplayName("start가 end보다 이후면 예외가 발생한다")
+    void create_startAfterEnd_throws() {
+        givenAuthenticatedClub();
+        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
+                "정기 모임", "2026-08-02", "2026-08-01", null, null);
+
+        assertThatThrownBy(() -> customCalendarEventService.create(user, request))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_DATE_RANGE);
+    }
+
+    @Test
+    @DisplayName("start와 end가 같은 날짜면 정상 생성된다")
+    void create_sameStartAndEnd_succeeds() {
+        givenAuthenticatedClub();
+        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
+                "정기 모임", "2026-08-01", "2026-08-01", null, null);
+        when(customCalendarEventRepository.save(any(CustomCalendarEvent.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        ClubCalendarEventResult result = customCalendarEventService.create(user, request);
+
+        assertThat(result.start()).isEqualTo("2026-08-01");
+        assertThat(result.end()).isEqualTo("2026-08-01");
+    }
+
+    @Test
     @DisplayName("인증된 사용자에게 동아리가 없으면 예외가 발생한다")
     void create_noClub_throws() {
         when(user.getId()).thenReturn(USER_ID);

--- a/backend/src/test/java/moadong/calendar/custom/service/CustomCalendarEventServiceTest.java
+++ b/backend/src/test/java/moadong/calendar/custom/service/CustomCalendarEventServiceTest.java
@@ -3,12 +3,16 @@ package moadong.calendar.custom.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Optional;
 import moadong.calendar.custom.entity.CustomCalendarEvent;
+import moadong.calendar.custom.entity.CustomEventRecurrence;
 import moadong.calendar.custom.payload.request.CustomCalendarEventRequest;
+import moadong.calendar.custom.payload.response.CustomCalendarEventResponse;
 import moadong.calendar.custom.repository.CustomCalendarEventRepository;
 import moadong.club.entity.Club;
 import moadong.club.payload.dto.ClubCalendarEventResult;
@@ -20,6 +24,7 @@ import moadong.util.annotations.UnitTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
 @UnitTest
@@ -45,7 +50,8 @@ class CustomCalendarEventServiceTest {
 
     @BeforeEach
     void setUp() {
-        customCalendarEventService = new CustomCalendarEventService(customCalendarEventRepository, clubRepository);
+        customCalendarEventService = new CustomCalendarEventService(
+                customCalendarEventRepository, clubRepository, new CustomEventOccurrenceExpander());
     }
 
     private void givenAuthenticatedClub() {
@@ -54,119 +60,209 @@ class CustomCalendarEventServiceTest {
         when(clubRepository.findClubByUserId(USER_ID)).thenReturn(Optional.of(club));
     }
 
-    @Test
-    @DisplayName("커스텀 이벤트를 생성하면 source가 CUSTOM인 결과를 반환한다")
-    void create_returnsCustomResult() {
-        givenAuthenticatedClub();
-        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
-                "정기 모임", "2026-08-01", "2026-08-02", "https://example.com", "설명");
+    private void givenSaveReturnsArgument() {
         when(customCalendarEventRepository.save(any(CustomCalendarEvent.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
-
-        ClubCalendarEventResult result = customCalendarEventService.create(user, request);
-
-        assertThat(result.source()).isEqualTo("CUSTOM");
-        assertThat(result.title()).isEqualTo("정기 모임");
-        assertThat(result.start()).isEqualTo("2026-08-01");
-        assertThat(result.end()).isEqualTo("2026-08-02");
     }
 
-    @Test
-    @DisplayName("clubId로 커스텀 이벤트 목록을 CUSTOM 결과로 매핑한다")
-    void getClubCalendarEvents_mapsToCustomResults() {
-        CustomCalendarEvent event = CustomCalendarEvent.builder()
+    private CustomCalendarEventRequest request(String start, String end, String eventType, String color,
+                                               List<String> dates, CustomEventRecurrence recurrence) {
+        return new CustomCalendarEventRequest("정기 모임", start, end, null, null, eventType, color, dates, recurrence);
+    }
+
+    private CustomCalendarEvent storedEvent(String eventType, String start, String end,
+                                            List<String> dates, CustomEventRecurrence recurrence) {
+        return CustomCalendarEvent.builder()
                 .id(EVENT_ID)
                 .clubId(CLUB_ID)
                 .title("정기 모임")
-                .start("2026-08-01")
+                .start(start)
+                .end(end)
+                .eventType(eventType)
+                .dates(dates)
+                .recurrence(recurrence)
                 .build();
-        when(customCalendarEventRepository.findByClubId(CLUB_ID)).thenReturn(List.of(event));
-
-        List<ClubCalendarEventResult> results = customCalendarEventService.getClubCalendarEvents(CLUB_ID);
-
-        assertThat(results).hasSize(1);
-        assertThat(results.get(0).id()).isEqualTo(EVENT_ID);
-        assertThat(results.get(0).source()).isEqualTo("CUSTOM");
     }
 
     @Test
-    @DisplayName("clubId가 비어있으면 빈 리스트를 반환한다")
-    void getClubCalendarEvents_blankClubId_returnsEmpty() {
-        List<ClubCalendarEventResult> results = customCalendarEventService.getClubCalendarEvents(" ");
-
-        assertThat(results).isEmpty();
-    }
-
-    @Test
-    @DisplayName("다른 동아리의 이벤트를 수정하면 예외가 발생한다")
-    void update_otherClubEvent_throwsNotFound() {
+    @DisplayName("SINGLE 이벤트를 생성하면 source가 CUSTOM인 결과를 반환한다")
+    void create_single() {
         givenAuthenticatedClub();
-        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
-                "수정", "2026-08-01", null, null, null);
-        when(customCalendarEventRepository.findByIdAndClubId(EVENT_ID, CLUB_ID)).thenReturn(Optional.empty());
+        givenSaveReturnsArgument();
 
-        assertThatThrownBy(() -> customCalendarEventService.update(user, EVENT_ID, request))
+        CustomCalendarEventResponse response = customCalendarEventService.create(
+                user, request("2026-08-01", null, "SINGLE", "PINK", null, null));
+
+        assertThat(response.source()).isEqualTo("CUSTOM");
+        assertThat(response.eventType()).isEqualTo("SINGLE");
+        assertThat(response.color()).isEqualTo("PINK");
+        assertThat(response.start()).isEqualTo("2026-08-01");
+    }
+
+    @Test
+    @DisplayName("eventType이 없으면 SINGLE로 저장하고 반환한다")
+    void create_withoutEventType_defaultsToSingle() {
+        givenAuthenticatedClub();
+        givenSaveReturnsArgument();
+
+        CustomCalendarEventResponse response = customCalendarEventService.create(
+                user, request("2026-08-01", null, null, null, null, null));
+
+        assertThat(response.eventType()).isEqualTo("SINGLE");
+    }
+
+    @Test
+    @DisplayName("PERIOD 이벤트를 생성하면 start/end가 그대로 저장된다")
+    void create_period() {
+        givenAuthenticatedClub();
+        givenSaveReturnsArgument();
+
+        CustomCalendarEventResponse response = customCalendarEventService.create(
+                user, request("2026-08-01", "2026-08-05", "PERIOD", "MINT", null, null));
+
+        assertThat(response.eventType()).isEqualTo("PERIOD");
+        assertThat(response.start()).isEqualTo("2026-08-01");
+        assertThat(response.end()).isEqualTo("2026-08-05");
+    }
+
+    @Test
+    @DisplayName("MULTI 이벤트를 생성하면 dates가 그대로 저장된다")
+    void create_multi() {
+        givenAuthenticatedClub();
+        givenSaveReturnsArgument();
+        List<String> dates = List.of("2026-08-01", "2026-08-10");
+
+        CustomCalendarEventResponse response = customCalendarEventService.create(
+                user, request("2026-08-01", null, "MULTI", "BLUE", dates, null));
+
+        assertThat(response.eventType()).isEqualTo("MULTI");
+        assertThat(response.dates()).containsExactlyElementsOf(dates);
+    }
+
+    @Test
+    @DisplayName("RECURRING 이벤트를 생성하면 recurrence가 그대로 저장된다")
+    void create_recurring() {
+        givenAuthenticatedClub();
+        givenSaveReturnsArgument();
+        CustomEventRecurrence recurrence =
+                new CustomEventRecurrence("WEEKLY", List.of(5, 6), "2026-09-30", List.of("2026-08-15"));
+
+        CustomCalendarEventResponse response = customCalendarEventService.create(
+                user, request("2026-08-01", null, "RECURRING", "PURPLE", null, recurrence));
+
+        assertThat(response.eventType()).isEqualTo("RECURRING");
+        assertThat(response.recurrence().frequency()).isEqualTo("WEEKLY");
+        assertThat(response.recurrence().weekdays()).containsExactly(5, 6);
+        assertThat(response.recurrence().end()).isEqualTo("2026-09-30");
+        assertThat(response.recurrence().excludedDates()).containsExactly("2026-08-15");
+    }
+
+    @Test
+    @DisplayName("허용되지 않은 eventType이면 예외가 발생한다")
+    void create_invalidEventType_throws() {
+        givenAuthenticatedClub();
+
+        assertThatThrownBy(() -> customCalendarEventService.create(
+                user, request("2026-08-01", null, "DAILY", null, null, null)))
                 .isInstanceOf(RestApiException.class)
                 .extracting("errorCode")
-                .isEqualTo(ErrorCode.CUSTOM_EVENT_NOT_FOUND);
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
     }
 
     @Test
-    @DisplayName("커스텀 이벤트를 수정하면 변경된 값이 반영된다")
-    void update_updatesFields() {
+    @DisplayName("허용되지 않은 color면 예외가 발생한다")
+    void create_invalidColor_throws() {
         givenAuthenticatedClub();
-        CustomCalendarEvent event = CustomCalendarEvent.builder()
-                .id(EVENT_ID)
-                .clubId(CLUB_ID)
-                .title("이전 제목")
-                .start("2026-08-01")
-                .build();
-        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
-                "새 제목", "2026-09-01", null, null, null);
-        when(customCalendarEventRepository.findByIdAndClubId(EVENT_ID, CLUB_ID)).thenReturn(Optional.of(event));
-        when(customCalendarEventRepository.save(any(CustomCalendarEvent.class)))
-                .thenAnswer(invocation -> invocation.getArgument(0));
 
-        ClubCalendarEventResult result = customCalendarEventService.update(user, EVENT_ID, request);
-
-        assertThat(result.title()).isEqualTo("새 제목");
-        assertThat(result.start()).isEqualTo("2026-09-01");
-        assertThat(result.source()).isEqualTo("CUSTOM");
-    }
-
-    @Test
-    @DisplayName("존재하지 않는 이벤트를 삭제하면 예외가 발생한다")
-    void delete_notFound_throws() {
-        givenAuthenticatedClub();
-        when(customCalendarEventRepository.deleteByIdAndClubId(EVENT_ID, CLUB_ID)).thenReturn(0L);
-
-        assertThatThrownBy(() -> customCalendarEventService.delete(user, EVENT_ID))
+        assertThatThrownBy(() -> customCalendarEventService.create(
+                user, request("2026-08-01", null, "SINGLE", "RED", null, null)))
                 .isInstanceOf(RestApiException.class)
                 .extracting("errorCode")
-                .isEqualTo(ErrorCode.CUSTOM_EVENT_NOT_FOUND);
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
     }
 
     @Test
-    @DisplayName("start가 YYYY-MM-DD 형식이 아니면 예외가 발생한다")
-    void create_invalidStartFormat_throws() {
+    @DisplayName("허용되지 않은 반복 주기면 예외가 발생한다")
+    void create_invalidFrequency_throws() {
         givenAuthenticatedClub();
-        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
-                "정기 모임", "2026/08/01", null, null, null);
+        CustomEventRecurrence recurrence = new CustomEventRecurrence("DAILY", null, null, null);
 
-        assertThatThrownBy(() -> customCalendarEventService.create(user, request))
+        assertThatThrownBy(() -> customCalendarEventService.create(
+                user, request("2026-08-01", null, "RECURRING", null, null, recurrence)))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
+    }
+
+    @Test
+    @DisplayName("WEEKLY weekdays가 0에서 6 범위를 벗어나면 예외가 발생한다")
+    void create_invalidWeekday_throws() {
+        givenAuthenticatedClub();
+        CustomEventRecurrence recurrence = new CustomEventRecurrence("WEEKLY", List.of(7), null, null);
+
+        assertThatThrownBy(() -> customCalendarEventService.create(
+                user, request("2026-08-01", null, "RECURRING", null, null, recurrence)))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
+    }
+
+    @Test
+    @DisplayName("RECURRING 이벤트에 recurrence가 없으면 예외가 발생한다")
+    void create_recurringWithoutRecurrence_throws() {
+        givenAuthenticatedClub();
+
+        assertThatThrownBy(() -> customCalendarEventService.create(
+                user, request("2026-08-01", null, "RECURRING", null, null, null)))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
+    }
+
+    @Test
+    @DisplayName("반복 종료일이 시작일보다 앞이면 예외가 발생한다")
+    void create_recurrenceEndBeforeStart_throws() {
+        givenAuthenticatedClub();
+        CustomEventRecurrence recurrence = new CustomEventRecurrence("MONTHLY", null, "2026-07-31", null);
+
+        assertThatThrownBy(() -> customCalendarEventService.create(
+                user, request("2026-08-01", null, "RECURRING", null, null, recurrence)))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_DATE_RANGE);
+    }
+
+    @Test
+    @DisplayName("MULTI 일정의 start는 dates 첫 날짜와 같아야 한다")
+    void create_multiStartMustMatchFirstDate_throws() {
+        givenAuthenticatedClub();
+
+        assertThatThrownBy(() -> customCalendarEventService.create(
+                user, request("2026-08-01", null, "MULTI", null, List.of("2026-08-02"), null)))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_FIELD_VALUE);
+    }
+
+    @Test
+    @DisplayName("dates에 잘못된 날짜 형식이 있으면 예외가 발생한다")
+    void create_invalidDatesFormat_throws() {
+        givenAuthenticatedClub();
+
+        assertThatThrownBy(() -> customCalendarEventService.create(
+                user, request("2026-08-01", null, "MULTI", null, List.of("2026/08/10"), null)))
                 .isInstanceOf(RestApiException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_DATE_FORMAT);
     }
 
     @Test
-    @DisplayName("end가 YYYY-MM-DD 형식이 아니면 예외가 발생한다")
-    void create_invalidEndFormat_throws() {
+    @DisplayName("start가 YYYY-MM-DD 형식이 아니면 예외가 발생한다")
+    void create_invalidStartFormat_throws() {
         givenAuthenticatedClub();
-        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
-                "정기 모임", "2026-08-01", "08-02", null, null);
 
-        assertThatThrownBy(() -> customCalendarEventService.create(user, request))
+        assertThatThrownBy(() -> customCalendarEventService.create(
+                user, request("2026/08/01", null, null, null, null, null)))
                 .isInstanceOf(RestApiException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_DATE_FORMAT);
@@ -176,28 +272,187 @@ class CustomCalendarEventServiceTest {
     @DisplayName("start가 end보다 이후면 예외가 발생한다")
     void create_startAfterEnd_throws() {
         givenAuthenticatedClub();
-        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
-                "정기 모임", "2026-08-02", "2026-08-01", null, null);
 
-        assertThatThrownBy(() -> customCalendarEventService.create(user, request))
+        assertThatThrownBy(() -> customCalendarEventService.create(
+                user, request("2026-08-02", "2026-08-01", null, null, null, null)))
                 .isInstanceOf(RestApiException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_DATE_RANGE);
     }
 
     @Test
-    @DisplayName("start와 end가 같은 날짜면 정상 생성된다")
-    void create_sameStartAndEnd_succeeds() {
+    @DisplayName("관리자 목록 조회는 전개하지 않고 원형을 반환한다")
+    void list_returnsRawEvents() {
         givenAuthenticatedClub();
-        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
-                "정기 모임", "2026-08-01", "2026-08-01", null, null);
-        when(customCalendarEventRepository.save(any(CustomCalendarEvent.class)))
-                .thenAnswer(invocation -> invocation.getArgument(0));
+        CustomEventRecurrence recurrence = new CustomEventRecurrence("WEEKLY", null, "2026-03-31", null);
+        when(customCalendarEventRepository.findByClubId(CLUB_ID))
+                .thenReturn(List.of(storedEvent("RECURRING", "2026-03-06", null, null, recurrence)));
 
-        ClubCalendarEventResult result = customCalendarEventService.create(user, request);
+        List<CustomCalendarEventResponse> results = customCalendarEventService.list(user);
 
-        assertThat(result.start()).isEqualTo("2026-08-01");
-        assertThat(result.end()).isEqualTo("2026-08-01");
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).id()).isEqualTo(EVENT_ID);
+        assertThat(results.get(0).start()).isEqualTo("2026-03-06");
+        assertThat(results.get(0).recurrence().frequency()).isEqualTo("WEEKLY");
+    }
+
+    @Test
+    @DisplayName("이벤트를 수정하면 확장 필드까지 갱신된다")
+    void update_updatesExtendedFields() {
+        givenAuthenticatedClub();
+        givenSaveReturnsArgument();
+        when(customCalendarEventRepository.findByIdAndClubId(EVENT_ID, CLUB_ID))
+                .thenReturn(Optional.of(storedEvent("SINGLE", "2026-08-01", null, null, null)));
+        List<String> dates = List.of("2026-09-01", "2026-09-02");
+
+        CustomCalendarEventResponse response = customCalendarEventService.update(
+                user, EVENT_ID, request("2026-09-01", null, "MULTI", "ORANGE", dates, null));
+
+        assertThat(response.eventType()).isEqualTo("MULTI");
+        assertThat(response.color()).isEqualTo("ORANGE");
+        assertThat(response.dates()).containsExactlyElementsOf(dates);
+    }
+
+    @Test
+    @DisplayName("다른 동아리의 이벤트를 수정하면 예외가 발생한다")
+    void update_otherClubEvent_throwsNotFound() {
+        givenAuthenticatedClub();
+        when(customCalendarEventRepository.findByIdAndClubId(EVENT_ID, CLUB_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> customCalendarEventService.update(
+                user, EVENT_ID, request("2026-08-01", null, null, null, null, null)))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("scope가 없으면 이벤트를 삭제한다")
+    void delete_withoutScope_deletesEvent() {
+        givenAuthenticatedClub();
+        CustomCalendarEvent event = storedEvent("SINGLE", "2026-08-01", null, null, null);
+        when(customCalendarEventRepository.findByIdAndClubId(EVENT_ID, CLUB_ID)).thenReturn(Optional.of(event));
+
+        customCalendarEventService.delete(user, EVENT_ID, null, null);
+
+        verify(customCalendarEventRepository).delete(event);
+    }
+
+    @Test
+    @DisplayName("THIS 스코프는 해당 발생일을 excludedDates에 추가한다")
+    void delete_thisScope_addsExcludedDate() {
+        givenAuthenticatedClub();
+        givenSaveReturnsArgument();
+        CustomEventRecurrence recurrence = new CustomEventRecurrence("WEEKLY", null, "2026-03-31", null);
+        CustomCalendarEvent event = storedEvent("RECURRING", "2026-03-06", null, null, recurrence);
+        when(customCalendarEventRepository.findByIdAndClubId(EVENT_ID, CLUB_ID)).thenReturn(Optional.of(event));
+
+        customCalendarEventService.delete(user, EVENT_ID, "THIS", "2026-03-13");
+
+        ArgumentCaptor<CustomCalendarEvent> captor = ArgumentCaptor.forClass(CustomCalendarEvent.class);
+        verify(customCalendarEventRepository).save(captor.capture());
+        verify(customCalendarEventRepository, never()).delete(any(CustomCalendarEvent.class));
+        assertThat(captor.getValue().getRecurrence().excludedDates()).containsExactly("2026-03-13");
+    }
+
+    @Test
+    @DisplayName("THIS_AND_FOLLOWING 스코프는 반복 종료일을 기준일 하루 전으로 당긴다")
+    void delete_thisAndFollowingScope_truncatesRecurrenceEnd() {
+        givenAuthenticatedClub();
+        givenSaveReturnsArgument();
+        CustomEventRecurrence recurrence = new CustomEventRecurrence("WEEKLY", null, "2026-03-31", null);
+        CustomCalendarEvent event = storedEvent("RECURRING", "2026-03-06", null, null, recurrence);
+        when(customCalendarEventRepository.findByIdAndClubId(EVENT_ID, CLUB_ID)).thenReturn(Optional.of(event));
+
+        customCalendarEventService.delete(user, EVENT_ID, "THIS_AND_FOLLOWING", "2026-03-20");
+
+        ArgumentCaptor<CustomCalendarEvent> captor = ArgumentCaptor.forClass(CustomCalendarEvent.class);
+        verify(customCalendarEventRepository).save(captor.capture());
+        assertThat(captor.getValue().getRecurrence().end()).isEqualTo("2026-03-19");
+    }
+
+    @Test
+    @DisplayName("THIS_AND_FOLLOWING 기준일이 시작일이면 이벤트를 삭제한다")
+    void delete_thisAndFollowingFromStart_deletesEvent() {
+        givenAuthenticatedClub();
+        CustomEventRecurrence recurrence = new CustomEventRecurrence("WEEKLY", null, "2026-03-31", null);
+        CustomCalendarEvent event = storedEvent("RECURRING", "2026-03-06", null, null, recurrence);
+        when(customCalendarEventRepository.findByIdAndClubId(EVENT_ID, CLUB_ID)).thenReturn(Optional.of(event));
+
+        customCalendarEventService.delete(user, EVENT_ID, "THIS_AND_FOLLOWING", "2026-03-06");
+
+        verify(customCalendarEventRepository).delete(event);
+        verify(customCalendarEventRepository, never()).save(any(CustomCalendarEvent.class));
+    }
+
+    @Test
+    @DisplayName("반복이 아닌 일정은 THIS 스코프여도 삭제한다")
+    void delete_nonRecurringWithScope_deletesEvent() {
+        givenAuthenticatedClub();
+        CustomCalendarEvent event = storedEvent("PERIOD", "2026-08-01", "2026-08-05", null, null);
+        when(customCalendarEventRepository.findByIdAndClubId(EVENT_ID, CLUB_ID)).thenReturn(Optional.of(event));
+
+        customCalendarEventService.delete(user, EVENT_ID, "THIS", "2026-08-03");
+
+        verify(customCalendarEventRepository).delete(event);
+    }
+
+    @Test
+    @DisplayName("허용되지 않은 삭제 스코프면 예외가 발생한다")
+    void delete_invalidScope_throws() {
+        givenAuthenticatedClub();
+
+        assertThatThrownBy(() -> customCalendarEventService.delete(user, EVENT_ID, "ONLY_ONE", "2026-08-01"))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_INVALID_DELETE_SCOPE);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 이벤트를 삭제하면 예외가 발생한다")
+    void delete_notFound_throws() {
+        givenAuthenticatedClub();
+        when(customCalendarEventRepository.findByIdAndClubId(EVENT_ID, CLUB_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> customCalendarEventService.delete(user, EVENT_ID, null, null))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("공개 캘린더 조회는 발생일마다 하나씩 펼쳐서 반환한다")
+    void getClubCalendarEvents_expandsOccurrences() {
+        when(customCalendarEventRepository.findByClubId(CLUB_ID))
+                .thenReturn(List.of(storedEvent("PERIOD", "2026-08-01", "2026-08-03", null, null)));
+
+        List<ClubCalendarEventResult> results = customCalendarEventService.getClubCalendarEvents(CLUB_ID);
+
+        assertThat(results).hasSize(3);
+        assertThat(results).extracting(ClubCalendarEventResult::start)
+                .containsExactly("2026-08-01", "2026-08-02", "2026-08-03");
+        assertThat(results).extracting(ClubCalendarEventResult::id)
+                .containsExactly(EVENT_ID + ":2026-08-01", EVENT_ID + ":2026-08-02", EVENT_ID + ":2026-08-03");
+        assertThat(results).allSatisfy(result -> assertThat(result.source()).isEqualTo("CUSTOM"));
+    }
+
+    @Test
+    @DisplayName("발생일이 하나면 원래 id와 end를 유지한다")
+    void getClubCalendarEvents_singleOccurrenceKeepsId() {
+        when(customCalendarEventRepository.findByClubId(CLUB_ID))
+                .thenReturn(List.of(storedEvent("SINGLE", "2026-08-01", "2026-08-05", null, null)));
+
+        List<ClubCalendarEventResult> results = customCalendarEventService.getClubCalendarEvents(CLUB_ID);
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).id()).isEqualTo(EVENT_ID);
+        assertThat(results.get(0).end()).isEqualTo("2026-08-05");
+    }
+
+    @Test
+    @DisplayName("clubId가 비어있으면 빈 리스트를 반환한다")
+    void getClubCalendarEvents_blankClubId_returnsEmpty() {
+        assertThat(customCalendarEventService.getClubCalendarEvents(" ")).isEmpty();
     }
 
     @Test
@@ -205,10 +460,9 @@ class CustomCalendarEventServiceTest {
     void create_noClub_throws() {
         when(user.getId()).thenReturn(USER_ID);
         when(clubRepository.findClubByUserId(USER_ID)).thenReturn(Optional.empty());
-        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
-                "정기 모임", "2026-08-01", null, null, null);
 
-        assertThatThrownBy(() -> customCalendarEventService.create(user, request))
+        assertThatThrownBy(() -> customCalendarEventService.create(
+                user, request("2026-08-01", null, null, null, null, null)))
                 .isInstanceOf(RestApiException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.CUSTOM_EVENT_CLUB_NOT_FOUND);

--- a/backend/src/test/java/moadong/calendar/custom/service/CustomCalendarEventServiceTest.java
+++ b/backend/src/test/java/moadong/calendar/custom/service/CustomCalendarEventServiceTest.java
@@ -80,6 +80,7 @@ class CustomCalendarEventServiceTest {
                 .start(start)
                 .end(end)
                 .eventType(eventType)
+                .color("MINT")
                 .dates(dates)
                 .recurrence(recurrence)
                 .build();
@@ -463,17 +464,50 @@ class CustomCalendarEventServiceTest {
     @Test
     @DisplayName("공개 캘린더 조회는 발생일마다 하나씩 펼쳐서 반환한다")
     void getClubCalendarEvents_expandsOccurrences() {
+        List<String> dates = List.of("2026-08-01", "2026-08-02", "2026-08-03");
         when(customCalendarEventRepository.findByClubId(CLUB_ID))
-                .thenReturn(List.of(storedEvent("PERIOD", "2026-08-01", "2026-08-03", null, null)));
+                .thenReturn(List.of(storedEvent("MULTI", "2026-08-01", null, dates, null)));
 
         List<ClubCalendarEventResult> results = customCalendarEventService.getClubCalendarEvents(CLUB_ID);
 
         assertThat(results).hasSize(3);
         assertThat(results).extracting(ClubCalendarEventResult::start)
-                .containsExactly("2026-08-01", "2026-08-02", "2026-08-03");
+                .containsExactlyElementsOf(dates);
         assertThat(results).extracting(ClubCalendarEventResult::id)
                 .containsExactly(EVENT_ID + ":2026-08-01", EVENT_ID + ":2026-08-02", EVENT_ID + ":2026-08-03");
-        assertThat(results).allSatisfy(result -> assertThat(result.source()).isEqualTo("CUSTOM"));
+        assertThat(results).allSatisfy(result -> {
+            assertThat(result.source()).isEqualTo("CUSTOM");
+            assertThat(result.eventType()).isEqualTo("MULTI");
+            assertThat(result.color()).isEqualTo("MINT");
+        });
+    }
+
+    @Test
+    @DisplayName("PERIOD는 전개하지 않고 start/end를 가진 한 건으로 반환한다")
+    void getClubCalendarEvents_periodIsNotExpanded() {
+        when(customCalendarEventRepository.findByClubId(CLUB_ID))
+                .thenReturn(List.of(storedEvent("PERIOD", "2026-03-16", "2026-03-20", null, null)));
+
+        List<ClubCalendarEventResult> results = customCalendarEventService.getClubCalendarEvents(CLUB_ID);
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).id()).isEqualTo(EVENT_ID);
+        assertThat(results.get(0).start()).isEqualTo("2026-03-16");
+        assertThat(results.get(0).end()).isEqualTo("2026-03-20");
+        assertThat(results.get(0).eventType()).isEqualTo("PERIOD");
+        assertThat(results.get(0).color()).isEqualTo("MINT");
+    }
+
+    @Test
+    @DisplayName("eventType이 없는 이벤트는 SINGLE로 내려준다")
+    void getClubCalendarEvents_nullEventTypeDefaultsToSingle() {
+        when(customCalendarEventRepository.findByClubId(CLUB_ID))
+                .thenReturn(List.of(storedEvent(null, "2026-08-01", null, null, null)));
+
+        List<ClubCalendarEventResult> results = customCalendarEventService.getClubCalendarEvents(CLUB_ID);
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).eventType()).isEqualTo("SINGLE");
     }
 
     @Test

--- a/backend/src/test/java/moadong/calendar/custom/service/CustomCalendarEventServiceTest.java
+++ b/backend/src/test/java/moadong/calendar/custom/service/CustomCalendarEventServiceTest.java
@@ -413,6 +413,22 @@ class CustomCalendarEventServiceTest {
     }
 
     @Test
+    @DisplayName("THIS_AND_FOLLOWING 기준일이 기존 종료일보다 뒤면 종료일을 연장하지 않는다")
+    void delete_thisAndFollowingAfterRecurrenceEnd_keepsRecurrenceEnd() {
+        givenAuthenticatedClub();
+        givenSaveReturnsArgument();
+        CustomEventRecurrence recurrence = new CustomEventRecurrence("WEEKLY", null, "2026-03-31", null);
+        CustomCalendarEvent event = storedEvent("RECURRING", "2026-03-06", null, null, recurrence);
+        when(customCalendarEventRepository.findByIdAndClubId(EVENT_ID, CLUB_ID)).thenReturn(Optional.of(event));
+
+        customCalendarEventService.delete(user, EVENT_ID, "THIS_AND_FOLLOWING", "2027-01-01");
+
+        ArgumentCaptor<CustomCalendarEvent> captor = ArgumentCaptor.forClass(CustomCalendarEvent.class);
+        verify(customCalendarEventRepository).save(captor.capture());
+        assertThat(captor.getValue().getRecurrence().end()).isEqualTo("2026-03-31");
+    }
+
+    @Test
     @DisplayName("THIS_AND_FOLLOWING 기준일이 시작일이면 이벤트를 삭제한다")
     void delete_thisAndFollowingFromStart_deletesEvent() {
         givenAuthenticatedClub();

--- a/backend/src/test/java/moadong/calendar/custom/service/CustomCalendarEventServiceTest.java
+++ b/backend/src/test/java/moadong/calendar/custom/service/CustomCalendarEventServiceTest.java
@@ -1,0 +1,170 @@
+package moadong.calendar.custom.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import moadong.calendar.custom.entity.CustomCalendarEvent;
+import moadong.calendar.custom.payload.request.CustomCalendarEventRequest;
+import moadong.calendar.custom.repository.CustomCalendarEventRepository;
+import moadong.club.entity.Club;
+import moadong.club.payload.dto.ClubCalendarEventResult;
+import moadong.club.repository.ClubRepository;
+import moadong.global.exception.ErrorCode;
+import moadong.global.exception.RestApiException;
+import moadong.user.payload.CustomUserDetails;
+import moadong.util.annotations.UnitTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+@UnitTest
+class CustomCalendarEventServiceTest {
+
+    @Mock
+    private CustomCalendarEventRepository customCalendarEventRepository;
+
+    @Mock
+    private ClubRepository clubRepository;
+
+    @Mock
+    private CustomUserDetails user;
+
+    @Mock
+    private Club club;
+
+    private CustomCalendarEventService customCalendarEventService;
+
+    private static final String USER_ID = "test-user-id";
+    private static final String CLUB_ID = "test-club-id";
+    private static final String EVENT_ID = "test-event-id";
+
+    @BeforeEach
+    void setUp() {
+        customCalendarEventService = new CustomCalendarEventService(customCalendarEventRepository, clubRepository);
+    }
+
+    private void givenAuthenticatedClub() {
+        when(user.getId()).thenReturn(USER_ID);
+        when(club.getId()).thenReturn(CLUB_ID);
+        when(clubRepository.findClubByUserId(USER_ID)).thenReturn(Optional.of(club));
+    }
+
+    @Test
+    @DisplayName("커스텀 이벤트를 생성하면 source가 CUSTOM인 결과를 반환한다")
+    void create_returnsCustomResult() {
+        givenAuthenticatedClub();
+        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
+                "정기 모임", "2026-08-01", "2026-08-02", "https://example.com", "설명");
+        when(customCalendarEventRepository.save(any(CustomCalendarEvent.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        ClubCalendarEventResult result = customCalendarEventService.create(user, request);
+
+        assertThat(result.source()).isEqualTo("CUSTOM");
+        assertThat(result.title()).isEqualTo("정기 모임");
+        assertThat(result.start()).isEqualTo("2026-08-01");
+        assertThat(result.end()).isEqualTo("2026-08-02");
+    }
+
+    @Test
+    @DisplayName("clubId로 커스텀 이벤트 목록을 CUSTOM 결과로 매핑한다")
+    void getClubCalendarEvents_mapsToCustomResults() {
+        CustomCalendarEvent event = CustomCalendarEvent.builder()
+                .id(EVENT_ID)
+                .clubId(CLUB_ID)
+                .title("정기 모임")
+                .start("2026-08-01")
+                .build();
+        when(customCalendarEventRepository.findByClubId(CLUB_ID)).thenReturn(List.of(event));
+
+        List<ClubCalendarEventResult> results = customCalendarEventService.getClubCalendarEvents(CLUB_ID);
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).id()).isEqualTo(EVENT_ID);
+        assertThat(results.get(0).source()).isEqualTo("CUSTOM");
+    }
+
+    @Test
+    @DisplayName("clubId가 비어있으면 빈 리스트를 반환한다")
+    void getClubCalendarEvents_blankClubId_returnsEmpty() {
+        List<ClubCalendarEventResult> results = customCalendarEventService.getClubCalendarEvents(" ");
+
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    @DisplayName("다른 동아리의 이벤트를 수정하면 예외가 발생한다")
+    void update_otherClubEvent_throwsNotFound() {
+        givenAuthenticatedClub();
+        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
+                "수정", "2026-08-01", null, null, null);
+        when(customCalendarEventRepository.findByIdAndClubId(EVENT_ID, CLUB_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> customCalendarEventService.update(user, EVENT_ID, request))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("커스텀 이벤트를 수정하면 변경된 값이 반영된다")
+    void update_updatesFields() {
+        givenAuthenticatedClub();
+        CustomCalendarEvent event = CustomCalendarEvent.builder()
+                .id(EVENT_ID)
+                .clubId(CLUB_ID)
+                .title("이전 제목")
+                .start("2026-08-01")
+                .build();
+        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
+                "새 제목", "2026-09-01", null, null, null);
+        when(customCalendarEventRepository.findByIdAndClubId(EVENT_ID, CLUB_ID)).thenReturn(Optional.of(event));
+        when(customCalendarEventRepository.save(any(CustomCalendarEvent.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        ClubCalendarEventResult result = customCalendarEventService.update(user, EVENT_ID, request);
+
+        assertThat(result.title()).isEqualTo("새 제목");
+        assertThat(result.start()).isEqualTo("2026-09-01");
+        assertThat(result.source()).isEqualTo("CUSTOM");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 이벤트를 삭제하면 예외가 발생한다")
+    void delete_notFound_throws() {
+        givenAuthenticatedClub();
+        when(customCalendarEventRepository.deleteByIdAndClubId(EVENT_ID, CLUB_ID)).thenReturn(0L);
+
+        assertThatThrownBy(() -> customCalendarEventService.delete(user, EVENT_ID))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("인증된 사용자에게 동아리가 없으면 예외가 발생한다")
+    void create_noClub_throws() {
+        when(user.getId()).thenReturn(USER_ID);
+        when(clubRepository.findClubByUserId(USER_ID)).thenReturn(Optional.empty());
+        CustomCalendarEventRequest request = new CustomCalendarEventRequest(
+                "정기 모임", "2026-08-01", null, null, null);
+
+        assertThatThrownBy(() -> customCalendarEventService.create(user, request))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.CUSTOM_EVENT_CLUB_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("이벤트가 존재하면 hasCalendarConnection이 true를 반환한다")
+    void hasCalendarConnection_eventsExist_returnsTrue() {
+        when(customCalendarEventRepository.existsByClubId(CLUB_ID)).thenReturn(true);
+
+        assertThat(customCalendarEventService.hasCalendarConnection(CLUB_ID)).isTrue();
+    }
+}

--- a/backend/src/test/java/moadong/calendar/custom/service/CustomEventOccurrenceExpanderTest.java
+++ b/backend/src/test/java/moadong/calendar/custom/service/CustomEventOccurrenceExpanderTest.java
@@ -165,6 +165,21 @@ class CustomEventOccurrenceExpanderTest {
     }
 
     @Test
+    @DisplayName("오래된 무기한 WEEKLY 반복도 미래 발생일을 포함한다")
+    void expand_unboundedPastWeeklyIncludesFutureOccurrences() {
+        LocalDate today = LocalDate.now();
+        CustomEventRecurrence recurrence = new CustomEventRecurrence("WEEKLY", null, null, null);
+
+        List<String> occurrences = expander.expand(event(
+                "RECURRING", today.minusYears(20).toString(), null, null, recurrence));
+
+        assertThat(occurrences).isNotEmpty();
+        assertThat(occurrences)
+                .anySatisfy(date -> assertThat(LocalDate.parse(date)).isAfter(today))
+                .allSatisfy(date -> assertThat(LocalDate.parse(date)).isBeforeOrEqualTo(today.plusYears(1)));
+    }
+
+    @Test
     @DisplayName("RECURRING인데 recurrence가 없으면 start 하루만 전개한다")
     void expand_recurringWithoutRecurrence() {
         assertThat(expander.expand(event("RECURRING", "2026-03-01", null, null, null)))

--- a/backend/src/test/java/moadong/calendar/custom/service/CustomEventOccurrenceExpanderTest.java
+++ b/backend/src/test/java/moadong/calendar/custom/service/CustomEventOccurrenceExpanderTest.java
@@ -1,0 +1,180 @@
+package moadong.calendar.custom.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.util.List;
+import moadong.calendar.custom.entity.CustomCalendarEvent;
+import moadong.calendar.custom.entity.CustomEventRecurrence;
+import moadong.util.annotations.UnitTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@UnitTest
+class CustomEventOccurrenceExpanderTest {
+
+    private CustomEventOccurrenceExpander expander;
+
+    @BeforeEach
+    void setUp() {
+        expander = new CustomEventOccurrenceExpander();
+    }
+
+    private CustomCalendarEvent event(String eventType, String start, String end,
+                                      List<String> dates, CustomEventRecurrence recurrence) {
+        return CustomCalendarEvent.builder()
+                .id("event-1")
+                .clubId("club-1")
+                .title("일정")
+                .start(start)
+                .end(end)
+                .eventType(eventType)
+                .dates(dates)
+                .recurrence(recurrence)
+                .build();
+    }
+
+    @Test
+    @DisplayName("SINGLE은 start 하루만 전개한다")
+    void expand_single() {
+        assertThat(expander.expand(event("SINGLE", "2026-03-01", null, null, null)))
+                .containsExactly("2026-03-01");
+    }
+
+    @Test
+    @DisplayName("eventType이 없으면 SINGLE로 취급한다")
+    void expand_nullEventType_treatedAsSingle() {
+        assertThat(expander.expand(event(null, "2026-03-01", "2026-03-05", null, null)))
+                .containsExactly("2026-03-01");
+    }
+
+    @Test
+    @DisplayName("PERIOD는 start부터 end까지 매일 전개한다")
+    void expand_period() {
+        assertThat(expander.expand(event("PERIOD", "2026-03-01", "2026-03-05", null, null)))
+                .containsExactly("2026-03-01", "2026-03-02", "2026-03-03", "2026-03-04", "2026-03-05");
+    }
+
+    @Test
+    @DisplayName("PERIOD에 end가 없으면 start 하루만 전개한다")
+    void expand_periodWithoutEnd() {
+        assertThat(expander.expand(event("PERIOD", "2026-03-01", null, null, null)))
+                .containsExactly("2026-03-01");
+    }
+
+    @Test
+    @DisplayName("MULTI는 dates의 각 날짜를 전개한다")
+    void expand_multi() {
+        List<String> dates = List.of("2026-03-01", "2026-03-10", "2026-03-20");
+
+        assertThat(expander.expand(event("MULTI", "2026-03-01", null, dates, null)))
+                .containsExactlyElementsOf(dates);
+    }
+
+    @Test
+    @DisplayName("MULTI에 dates가 비어있으면 start 하루만 전개한다")
+    void expand_multiWithoutDates() {
+        assertThat(expander.expand(event("MULTI", "2026-03-01", null, List.of(), null)))
+                .containsExactly("2026-03-01");
+    }
+
+    @Test
+    @DisplayName("WEEKLY는 지정한 요일마다 전개한다")
+    void expand_weeklyWithWeekdays() {
+        // 2026-03-06(금, 5), 2026-03-07(토, 6)
+        CustomEventRecurrence recurrence =
+                new CustomEventRecurrence("WEEKLY", List.of(5, 6), "2026-03-31", null);
+
+        assertThat(expander.expand(event("RECURRING", "2026-03-06", null, null, recurrence)))
+                .containsExactly("2026-03-06", "2026-03-07", "2026-03-13", "2026-03-14",
+                        "2026-03-20", "2026-03-21", "2026-03-27", "2026-03-28");
+    }
+
+    @Test
+    @DisplayName("WEEKLY에 weekdays가 없으면 start의 요일로 반복한다")
+    void expand_weeklyWithoutWeekdays() {
+        CustomEventRecurrence recurrence =
+                new CustomEventRecurrence("WEEKLY", null, "2026-03-31", null);
+
+        assertThat(expander.expand(event("RECURRING", "2026-03-06", null, null, recurrence)))
+                .containsExactly("2026-03-06", "2026-03-13", "2026-03-20", "2026-03-27");
+    }
+
+    @Test
+    @DisplayName("MONTHLY는 매월 start의 일자로 반복하고 없는 날짜는 건너뛴다")
+    void expand_monthlySkipsShortMonths() {
+        CustomEventRecurrence recurrence =
+                new CustomEventRecurrence("MONTHLY", null, "2026-06-30", null);
+
+        assertThat(expander.expand(event("RECURRING", "2026-01-31", null, null, recurrence)))
+                .containsExactly("2026-01-31", "2026-03-31", "2026-05-31");
+    }
+
+    @Test
+    @DisplayName("YEARLY는 매년 start의 월/일로 반복한다")
+    void expand_yearly() {
+        CustomEventRecurrence recurrence =
+                new CustomEventRecurrence("YEARLY", null, "2026-12-31", null);
+
+        assertThat(expander.expand(event("RECURRING", "2024-05-01", null, null, recurrence)))
+                .containsExactly("2024-05-01", "2025-05-01", "2026-05-01");
+    }
+
+    @Test
+    @DisplayName("YEARLY는 윤년이 아닌 해의 2월 29일을 건너뛴다")
+    void expand_yearlySkipsNonLeapYears() {
+        CustomEventRecurrence recurrence =
+                new CustomEventRecurrence("YEARLY", null, "2026-12-31", null);
+
+        assertThat(expander.expand(event("RECURRING", "2024-02-29", null, null, recurrence)))
+                .containsExactly("2024-02-29");
+    }
+
+    @Test
+    @DisplayName("excludedDates에 포함된 발생일은 제외한다")
+    void expand_excludesExcludedDates() {
+        CustomEventRecurrence recurrence = new CustomEventRecurrence(
+                "WEEKLY", null, "2026-03-31", List.of("2026-03-13"));
+
+        assertThat(expander.expand(event("RECURRING", "2026-03-06", null, null, recurrence)))
+                .containsExactly("2026-03-06", "2026-03-20", "2026-03-27");
+    }
+
+    @Test
+    @DisplayName("반복 종료일이 시작일보다 앞이면 발생일이 없다")
+    void expand_recurrenceEndBeforeStart() {
+        CustomEventRecurrence recurrence =
+                new CustomEventRecurrence("WEEKLY", null, "2026-02-28", null);
+
+        assertThat(expander.expand(event("RECURRING", "2026-03-06", null, null, recurrence)))
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("반복 종료일이 없으면 오늘 기준 1년까지만 전개한다")
+    void expand_unboundedRecurrenceStopsAtWindowLimit() {
+        CustomEventRecurrence recurrence = new CustomEventRecurrence("MONTHLY", null, null, null);
+        LocalDate windowLimit = LocalDate.now().plusYears(1);
+
+        List<String> occurrences = expander.expand(event("RECURRING", "2026-03-01", null, null, recurrence));
+
+        assertThat(occurrences).isNotEmpty();
+        assertThat(occurrences).allSatisfy(date ->
+                assertThat(LocalDate.parse(date)).isBeforeOrEqualTo(windowLimit));
+    }
+
+    @Test
+    @DisplayName("RECURRING인데 recurrence가 없으면 start 하루만 전개한다")
+    void expand_recurringWithoutRecurrence() {
+        assertThat(expander.expand(event("RECURRING", "2026-03-01", null, null, null)))
+                .containsExactly("2026-03-01");
+    }
+
+    @Test
+    @DisplayName("start가 없거나 형식이 잘못되면 발생일이 없다")
+    void expand_invalidStart() {
+        assertThat(expander.expand(event("SINGLE", "2026/03/01", null, null, null))).isEmpty();
+        assertThat(expander.expand(event("SINGLE", null, null, null, null))).isEmpty();
+    }
+}

--- a/backend/src/test/java/moadong/calendar/custom/service/CustomEventOccurrenceExpanderTest.java
+++ b/backend/src/test/java/moadong/calendar/custom/service/CustomEventOccurrenceExpanderTest.java
@@ -155,9 +155,9 @@ class CustomEventOccurrenceExpanderTest {
     @DisplayName("반복 종료일이 없으면 오늘 기준 1년까지만 전개한다")
     void expand_unboundedRecurrenceStopsAtWindowLimit() {
         CustomEventRecurrence recurrence = new CustomEventRecurrence("MONTHLY", null, null, null);
-        LocalDate windowLimit = LocalDate.now().plusYears(1);
 
         List<String> occurrences = expander.expand(event("RECURRING", "2026-03-01", null, null, recurrence));
+        LocalDate windowLimit = LocalDate.now().plusYears(1);
 
         assertThat(occurrences).isNotEmpty();
         assertThat(occurrences).allSatisfy(date ->

--- a/backend/src/test/java/moadong/calendar/custom/service/CustomEventOccurrenceExpanderTest.java
+++ b/backend/src/test/java/moadong/calendar/custom/service/CustomEventOccurrenceExpanderTest.java
@@ -50,14 +50,14 @@ class CustomEventOccurrenceExpanderTest {
     }
 
     @Test
-    @DisplayName("PERIOD는 start부터 end까지 매일 전개한다")
+    @DisplayName("PERIOD는 여러 날에 걸친 하나의 일정이므로 전개하지 않고 start 한 건만 반환한다")
     void expand_period() {
         assertThat(expander.expand(event("PERIOD", "2026-03-01", "2026-03-05", null, null)))
-                .containsExactly("2026-03-01", "2026-03-02", "2026-03-03", "2026-03-04", "2026-03-05");
+                .containsExactly("2026-03-01");
     }
 
     @Test
-    @DisplayName("PERIOD에 end가 없으면 start 하루만 전개한다")
+    @DisplayName("PERIOD에 end가 없어도 start 한 건만 반환한다")
     void expand_periodWithoutEnd() {
         assertThat(expander.expand(event("PERIOD", "2026-03-01", null, null, null)))
                 .containsExactly("2026-03-01");

--- a/backend/src/test/java/moadong/calendar/hidden/service/HiddenCalendarEventServiceTest.java
+++ b/backend/src/test/java/moadong/calendar/hidden/service/HiddenCalendarEventServiceTest.java
@@ -1,0 +1,154 @@
+package moadong.calendar.hidden.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import moadong.calendar.hidden.entity.HiddenCalendarEvent;
+import moadong.calendar.hidden.payload.dto.HiddenCalendarEventResult;
+import moadong.calendar.hidden.repository.HiddenCalendarEventRepository;
+import moadong.club.entity.Club;
+import moadong.club.repository.ClubRepository;
+import moadong.global.exception.ErrorCode;
+import moadong.global.exception.RestApiException;
+import moadong.user.payload.CustomUserDetails;
+import moadong.util.annotations.UnitTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+@UnitTest
+class HiddenCalendarEventServiceTest {
+
+    @Mock
+    private HiddenCalendarEventRepository hiddenCalendarEventRepository;
+
+    @Mock
+    private ClubRepository clubRepository;
+
+    @Mock
+    private CustomUserDetails user;
+
+    @Mock
+    private Club club;
+
+    private HiddenCalendarEventService hiddenCalendarEventService;
+
+    private static final String USER_ID = "test-user-id";
+    private static final String CLUB_ID = "test-club-id";
+    private static final String EVENT_ID = "google-event-1";
+
+    @BeforeEach
+    void setUp() {
+        hiddenCalendarEventService = new HiddenCalendarEventService(hiddenCalendarEventRepository, clubRepository);
+    }
+
+    private void givenAuthenticatedClub() {
+        when(user.getId()).thenReturn(USER_ID);
+        when(club.getId()).thenReturn(CLUB_ID);
+        when(clubRepository.findClubByUserId(USER_ID)).thenReturn(Optional.of(club));
+    }
+
+    @Test
+    @DisplayName("GOOGLE 이벤트를 숨김 처리하면 저장된다")
+    void hide_savesHiddenEvent() {
+        givenAuthenticatedClub();
+        when(hiddenCalendarEventRepository.existsByClubIdAndSourceAndEventId(CLUB_ID, "GOOGLE", EVENT_ID))
+                .thenReturn(false);
+
+        hiddenCalendarEventService.hide(user, "GOOGLE", EVENT_ID);
+
+        verify(hiddenCalendarEventRepository).save(any(HiddenCalendarEvent.class));
+    }
+
+    @Test
+    @DisplayName("이미 숨김 처리된 이벤트는 다시 저장하지 않는다")
+    void hide_alreadyHidden_isIdempotent() {
+        givenAuthenticatedClub();
+        when(hiddenCalendarEventRepository.existsByClubIdAndSourceAndEventId(CLUB_ID, "GOOGLE", EVENT_ID))
+                .thenReturn(true);
+
+        hiddenCalendarEventService.hide(user, "GOOGLE", EVENT_ID);
+
+        verify(hiddenCalendarEventRepository, never()).save(any(HiddenCalendarEvent.class));
+    }
+
+    @Test
+    @DisplayName("GOOGLE/NOTION이 아닌 source는 예외가 발생한다")
+    void hide_invalidSource_throws() {
+        givenAuthenticatedClub();
+
+        assertThatThrownBy(() -> hiddenCalendarEventService.hide(user, "CUSTOM", EVENT_ID))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.HIDDEN_EVENT_INVALID_SOURCE);
+    }
+
+    @Test
+    @DisplayName("숨김 해제 시 삭제를 호출한다")
+    void unhide_deletesHiddenEvent() {
+        givenAuthenticatedClub();
+
+        hiddenCalendarEventService.unhide(user, "NOTION", EVENT_ID);
+
+        verify(hiddenCalendarEventRepository).deleteByClubIdAndSourceAndEventId(CLUB_ID, "NOTION", EVENT_ID);
+    }
+
+    @Test
+    @DisplayName("숨김 목록을 source:eventId 키 집합으로 반환한다")
+    void getHiddenKeys_returnsKeySet() {
+        HiddenCalendarEvent hidden = HiddenCalendarEvent.builder()
+                .clubId(CLUB_ID)
+                .source("GOOGLE")
+                .eventId(EVENT_ID)
+                .build();
+        when(hiddenCalendarEventRepository.findByClubId(CLUB_ID)).thenReturn(List.of(hidden));
+
+        Set<String> keys = hiddenCalendarEventService.getHiddenKeys(CLUB_ID);
+
+        assertThat(keys).containsExactly("GOOGLE:" + EVENT_ID);
+    }
+
+    @Test
+    @DisplayName("clubId가 비어있으면 빈 집합을 반환한다")
+    void getHiddenKeys_blankClubId_returnsEmpty() {
+        assertThat(hiddenCalendarEventService.getHiddenKeys(" ")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("숨김 목록 조회는 source/eventId 형태로 매핑된다")
+    void list_mapsToResults() {
+        givenAuthenticatedClub();
+        HiddenCalendarEvent hidden = HiddenCalendarEvent.builder()
+                .clubId(CLUB_ID)
+                .source("NOTION")
+                .eventId(EVENT_ID)
+                .build();
+        when(hiddenCalendarEventRepository.findByClubId(CLUB_ID)).thenReturn(List.of(hidden));
+
+        List<HiddenCalendarEventResult> results = hiddenCalendarEventService.list(user);
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).source()).isEqualTo("NOTION");
+        assertThat(results.get(0).eventId()).isEqualTo(EVENT_ID);
+    }
+
+    @Test
+    @DisplayName("인증된 사용자에게 동아리가 없으면 예외가 발생한다")
+    void hide_noClub_throws() {
+        when(user.getId()).thenReturn(USER_ID);
+        when(clubRepository.findClubByUserId(USER_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> hiddenCalendarEventService.hide(user, "GOOGLE", EVENT_ID))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.HIDDEN_EVENT_CLUB_NOT_FOUND);
+    }
+}

--- a/backend/src/test/java/moadong/calendar/hidden/service/HiddenCalendarEventServiceTest.java
+++ b/backend/src/test/java/moadong/calendar/hidden/service/HiddenCalendarEventServiceTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.springframework.dao.DuplicateKeyException;
 
 @UnitTest
 class HiddenCalendarEventServiceTest {
@@ -78,6 +79,20 @@ class HiddenCalendarEventServiceTest {
         hiddenCalendarEventService.hide(user, "GOOGLE", EVENT_ID);
 
         verify(hiddenCalendarEventRepository, never()).save(any(HiddenCalendarEvent.class));
+    }
+
+    @Test
+    @DisplayName("동시 요청으로 인한 중복 저장은 멱등적으로 처리한다")
+    void hide_duplicateKey_isIdempotent() {
+        givenAuthenticatedClub();
+        when(hiddenCalendarEventRepository.existsByClubIdAndSourceAndEventId(CLUB_ID, "GOOGLE", EVENT_ID))
+                .thenReturn(false);
+        when(hiddenCalendarEventRepository.save(any(HiddenCalendarEvent.class)))
+                .thenThrow(new DuplicateKeyException("duplicate"));
+
+        hiddenCalendarEventService.hide(user, "GOOGLE", EVENT_ID);
+
+        verify(hiddenCalendarEventRepository).save(any(HiddenCalendarEvent.class));
     }
 
     @Test

--- a/backend/src/test/java/moadong/calendar/notion/service/NotionOAuthServiceTest.java
+++ b/backend/src/test/java/moadong/calendar/notion/service/NotionOAuthServiceTest.java
@@ -1,0 +1,64 @@
+package moadong.calendar.notion.service;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import moadong.calendar.notion.config.NotionProperties;
+import moadong.calendar.notion.repository.NotionConnectionRepository;
+import moadong.club.entity.Club;
+import moadong.club.repository.ClubRepository;
+import moadong.fixture.UserFixture;
+import moadong.global.util.AESCipher;
+import moadong.user.payload.CustomUserDetails;
+import moadong.util.annotations.UnitTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+@UnitTest
+class NotionOAuthServiceTest {
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @Mock
+    private NotionConnectionRepository notionConnectionRepository;
+
+    @Mock
+    private ClubRepository clubRepository;
+
+    @Mock
+    private AESCipher cipher;
+
+    @Mock
+    private NotionProperties notionProperties;
+
+    private NotionOAuthService notionOAuthService;
+
+    private static final String USER_ID = "test-user-id";
+    private static final String CLUB_ID = "test-club-id";
+
+    @BeforeEach
+    void setUp() {
+        notionOAuthService = new NotionOAuthService(
+                restTemplate, notionConnectionRepository, clubRepository, cipher, notionProperties);
+    }
+
+    @Test
+    @DisplayName("연결 해제 시 clubId 문서와 userId 기반 레거시 문서를 모두 삭제한다")
+    void deleteConnection_deletesClubAndLegacyDocuments() {
+        CustomUserDetails user = UserFixture.createUserDetails(USER_ID);
+        Club club = Club.builder().userId(USER_ID).build();
+        ReflectionTestUtils.setField(club, "id", CLUB_ID);
+        when(clubRepository.findClubByUserId(USER_ID)).thenReturn(Optional.of(club));
+
+        notionOAuthService.deleteConnection(user);
+
+        verify(notionConnectionRepository).deleteById(CLUB_ID);
+        verify(notionConnectionRepository).deleteById(USER_ID);
+    }
+}

--- a/backend/src/test/java/moadong/calendar/notion/service/NotionOAuthServiceTest.java
+++ b/backend/src/test/java/moadong/calendar/notion/service/NotionOAuthServiceTest.java
@@ -1,6 +1,6 @@
 package moadong.calendar.notion.service;
 
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
@@ -15,6 +15,7 @@ import moadong.util.annotations.UnitTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
@@ -49,8 +50,8 @@ class NotionOAuthServiceTest {
     }
 
     @Test
-    @DisplayName("연결 해제 시 clubId 문서와 userId 기반 레거시 문서를 모두 삭제한다")
-    void deleteConnection_deletesClubAndLegacyDocuments() {
+    @DisplayName("연결 해제 시 레거시 문서를 먼저 삭제한 뒤 clubId 문서를 삭제한다")
+    void deleteConnection_deletesLegacyDocumentBeforeClubDocument() {
         CustomUserDetails user = UserFixture.createUserDetails(USER_ID);
         Club club = Club.builder().userId(USER_ID).build();
         ReflectionTestUtils.setField(club, "id", CLUB_ID);
@@ -58,7 +59,9 @@ class NotionOAuthServiceTest {
 
         notionOAuthService.deleteConnection(user);
 
-        verify(notionConnectionRepository).deleteById(CLUB_ID);
-        verify(notionConnectionRepository).deleteById(USER_ID);
+        // clubId 문서를 먼저 지우면 그 사이 조회가 레거시 문서를 다시 마이그레이션하므로 순서를 고정한다.
+        InOrder inOrder = inOrder(notionConnectionRepository);
+        inOrder.verify(notionConnectionRepository).deleteById(USER_ID);
+        inOrder.verify(notionConnectionRepository).deleteById(CLUB_ID);
     }
 }

--- a/backend/src/test/java/moadong/calendar/service/CalendarAggregationServiceTest.java
+++ b/backend/src/test/java/moadong/calendar/service/CalendarAggregationServiceTest.java
@@ -97,7 +97,7 @@ class CalendarAggregationServiceTest {
         ClubCalendarEventResult googleEvent = ClubCalendarEventResult.ofGoogle(
                 "google-1", "Google 이벤트", "2026-04-01", null, null, null);
         ClubCalendarEventResult customEvent = ClubCalendarEventResult.ofCustom(
-                "custom-1", "커스텀 이벤트", "2026-04-02", null, null, null);
+                "custom-1", "커스텀 이벤트", "2026-04-02", null, null, null, "SINGLE", "MINT");
 
         when(notionOAuthService.getClubCalendarEvents(CLUB_ID)).thenReturn(List.of(notionEvent));
         when(googleOAuthService.getClubCalendarEvents(CLUB_ID)).thenReturn(List.of(googleEvent));
@@ -119,7 +119,7 @@ class CalendarAggregationServiceTest {
         ClubCalendarEventResult googleEvent = ClubCalendarEventResult.ofGoogle(
                 "google-1", "Google 이벤트", "2026-04-02", null, null, null);
         ClubCalendarEventResult customEvent = ClubCalendarEventResult.ofCustom(
-                "custom-1", "커스텀 이벤트", "2026-04-03", null, null, null);
+                "custom-1", "커스텀 이벤트", "2026-04-03", null, null, null, "SINGLE", "MINT");
 
         when(notionOAuthService.getClubCalendarEvents(CLUB_ID)).thenReturn(List.of(notionEvent));
         when(googleOAuthService.getClubCalendarEvents(CLUB_ID)).thenReturn(List.of(googleEvent));

--- a/backend/src/test/java/moadong/calendar/service/CalendarAggregationServiceTest.java
+++ b/backend/src/test/java/moadong/calendar/service/CalendarAggregationServiceTest.java
@@ -4,7 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Set;
+import moadong.calendar.custom.service.CustomCalendarEventService;
 import moadong.calendar.google.service.GoogleOAuthService;
+import moadong.calendar.hidden.service.HiddenCalendarEventService;
 import moadong.calendar.notion.service.NotionOAuthService;
 import moadong.club.payload.dto.ClubCalendarEventResult;
 import moadong.util.annotations.UnitTest;
@@ -22,13 +25,20 @@ class CalendarAggregationServiceTest {
     @Mock
     private GoogleOAuthService googleOAuthService;
 
+    @Mock
+    private CustomCalendarEventService customCalendarEventService;
+
+    @Mock
+    private HiddenCalendarEventService hiddenCalendarEventService;
+
     private CalendarAggregationService calendarAggregationService;
 
     private static final String CLUB_ID = "test-club-id";
 
     @BeforeEach
     void setUp() {
-        calendarAggregationService = new CalendarAggregationService(notionOAuthService, googleOAuthService);
+        calendarAggregationService = new CalendarAggregationService(
+                notionOAuthService, googleOAuthService, customCalendarEventService, hiddenCalendarEventService);
     }
 
     @Test
@@ -80,6 +90,65 @@ class CalendarAggregationServiceTest {
     }
 
     @Test
+    @DisplayName("커스텀 이벤트도 함께 병합하여 시작일 기준 정렬한다")
+    void getAggregatedEvents_includesCustomEvents() {
+        ClubCalendarEventResult notionEvent = ClubCalendarEventResult.ofNotion(
+                "notion-1", "Notion 이벤트", "2026-04-03", null, null, null);
+        ClubCalendarEventResult googleEvent = ClubCalendarEventResult.ofGoogle(
+                "google-1", "Google 이벤트", "2026-04-01", null, null, null);
+        ClubCalendarEventResult customEvent = ClubCalendarEventResult.ofCustom(
+                "custom-1", "커스텀 이벤트", "2026-04-02", null, null, null);
+
+        when(notionOAuthService.getClubCalendarEvents(CLUB_ID)).thenReturn(List.of(notionEvent));
+        when(googleOAuthService.getClubCalendarEvents(CLUB_ID)).thenReturn(List.of(googleEvent));
+        when(customCalendarEventService.getClubCalendarEvents(CLUB_ID)).thenReturn(List.of(customEvent));
+
+        List<ClubCalendarEventResult> results = calendarAggregationService.getAggregatedEvents(CLUB_ID);
+
+        assertThat(results).hasSize(3);
+        assertThat(results.get(0).source()).isEqualTo("GOOGLE");
+        assertThat(results.get(1).source()).isEqualTo("CUSTOM");
+        assertThat(results.get(2).source()).isEqualTo("NOTION");
+    }
+
+    @Test
+    @DisplayName("숨김 목록의 GOOGLE/NOTION 이벤트는 결과에서 제외된다")
+    void getAggregatedEvents_excludesHiddenEvents() {
+        ClubCalendarEventResult notionEvent = ClubCalendarEventResult.ofNotion(
+                "notion-1", "Notion 이벤트", "2026-04-01", null, null, null);
+        ClubCalendarEventResult googleEvent = ClubCalendarEventResult.ofGoogle(
+                "google-1", "Google 이벤트", "2026-04-02", null, null, null);
+        ClubCalendarEventResult customEvent = ClubCalendarEventResult.ofCustom(
+                "custom-1", "커스텀 이벤트", "2026-04-03", null, null, null);
+
+        when(notionOAuthService.getClubCalendarEvents(CLUB_ID)).thenReturn(List.of(notionEvent));
+        when(googleOAuthService.getClubCalendarEvents(CLUB_ID)).thenReturn(List.of(googleEvent));
+        when(customCalendarEventService.getClubCalendarEvents(CLUB_ID)).thenReturn(List.of(customEvent));
+        when(hiddenCalendarEventService.getHiddenKeys(CLUB_ID)).thenReturn(Set.of("GOOGLE:google-1"));
+
+        List<ClubCalendarEventResult> results = calendarAggregationService.getAggregatedEvents(CLUB_ID);
+
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0).source()).isEqualTo("NOTION");
+        assertThat(results.get(1).source()).isEqualTo("CUSTOM");
+    }
+
+    @Test
+    @DisplayName("숨김 목록 조회가 실패해도 이벤트는 그대로 반환된다")
+    void getAggregatedEvents_hiddenLookupFails_returnsAllEvents() {
+        ClubCalendarEventResult googleEvent = ClubCalendarEventResult.ofGoogle(
+                "google-1", "Google 이벤트", "2026-04-01", null, null, null);
+
+        when(googleOAuthService.getClubCalendarEvents(CLUB_ID)).thenReturn(List.of(googleEvent));
+        when(hiddenCalendarEventService.getHiddenKeys(CLUB_ID)).thenThrow(new RuntimeException("조회 오류"));
+
+        List<ClubCalendarEventResult> results = calendarAggregationService.getAggregatedEvents(CLUB_ID);
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).source()).isEqualTo("GOOGLE");
+    }
+
+    @Test
     @DisplayName("둘 다 실패 시 빈 리스트를 반환한다")
     void getAggregatedEvents_bothFail_returnsEmpty() {
         when(notionOAuthService.getClubCalendarEvents(CLUB_ID)).thenThrow(new RuntimeException("Notion 오류"));
@@ -106,6 +175,18 @@ class CalendarAggregationServiceTest {
     void hasAnyCalendarConnection_googleOnly_returnsTrue() {
         when(notionOAuthService.hasCalendarConnection(CLUB_ID)).thenReturn(false);
         when(googleOAuthService.hasCalendarConnection(CLUB_ID)).thenReturn(true);
+
+        boolean result = calendarAggregationService.hasAnyCalendarConnection(CLUB_ID);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("커스텀 이벤트만 있는 경우 true를 반환한다")
+    void hasAnyCalendarConnection_customOnly_returnsTrue() {
+        when(notionOAuthService.hasCalendarConnection(CLUB_ID)).thenReturn(false);
+        when(googleOAuthService.hasCalendarConnection(CLUB_ID)).thenReturn(false);
+        when(customCalendarEventService.hasCalendarConnection(CLUB_ID)).thenReturn(true);
 
         boolean result = calendarAggregationService.hasAnyCalendarConnection(CLUB_ID);
 

--- a/backend/src/test/java/moadong/club/entity/ClubApplicationFormTest.java
+++ b/backend/src/test/java/moadong/club/entity/ClubApplicationFormTest.java
@@ -18,6 +18,7 @@ class ClubApplicationFormTest {
             "https://docs.google.com/forms/d/e/1FAIpQL/viewform",
             "https://form.naver.com/response/abcd",
             "https://naver.me/xyz",
+            "https://m.site.naver.com/2djWG",
             "https://everytime.kr/board/1",
             "https://cafe.daum.net/pknusic/OMPr/43",
             "https://open.kakao.com/o/gFWZdlFi"
@@ -35,6 +36,7 @@ class ClubApplicationFormTest {
             "https://forms.gle@evil.example/abcd",           // userinfo로 host 위장
             "https://forms.gle.evil.example/abcd",           // suffix 로 host 위장
             "https://everytime.kr.evil.example/board/1",
+            "https://m.site.naver.com.evil.example/2djWG",
             "https://cafe.daum.net.evil.example/pknusic/OMPr/43",
             "https://evil.example/abcd",
             "http://forms.gle/abcd",                         // https 아님

--- a/backend/src/test/java/moadong/club/service/ClubApplyAdminServiceTest.java
+++ b/backend/src/test/java/moadong/club/service/ClubApplyAdminServiceTest.java
@@ -13,8 +13,8 @@ import moadong.club.entity.Club;
 import moadong.club.entity.ClubApplicationForm;
 import moadong.club.payload.dto.ClubApplicationFormsResultItem;
 import moadong.club.payload.request.ClubApplicationFormEditRequest;
-import moadong.club.payload.response.ClubApplicationFormsResponse;
 import moadong.club.repository.ClubApplicationFormsRepository;
+import moadong.club.repository.ClubApplicationFormsRepositoryCustom;
 import moadong.club.repository.ClubRepository;
 import moadong.fixture.ClubApplicationEditFixture;
 import moadong.fixture.UserFixture;
@@ -40,6 +40,8 @@ public class ClubApplyAdminServiceTest {
     private ClubRepository clubRepository;
     @Autowired
     private ClubApplicationFormsRepository clubApplicationFormsRepository;
+    @Autowired
+    private ClubApplicationFormsRepositoryCustom clubApplicationFormsRepositoryCustom;
     @Autowired
     private PasswordEncoder passwordEncoder;
 
@@ -140,16 +142,16 @@ public class ClubApplyAdminServiceTest {
 
         try {
             // WHEN
-            ClubApplicationFormsResponse response = clubApplyAdminService.getClubApplicationForms(userDetails);
-
-            // THEN
-            ClubApplicationFormsResultItem item = response.forms().stream()
+            // 서비스는 userDetails.clubId로 조회하는데 픽스처가 User.clubId를 채우지 않으므로 레포지토리를 직접 호출한다
+            ClubApplicationFormsResultItem item = clubApplicationFormsRepositoryCustom
+                    .findClubApplicationFormsByClubId(clubId).stream()
                     .filter(group -> semesterYear.equals(group.semesterYear()))
                     .flatMap(group -> group.forms().stream())
                     .filter(form -> savedForm.getId().equals(form.id()))
                     .findFirst()
                     .orElseThrow(() -> new AssertionError("저장한 지원서가 조회 결과에 포함되어야 합니다."));
 
+            // THEN
             assertEquals(createdAt, item.createdAt(), "createdAt이 저장한 값 그대로 내려와야 합니다.");
             assertEquals(editedAt, item.editedAt(), "editedAt이 저장한 값 그대로 내려와야 합니다.");
         } finally {

--- a/backend/src/test/java/moadong/club/service/ClubApplyAdminServiceTest.java
+++ b/backend/src/test/java/moadong/club/service/ClubApplyAdminServiceTest.java
@@ -2,6 +2,7 @@ package moadong.club.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.time.LocalDateTime;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
@@ -10,7 +11,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import moadong.club.entity.Club;
 import moadong.club.entity.ClubApplicationForm;
+import moadong.club.payload.dto.ClubApplicationFormsResultItem;
 import moadong.club.payload.request.ClubApplicationFormEditRequest;
+import moadong.club.payload.response.ClubApplicationFormsResponse;
 import moadong.club.repository.ClubApplicationFormsRepository;
 import moadong.club.repository.ClubRepository;
 import moadong.fixture.ClubApplicationEditFixture;
@@ -117,6 +120,42 @@ public class ClubApplyAdminServiceTest {
 //        );
 //        assertEquals(expected, items);
 //    }
+
+    @Test
+    @DisplayName("지원서 목록 조회 시 각 지원서 항목에 createdAt이 함께 내려와야 한다")
+    void getClubApplicationFormsIncludesCreatedAt() {
+        // GIVEN: createdAt과 editedAt을 서로 다른 값으로 지정해 두 필드가 뒤바뀌지 않았는지 구분할 수 있게 한다
+        LocalDateTime createdAt = LocalDateTime.of(2024, 3, 1, 10, 0, 0);
+        LocalDateTime editedAt = LocalDateTime.of(2025, 5, 5, 12, 0, 0);
+        Integer semesterYear = 2024;
+
+        ClubApplicationForm savedForm = clubApplicationFormsRepository.save(
+                ClubApplicationForm.builder()
+                        .clubId(clubId)
+                        .title("createdAt 검증용 지원서")
+                        .createdAt(createdAt)
+                        .editedAt(editedAt)
+                        .semesterYear(semesterYear)
+                        .build());
+
+        try {
+            // WHEN
+            ClubApplicationFormsResponse response = clubApplyAdminService.getClubApplicationForms(userDetails);
+
+            // THEN
+            ClubApplicationFormsResultItem item = response.forms().stream()
+                    .filter(group -> semesterYear.equals(group.semesterYear()))
+                    .flatMap(group -> group.forms().stream())
+                    .filter(form -> savedForm.getId().equals(form.id()))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("저장한 지원서가 조회 결과에 포함되어야 합니다."));
+
+            assertEquals(createdAt, item.createdAt(), "createdAt이 저장한 값 그대로 내려와야 합니다.");
+            assertEquals(editedAt, item.editedAt(), "editedAt이 저장한 값 그대로 내려와야 합니다.");
+        } finally {
+            clubApplicationFormsRepository.deleteById(savedForm.getId());
+        }
+    }
 
     @Test
     @DisplayName("DB에 이미 존재하는 문서에 대해 동시 수정 시, 한 스레드만 성공하고 나머지는 실패해야 한다")

--- a/docs/spec/club-detail-duration-analytics-spec.md
+++ b/docs/spec/club-detail-duration-analytics-spec.md
@@ -1,0 +1,447 @@
+# 동아리 상세 체류 시간 자체 수집 스펙
+
+## 목적
+
+동아리 관리자 통계에서 평균 체류 시간이 Mixpanel backfill 없이는 `0초`로 표시되는 문제를 해결한다.
+
+상세 조회수는 기존 백엔드 조회 흐름에서 직접 집계되지만, 체류 시간은 Mixpanel `ClubDetailPage Duration` 이벤트를 수동 backfill해야만 집계된다.
+이 스펙은 백엔드 자체 체류 시간 수집 API와 관리자 통계 overview 확장 계약을 정의한다.
+
+## 대상 범위
+
+- 동아리 상세 페이지 체류 시간 수집 API
+- 체류 시간 원시 세션 저장 컬렉션
+- 방문자 일별 집계 컬렉션
+- 기존 `club_analytics_daily` duration 집계 확장
+- 관리자 통계 overview 응답 확장
+- 백엔드 단위/컨트롤러 테스트
+
+프론트 `sendBeacon` 연결과 관리자 통계 화면 UI 변경은 이 스펙의 구현 범위가 아니다.
+
+## 사용자 시나리오
+
+1. 사용자가 동아리 상세 페이지에 진입한다.
+2. 프론트는 상세 페이지 진입마다 `sessionId`를 생성한다.
+3. 프론트는 브라우저에 저장된 익명 `visitorId`를 함께 사용한다.
+4. 사용자가 페이지를 이탈하거나 페이지가 숨겨지면 체류 시간을 계산한다.
+5. 프론트는 백엔드 수집 API로 `clubId`, `sessionId`, `visitorId`, `durationSeconds`를 전송한다.
+6. 백엔드는 중복 세션이 아니면 원시 세션을 저장하고 일별 통계를 증가시킨다.
+7. 관리자는 통계 overview에서 평균 체류 시간과 인당 평균 체류 시간을 조회한다.
+
+## 지표 정의
+
+### 평균 체류 시간
+
+방문 세션 1회당 평균 체류 시간이다.
+
+```text
+averageDetailDurationSeconds
+  = detailDurationSumSeconds / detailDurationCount
+```
+
+기존 응답 필드명을 유지한다.
+
+### 고유 상세 방문자 수
+
+선택 기간 내 같은 동아리 상세 페이지를 방문한 고유 방문자 수다.
+
+```text
+uniqueDetailVisitors
+  = count(distinct visitorId)
+```
+
+집계 기준은 `club_detail_visitor_daily`를 기간 내 `visitorId`로 group한 결과다.
+
+### 인당 평균 체류 시간
+
+선택 기간 내 고유 방문자 1명당 평균 누적 체류 시간이다.
+
+```text
+averageDetailDurationSecondsPerVisitor
+  = 기간 내 전체 durationSumSeconds / uniqueDetailVisitors
+```
+
+예:
+
+```text
+A 방문자: 10초 + 20초
+B 방문자: 30초
+
+방문 세션 평균 = 60초 / 3세션 = 20초
+인당 평균 = 60초 / 2명 = 30초
+```
+
+## API 스펙
+
+### 체류 시간 수집
+
+`POST /api/analytics/club-detail/duration`
+
+권한:
+
+- 인증 없음
+- 일반 사용자 상세 페이지에서 호출하는 공개 수집 API
+
+요청:
+
+```json
+{
+  "clubId": "club-id",
+  "clubName": "동아리명",
+  "sessionId": "uuid",
+  "visitorId": "uuid",
+  "enteredAt": "2026-08-06T01:00:00Z",
+  "leftAt": "2026-08-06T01:00:35Z",
+  "durationSeconds": 35
+}
+```
+
+필수 필드:
+
+- `clubId`
+- `sessionId`
+- `visitorId`
+- `durationSeconds`
+
+선택 필드:
+
+- `clubName`
+- `enteredAt`
+- `leftAt`
+
+성공 응답:
+
+- HTTP `204 No Content`
+
+중복 세션 응답:
+
+- HTTP `204 No Content`
+- 이미 처리한 `sessionId + clubId`는 다시 집계하지 않는다.
+
+실패 응답:
+
+- HTTP `400`
+  - 에러 코드: `903-4`
+  - 메시지: `통계 이벤트 요청이 올바르지 않습니다.`
+- HTTP `429`
+  - 에러 코드: `903-5`
+  - 메시지: `통계 이벤트 요청이 너무 많습니다.`
+- HTTP `404`
+  - 에러 코드: `600-1`
+  - 메시지: `동아리가 존재하지 않습니다.`
+
+검증:
+
+- `clubId`, `sessionId`, `visitorId`는 blank일 수 없다.
+- `durationSeconds`는 `1` 이상 `3600` 이하이다.
+- `enteredAt`과 `leftAt`이 모두 있으면 `leftAt`은 `enteredAt`보다 이전일 수 없다.
+- `clubId`는 존재하는 동아리여야 한다.
+
+요청 제한:
+
+- Redis window counter로 `clubId + clientIp` 단위 요청 수를 제한한다.
+- 기준값은 60초당 120회다.
+- `X-Forwarded-For`가 있으면 첫 번째 IP를 사용하고, 없으면 `remoteAddr`를 사용한다.
+
+날짜 기준:
+
+- `leftAt`이 있으면 `leftAt`을 KST 날짜로 변환해 집계 날짜로 사용한다.
+- `leftAt`이 없으면 서버 현재 KST 날짜를 사용한다.
+
+## 관리자 통계 API 확장
+
+대상 API:
+
+`GET /api/club/statistics/overview?from=yyyy-MM-dd&to=yyyy-MM-dd`
+
+기존 응답:
+
+```java
+public record ClubStatisticsOverviewResponse(
+    String clubId,
+    String clubName,
+    LocalDate from,
+    LocalDate to,
+    long totalDetailViews,
+    long averageDetailDurationSeconds,
+    long totalApplicants
+) {
+}
+```
+
+변경 후 응답:
+
+```java
+public record ClubStatisticsOverviewResponse(
+    String clubId,
+    String clubName,
+    LocalDate from,
+    LocalDate to,
+    long totalDetailViews,
+    long averageDetailDurationSeconds,
+    long uniqueDetailVisitors,
+    long averageDetailDurationSecondsPerVisitor,
+    long totalApplicants
+) {
+}
+```
+
+정책:
+
+- `averageDetailDurationSeconds`는 기존 의미를 유지한다.
+- `uniqueDetailVisitors`와 `averageDetailDurationSecondsPerVisitor`는 overview에만 추가한다.
+- trend API 응답은 이 스펙에서 변경하지 않는다.
+- visitor 데이터가 없으면 `uniqueDetailVisitors = 0`, `averageDetailDurationSecondsPerVisitor = 0`이다.
+
+## 데이터 스펙
+
+### club_detail_duration_sessions
+
+원시 체류 세션 컬렉션이다.
+
+엔티티:
+
+- `ClubDetailDurationSession`
+
+컬렉션:
+
+- `club_detail_duration_sessions`
+
+필드:
+
+- `id`
+- `sessionId`
+- `visitorId`
+- `clubId`
+- `clubName`
+- `date`
+- `enteredAt`
+- `leftAt`
+- `durationSeconds`
+- `createdAt`
+
+인덱스:
+
+- unique `{ sessionId: 1, clubId: 1 }`
+- `{ clubId: 1, date: 1 }`
+- single `sessionId`
+- single `visitorId`
+- single `clubId`
+- single `date`
+
+정책:
+
+- 원시 세션 upsert에서 신규 insert가 발생한 경우에만 집계를 증가시킨다.
+- 기존 문서가 있으면 이미 처리된 세션으로 보고 성공 응답한다.
+- 이 컬렉션은 디버깅과 재집계 원본이다.
+- 관리자 통계 조회는 이 컬렉션을 직접 scan하지 않는다.
+
+### club_detail_visitor_daily
+
+방문자별 일별 체류 시간 집계 컬렉션이다.
+
+엔티티:
+
+- `ClubDetailVisitorDaily`
+
+컬렉션:
+
+- `club_detail_visitor_daily`
+
+필드:
+
+- `id`
+- `date`
+- `clubId`
+- `visitorId`
+- `durationSumSeconds`
+- `sessionCount`
+- `createdAt`
+- `updatedAt`
+
+인덱스:
+
+- unique `{ clubId: 1, date: 1, visitorId: 1 }`
+- single `date`
+- single `clubId`
+- single `visitorId`
+
+정책:
+
+- 같은 날짜, 같은 동아리, 같은 방문자의 여러 세션은 하나의 문서에 누적한다.
+- overview의 고유 방문자 수는 기간 내 이 컬렉션을 `visitorId` 기준으로 group해서 계산한다.
+- overview의 인당 평균 체류 시간은 기간 내 visitor별 duration 합계를 다시 합산해 계산한다.
+
+### club_analytics_daily
+
+기존 일별 통계 컬렉션이다.
+
+변경:
+
+- 기존 duration 필드 사용
+  - `detailDurationSumSeconds`
+  - `detailDurationCount`
+- 조회 최적화 인덱스 추가
+  - `{ clubId: 1, date: 1 }`
+
+정책:
+
+- 체류 시간 수집 성공 시 `detailDurationSumSeconds += durationSeconds`
+- 체류 시간 수집 성공 시 `detailDurationCount += 1`
+- 기존 `{ date: 1, clubId: 1 }` unique index는 유지한다.
+
+## 처리 흐름
+
+정상 수집:
+
+```text
+POST /api/analytics/club-detail/duration
+  |
+  v
+ClubDetailDurationService.record
+  |
+  v
+요청 검증
+  |
+  v
+clubId 존재 확인
+  |
+  v
+Mongo transaction 시작
+  |
+  v
+club_detail_duration_sessions upsert
+  |
+  v
+신규 세션이면 다음 집계 진행
+  |
+  v
+club_analytics_daily duration sum/count 증가
+  |
+  v
+club_detail_visitor_daily duration/session count 증가
+  |
+  v
+Mongo transaction commit
+  |
+  v
+204 No Content
+```
+
+중복 수집:
+
+```text
+club_detail_duration_sessions upsert
+  |
+  v
+기존 sessionId + clubId 문서 확인
+  |
+  v
+집계 증가 없이 204 No Content
+```
+
+집계 실패:
+
+```text
+daily 또는 visitor 집계 실패
+  |
+  v
+Mongo transaction rollback
+  |
+  v
+예외 전파
+```
+
+세션 저장, `club_analytics_daily` 증가, `club_detail_visitor_daily` 증가는 하나의 MongoDB 트랜잭션 안에서 처리한다.
+따라서 중간 write 성공 후 예외가 발생해도 부분 집계가 남지 않아야 한다.
+
+## 부하와 확장성
+
+정상 수집 1건당 MongoDB 쓰기:
+
+1. `club_detail_duration_sessions` insert
+2. `club_analytics_daily` upsert + `$inc`
+3. `club_detail_visitor_daily` upsert + `$inc`
+
+관리자 overview 조회:
+
+1. 최대 370일치 `club_analytics_daily` 문서를 조회해 애플리케이션에서 합산한다.
+2. `club_detail_visitor_daily`를 기간 내 `visitorId` 기준으로 aggregation한다.
+3. 원시 세션 컬렉션은 조회하지 않는다.
+
+현재 평균 체류 시간 계산은 최대 370개 일별 문서를 합산하므로 실무 부하로 충분히 가볍다.
+성능 보완은 계산식 변경이 아니라 자체 수집과 적절한 집계 컬렉션 유지로 해결한다.
+
+큐나 스트림은 1차 범위에 포함하지 않는다.
+아래 조건이 관측되면 후속으로 비동기 집계를 검토한다.
+
+- duration 수집 API p95 latency가 지속적으로 높다.
+- 특정 `club_analytics_daily` 문서에 `$inc`가 집중되어 hot document 문제가 나타난다.
+- 수집 이벤트가 초당 수백 건 이상 안정적으로 발생한다.
+
+## 보안 정책
+
+수집 API는 공개 API이므로 완전한 위조 방지는 어렵다.
+1차 방어는 아래 수준으로 제한한다.
+
+- 존재하는 `clubId`만 기록한다.
+- `durationSeconds`는 1초 이상 3600초 이하만 허용한다.
+- `sessionId + clubId` unique index로 중복 집계를 막는다.
+- Redis 기반 `clubId + clientIp` rate limit을 적용한다.
+- 사용자 식별 정보, IP, user-agent 원문, full URL은 저장하지 않는다.
+
+`visitorId`는 프론트가 생성한 익명 UUID를 전제로 한다.
+
+## Mixpanel backfill과의 관계
+
+Mixpanel backfill은 과거 보정과 검증 용도로 유지한다.
+
+주의:
+
+- 자체 수집 배포 이후 기간에 Mixpanel duration backfill을 실행하면 중복 집계될 수 있다.
+- 자체 수집 배포일 이후 기간은 백엔드 자체 수집 데이터를 기준으로 본다.
+- 운영에서는 duration backfill cutoff 정책을 별도로 두는 것을 권장한다.
+
+## 테스트 스펙
+
+### ClubDetailDurationServiceTest
+
+검증:
+
+1. 정상 요청이면 세션을 저장하고 daily 및 visitor 집계를 증가시킨다.
+2. 중복 세션이면 daily와 visitor 집계를 증가시키지 않는다.
+3. daily 집계 실패 시 트랜잭션에 예외를 전파한다.
+4. visitor 집계 실패 시 트랜잭션에 예외를 전파한다.
+5. duration이 0이거나 3600초를 넘으면 실패한다.
+6. `leftAt`이 `enteredAt`보다 이전이면 실패한다.
+7. 요청 제한을 초과하면 `STATISTICS_EVENT_RATE_LIMITED` 예외가 발생한다.
+
+### ClubDetailDurationControllerTest
+
+검증:
+
+1. 체류 시간 기록 요청은 service를 호출한다.
+2. 정상 요청은 `204 No Content`를 반환한다.
+
+### ClubStatisticsAdminServiceTest
+
+검증:
+
+1. overview에서 기존 방문 세션 평균 체류 시간을 계산한다.
+2. overview에서 고유 방문자 수를 계산한다.
+3. overview에서 인당 평균 체류 시간을 계산한다.
+4. 지원자 수 합산과 기존 상세 조회수 합산은 유지된다.
+
+## 배포 전 검증 기준
+
+아래 조건이 모두 만족되면 백엔드 배포 가능하다.
+
+1. `POST /api/analytics/club-detail/duration` 정상 요청이 `204`를 반환한다.
+2. 같은 `sessionId + clubId` 요청을 두 번 보내도 한 번만 집계된다.
+3. invalid duration 요청은 `400`을 반환한다.
+4. rate limit 초과 요청은 `429`를 반환한다.
+5. 없는 `clubId` 요청은 `404`를 반환한다.
+6. `club_analytics_daily.detailDurationSumSeconds`와 `detailDurationCount`가 증가한다.
+7. `club_detail_visitor_daily`에 visitor별 일별 집계가 누적된다.
+8. overview 응답에 `uniqueDetailVisitors`와 `averageDetailDurationSecondsPerVisitor`가 포함된다.
+9. `./gradlew.bat unitTest`가 통과한다.

--- a/docs/spec/club-detail-duration-analytics-spec.md
+++ b/docs/spec/club-detail-duration-analytics-spec.md
@@ -111,11 +111,12 @@ B 방문자: 30초
 
 성공 응답:
 
-- HTTP `204 No Content`
+- HTTP `200`
+- 공통 `Response<T>` 래퍼(`statuscode`, `message`, `data`)를 사용한다.
 
 중복 세션 응답:
 
-- HTTP `204 No Content`
+- HTTP `200`
 - 이미 처리한 `sessionId + clubId`는 다시 집계하지 않는다.
 
 실패 응답:
@@ -132,7 +133,7 @@ B 방문자: 30초
 
 검증:
 
-- `clubId`, `sessionId`, `visitorId`는 blank일 수 없다.
+- `clubId`, `sessionId`, `visitorId`는 blank일 수 없고 64자를 넘을 수 없다.
 - `durationSeconds`는 `1` 이상 `3600` 이하이다.
 - `enteredAt`과 `leftAt`이 모두 있으면 `leftAt`은 `enteredAt`보다 이전일 수 없다.
 - `clubId`는 존재하는 동아리여야 한다.
@@ -141,7 +142,8 @@ B 방문자: 30초
 
 - Redis window counter로 `clubId + clientIp` 단위 요청 수를 제한한다.
 - 기준값은 60초당 120회다.
-- `X-Forwarded-For`가 있으면 첫 번째 IP를 사용하고, 없으면 `remoteAddr`를 사용한다.
+- `X-Forwarded-For`가 있으면 첫 번째 IP를 사용하고, 없거나 IP 길이(45자)를 넘으면 `remoteAddr`를 사용한다.
+- `X-Forwarded-For`는 호출자가 조작할 수 있으므로, 인그레스에서 이 헤더를 덮어쓰도록 설정되어 있어야 요청 제한이 실제로 동작한다.
 
 날짜 기준:
 


### PR DESCRIPTION
## 🚀 릴리즈 PR

### 📦 버전 정보

| 항목          | 내용                                 |
| ------------- | ------------------------------------ |
| **서비스**    | `💾 BE` / `💻 FE`                    |
| **Bump 타입** | `🚨 MAJOR` / `➕ MINOR` / `🔧 PATCH` |
| **예상 버전** | `vX.Y.Z`                             |

> ⚠️ **반드시 라벨을 지정해주세요**: 서비스 라벨(`💾 BE`, `💻 FE`)과 버전 라벨(`🚨 MAJOR`, `➕ MINOR`, `🔧 PATCH`)이 없으면 태그가 생성되지 않습니다.

<details>
<summary>📖 버전 라벨 선택 가이드 (Semantic Versioning)</summary>

| 라벨       | 버전 변화           | 선택 기준                               | 예시                                                                 |
| ---------- | ------------------- | --------------------------------------- | -------------------------------------------------------------------- |
| `🚨 MAJOR` | `v1.0.0` → `v2.0.0` | 기존 API/기능이 **호환되지 않는** 변경  | API 엔드포인트 삭제/변경, 요청/응답 스펙 변경, DB 스키마 대규모 변경 |
| `➕ MINOR` | `v1.0.0` → `v1.1.0` | 기존 기능은 유지하면서 **새 기능 추가** | 새 API 엔드포인트 추가, 새 기능 도입, 기존 API에 선택적 필드 추가    |
| `🔧 PATCH` | `v1.0.0` → `v1.0.1` | 기능 변경 없이 **버그 수정/내부 개선**  | 버그 수정, 성능 개선, 리팩토링, 문서 수정                            |

</details>

---

### 📋 포함된 변경사항

> 이번 릴리즈에 포함된 주요 변경사항을 요약합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 사용자 지정 캘린더 이벤트를 생성·조회·수정·삭제할 수 있습니다.
  * 주간·월간·연간 반복 일정과 특정 날짜 제외 및 종료일 변경을 지원합니다.
  * 캘린더 이벤트를 숨기거나 숨김 해제하고, 숨김 목록을 확인할 수 있습니다.
  * 캘린더에 사용자 지정 일정이 통합되어 표시됩니다.
  * Notion 캘린더 연결을 해제할 수 있습니다.
  * 동아리 상세 페이지 체류 시간을 기록하고 관리자 통계에서 고유 방문자 수와 방문자당 평균 체류 시간을 확인할 수 있습니다.

* **개선**
  * 일정 유형과 색상을 캘린더에 표시합니다.
  * 네이버 모바일 폼 링크를 외부 지원 URL로 허용합니다.
  * 잘못된 일정 정보에 대한 검증과 오류 안내를 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->