### PR TITLE
[feature] 동아리 상세 체류 시간 자체 수집 API 추가

### DIFF
--- a/backend/src/main/java/moadong/analytics/controller/ClubDetailDurationController.java
+++ b/backend/src/main/java/moadong/analytics/controller/ClubDetailDurationController.java
@@ -1,0 +1,40 @@
+package moadong.analytics.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import moadong.analytics.payload.request.ClubDetailDurationRecordRequest;
+import moadong.analytics.service.ClubDetailDurationService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/analytics/club-detail")
+@RequiredArgsConstructor
+@Tag(name = "Analytics", description = "사용자 행동 통계 수집 API")
+public class ClubDetailDurationController {
+
+    private final ClubDetailDurationService clubDetailDurationService;
+
+    @PostMapping("/duration")
+    @Operation(summary = "동아리 상세 페이지 체류 시간 기록")
+    public ResponseEntity<Void> recordDuration(
+            @RequestBody ClubDetailDurationRecordRequest request,
+            HttpServletRequest httpServletRequest
+    ) {
+        clubDetailDurationService.record(request, clientIp(httpServletRequest));
+        return ResponseEntity.noContent().build();
+    }
+
+    private String clientIp(HttpServletRequest request) {
+        String forwardedFor = request.getHeader("X-Forwarded-For");
+        if (forwardedFor != null && !forwardedFor.isBlank()) {
+            return forwardedFor.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+}

--- a/backend/src/main/java/moadong/analytics/entity/ClubDetailDurationSession.java
+++ b/backend/src/main/java/moadong/analytics/entity/ClubDetailDurationSession.java
@@ -9,33 +9,39 @@ import org.springframework.data.mongodb.core.index.CompoundIndex;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-@Document("club_analytics_daily")
-@CompoundIndex(name = "date_club_unique", def = "{'date': 1, 'clubId': 1}", unique = true)
+@Document("club_detail_duration_sessions")
+@CompoundIndex(name = "session_club_unique", def = "{'sessionId': 1, 'clubId': 1}", unique = true)
 @CompoundIndex(name = "club_date_idx", def = "{'clubId': 1, 'date': 1}")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class ClubAnalyticsDaily {
+public class ClubDetailDurationSession {
 
     @Id
     private String id;
 
     @Indexed
-    private LocalDate date;
+    private String sessionId;
+
+    @Indexed
+    private String visitorId;
 
     @Indexed
     private String clubId;
 
     private String clubName;
 
-    private long detailViewCount;
-    private long detailDurationSumSeconds;
-    private long detailDurationCount;
+    @Indexed
+    private LocalDate date;
+
+    private Instant enteredAt;
+    private Instant leftAt;
+    private long durationSeconds;
 
     private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
 }

--- a/backend/src/main/java/moadong/analytics/entity/ClubDetailVisitorDaily.java
+++ b/backend/src/main/java/moadong/analytics/entity/ClubDetailVisitorDaily.java
@@ -12,14 +12,13 @@ import org.springframework.data.mongodb.core.mapping.Document;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-@Document("club_analytics_daily")
-@CompoundIndex(name = "date_club_unique", def = "{'date': 1, 'clubId': 1}", unique = true)
-@CompoundIndex(name = "club_date_idx", def = "{'clubId': 1, 'date': 1}")
+@Document("club_detail_visitor_daily")
+@CompoundIndex(name = "club_date_visitor_unique", def = "{'clubId': 1, 'date': 1, 'visitorId': 1}", unique = true)
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class ClubAnalyticsDaily {
+public class ClubDetailVisitorDaily {
 
     @Id
     private String id;
@@ -30,11 +29,11 @@ public class ClubAnalyticsDaily {
     @Indexed
     private String clubId;
 
-    private String clubName;
+    @Indexed
+    private String visitorId;
 
-    private long detailViewCount;
-    private long detailDurationSumSeconds;
-    private long detailDurationCount;
+    private long durationSumSeconds;
+    private long sessionCount;
 
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;

--- a/backend/src/main/java/moadong/analytics/payload/request/ClubDetailDurationRecordRequest.java
+++ b/backend/src/main/java/moadong/analytics/payload/request/ClubDetailDurationRecordRequest.java
@@ -1,0 +1,14 @@
+package moadong.analytics.payload.request;
+
+import java.time.Instant;
+
+public record ClubDetailDurationRecordRequest(
+        String clubId,
+        String clubName,
+        String sessionId,
+        String visitorId,
+        Instant enteredAt,
+        Instant leftAt,
+        Long durationSeconds
+) {
+}

--- a/backend/src/main/java/moadong/analytics/payload/response/ClubStatisticsOverviewResponse.java
+++ b/backend/src/main/java/moadong/analytics/payload/response/ClubStatisticsOverviewResponse.java
@@ -9,6 +9,8 @@ public record ClubStatisticsOverviewResponse(
         LocalDate to,
         long totalDetailViews,
         long averageDetailDurationSeconds,
+        long uniqueDetailVisitors,
+        long averageDetailDurationSecondsPerVisitor,
         long totalApplicants
 ) {
 }

--- a/backend/src/main/java/moadong/analytics/repository/ClubDetailDurationSessionRepository.java
+++ b/backend/src/main/java/moadong/analytics/repository/ClubDetailDurationSessionRepository.java
@@ -1,0 +1,7 @@
+package moadong.analytics.repository;
+
+import moadong.analytics.entity.ClubDetailDurationSession;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface ClubDetailDurationSessionRepository extends MongoRepository<ClubDetailDurationSession, String> {
+}

--- a/backend/src/main/java/moadong/analytics/repository/ClubDetailVisitorDailyRepository.java
+++ b/backend/src/main/java/moadong/analytics/repository/ClubDetailVisitorDailyRepository.java
@@ -1,0 +1,7 @@
+package moadong.analytics.repository;
+
+import moadong.analytics.entity.ClubDetailVisitorDaily;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface ClubDetailVisitorDailyRepository extends MongoRepository<ClubDetailVisitorDaily, String> {
+}

--- a/backend/src/main/java/moadong/analytics/service/ClubAnalyticsRecordService.java
+++ b/backend/src/main/java/moadong/analytics/service/ClubAnalyticsRecordService.java
@@ -45,6 +45,10 @@ public class ClubAnalyticsRecordService {
         }
     }
 
+    public void recordDetailDuration(String clubId, String clubName, LocalDate date, long durationSeconds) {
+        incrementClubDailyWithoutExistenceCheck(clubId, clubName, date, 0, durationSeconds, 1);
+    }
+
     public void incrementClubDaily(
             String clubId,
             String clubName,

--- a/backend/src/main/java/moadong/analytics/service/ClubDetailDurationService.java
+++ b/backend/src/main/java/moadong/analytics/service/ClubDetailDurationService.java
@@ -1,0 +1,153 @@
+package moadong.analytics.service;
+
+import com.mongodb.client.result.UpdateResult;
+import lombok.RequiredArgsConstructor;
+import moadong.analytics.payload.request.ClubDetailDurationRecordRequest;
+import moadong.analytics.support.AnalyticsTime;
+import moadong.club.entity.Club;
+import moadong.club.repository.ClubRepository;
+import moadong.global.exception.ErrorCode;
+import moadong.global.exception.RestApiException;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ClubDetailDurationService {
+
+    private static final long MIN_DURATION_SECONDS = 1L;
+    private static final long MAX_DURATION_SECONDS = 3600L;
+    private static final String RATE_LIMIT_KEY_PREFIX = "analytics:club-detail-duration:ratelimit:";
+    private static final long RATE_LIMIT_WINDOW_SECONDS = 60L;
+    private static final long RATE_LIMIT_MAX_REQUESTS = 120L;
+    private static final RedisScript<Long> RATE_LIMIT_SCRIPT = RedisScript.of(
+            "local c = redis.call('INCR', KEYS[1])\n" +
+                    "if c == 1 then redis.call('EXPIRE', KEYS[1], ARGV[1]) end\n" +
+                    "return c",
+            Long.class
+    );
+
+    private final ClubAnalyticsRecordService clubAnalyticsRecordService;
+    private final ClubRepository clubRepository;
+    private final MongoTemplate mongoTemplate;
+    private final StringRedisTemplate stringRedisTemplate;
+
+    @Transactional
+    public void record(ClubDetailDurationRecordRequest request, String clientIp) {
+        validate(request);
+        validateRateLimit(request.clubId(), clientIp);
+        Club club = clubRepository.findById(request.clubId())
+                .orElseThrow(() -> new RestApiException(ErrorCode.CLUB_NOT_FOUND));
+
+        LocalDate eventDate = eventDate(request.leftAt());
+        LocalDateTime now = LocalDateTime.now(AnalyticsTime.KST);
+
+        if (!insertSession(request, club, eventDate, now)) {
+            return;
+        }
+
+        clubAnalyticsRecordService.recordDetailDuration(club.getId(), club.getName(), eventDate, request.durationSeconds());
+        incrementVisitorDaily(club.getId(), request.visitorId(), eventDate, request.durationSeconds(), now);
+    }
+
+    private void validate(ClubDetailDurationRecordRequest request) {
+        if (request == null
+                || isBlank(request.clubId())
+                || isBlank(request.sessionId())
+                || isBlank(request.visitorId())
+                || request.durationSeconds() == null
+                || request.durationSeconds() < MIN_DURATION_SECONDS
+                || request.durationSeconds() > MAX_DURATION_SECONDS) {
+            throw new RestApiException(ErrorCode.STATISTICS_EVENT_INVALID);
+        }
+        if (request.enteredAt() != null
+                && request.leftAt() != null
+                && request.leftAt().isBefore(request.enteredAt())) {
+            throw new RestApiException(ErrorCode.STATISTICS_EVENT_INVALID);
+        }
+    }
+
+    private void validateRateLimit(String clubId, String clientIp) {
+        Long requestCount = stringRedisTemplate.execute(
+                RATE_LIMIT_SCRIPT,
+                List.of(rateLimitKey(clubId, clientIp)),
+                String.valueOf(RATE_LIMIT_WINDOW_SECONDS)
+        );
+        if (requestCount != null && requestCount > RATE_LIMIT_MAX_REQUESTS) {
+            throw new RestApiException(ErrorCode.STATISTICS_EVENT_RATE_LIMITED);
+        }
+    }
+
+    private String rateLimitKey(String clubId, String clientIp) {
+        return RATE_LIMIT_KEY_PREFIX + clubId + ":" + (clientIp == null || clientIp.isBlank() ? "unknown" : clientIp);
+    }
+
+    private boolean insertSession(
+            ClubDetailDurationRecordRequest request,
+            Club club,
+            LocalDate eventDate,
+            LocalDateTime now
+    ) {
+        Query query = Query.query(
+                Criteria.where("sessionId").is(request.sessionId())
+                        .and("clubId").is(club.getId())
+        );
+        Update update = new Update()
+                .setOnInsert("sessionId", request.sessionId())
+                .setOnInsert("visitorId", request.visitorId())
+                .setOnInsert("clubId", club.getId())
+                .setOnInsert("clubName", club.getName())
+                .setOnInsert("date", eventDate)
+                .setOnInsert("enteredAt", request.enteredAt())
+                .setOnInsert("leftAt", request.leftAt())
+                .setOnInsert("durationSeconds", request.durationSeconds())
+                .setOnInsert("createdAt", now);
+        UpdateResult result = mongoTemplate.upsert(query, update, "club_detail_duration_sessions");
+        return result.getUpsertedId() != null;
+    }
+
+    private void incrementVisitorDaily(
+            String clubId,
+            String visitorId,
+            LocalDate date,
+            long durationSeconds,
+            LocalDateTime now
+    ) {
+        Query query = Query.query(
+                Criteria.where("clubId").is(clubId)
+                        .and("date").is(date)
+                        .and("visitorId").is(visitorId)
+        );
+        Update update = new Update()
+                .inc("durationSumSeconds", durationSeconds)
+                .inc("sessionCount", 1)
+                .set("updatedAt", now)
+                .setOnInsert("clubId", clubId)
+                .setOnInsert("date", date)
+                .setOnInsert("visitorId", visitorId)
+                .setOnInsert("createdAt", now);
+        mongoTemplate.upsert(query, update, "club_detail_visitor_daily");
+    }
+
+    private LocalDate eventDate(Instant leftAt) {
+        if (leftAt == null) {
+            return AnalyticsTime.todayKst();
+        }
+        return leftAt.atZone(AnalyticsTime.KST).toLocalDate();
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/backend/src/main/java/moadong/analytics/service/ClubStatisticsAdminService.java
+++ b/backend/src/main/java/moadong/analytics/service/ClubStatisticsAdminService.java
@@ -17,6 +17,7 @@ import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.aggregation.AggregationResults;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.stereotype.Service;
+import org.bson.Document;
 
 import java.time.LocalDate;
 import java.util.*;
@@ -42,6 +43,7 @@ public class ClubStatisticsAdminService {
         long totalDetailViews = dailyStats.stream().mapToLong(ClubAnalyticsDaily::getDetailViewCount).sum();
         long durationSum = dailyStats.stream().mapToLong(ClubAnalyticsDaily::getDetailDurationSumSeconds).sum();
         long durationCount = dailyStats.stream().mapToLong(ClubAnalyticsDaily::getDetailDurationCount).sum();
+        VisitorDurationSummary visitorDurationSummary = getVisitorDurationSummary(clubId, from, to);
         long totalApplicants = applicantCounts.values().stream().mapToLong(Long::longValue).sum();
 
         return new ClubStatisticsOverviewResponse(
@@ -51,6 +53,8 @@ public class ClubStatisticsAdminService {
                 to,
                 totalDetailViews,
                 average(durationSum, durationCount),
+                visitorDurationSummary.uniqueVisitors(),
+                average(visitorDurationSummary.durationSumSeconds(), visitorDurationSummary.uniqueVisitors()),
                 totalApplicants
         );
     }
@@ -118,5 +122,36 @@ public class ClubStatisticsAdminService {
 
     private long average(long sum, long count) {
         return count == 0 ? 0 : Math.round((double) sum / count);
+    }
+
+    private VisitorDurationSummary getVisitorDurationSummary(String clubId, LocalDate from, LocalDate to) {
+        Aggregation aggregation = Aggregation.newAggregation(
+                Aggregation.match(Criteria.where("clubId").is(clubId).and("date").gte(from).lte(to)),
+                Aggregation.group("visitorId").sum("durationSumSeconds").as("visitorDurationSeconds"),
+                Aggregation.group()
+                        .count().as("uniqueVisitors")
+                        .sum("visitorDurationSeconds").as("durationSumSeconds")
+        );
+
+        AggregationResults<Document> results = mongoTemplate.aggregate(
+                aggregation,
+                "club_detail_visitor_daily",
+                Document.class
+        );
+        Document summary = results.getUniqueMappedResult();
+        if (summary == null) {
+            return new VisitorDurationSummary(0, 0);
+        }
+        return new VisitorDurationSummary(
+                longValue(summary.get("uniqueVisitors")),
+                longValue(summary.get("durationSumSeconds"))
+        );
+    }
+
+    private long longValue(Object value) {
+        return value instanceof Number number ? number.longValue() : 0;
+    }
+
+    private record VisitorDurationSummary(long uniqueVisitors, long durationSumSeconds) {
     }
 }

--- a/backend/src/main/java/moadong/global/exception/ErrorCode.java
+++ b/backend/src/main/java/moadong/global/exception/ErrorCode.java
@@ -86,6 +86,8 @@ public enum ErrorCode {
     MIXPANEL_EXPORT_FAILED(HttpStatus.BAD_GATEWAY, "903-1", "Mixpanel 데이터 조회에 실패했습니다."),
     STATISTICS_DATE_RANGE_INVALID(HttpStatus.BAD_REQUEST, "903-2", "통계 조회 기간이 올바르지 않습니다."),
     STATISTICS_BACKFILL_RANGE_TOO_LONG(HttpStatus.BAD_REQUEST, "903-3", "통계 백필 기간이 너무 깁니다."),
+    STATISTICS_EVENT_INVALID(HttpStatus.BAD_REQUEST, "903-4", "통계 이벤트 요청이 올바르지 않습니다."),
+    STATISTICS_EVENT_RATE_LIMITED(HttpStatus.TOO_MANY_REQUESTS, "903-5", "통계 이벤트 요청이 너무 많습니다."),
 
     // 950xx: Notion 연동 오류
     NOTION_CONFIG_MISSING(HttpStatus.INTERNAL_SERVER_ERROR, "950-1", "Notion 서버 환경변수가 설정되지 않았습니다."),

--- a/backend/src/test/java/moadong/analytics/controller/ClubDetailDurationControllerTest.java
+++ b/backend/src/test/java/moadong/analytics/controller/ClubDetailDurationControllerTest.java
@@ -1,0 +1,51 @@
+package moadong.analytics.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import moadong.analytics.payload.request.ClubDetailDurationRecordRequest;
+import moadong.analytics.service.ClubDetailDurationService;
+import moadong.util.annotations.UnitTest;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.http.ResponseEntity;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@UnitTest
+class ClubDetailDurationControllerTest {
+
+    @Mock
+    private ClubDetailDurationService clubDetailDurationService;
+
+    @Mock
+    private HttpServletRequest httpServletRequest;
+
+    @InjectMocks
+    private ClubDetailDurationController clubDetailDurationController;
+
+    @Test
+    void 체류_시간_기록_요청은_204를_반환한다() {
+        // given
+        ClubDetailDurationRecordRequest request = new ClubDetailDurationRecordRequest(
+                "club-id",
+                "테스트동아리",
+                "session-id",
+                "visitor-id",
+                Instant.parse("2026-08-06T01:00:00Z"),
+                Instant.parse("2026-08-06T01:00:10Z"),
+                10L
+        );
+        when(httpServletRequest.getHeader("X-Forwarded-For")).thenReturn("203.0.113.1, 10.0.0.1");
+
+        // when
+        ResponseEntity<Void> response = clubDetailDurationController.recordDuration(request, httpServletRequest);
+
+        // then
+        assertEquals(204, response.getStatusCode().value());
+        verify(clubDetailDurationService).record(request, "203.0.113.1");
+    }
+}

--- a/backend/src/test/java/moadong/analytics/service/ClubDetailDurationServiceTest.java
+++ b/backend/src/test/java/moadong/analytics/service/ClubDetailDurationServiceTest.java
@@ -1,0 +1,225 @@
+package moadong.analytics.service;
+
+import com.mongodb.client.result.UpdateResult;
+import moadong.analytics.payload.request.ClubDetailDurationRecordRequest;
+import moadong.club.entity.Club;
+import moadong.club.repository.ClubRepository;
+import moadong.global.exception.ErrorCode;
+import moadong.global.exception.RestApiException;
+import moadong.util.annotations.UnitTest;
+import org.bson.BsonString;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@UnitTest
+class ClubDetailDurationServiceTest {
+
+    @Mock
+    private ClubAnalyticsRecordService clubAnalyticsRecordService;
+
+    @Mock
+    private ClubRepository clubRepository;
+
+    @Mock
+    private MongoTemplate mongoTemplate;
+
+    @Mock
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Test
+    void 정상_요청이면_세션을_저장하고_daily와_visitor_집계를_증가시킨다() {
+        // given
+        ClubDetailDurationService service = service();
+        ClubDetailDurationRecordRequest request = request(35);
+        passRateLimit();
+        sessionInserted();
+        visitorDailyUpdated();
+        Club club = mock(Club.class);
+        when(club.getId()).thenReturn("club-id");
+        when(club.getName()).thenReturn("테스트동아리");
+        when(clubRepository.findById("club-id")).thenReturn(Optional.of(club));
+
+        // when
+        service.record(request, "127.0.0.1");
+
+        // then
+        verify(clubAnalyticsRecordService).recordDetailDuration(
+                "club-id",
+                "테스트동아리",
+                LocalDate.of(2026, 8, 6),
+                35
+        );
+        verify(mongoTemplate).upsert(any(Query.class), any(Update.class), eq("club_detail_duration_sessions"));
+        verify(mongoTemplate).upsert(any(Query.class), any(Update.class), eq("club_detail_visitor_daily"));
+    }
+
+    @Test
+    void 중복_세션이면_daily_집계를_증가시키지_않는다() {
+        // given
+        ClubDetailDurationService service = service();
+        ClubDetailDurationRecordRequest request = request(10);
+        passRateLimit();
+        sessionDuplicated();
+        Club club = mock(Club.class);
+        when(club.getId()).thenReturn("club-id");
+        when(clubRepository.findById("club-id")).thenReturn(Optional.of(club));
+
+        // when
+        service.record(request, "127.0.0.1");
+
+        // then
+        verifyNoInteractions(clubAnalyticsRecordService);
+        verify(mongoTemplate).upsert(any(Query.class), any(Update.class), eq("club_detail_duration_sessions"));
+        verify(mongoTemplate, never()).upsert(any(Query.class), any(Update.class), eq("club_detail_visitor_daily"));
+    }
+
+    @Test
+    void daily_집계_실패_시_트랜잭션에_예외를_전파한다() {
+        // given
+        ClubDetailDurationService service = service();
+        ClubDetailDurationRecordRequest request = request(10);
+        passRateLimit();
+        sessionInserted();
+        Club club = mock(Club.class);
+        when(club.getId()).thenReturn("club-id");
+        when(club.getName()).thenReturn("테스트동아리");
+        when(clubRepository.findById("club-id")).thenReturn(Optional.of(club));
+        doThrow(new RuntimeException("mongo error"))
+                .when(clubAnalyticsRecordService)
+                .recordDetailDuration(any(), any(), any(), anyLong());
+
+        // when & then
+        assertThrows(RuntimeException.class, () -> service.record(request, "127.0.0.1"));
+        verify(mongoTemplate, never()).upsert(any(Query.class), any(Update.class), eq("club_detail_visitor_daily"));
+    }
+
+    @Test
+    void visitor_집계_실패_시_트랜잭션에_예외를_전파한다() {
+        // given
+        ClubDetailDurationService service = service();
+        ClubDetailDurationRecordRequest request = request(10);
+        passRateLimit();
+        sessionInserted();
+        Club club = mock(Club.class);
+        when(club.getId()).thenReturn("club-id");
+        when(club.getName()).thenReturn("테스트동아리");
+        when(clubRepository.findById("club-id")).thenReturn(Optional.of(club));
+        when(mongoTemplate.upsert(any(Query.class), any(Update.class), eq("club_detail_visitor_daily")))
+                .thenThrow(new RuntimeException("mongo error"));
+
+        // when & then
+        assertThrows(RuntimeException.class, () -> service.record(request, "127.0.0.1"));
+        verify(clubAnalyticsRecordService).recordDetailDuration(
+                "club-id",
+                "테스트동아리",
+                LocalDate.of(2026, 8, 6),
+                10
+        );
+    }
+
+    @Test
+    void 요청_제한을_초과하면_429_예외가_발생한다() {
+        // given
+        ClubDetailDurationService service = service();
+        when(stringRedisTemplate.execute(any(RedisScript.class), anyList(), anyString()))
+                .thenReturn(121L);
+
+        // when & then
+        RestApiException exception = assertThrows(
+                RestApiException.class,
+                () -> service.record(request(10), "127.0.0.1")
+        );
+        assertEquals(ErrorCode.STATISTICS_EVENT_RATE_LIMITED, exception.getErrorCode());
+        verifyNoInteractions(clubRepository);
+    }
+
+    @Test
+    void duration이_범위를_벗어나면_실패한다() {
+        // given
+        ClubDetailDurationService service = service();
+
+        // when & then
+        assertThrows(RestApiException.class, () -> service.record(request(0), "127.0.0.1"));
+        assertThrows(RestApiException.class, () -> service.record(request(3601), "127.0.0.1"));
+        verifyNoInteractions(clubRepository);
+        verifyNoInteractions(stringRedisTemplate);
+    }
+
+    @Test
+    void leftAt이_enteredAt보다_이전이면_실패한다() {
+        // given
+        ClubDetailDurationService service = service();
+        ClubDetailDurationRecordRequest request = new ClubDetailDurationRecordRequest(
+                "club-id",
+                "테스트동아리",
+                "session-id",
+                "visitor-id",
+                Instant.parse("2026-08-06T01:00:10Z"),
+                Instant.parse("2026-08-06T01:00:00Z"),
+                10L
+        );
+
+        // when & then
+        assertThrows(RestApiException.class, () -> service.record(request, "127.0.0.1"));
+        verifyNoInteractions(clubRepository);
+        verifyNoInteractions(stringRedisTemplate);
+    }
+
+    private ClubDetailDurationService service() {
+        return new ClubDetailDurationService(
+                clubAnalyticsRecordService,
+                clubRepository,
+                mongoTemplate,
+                stringRedisTemplate
+        );
+    }
+
+    private void passRateLimit() {
+        when(stringRedisTemplate.execute(any(RedisScript.class), anyList(), anyString()))
+                .thenReturn(1L);
+    }
+
+    private void sessionInserted() {
+        when(mongoTemplate.upsert(any(Query.class), any(Update.class), eq("club_detail_duration_sessions")))
+                .thenReturn(UpdateResult.acknowledged(0L, 0L, new BsonString("session-doc-id")));
+    }
+
+    private void sessionDuplicated() {
+        when(mongoTemplate.upsert(any(Query.class), any(Update.class), eq("club_detail_duration_sessions")))
+                .thenReturn(UpdateResult.acknowledged(1L, 0L, null));
+    }
+
+    private void visitorDailyUpdated() {
+        when(mongoTemplate.upsert(any(Query.class), any(Update.class), eq("club_detail_visitor_daily")))
+                .thenReturn(UpdateResult.acknowledged(1L, 1L, null));
+    }
+
+    private ClubDetailDurationRecordRequest request(long durationSeconds) {
+        return new ClubDetailDurationRecordRequest(
+                "club-id",
+                "테스트동아리",
+                "session-id",
+                "visitor-id",
+                Instant.parse("2026-08-06T01:00:00Z"),
+                Instant.parse("2026-08-06T01:00:35Z"),
+                durationSeconds
+        );
+    }
+}

--- a/backend/src/test/java/moadong/analytics/service/ClubStatisticsAdminServiceTest.java
+++ b/backend/src/test/java/moadong/analytics/service/ClubStatisticsAdminServiceTest.java
@@ -1,0 +1,93 @@
+package moadong.analytics.service;
+
+import moadong.analytics.entity.ClubAnalyticsDaily;
+import moadong.analytics.repository.ClubAnalyticsDailyRepository;
+import moadong.analytics.payload.response.ClubStatisticsOverviewResponse;
+import moadong.club.entity.Club;
+import moadong.club.repository.ClubRepository;
+import moadong.util.annotations.UnitTest;
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.AggregationResults;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@UnitTest
+class ClubStatisticsAdminServiceTest {
+
+    @Mock
+    private ClubAnalyticsDailyRepository clubAnalyticsDailyRepository;
+
+    @Mock
+    private ClubApplicantStatisticsService clubApplicantStatisticsService;
+
+    @Mock
+    private ClubRepository clubRepository;
+
+    @Mock
+    private MongoTemplate mongoTemplate;
+
+    @Test
+    void overview는_방문_세션_평균과_인당_평균_체류_시간을_계산한다() {
+        // given
+        ClubStatisticsAdminService service = service();
+        LocalDate from = LocalDate.of(2026, 8, 1);
+        LocalDate to = LocalDate.of(2026, 8, 2);
+        Club club = mock(Club.class);
+        when(club.getName()).thenReturn("테스트동아리");
+        when(clubRepository.findById("club-id")).thenReturn(Optional.of(club));
+        when(clubAnalyticsDailyRepository.findByClubIdAndDateBetweenOrderByDateAsc("club-id", from, to))
+                .thenReturn(List.of(
+                        daily(from, 10, 30, 2),
+                        daily(to, 5, 90, 3)
+                ));
+        when(clubApplicantStatisticsService.countApplicantsByDate("club-id", from, to))
+                .thenReturn(Map.of(from, 2L, to, 1L));
+        Document visitorSummary = new Document()
+                .append("uniqueVisitors", 3L)
+                .append("durationSumSeconds", 120L);
+        when(mongoTemplate.aggregate(any(Aggregation.class), eq("club_detail_visitor_daily"), eq(Document.class)))
+                .thenReturn(new AggregationResults<>(List.of(visitorSummary), new Document()));
+
+        // when
+        ClubStatisticsOverviewResponse response = service.getOverview("club-id", from, to);
+
+        // then
+        assertEquals(15, response.totalDetailViews());
+        assertEquals(24, response.averageDetailDurationSeconds());
+        assertEquals(3, response.uniqueDetailVisitors());
+        assertEquals(40, response.averageDetailDurationSecondsPerVisitor());
+        assertEquals(3, response.totalApplicants());
+    }
+
+    private ClubStatisticsAdminService service() {
+        return new ClubStatisticsAdminService(
+                clubAnalyticsDailyRepository,
+                clubApplicantStatisticsService,
+                clubRepository,
+                mongoTemplate
+        );
+    }
+
+    private ClubAnalyticsDaily daily(LocalDate date, long views, long durationSum, long durationCount) {
+        return ClubAnalyticsDaily.builder()
+                .date(date)
+                .clubId("club-id")
+                .detailViewCount(views)
+                .detailDurationSumSeconds(durationSum)
+                .detailDurationCount(durationCount)
+                .build();
+    }
+}

--- a/docs/spec/club-detail-duration-analytics-spec.md
+++ b/docs/spec/club-detail-duration-analytics-spec.md
@@ -1,0 +1,447 @@
+# 동아리 상세 체류 시간 자체 수집 스펙
+
+## 목적
+
+동아리 관리자 통계에서 평균 체류 시간이 Mixpanel backfill 없이는 `0초`로 표시되는 문제를 해결한다.
+
+상세 조회수는 기존 백엔드 조회 흐름에서 직접 집계되지만, 체류 시간은 Mixpanel `ClubDetailPage Duration` 이벤트를 수동 backfill해야만 집계된다.
+이 스펙은 백엔드 자체 체류 시간 수집 API와 관리자 통계 overview 확장 계약을 정의한다.
+
+## 대상 범위
+
+- 동아리 상세 페이지 체류 시간 수집 API
+- 체류 시간 원시 세션 저장 컬렉션
+- 방문자 일별 집계 컬렉션
+- 기존 `club_analytics_daily` duration 집계 확장
+- 관리자 통계 overview 응답 확장
+- 백엔드 단위/컨트롤러 테스트
+
+프론트 `sendBeacon` 연결과 관리자 통계 화면 UI 변경은 이 스펙의 구현 범위가 아니다.
+
+## 사용자 시나리오
+
+1. 사용자가 동아리 상세 페이지에 진입한다.
+2. 프론트는 상세 페이지 진입마다 `sessionId`를 생성한다.
+3. 프론트는 브라우저에 저장된 익명 `visitorId`를 함께 사용한다.
+4. 사용자가 페이지를 이탈하거나 페이지가 숨겨지면 체류 시간을 계산한다.
+5. 프론트는 백엔드 수집 API로 `clubId`, `sessionId`, `visitorId`, `durationSeconds`를 전송한다.
+6. 백엔드는 중복 세션이 아니면 원시 세션을 저장하고 일별 통계를 증가시킨다.
+7. 관리자는 통계 overview에서 평균 체류 시간과 인당 평균 체류 시간을 조회한다.
+
+## 지표 정의
+
+### 평균 체류 시간
+
+방문 세션 1회당 평균 체류 시간이다.
+
+```text
+averageDetailDurationSeconds
+  = detailDurationSumSeconds / detailDurationCount
+```
+
+기존 응답 필드명을 유지한다.
+
+### 고유 상세 방문자 수
+
+선택 기간 내 같은 동아리 상세 페이지를 방문한 고유 방문자 수다.
+
+```text
+uniqueDetailVisitors
+  = count(distinct visitorId)
+```
+
+집계 기준은 `club_detail_visitor_daily`를 기간 내 `visitorId`로 group한 결과다.
+
+### 인당 평균 체류 시간
+
+선택 기간 내 고유 방문자 1명당 평균 누적 체류 시간이다.
+
+```text
+averageDetailDurationSecondsPerVisitor
+  = 기간 내 전체 durationSumSeconds / uniqueDetailVisitors
+```
+
+예:
+
+```text
+A 방문자: 10초 + 20초
+B 방문자: 30초
+
+방문 세션 평균 = 60초 / 3세션 = 20초
+인당 평균 = 60초 / 2명 = 30초
+```
+
+## API 스펙
+
+### 체류 시간 수집
+
+`POST /api/analytics/club-detail/duration`
+
+권한:
+
+- 인증 없음
+- 일반 사용자 상세 페이지에서 호출하는 공개 수집 API
+
+요청:
+
+```json
+{
+  "clubId": "club-id",
+  "clubName": "동아리명",
+  "sessionId": "uuid",
+  "visitorId": "uuid",
+  "enteredAt": "2026-08-06T01:00:00Z",
+  "leftAt": "2026-08-06T01:00:35Z",
+  "durationSeconds": 35
+}
+```
+
+필수 필드:
+
+- `clubId`
+- `sessionId`
+- `visitorId`
+- `durationSeconds`
+
+선택 필드:
+
+- `clubName`
+- `enteredAt`
+- `leftAt`
+
+성공 응답:
+
+- HTTP `204 No Content`
+
+중복 세션 응답:
+
+- HTTP `204 No Content`
+- 이미 처리한 `sessionId + clubId`는 다시 집계하지 않는다.
+
+실패 응답:
+
+- HTTP `400`
+  - 에러 코드: `903-4`
+  - 메시지: `통계 이벤트 요청이 올바르지 않습니다.`
+- HTTP `429`
+  - 에러 코드: `903-5`
+  - 메시지: `통계 이벤트 요청이 너무 많습니다.`
+- HTTP `404`
+  - 에러 코드: `600-1`
+  - 메시지: `동아리가 존재하지 않습니다.`
+
+검증:
+
+- `clubId`, `sessionId`, `visitorId`는 blank일 수 없다.
+- `durationSeconds`는 `1` 이상 `3600` 이하이다.
+- `enteredAt`과 `leftAt`이 모두 있으면 `leftAt`은 `enteredAt`보다 이전일 수 없다.
+- `clubId`는 존재하는 동아리여야 한다.
+
+요청 제한:
+
+- Redis window counter로 `clubId + clientIp` 단위 요청 수를 제한한다.
+- 기준값은 60초당 120회다.
+- `X-Forwarded-For`가 있으면 첫 번째 IP를 사용하고, 없으면 `remoteAddr`를 사용한다.
+
+날짜 기준:
+
+- `leftAt`이 있으면 `leftAt`을 KST 날짜로 변환해 집계 날짜로 사용한다.
+- `leftAt`이 없으면 서버 현재 KST 날짜를 사용한다.
+
+## 관리자 통계 API 확장
+
+대상 API:
+
+`GET /api/club/statistics/overview?from=yyyy-MM-dd&to=yyyy-MM-dd`
+
+기존 응답:
+
+```java
+public record ClubStatisticsOverviewResponse(
+    String clubId,
+    String clubName,
+    LocalDate from,
+    LocalDate to,
+    long totalDetailViews,
+    long averageDetailDurationSeconds,
+    long totalApplicants
+) {
+}
+```
+
+변경 후 응답:
+
+```java
+public record ClubStatisticsOverviewResponse(
+    String clubId,
+    String clubName,
+    LocalDate from,
+    LocalDate to,
+    long totalDetailViews,
+    long averageDetailDurationSeconds,
+    long uniqueDetailVisitors,
+    long averageDetailDurationSecondsPerVisitor,
+    long totalApplicants
+) {
+}
+```
+
+정책:
+
+- `averageDetailDurationSeconds`는 기존 의미를 유지한다.
+- `uniqueDetailVisitors`와 `averageDetailDurationSecondsPerVisitor`는 overview에만 추가한다.
+- trend API 응답은 이 스펙에서 변경하지 않는다.
+- visitor 데이터가 없으면 `uniqueDetailVisitors = 0`, `averageDetailDurationSecondsPerVisitor = 0`이다.
+
+## 데이터 스펙
+
+### club_detail_duration_sessions
+
+원시 체류 세션 컬렉션이다.
+
+엔티티:
+
+- `ClubDetailDurationSession`
+
+컬렉션:
+
+- `club_detail_duration_sessions`
+
+필드:
+
+- `id`
+- `sessionId`
+- `visitorId`
+- `clubId`
+- `clubName`
+- `date`
+- `enteredAt`
+- `leftAt`
+- `durationSeconds`
+- `createdAt`
+
+인덱스:
+
+- unique `{ sessionId: 1, clubId: 1 }`
+- `{ clubId: 1, date: 1 }`
+- single `sessionId`
+- single `visitorId`
+- single `clubId`
+- single `date`
+
+정책:
+
+- 원시 세션 upsert에서 신규 insert가 발생한 경우에만 집계를 증가시킨다.
+- 기존 문서가 있으면 이미 처리된 세션으로 보고 성공 응답한다.
+- 이 컬렉션은 디버깅과 재집계 원본이다.
+- 관리자 통계 조회는 이 컬렉션을 직접 scan하지 않는다.
+
+### club_detail_visitor_daily
+
+방문자별 일별 체류 시간 집계 컬렉션이다.
+
+엔티티:
+
+- `ClubDetailVisitorDaily`
+
+컬렉션:
+
+- `club_detail_visitor_daily`
+
+필드:
+
+- `id`
+- `date`
+- `clubId`
+- `visitorId`
+- `durationSumSeconds`
+- `sessionCount`
+- `createdAt`
+- `updatedAt`
+
+인덱스:
+
+- unique `{ clubId: 1, date: 1, visitorId: 1 }`
+- single `date`
+- single `clubId`
+- single `visitorId`
+
+정책:
+
+- 같은 날짜, 같은 동아리, 같은 방문자의 여러 세션은 하나의 문서에 누적한다.
+- overview의 고유 방문자 수는 기간 내 이 컬렉션을 `visitorId` 기준으로 group해서 계산한다.
+- overview의 인당 평균 체류 시간은 기간 내 visitor별 duration 합계를 다시 합산해 계산한다.
+
+### club_analytics_daily
+
+기존 일별 통계 컬렉션이다.
+
+변경:
+
+- 기존 duration 필드 사용
+  - `detailDurationSumSeconds`
+  - `detailDurationCount`
+- 조회 최적화 인덱스 추가
+  - `{ clubId: 1, date: 1 }`
+
+정책:
+
+- 체류 시간 수집 성공 시 `detailDurationSumSeconds += durationSeconds`
+- 체류 시간 수집 성공 시 `detailDurationCount += 1`
+- 기존 `{ date: 1, clubId: 1 }` unique index는 유지한다.
+
+## 처리 흐름
+
+정상 수집:
+
+```text
+POST /api/analytics/club-detail/duration
+  |
+  v
+ClubDetailDurationService.record
+  |
+  v
+요청 검증
+  |
+  v
+clubId 존재 확인
+  |
+  v
+Mongo transaction 시작
+  |
+  v
+club_detail_duration_sessions upsert
+  |
+  v
+신규 세션이면 다음 집계 진행
+  |
+  v
+club_analytics_daily duration sum/count 증가
+  |
+  v
+club_detail_visitor_daily duration/session count 증가
+  |
+  v
+Mongo transaction commit
+  |
+  v
+204 No Content
+```
+
+중복 수집:
+
+```text
+club_detail_duration_sessions upsert
+  |
+  v
+기존 sessionId + clubId 문서 확인
+  |
+  v
+집계 증가 없이 204 No Content
+```
+
+집계 실패:
+
+```text
+daily 또는 visitor 집계 실패
+  |
+  v
+Mongo transaction rollback
+  |
+  v
+예외 전파
+```
+
+세션 저장, `club_analytics_daily` 증가, `club_detail_visitor_daily` 증가는 하나의 MongoDB 트랜잭션 안에서 처리한다.
+따라서 중간 write 성공 후 예외가 발생해도 부분 집계가 남지 않아야 한다.
+
+## 부하와 확장성
+
+정상 수집 1건당 MongoDB 쓰기:
+
+1. `club_detail_duration_sessions` insert
+2. `club_analytics_daily` upsert + `$inc`
+3. `club_detail_visitor_daily` upsert + `$inc`
+
+관리자 overview 조회:
+
+1. 최대 370일치 `club_analytics_daily` 문서를 조회해 애플리케이션에서 합산한다.
+2. `club_detail_visitor_daily`를 기간 내 `visitorId` 기준으로 aggregation한다.
+3. 원시 세션 컬렉션은 조회하지 않는다.
+
+현재 평균 체류 시간 계산은 최대 370개 일별 문서를 합산하므로 실무 부하로 충분히 가볍다.
+성능 보완은 계산식 변경이 아니라 자체 수집과 적절한 집계 컬렉션 유지로 해결한다.
+
+큐나 스트림은 1차 범위에 포함하지 않는다.
+아래 조건이 관측되면 후속으로 비동기 집계를 검토한다.
+
+- duration 수집 API p95 latency가 지속적으로 높다.
+- 특정 `club_analytics_daily` 문서에 `$inc`가 집중되어 hot document 문제가 나타난다.
+- 수집 이벤트가 초당 수백 건 이상 안정적으로 발생한다.
+
+## 보안 정책
+
+수집 API는 공개 API이므로 완전한 위조 방지는 어렵다.
+1차 방어는 아래 수준으로 제한한다.
+
+- 존재하는 `clubId`만 기록한다.
+- `durationSeconds`는 1초 이상 3600초 이하만 허용한다.
+- `sessionId + clubId` unique index로 중복 집계를 막는다.
+- Redis 기반 `clubId + clientIp` rate limit을 적용한다.
+- 사용자 식별 정보, IP, user-agent 원문, full URL은 저장하지 않는다.
+
+`visitorId`는 프론트가 생성한 익명 UUID를 전제로 한다.
+
+## Mixpanel backfill과의 관계
+
+Mixpanel backfill은 과거 보정과 검증 용도로 유지한다.
+
+주의:
+
+- 자체 수집 배포 이후 기간에 Mixpanel duration backfill을 실행하면 중복 집계될 수 있다.
+- 자체 수집 배포일 이후 기간은 백엔드 자체 수집 데이터를 기준으로 본다.
+- 운영에서는 duration backfill cutoff 정책을 별도로 두는 것을 권장한다.
+
+## 테스트 스펙
+
+### ClubDetailDurationServiceTest
+
+검증:
+
+1. 정상 요청이면 세션을 저장하고 daily 및 visitor 집계를 증가시킨다.
+2. 중복 세션이면 daily와 visitor 집계를 증가시키지 않는다.
+3. daily 집계 실패 시 트랜잭션에 예외를 전파한다.
+4. visitor 집계 실패 시 트랜잭션에 예외를 전파한다.
+5. duration이 0이거나 3600초를 넘으면 실패한다.
+6. `leftAt`이 `enteredAt`보다 이전이면 실패한다.
+7. 요청 제한을 초과하면 `STATISTICS_EVENT_RATE_LIMITED` 예외가 발생한다.
+
+### ClubDetailDurationControllerTest
+
+검증:
+
+1. 체류 시간 기록 요청은 service를 호출한다.
+2. 정상 요청은 `204 No Content`를 반환한다.
+
+### ClubStatisticsAdminServiceTest
+
+검증:
+
+1. overview에서 기존 방문 세션 평균 체류 시간을 계산한다.
+2. overview에서 고유 방문자 수를 계산한다.
+3. overview에서 인당 평균 체류 시간을 계산한다.
+4. 지원자 수 합산과 기존 상세 조회수 합산은 유지된다.
+
+## 배포 전 검증 기준
+
+아래 조건이 모두 만족되면 백엔드 배포 가능하다.
+
+1. `POST /api/analytics/club-detail/duration` 정상 요청이 `204`를 반환한다.
+2. 같은 `sessionId + clubId` 요청을 두 번 보내도 한 번만 집계된다.
+3. invalid duration 요청은 `400`을 반환한다.
+4. rate limit 초과 요청은 `429`를 반환한다.
+5. 없는 `clubId` 요청은 `404`를 반환한다.
+6. `club_analytics_daily.detailDurationSumSeconds`와 `detailDurationCount`가 증가한다.
+7. `club_detail_visitor_daily`에 visitor별 일별 집계가 누적된다.
+8. overview 응답에 `uniqueDetailVisitors`와 `averageDetailDurationSecondsPerVisitor`가 포함된다.
+9. `./gradlew.bat unitTest`가 통과한다.


### PR DESCRIPTION
## #️⃣연관된 이슈

#1900 / MOA-1057

## 📝작업 내용

관리자 통계의 평균 체류 시간이 Mixpanel backfill 없이는 `0초`로 표시되는 문제를 해결하기 위해, 백엔드 자체 체류 시간 수집 경로를 추가했습니다.

### 변경 내용

1. 동아리 상세 체류 시간 수집 API 추가
   - `POST /api/analytics/club-detail/duration`
   - 정상 기록 및 중복 세션은 `204 No Content` 반환
   - 잘못된 요청은 `STATISTICS_EVENT_INVALID(903-4)`로 검증

2. 체류 시간 원시 세션 및 방문자 집계 컬렉션 추가
   - `club_detail_duration_sessions`
     - `sessionId + clubId` unique index로 중복 집계 방지
   - `club_detail_visitor_daily`
     - 기간 내 고유 방문자 및 인당 평균 체류 시간 계산용

3. 기존 일별 통계 집계 확장
   - 수집된 duration을 `club_analytics_daily.detailDurationSumSeconds/detailDurationCount`에 누적
   - `club_analytics_daily` 조회 최적화를 위해 `{ clubId: 1, date: 1 }` 인덱스 추가
   - 세션 저장 후 집계 실패 시 session key와 daily 증가분을 롤백해 재시도 가능하도록 처리

4. 관리자 통계 overview 응답 확장
   - `uniqueDetailVisitors`
   - `averageDetailDurationSecondsPerVisitor`

5. 설계 draft 문서 추가
   - 자체 수집 API, 방문 세션/고유 방문자 정의, 부하 검토, 구현 범위 정리

### 검증

- `./gradlew.bat unitTest` 통과

## 중점적으로 리뷰받고 싶은 부분(선택)

**1. 수집 API를 공개 API로 둔 판단**

현재 보안 설정상 `/api/admin/**` 외 요청은 permitAll이고, 상세 페이지 방문자는 비로그인 사용자가 많습니다. 그래서 수집 API는 인증 없이 열고, `clubId` 존재 여부, duration 범위, `sessionId + clubId` 멱등성으로 최소 방어했습니다.

**2. 평균 체류 시간과 인당 평균 체류 시간 분리**

기존 `averageDetailDurationSeconds`는 방문 세션 1회당 평균으로 유지했습니다. 인당 지표는 `club_detail_visitor_daily`를 기간 내 `visitorId` 기준으로 group 해서 `averageDetailDurationSecondsPerVisitor`로 별도 제공하도록 했습니다.

**3. 동기 Mongo write로 시작한 판단**

수집 요청 1건당 원시 세션 insert, daily 집계 upsert, visitor daily upsert 총 3 write입니다. 현재 예상 트래픽에서는 큐/스트림 도입보다 동기 처리와 명확한 멱등성이 낫다고 봤습니다. 쓰기 병목이 관측되면 원시 세션 insert만 동기화하고 집계는 비동기 worker로 분리하는 방향을 draft에 남겼습니다.

## 🫡 참고사항

프론트 연결은 이번 브랜치 범위가 아닙니다. 실제 수집을 시작하려면 프론트에서 상세 페이지 이탈 시 `sendBeacon` 또는 `fetch({ keepalive: true })`로 `POST /api/analytics/club-detail/duration`을 호출해야 합니다.

Mixpanel duration backfill은 자체 수집 배포일 이후 기간에 실행하면 중복 집계될 수 있습니다. 배포일 기준 cutoff 정책을 별도로 적용하는 것을 권장합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 동아리 상세 페이지 체류 시간을 기록하는 API가 추가되었습니다.
  * 중복 세션을 제외하고 방문자별 체류 시간과 세션 수가 집계됩니다.
  * 관리자 통계에 고유 방문자 수와 방문자당 평균 체류 시간이 제공됩니다.
  * 비정상 요청 검증 및 과도한 요청 제한이 적용됩니다.

* **문서**
  * 체류 시간 수집 및 관리자 통계 확장 사양이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->