### PR TITLE
[feature] FAQ 토글 이벤트에 faq_index·club_id 속성 추가

### DIFF
--- a/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
@@ -217,7 +217,10 @@ const ClubDetailPage = () => {
                   display: activeTab === TAB_TYPE.INTRO ? 'block' : 'none',
                 }}
               >
-                <ClubIntroContent {...clubDetail.description} />
+                <ClubIntroContent
+                  {...clubDetail.description}
+                  clubId={clubDetail.id}
+                />
               </div>
               <div
                 style={{

--- a/frontend/src/pages/ClubDetailPage/components/ClubIntroContent/ClubIntroContent.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubIntroContent/ClubIntroContent.tsx
@@ -12,6 +12,7 @@ interface ClubIntroContentProps {
   idealCandidate?: IdealCandidate;
   benefits?: string;
   faqs?: FAQ[];
+  clubId?: string;
 }
 
 const ClubIntroContent = ({
@@ -20,6 +21,7 @@ const ClubIntroContent = ({
   idealCandidate,
   benefits,
   faqs,
+  clubId,
 }: ClubIntroContentProps) => {
   const trackEvent = useMixpanelTrack();
 
@@ -44,11 +46,13 @@ const ClubIntroContent = ({
       if (faqs?.[index]) {
         trackEvent(USER_EVENT.FAQ_TOGGLE_CLICKED, {
           question: faqs[index].question,
+          faq_index: index,
+          club_id: clubId,
           action: isOpening ? 'open' : 'close',
         });
       }
     },
-    [faqs, trackEvent, openFaqIndexes],
+    [faqs, trackEvent, openFaqIndexes, clubId],
   );
 
   const isEmpty =


### PR DESCRIPTION
## #️⃣연관된 이슈

없음 (데이터팀 FAQ 이벤트 속성 요청)

## 📝작업 내용

`FAQ Toggle Clicked` 이벤트에 어떤 항목이 열렸는지 식별할 속성이 부족해서 추가했습니다.

**변경 후 스키마**

```ts
FAQ Toggle Clicked {
  question:  "지원 자격이 어떻게 되나요?",  // 기존 유지
  faq_index: 2,                            // 신규
  club_id:   "68a1...",                    // 신규
  action:    "open" | "close",
}
```

- `ClubIntroContent.tsx` — `clubId?: string` prop 추가, 이벤트에 `faq_index` / `club_id` 추가
- `ClubDetailPage.tsx` — `<ClubIntroContent ... clubId={clubDetail.id} />`

## 중점적으로 리뷰받고 싶은 부분(선택)

**1. `question` 속성명을 유지했습니다.**
요청서에는 `faq_title`로 적혀 있었지만, 이미 `question`으로 데이터가 쌓이고 있어서 리네임하면 Mixpanel 히스토리가 끊깁니다. 기존 이름을 유지하는 쪽을 택했는데, Lexicon에서 정리할 계획이 있다면 알려주세요.

**2. Legacy 경로는 손대지 않았습니다.**
`clubId`를 optional로 둬서 `LegacyClubDetailPage`(`/club/:clubId`)는 수정 없이 컴파일됩니다. 앱 내부 이동은 전부 `/clubDetail/`로 향하고 Legacy는 옛 북마크·구버전 안드로이드 유입만 받으므로, 해당 경로의 FAQ 이벤트는 기존 형태로 계속 쌓입니다. 잔여 유입이 유의미하면 후속으로 붙이겠습니다.

## 🫡 참고사항

`faq_index`는 렌더 순서 기준이라 동아리가 FAQ 순서를 바꾸면 같은 질문의 index가 달라집니다. "어떤 질문이 많이 열리는지"는 `question`으로, `faq_index`는 위치 효과 분석용으로 나눠 보는 게 맞습니다.

검증: `npm run typecheck` 통과(에러 0), 변경 파일 prettier 통과.
