### PR TITLE
[fix] react-doctor 지적 사항 반영

### DIFF
--- a/frontend/src/components/application/questionTypes/Choice.tsx
+++ b/frontend/src/components/application/questionTypes/Choice.tsx
@@ -114,7 +114,7 @@ const Choice = ({
                   handleDeleteItem(index);
                 }}
               >
-                <img src={DeleteIcon} />
+                <img src={DeleteIcon} alt="선택지 삭제" />
               </Styled.DeleteButton>
             )}
           </Styled.ItemWrapper>

--- a/frontend/src/components/application/questionTypes/Choice.tsx
+++ b/frontend/src/components/application/questionTypes/Choice.tsx
@@ -114,7 +114,7 @@ const Choice = ({
                   handleDeleteItem(index);
                 }}
               >
-                <img src={DeleteIcon} alt="선택지 삭제" />
+                <img src={DeleteIcon} alt='선택지 삭제' />
               </Styled.DeleteButton>
             )}
           </Styled.ItemWrapper>

--- a/frontend/src/hooks/useNavigator.ts
+++ b/frontend/src/hooks/useNavigator.ts
@@ -17,7 +17,7 @@ const useNavigator = () => {
 
       if (isExternal) {
         if (inWebview && !requestOpenExternalUrl(trimmedUrl))
-          window.open(trimmedUrl);
+          window.open(trimmedUrl, '_blank', 'noopener');
         else if (!inWebview) window.location.href = trimmedUrl;
         return;
       }

--- a/frontend/src/pages/ApplicationFormPage/ApplicationFormPage.tsx
+++ b/frontend/src/pages/ApplicationFormPage/ApplicationFormPage.tsx
@@ -59,18 +59,21 @@ const ApplicationFormPage = () => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(answers));
   }, [answers, STORAGE_KEY]);
 
+  const hasLoadError = isError || !!clubError;
+  const clubName = clubDetail?.name;
+
+  useEffect(() => {
+    if (!hasLoadError) return;
+    alert(applicationError?.message || '문제가 발생했어요.');
+    navigate(clubName ? `/clubDetail/@${encodeURIComponent(clubName)}` : `/`, {
+      replace: true,
+    });
+  }, [hasLoadError, applicationError, clubName, navigate]);
+
   if (!clubId || !applicationFormId) return null;
 
   if (isLoading) return <Spinner />;
-  if (isError || clubError) {
-    alert(applicationError?.message || '문제가 발생했어요.');
-    if (clubDetail?.name) {
-      navigate(`/clubDetail/@${encodeURIComponent(clubDetail?.name)}`);
-    } else {
-      navigate(`/`);
-    }
-    return null;
-  }
+  if (hasLoadError) return null;
   if (!formData || !clubDetail || !formData.questions) {
     return (
       <div>

--- a/frontend/src/pages/MainPage/components/Popup/popupConfigs.ts
+++ b/frontend/src/pages/MainPage/components/Popup/popupConfigs.ts
@@ -16,6 +16,6 @@ export const APP_DOWNLOAD_POPUP: PopupConfig = {
       popupType: 'app_download',
       platform: detectPlatform(),
     });
-    window.open(getAppStoreLink(), '_blank');
+    window.open(getAppStoreLink(), '_blank', 'noopener');
   },
 };


### PR DESCRIPTION
## 배경

`npx react-doctor`로 프론트엔드를 스캔했습니다. 총 216건이 나왔는데, 그중 **코드를 직접 열어 진짜 문제로 확인한 것만** 골라 고쳤습니다. 나머지는 손대지 않았습니다.

## 변경 사항

### 1. `window.open`에 `noopener` 추가

- `src/hooks/useNavigator.ts`
- `src/pages/MainPage/components/Popup/popupConfigs.ts`

`noopener` 없이 연 페이지는 `window.opener`로 원래 탭을 다른 URL로 리다이렉트할 수 있습니다. 인자 없는 `window.open(url)`도 기본 타겟이 `_blank`라 **동작 변화는 없고 옵션만 추가**됐습니다.

### 2. 삭제 아이콘에 `alt` 추가

- `src/components/application/questionTypes/Choice.tsx`

`Styled.DeleteButton`에 `aria-label`이 없어서, 장식용 `alt=""` 대신 실제 텍스트를 넣었습니다. 이러면 버튼 자체가 스크린리더에서 "선택지 삭제"로 읽힙니다.

### 3. 지원서 로드 실패 처리를 effect로 이동 ← 이번 PR의 핵심

- `src/pages/ApplicationFormPage/ApplicationFormPage.tsx`

렌더 함수 본문에서 `alert()`과 `navigate()`를 직접 호출하고 있었습니다.

```tsx
if (isError || clubError) {
  alert(...);        // 렌더 중 부수효과
  navigate(...);     // 렌더 중 네비게이션
  return null;
}
```

**고친 문제 2가지**

1. **alert 반복** — 렌더는 순수해야 하는데 에러 상태에서 리렌더가 일어날 때마다 alert이 다시 떴습니다. effect로 옮기면서 1회만 뜨도록 바뀌었습니다.
2. **뒤로가기 트랩** — `navigate()`가 push라서 히스토리에 실패한 URL이 남았습니다. 뒤로가기를 누르면 다시 지원서 페이지로 진입 → 또 에러 → 또 alert → 또 튕겨나옴이 반복돼서 탈출이 안 됐습니다. `replace: true`로 해결했습니다.

`replace`는 **제출 성공 경로가 이미 쓰고 있던 방식**이라 (`ApplicationFormPage.tsx` 제출 핸들러), 에러 경로만 어긋나 있던 걸 맞춘 것이기도 합니다.

선언적 `<Navigate>` 대신 명령형 `navigate()`를 effect 안에서 쓴 이유는, `alert`이 블로킹 호출이라 `<Navigate>`(자식 effect)와 `alert`(부모 effect)의 실행 순서가 미묘해지기 때문입니다. 한 effect에 넣으면 "alert 뜨고 → 이동" 순서가 확정됩니다.

## 영향 범위

지원서 페이지의 **에러 경로**만 바뀝니다. 정상 진입·작성·제출 플로우는 그대로입니다.

참고로 `ClubApplyButton`이 `getApplication()`을 먼저 호출해 성공한 뒤에 이동하므로, 이 에러 경로는 **URL 직접 입력 / 새로고침 / 공유 링크 / 지원서가 중간에 내려간 경우**에 주로 탑니다.

## 검증

- `npm run typecheck` 통과 (rebase 후 재확인)
- `npx eslint` 에러 0건 — 남은 경고 1건은 기존 `catch (error)` 미사용 변수로 이번 변경과 무관
- react-doctor 재스캔: 고친 룰 4건 모두 사라짐. 점수 51 → 54, Bugs errors 18 → 17, Security 3 → 1 warning, A11y 2 → 1 error

## 안 고친 것

react-doctor 결과 중 아래는 **의도적으로 남겼습니다.**

- **메모이제이션 관련 경고 (약 15~20건)** — 이 프로젝트는 React Compiler를 쓰는데 react-doctor가 이를 인식하지 못해 발생한 노이즈입니다.
- **`Array index used as a key` 18건** — 지원서 문항/선택지가 포함돼 실제 위험하지만, 건별 조사가 필요해 분리합니다.
- **`Root route lacks an error boundary` 13건** — 개별 라우트에 `ContentErrorBoundary`가 이미 붙어 있어 오탐 가능성이 있습니다. 룰이 요구하는 건 라우트 객체의 `errorElement`라 loader/action 에러만 빈 상태로 보이며, 확인이 필요합니다.
- **`secureFetch.ts`의 auth token in web storage** — HttpOnly 쿠키로 가려면 백엔드까지 걸리는 아키텍처 결정입니다.