### PR TITLE
[feature] AI 답변엔진 대응 — JSON-LD·홈 프리렌더·llms.txt 추가

### DIFF
--- a/frontend/docs/claude/og.md
+++ b/frontend/docs/claude/og.md
@@ -1,4 +1,4 @@
-# OG 태그 (소셜 미디어 공유 미리보기)
+# OG 태그 · AEO (소셜 공유 미리보기 + AI 답변엔진)
 
 > `middleware.ts`(프로젝트 루트)를 수정할 때 참고. 이 문서는 [frontend/CLAUDE.md](../../CLAUDE.md) 인덱스에서 연결된다.
 
@@ -11,19 +11,42 @@ React SPA는 클라이언트 사이드 렌더링이라 카카오톡/페이스북
 ```
 크롤러 요청 → middleware.ts (User-Agent 감지)
   → 백엔드 API fetch (timeout 3초)
-  → OG 태그 포함 HTML 반환
+  → OG 태그 + JSON-LD + 본문 HTML 반환
 
 일반 브라우저 → middleware.ts → 통과 → index.html (SPA)
 ```
 
+## AEO (답변엔진 최적화)
+
+크롤러 응답 HTML에는 OG 태그뿐 아니라 **AI가 인용할 사실**이 함께 실린다.
+
+**동아리 상세** (`buildOgHtml`)
+
+- `<script type="application/ld+json">` — `@graph`에 `Organization`(동아리, `parentOrganization`은 국립부경대학교)과 FAQ가 있으면 `FAQPage`
+- `<body>` — `h1`(동아리명), 한 줄 소개, 핵심 사실 `dl`(소속·분과·카테고리·모집 상태·모집 기간·모집 대상), `활동 소개` / `이런 분을 찾아요` / `혜택` 섹션, `자주 묻는 질문` `dl`
+
+**홈 `/`** (`buildHomeHtml`) — 동아리 검색 API를 호출해 전체 목록을 렌더링한다. 답변엔진에 "부경대에 무슨 동아리가 있나" 자체를 답해주고, 동시에 모든 상세 페이지로 가는 크롤 경로가 된다.
+
+- `@graph`에 `WebSite` + 전체 동아리 `ItemList`
+- `<body>` — `h1`, 서비스 설명, `등록된 동아리 N개` 헤딩, 동아리별 `<li>`(상세 링크 · 카테고리 · 분과 · 모집 상태 · 한 줄 소개)
+
+정적 텍스트 페이지(`/introduce`, `/club-union`)는 커버하지 않는다. 문구가 React 컴포넌트·상수에 있어 middleware로 옮기면 복제본이 생기고 드리프트하는데, 답변엔진 관점의 이득은 작다.
+
+값이 비어 있으면 해당 항목·섹션은 통째로 생략된다(`nonEmpty` / `buildSection`). JSON-LD는 `</script>` 조기 종료를 막기 위해 모든 `<`를 `<`로 이스케이프한다(`toJsonLdScript`).
+
+`중동`/`과동`, `OPEN`/`CLOSED`/`UPCOMING`/`ALWAYS` 같은 API 코드값은 `DIVISION_LABELS`·`RECRUITMENT_STATUS_LABELS`로 사람이 읽는 한글로 변환해 노출한다. 백엔드에 값이 추가되면 이 맵도 함께 갱신할 것 (미등록 값은 원본 코드가 그대로 노출된다).
+
 **커버하는 라우트:**
 
+- `/` — 홈 (동아리 목록)
 - `/club/:objectId` — 클럽 상세 (ObjectId)
 - `/clubDetail/:objectId`
 - `/club/@:clubName` — 클럽 상세 (이름)
 - `/clubDetail/@:clubName`
 
-**감지 크롤러:** 카카오톡 스크랩 봇(`kakaotalk-scrap`), facebookexternalhit, Twitterbot, LINE, WhatsApp, Telegram, Discord, Slack 등
+**감지 크롤러:** 카카오톡 스크랩 봇(`kakaotalk-scrap`), facebookexternalhit, Twitterbot, LINE 봇(`line-poker`·`linespider`), WhatsApp, Telegram, Discord, Slack 등
+
+**감지 AI 답변엔진:** GPTBot·OAI-SearchBot·ClaudeBot·PerplexityBot·bingbot·Applebot은 기존 `bot` 토큰으로 매칭된다. `bot`이 없는 실시간 브라우징 에이전트(`ChatGPT-User`, `Claude-User`, `Perplexity-User`, `Google-Extended`)는 개별 토큰으로 추가했다. 새 에이전트를 넣을 때는 UA에 `bot`/`crawl`이 이미 들어있는지 먼저 확인할 것.
 
 > 카카오는 인앱 브라우저(`KAKAOTALK <버전>`)와 스크랩 봇(`kakaotalk-scrap`)이 UA가 다르다. 봇만 감지해야 실제 사용자가 SPA를 받는다. ([인앱 브라우저 오탐 위험](#현재-구조의-실질적-위험) 참고)
 
@@ -58,4 +81,4 @@ export const config = {
 1. **API 3초 초과 시 OG 미노출** — 백엔드가 느리면 크롤러에게 빈 HTML 반환
 2. **새 크롤러 미감지** — `CRAWLER_PATTERN` regex에 없는 봇은 SPA를 받아 OG 미노출
 3. **라우트 수동 관리** — 새 페이지에 OG가 필요하면 middleware를 직접 수정해야 함
-4. **인앱 브라우저 오탐 위험** — `CRAWLER_PATTERN` 토큰이 메신저 인앱 브라우저 UA까지 잡으면 실제 사용자가 SPA 대신 OG용 텍스트 HTML(제목+설명만)을 받아 빈 화면처럼 보인다. 과거 `kakao` 토큰이 카카오톡 인앱 브라우저(`KAKAOTALK <버전>`)를 오탐해 공유 링크가 빈 화면+텍스트로 떴고, 봇 전용 식별자 `kakaotalk-scrap`로 좁혀 해결했다. `line` 토큰도 LINE 인앱 브라우저(`Line/<버전>`)를 잡는 동일 위험이 남아 있으나 사용량이 적어 보류 — 손볼 경우 봇 전용 UA로 좁힐 것.
+4. **인앱 브라우저 오탐 위험** — `CRAWLER_PATTERN` 토큰이 메신저 인앱 브라우저 UA까지 잡으면 실제 사용자가 SPA 대신 크롤러용 텍스트 HTML을 받아 빈 화면처럼 보인다. 과거 `kakao` 토큰이 카카오톡 인앱 브라우저(`KAKAOTALK <버전>`)를 오탐해 공유 링크가 빈 화면+텍스트로 떴고, 봇 전용 식별자 `kakaotalk-scrap`로 좁혀 해결했다. `line` 토큰도 LINE 인앱 브라우저(`Line/<버전>`)를 잡던 동일 문제가 있어 `line-poker`·`linespider`로 좁혔다. **홈 `/`까지 커버 범위가 넓어졌으므로 토큰을 추가할 때는 반드시 인앱 브라우저 UA와 겹치지 않는지 확인할 것** — 오탐이 나면 홈 화면이 통째로 깨져 보인다.

--- a/frontend/docs/claude/og.md
+++ b/frontend/docs/claude/og.md
@@ -32,7 +32,7 @@ React SPA는 클라이언트 사이드 렌더링이라 카카오톡/페이스북
 
 정적 텍스트 페이지(`/introduce`, `/club-union`)는 커버하지 않는다. 문구가 React 컴포넌트·상수에 있어 middleware로 옮기면 복제본이 생기고 드리프트하는데, 답변엔진 관점의 이득은 작다.
 
-값이 비어 있으면 해당 항목·섹션은 통째로 생략된다(`nonEmpty` / `buildSection`). JSON-LD는 `</script>` 조기 종료를 막기 위해 모든 `<`를 `<`로 이스케이프한다(`toJsonLdScript`).
+값이 비어 있으면 해당 항목·섹션은 통째로 생략된다(`nonEmpty` / `buildSection`). JSON-LD는 `</script>` 조기 종료를 막기 위해 모든 `<`를 유니코드 이스케이프 시퀀스 `\u003c`로 치환한다(`toJsonLdScript`).
 
 `중동`/`과동`, `OPEN`/`CLOSED`/`UPCOMING`/`ALWAYS` 같은 API 코드값은 `DIVISION_LABELS`·`RECRUITMENT_STATUS_LABELS`로 사람이 읽는 한글로 변환해 노출한다. 백엔드에 값이 추가되면 이 맵도 함께 갱신할 것 (미등록 값은 원본 코드가 그대로 노출된다).
 

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -298,6 +298,10 @@ function htmlResponse(html: string): Response {
     headers: {
       'content-type': 'text/html; charset=utf-8',
       'cache-control': 'public, s-maxage=300, stale-while-revalidate=60',
+      // UA로 크롤러/일반 사용자 응답이 갈리므로 공유 캐시가 둘을 섞지 않도록 한다.
+      // Vercel Edge는 미들웨어 응답을 CDN 캐시에 담지 않지만, s-maxage는 사내
+      // 프록시 같은 중간 공유 캐시에도 적용된다.
+      vary: 'User-Agent',
     },
   });
 }

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,7 +1,11 @@
 /// <reference types="node" />
 
+// `bot`/`crawl`로 잡히지 않는 AI 답변엔진 UA는 개별 토큰으로 추가한다.
+// (GPTBot·OAI-SearchBot·ClaudeBot·PerplexityBot·bingbot·Applebot은 `bot`으로 이미 매칭)
+// LINE은 인앱 브라우저(`Line/<버전>`) 오탐을 피하려 봇 전용 토큰만 넣는다.
+// (채팅 링크 미리보기 봇은 UA에 `facebookexternalhit`도 함께 실어 이미 매칭된다)
 const CRAWLER_PATTERN =
-  /bot|crawl|facebookexternalhit|twitterbot|kakaotalk-scrap|line|whatsapp|telegram|discord|slack/i;
+  /bot|crawl|facebookexternalhit|twitterbot|kakaotalk-scrap|line-poker|linespider|whatsapp|telegram|discord|slack|chatgpt-user|claude-user|perplexity-user|google-extended/i;
 
 const API_BASE = process.env.VITE_API_BASE_URL;
 const SITE_URL = 'https://www.moadong.com';
@@ -23,16 +27,158 @@ function escapeHtml(str: string): string {
     .replace(/>/g, '&gt;');
 }
 
+const DIVISION_LABELS: Record<string, string> = {
+  중동: '중앙동아리',
+  과동: '과동아리',
+};
+
+const RECRUITMENT_STATUS_LABELS: Record<string, string> = {
+  OPEN: '모집 중',
+  CLOSED: '모집 마감',
+  UPCOMING: '모집 예정',
+  ALWAYS: '상시 모집',
+};
+
+interface CrawlerClub {
+  name?: string;
+  logo?: string;
+  cover?: string;
+  tags?: string[];
+  introduction?: string;
+  division?: string;
+  category?: string;
+  recruitmentStatus?: string;
+  recruitmentStart?: string;
+  recruitmentEnd?: string;
+  recruitmentTarget?: string;
+  socialLinks?: Record<string, string>;
+  description?: {
+    introDescription?: string;
+    activityDescription?: string;
+    benefits?: string;
+    idealCandidate?: { content?: string; tags?: string[] };
+    faqs?: { question?: string; answer?: string }[];
+  };
+}
+
+/** `</script>` 조기 종료를 막기 위해 `<`를 유니코드 이스케이프한다. */
+function toJsonLdScript(data: unknown): string {
+  return JSON.stringify(data).replace(/</g, '\\u003c');
+}
+
+function nonEmpty(values: (string | undefined)[]): string[] {
+  return values
+    .map((v) => (typeof v === 'string' ? v.trim() : ''))
+    .filter(Boolean);
+}
+
+/** 답변엔진이 인용할 수 있도록 dt/dd 쌍으로 노출할 핵심 사실 */
+function buildFacts(club: CrawlerClub): [string, string][] {
+  const period = nonEmpty([club.recruitmentStart, club.recruitmentEnd]).join(
+    ' ~ ',
+  );
+  const pairs: [string, string | undefined][] = [
+    ['소속', '국립부경대학교'],
+    [
+      '분과',
+      club.division && (DIVISION_LABELS[club.division] ?? club.division),
+    ],
+    ['카테고리', club.category],
+    [
+      '모집 상태',
+      club.recruitmentStatus &&
+        (RECRUITMENT_STATUS_LABELS[club.recruitmentStatus] ??
+          club.recruitmentStatus),
+    ],
+    ['모집 기간', period],
+    ['모집 대상', club.recruitmentTarget],
+  ];
+  return pairs.filter((pair): pair is [string, string] =>
+    Boolean(pair[1]?.trim()),
+  );
+}
+
+function buildSection(heading: string, body: string | undefined): string {
+  if (!body?.trim()) return '';
+  return `\n  <h2>${escapeHtml(heading)}</h2>\n  <p>${escapeHtml(body.trim())}</p>`;
+}
+
 function buildOgHtml(og: {
+  club: CrawlerClub;
   title: string;
   description: string;
   image: string;
   canonical: string;
 }): string {
+  const { club } = og;
   const t = escapeHtml(og.title);
   const d = escapeHtml(og.description);
   const i = escapeHtml(og.image);
   const c = escapeHtml(og.canonical);
+
+  const name = club.name?.trim() || og.title;
+  const keywords = nonEmpty([
+    club.category,
+    club.division && (DIVISION_LABELS[club.division] ?? club.division),
+    ...(club.tags ?? []),
+  ]);
+  const sameAs = nonEmpty(Object.values(club.socialLinks ?? {}));
+  const faqs = (club.description?.faqs ?? []).filter(
+    (faq) => faq.question?.trim() && faq.answer?.trim(),
+  );
+
+  const jsonLd = toJsonLdScript({
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'Organization',
+        '@id': og.canonical,
+        name,
+        url: og.canonical,
+        description: og.description,
+        ...(club.logo?.trim() ? { logo: club.logo } : {}),
+        ...(og.image ? { image: og.image } : {}),
+        parentOrganization: {
+          '@type': 'CollegeOrUniversity',
+          name: '국립부경대학교',
+        },
+        ...(keywords.length ? { keywords: keywords.join(', ') } : {}),
+        ...(sameAs.length ? { sameAs } : {}),
+      },
+      ...(faqs.length
+        ? [
+            {
+              '@type': 'FAQPage',
+              '@id': `${og.canonical}#faq`,
+              mainEntity: faqs.map((faq) => ({
+                '@type': 'Question',
+                name: faq.question,
+                acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+              })),
+            },
+          ]
+        : []),
+    ],
+  });
+
+  const facts = buildFacts(club)
+    .map(
+      ([label, value]) =>
+        `\n    <dt>${escapeHtml(label)}</dt><dd>${escapeHtml(value)}</dd>`,
+    )
+    .join('');
+
+  const faqHtml = faqs.length
+    ? `\n  <h2>자주 묻는 질문</h2>\n  <dl>${faqs
+        .map(
+          (faq) =>
+            `\n    <dt>${escapeHtml(faq.question!.trim())}</dt><dd>${escapeHtml(
+              faq.answer!.trim(),
+            )}</dd>`,
+        )
+        .join('')}\n  </dl>`
+    : '';
+
   return `<!DOCTYPE html>
 <html lang="ko">
 <head>
@@ -50,12 +196,136 @@ function buildOgHtml(og: {
   <meta name="twitter:title" content="${t}" />
   <meta name="twitter:description" content="${d}" />
   <meta name="twitter:image" content="${i}" />
+  <script type="application/ld+json">${jsonLd}</script>
 </head>
 <body>
-  <h1>${t}</h1>
+  <h1>${escapeHtml(name)}</h1>
   <p>${d}</p>
+  <dl>${facts}
+  </dl>${buildSection('활동 소개', club.description?.activityDescription)}${buildSection(
+    '이런 분을 찾아요',
+    club.description?.idealCandidate?.content,
+  )}${buildSection('혜택', club.description?.benefits)}${faqHtml}
+  <p><a href="${c}">모아동에서 ${escapeHtml(name)} 자세히 보기</a></p>
 </body>
 </html>`;
+}
+
+// index.html의 홈 메타태그와 동일하게 유지한다 (middleware는 src를 import할 수 없음)
+const HOME_TITLE = '모아동 - 부경대학교 모든 동아리를 한눈에';
+const HOME_DESCRIPTION =
+  '부경대학교 동아리 찾기, 모집 정보 확인부터 신규 동아리 가입과 홍보까지 한 번에 할 수 있어요.';
+
+function clubDetailUrl(name: string): string {
+  return `${SITE_URL}/clubDetail/@${encodeURIComponent(name)}`;
+}
+
+/** 홈: 답변엔진에 전체 동아리 목록과 각 상세 페이지로의 크롤 경로를 제공한다. */
+function buildHomeHtml(clubs: CrawlerClub[]): string {
+  const named = clubs.filter((club): club is CrawlerClub & { name: string } =>
+    Boolean(club.name?.trim()),
+  );
+
+  const jsonLd = toJsonLdScript({
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'WebSite',
+        '@id': `${SITE_URL}/`,
+        name: '모아동',
+        url: `${SITE_URL}/`,
+        description: HOME_DESCRIPTION,
+        inLanguage: 'ko',
+      },
+      {
+        '@type': 'ItemList',
+        '@id': `${SITE_URL}/#clubs`,
+        name: '국립부경대학교 동아리 목록',
+        numberOfItems: named.length,
+        itemListElement: named.map((club, index) => ({
+          '@type': 'ListItem',
+          position: index + 1,
+          name: club.name,
+          url: clubDetailUrl(club.name),
+        })),
+      },
+    ],
+  });
+
+  const items = named
+    .map((club) => {
+      const facts = nonEmpty([
+        club.category,
+        club.division && (DIVISION_LABELS[club.division] ?? club.division),
+        club.recruitmentStatus &&
+          (RECRUITMENT_STATUS_LABELS[club.recruitmentStatus] ??
+            club.recruitmentStatus),
+        club.introduction,
+      ]).join(' · ');
+      return `\n    <li><a href="${escapeHtml(clubDetailUrl(club.name))}">${escapeHtml(
+        club.name,
+      )}</a> — ${escapeHtml(facts)}</li>`;
+    })
+    .join('');
+
+  return `<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+  <title>${escapeHtml(HOME_TITLE)}</title>
+  <meta name="description" content="${escapeHtml(HOME_DESCRIPTION)}" />
+  <link rel="canonical" href="${SITE_URL}/" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="${escapeHtml(HOME_TITLE)}" />
+  <meta property="og:description" content="${escapeHtml(HOME_DESCRIPTION)}" />
+  <meta property="og:image" content="${DEFAULT_OG_IMAGE}" />
+  <meta property="og:url" content="${SITE_URL}/" />
+  <meta property="og:site_name" content="모아동" />
+  <script type="application/ld+json">${jsonLd}</script>
+</head>
+<body>
+  <h1>모아동 — 국립부경대학교 동아리 모음</h1>
+  <p>${escapeHtml(HOME_DESCRIPTION)}</p>
+  <h2>등록된 동아리 ${named.length}개</h2>
+  <ul>${items}
+  </ul>
+</body>
+</html>`;
+}
+
+function htmlResponse(html: string): Response {
+  return new Response(html, {
+    headers: {
+      'content-type': 'text/html; charset=utf-8',
+      'cache-control': 'public, s-maxage=300, stale-while-revalidate=60',
+    },
+  });
+}
+
+async function renderHome(): Promise<Response | undefined> {
+  if (!API_BASE) return;
+
+  const url = new URL('/api/club/search/', API_BASE);
+  url.search = new URLSearchParams({
+    keyword: '',
+    recruitmentStatus: 'all',
+    category: 'all',
+    division: 'all',
+  }).toString();
+
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(3000) });
+    if (!res.ok) return;
+
+    const json = await res.json();
+    const clubs = json?.data?.clubs;
+    if (!Array.isArray(clubs) || clubs.length === 0) return;
+
+    return htmlResponse(buildHomeHtml(clubs));
+  } catch {
+    // API 실패 시 SPA로 fallback
+    return;
+  }
 }
 
 export default async function middleware(request: Request) {
@@ -63,6 +333,8 @@ export default async function middleware(request: Request) {
   if (!CRAWLER_PATTERN.test(ua)) return;
 
   const { pathname } = new URL(request.url);
+
+  if (pathname === '/') return renderHome();
 
   // /club/:clubId, /clubDetail/:clubId, /club/@:clubName, /clubDetail/@:clubName 매칭
   const match = pathname.match(/^\/club(?:Detail)?\/([a-f0-9]{24}|@[^/]+)$/i);
@@ -90,8 +362,9 @@ export default async function middleware(request: Request) {
     const club = json?.data?.club;
     if (!club) return;
 
-    return new Response(
+    return htmlResponse(
       buildOgHtml({
+        club,
         title: `${club.name} - 모아동`,
         description:
           club.introduction ||
@@ -100,12 +373,6 @@ export default async function middleware(request: Request) {
         image: club.cover || club.logo || DEFAULT_OG_IMAGE,
         canonical: `${SITE_URL}${canonicalPath}`,
       }),
-      {
-        headers: {
-          'content-type': 'text/html; charset=utf-8',
-          'cache-control': 'public, s-maxage=300, stale-while-revalidate=60',
-        },
-      },
     );
   } catch {
     // API 실패 시 SPA로 fallback
@@ -114,5 +381,5 @@ export default async function middleware(request: Request) {
 }
 
 export const config = {
-  matcher: ['/club/:path*', '/clubDetail/:path*'],
+  matcher: ['/', '/club/:path*', '/clubDetail/:path*'],
 };

--- a/frontend/public/llms.txt
+++ b/frontend/public/llms.txt
@@ -1,0 +1,22 @@
+# 모아동 (Moadong)
+
+> 국립부경대학교 학생을 위한 동아리 플랫폼. 동아리 탐색, 모집 정보 확인, 지원까지 한 곳에서 할 수 있습니다.
+
+- 학생은 동아리를 검색하고 정보를 확인한 뒤 바로 지원할 수 있습니다.
+- 동아리 운영진은 동아리 정보를 수정하고 지원서를 관리할 수 있습니다.
+- 동아리 상세 페이지 URL 형식: `https://www.moadong.com/clubDetail/@{동아리명}`
+- 웹 외에 Android·iOS 앱으로도 제공됩니다.
+
+## 주요 페이지
+
+- [동아리 목록](https://www.moadong.com/): 카테고리(봉사·종교·취미교양·학술·운동·공연)와 모집 상태로 전체 동아리를 탐색합니다.
+- [모아동 소개](https://www.moadong.com/introduce): 서비스가 해결하는 문제와 주요 기능 소개.
+- [동아리연합회](https://www.moadong.com/club-union): 부경대학교 동아리연합회 집행부 소개.
+- [홍보글](https://www.moadong.com/promotions): 동아리가 올린 홍보·행사 게시글.
+
+## 데이터
+
+- [sitemap.xml](https://www.moadong.com/sitemap.xml): 전체 동아리 상세 페이지 URL 목록.
+- [robots.txt](https://www.moadong.com/robots.txt): 크롤링 정책 (전체 허용).
+
+각 동아리 상세 페이지에는 소속·분과·카테고리·모집 상태·모집 기간·모집 대상과 활동 소개, 자주 묻는 질문이 schema.org `Organization` / `FAQPage` 구조화 데이터로 함께 제공됩니다.

--- a/frontend/scripts/generate-sitemap.mjs
+++ b/frontend/scripts/generate-sitemap.mjs
@@ -5,12 +5,9 @@ const SITE_URL =
   process.env.SITE_URL ||
   process.env.VITE_SITE_URL ||
   'https://www.moadong.com';
-const STATIC_PATHS = [
-  '/',
-  '/introduce',
-  '/club-union',
-  '/festival-introduction',
-];
+// 실제 라우트가 있는 경로만 넣는다. 라우트 없는 경로는 SPA fallback으로 200을 주고
+// `/`로 리다이렉트돼 검색엔진에 soft 404로 잡힌다.
+const STATIC_PATHS = ['/', '/introduce', '/club-union', '/promotions'];
 const ENV_FILES = [
   '.env',
   '.env.local',


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음 (AEO 점검 중 발견)

## 📝작업 내용

AI 답변엔진(ChatGPT, Claude, Perplexity 등)이 모아동을 인용할 수 있도록 크롤러 응답을 보강했습니다.

**기존 상태**: robots/sitemap/OG/canonical 같은 전통 SEO 기반은 있었지만, 크롤러가 받는 HTML이 `<h1>제목</h1><p>한 줄 소개</p>`가 전부라 AI가 인용할 사실 자체가 없었습니다. JSON-LD는 레포 전체에 0건이었습니다.

### 1. AI 답변엔진 UA 감지 추가

`GPTBot`·`ClaudeBot`·`PerplexityBot`은 기존 `bot` 토큰으로 이미 매칭됐지만, `bot`이 없는 **실시간 브라우징 에이전트**(`ChatGPT-User`, `Claude-User`, `Perplexity-User`, `Google-Extended`)는 SPA 껍데기만 받고 있었습니다. 개별 토큰으로 추가했습니다.

### 2. `line` 토큰을 봇 전용으로 축소

`/line/i`는 LINE 인앱 브라우저(`Line/13.5.0`)를 오탐합니다. 상세 페이지만 커버할 땐 영향이 제한적이었지만 **홈까지 넓히면 LINE 인앱 사용자에게 홈이 통째로 텍스트 페이지로 뜹니다.** `line-poker`·`linespider`(봇 전용)로 좁혔고, LINE 채팅 미리보기 봇은 UA에 `facebookexternalhit`도 함께 실어 그대로 동작합니다.

### 3. 동아리 상세: JSON-LD + 본문 사실

- `@graph`에 `Organization`(logo·keywords·sameAs·`parentOrganization: 국립부경대학교`) + FAQ가 있으면 `FAQPage`
- `<body>`에 핵심 사실 `dl`(소속·분과·카테고리·모집 상태·모집 기간·모집 대상), 활동 소개 / 이런 분을 찾아요 / 혜택 / 자주 묻는 질문
- `중동`→`중앙동아리`, `CLOSED`→`모집 마감` 등 API 코드값을 한글 라벨로 변환

### 4. 홈 `/` 프리렌더 신규

검색 API로 전체 동아리를 받아 `WebSite` + `ItemList` JSON-LD와 목록을 렌더링합니다. 답변엔진에 "부경대에 무슨 동아리 있어?"를 직접 답해주고, 동시에 69개 상세 페이지로 가는 크롤 경로가 생깁니다.

### 5. `llms.txt` 추가

`/llms.txt`가 200을 주던 건 `vercel.json`의 SPA rewrite 때문이고 실제 내용은 index.html이었습니다. 서비스 요약·주요 페이지·URL 규칙·sitemap 포인터를 담은 실제 파일을 추가했습니다.

### 6. sitemap 유령 경로 정리

`/festival-introduction`은 라우트가 없어 SPA fallback으로 200을 준 뒤 `/`로 리다이렉트돼 **soft 404로 색인 제출**되고 있었습니다. 제거하고, 실제 공개 라우트인 `/promotions`를 추가했습니다.

## ✅ 검증

middleware를 esbuild로 트랜스파일해 **프로덕션 API(`api.moadong.com`)**를 물려 실행했습니다.

**UA 매칭 11종 전수 — 불일치 0건**

| UA | 결과 |
| --- | --- |
| GPTBot / ClaudeBot / PerplexityBot / ChatGPT-User / Google-Extended | 프리렌더 ✅ |
| line-poker / Linespider / kakaotalk-scrap | 프리렌더 ✅ |
| LINE 인앱(`Line/13.5.0`) / 카카오톡 인앱(`KAKAOTALK 10.4.0`) / 일반 Chrome | SPA 통과 ✅ |

**렌더링**

- 홈: 200, JSON-LD 파싱 성공, `ItemList` 69개 = `<li>` 69개 일치
- 동아리 상세 **프로덕션 69개 전수**: 성공 69 / 실패 0, 이 중 66개는 `FAQPage`까지 포함
- 회귀: 동아리 상세 200 · 레거시 `/club/` 301 · 없는 동아리 SPA fallback · 브라우저 홈 요청 SPA 통과

`tsc --strict --noEmit`, `prettier --check` 통과. sitemap 재생성 시 74 URL(정적 4 + 동아리 70)로 `/festival-introduction` 제거 확인.

## 중점적으로 리뷰받고 싶은 부분

1. **`line` 토큰 축소**가 가장 되돌릴 가능성이 있는 변경입니다. LINE 미리보기가 `facebookexternalhit`로 커버된다는 판단인데, LINE 공유를 실제로 쓰신다면 배포 후 한 번 확인 부탁드립니다. 되돌리려면 토큰 하나만 원복하면 됩니다.
2. **sitemap `/promotions` 추가**는 "유령 경로 제거" 범위를 넘는 판단입니다. 원치 않으시면 한 줄 빼면 됩니다.
3. 홈 프리렌더가 매 크롤러 요청마다 검색 API를 호출합니다. `s-maxage=300`으로 캐시하지만 Edge 5초 제한 안에서 3초 타임아웃을 두었습니다.

## 🫡 참고사항

- 정적 텍스트 페이지(`/introduce`, `/club-union`)는 의도적으로 커버하지 않았습니다. 문구가 React 컴포넌트·상수에 있어 middleware로 옮기면 복제본이 생기고 드리프트하는데, 답변엔진 관점의 이득은 작다고 판단했습니다.
- `frontend/docs/claude/og.md`를 함께 갱신했습니다 (CLAUDE.md 인덱스 연결 문서).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 동아리 상세 페이지에 구조화된 정보, FAQ, JSON-LD 및 주요 사실·설명 콘텐츠를 제공합니다.
  - 홈 경로에서 동아리 목록과 `ItemList` 구조화 데이터를 포함한 HTML 응답을 지원합니다.
  - AI 답변엔진, 메신저 및 검색 봇을 위한 콘텐츠 제공 범위를 확장했습니다.

- **문서**
  - 서비스 소개, 주요 기능, 페이지 및 데이터 링크를 `llms.txt`에 추가했습니다.
  - AEO 콘텐츠 제공 규칙과 인앱 브라우저 처리 기준을 보완했습니다.

- **개선**
  - 사이트맵 경로를 실제 `/promotions` 라우트에 맞게 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->