### PR TITLE
[hotfix] 상세페이지 알림 버튼 구독 이벤트 트래킹 누락 수정

### DIFF
--- a/frontend/src/constants/eventName.ts
+++ b/frontend/src/constants/eventName.ts
@@ -152,4 +152,7 @@ export const PAGE_NAME = {
   WEBVIEW_MAIN: 'webview-main',
   INTRODUCE: 'introduce',
   SUBSCRIPTIONS: 'subscriptions',
+  CLUB_DETAIL: 'club-detail',
 } as const;
+
+export type PageName = (typeof PAGE_NAME)[keyof typeof PAGE_NAME];

--- a/frontend/src/hooks/useWebviewSubscribe.ts
+++ b/frontend/src/hooks/useWebviewSubscribe.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { USER_EVENT } from '@/constants/eventName';
+import { USER_EVENT, type PageName } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import {
   AppToWebMessage,
@@ -57,11 +57,12 @@ const useWebviewSubscribe = () => {
   }, []);
 
   const toggleSubscribe = useCallback(
-    (clubId: string, subscribed: boolean) => {
+    (clubId: string, subscribed: boolean, source: PageName) => {
       requestSubscribeToggle(clubId);
       trackEvent(USER_EVENT.WEBVIEW_SUBSCRIBE_TOGGLED, {
         club_id: clubId,
         subscribed: !subscribed,
+        source,
       });
     },
     [trackEvent],

--- a/frontend/src/pages/ClubDetailPage/components/ClubDetailTopBar/ClubDetailTopBar.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubDetailTopBar/ClubDetailTopBar.tsx
@@ -4,7 +4,7 @@ import { useTheme } from 'styled-components';
 import NotificationIcon from '@/assets/images/icons/notification_icon.svg?react';
 import PrevButtonIcon from '@/assets/images/icons/prev_button_icon.svg?react';
 import Spinner from '@/components/common/Spinner/Spinner';
-import { USER_EVENT } from '@/constants/eventName';
+import { PAGE_NAME, USER_EVENT } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import { useScrollTrigger } from '@/hooks/Scroll/useScrollTrigger';
 import useOpenAppFromKakao from '@/hooks/useOpenAppFromKakao';
@@ -94,6 +94,11 @@ const ClubDetailTopBar = ({
 
   const handleNotificationClick = () => {
     requestSubscribeToggle(clubId);
+    trackEvent(USER_EVENT.WEBVIEW_SUBSCRIBE_TOGGLED, {
+      club_id: clubId,
+      subscribed: !isNotificationActive,
+      source: PAGE_NAME.CLUB_DETAIL,
+    });
   };
 
   return (

--- a/frontend/src/pages/MainPage/MainPage.tsx
+++ b/frontend/src/pages/MainPage/MainPage.tsx
@@ -76,7 +76,11 @@ const MainPage = () => {
           <SubscribeButton
             subscribed={subscribedClubIds.has(club.id)}
             onToggle={() =>
-              toggleSubscribe(club.id, subscribedClubIds.has(club.id))
+              toggleSubscribe(
+                club.id,
+                subscribedClubIds.has(club.id),
+                PAGE_NAME.WEBVIEW_MAIN,
+              )
             }
           />
         )}

--- a/frontend/src/pages/SubscriptionsPage/SubscriptionsPage.tsx
+++ b/frontend/src/pages/SubscriptionsPage/SubscriptionsPage.tsx
@@ -65,7 +65,11 @@ const SubscribedClubs = () => {
               <SubscribeButton
                 subscribed={subscribedClubIds.has(club.id)}
                 onToggle={() =>
-                  toggleSubscribe(club.id, subscribedClubIds.has(club.id))
+                  toggleSubscribe(
+                    club.id,
+                    subscribedClubIds.has(club.id),
+                    PAGE_NAME.SUBSCRIPTIONS,
+                  )
                 }
               />
             </ClubCard>


### PR DESCRIPTION
## 문제

동아리 상세페이지 상단바의 **알림(구독) 버튼 클릭이 Mixpanel에 전혀 잡히지 않았다.**

메인·구독 목록의 구독 토글은 `useWebviewSubscribe`의 `toggleSubscribe`를 거치고 트래킹도 이 훅 안에 있는데, `ClubDetailTopBar`는 자체 `isNotificationActive` 상태를 들고 있어 훅을 쓰지 않고 `requestSubscribeToggle(clubId)`를 **직접** 호출한다. 구독 동작 자체는 정상이지만 트래킹만 우회돼서, `Webview Subscribe Toggled` 이벤트에 상세페이지 유입분이 통째로 빠져 있었다.

## 변경

1. `ClubDetailTopBar.handleNotificationClick`에 트래킹 추가
2. 진입 지점을 구분할 수 있도록 `Webview Subscribe Toggled`에 `source` 프로퍼티 추가
   - `toggleSubscribe(clubId, subscribed, source)` — **필수 인자**로 둬서 앞으로 새 호출부가 생겨도 source 누락이 타입 에러로 잡힌다
   - 값은 새로 만들지 않고 기존 `PAGE_NAME`을 재사용 (ClubCard `page` 프로퍼티·스크롤 트래킹과 같은 체계). `CLUB_DETAIL: 'club-detail'`만 추가

최종 이벤트 스키마 — `club_id`, `subscribed`(토글 후 상태), `source`

## 범위

- 변경 파일 5개, `+22 / -5`. main 기준 클린 체리픽 (충돌 없음)
- 동작 변경 없음. 기존 구독 토글 동작은 그대로이고 트래킹 이벤트만 추가된다
- 같은 내용이 `develop-fe` 대상으로도 올라가 있다 (#1897). 릴리즈 대기가 길어 트래킹 공백이 계속 쌓이므로 main에 먼저 반영한다

## 확인

- `tsc --noEmit` 통과 (main 베이스에서 검증)
- 상세페이지 알림 버튼 클릭 → `Webview Subscribe Toggled` (`source: club-detail`) 발생 확인
- 메인/구독 목록 토글 → 기존과 동일하게 발생, `source`만 추가 확인
