### PR TITLE
[feature] 우체통 백엔드와 개발자 포털 화면 추가

### DIFF
--- a/backend/src/main/java/moadong/feedback/controller/FeedbackAdminController.java
+++ b/backend/src/main/java/moadong/feedback/controller/FeedbackAdminController.java
@@ -1,0 +1,123 @@
+package moadong.feedback.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import moadong.feedback.payload.request.FeedbackReplyRequest;
+import moadong.feedback.payload.request.FeedbackStatusUpdateRequest;
+import moadong.feedback.payload.request.LetterCreateRequest;
+import moadong.feedback.payload.request.LetterDraftRequest;
+import moadong.feedback.payload.response.AdminFeedbackListResponse;
+import moadong.feedback.payload.response.FeedbackReplyResponse;
+import moadong.feedback.payload.response.LetterCreateResponse;
+import moadong.feedback.payload.response.LetterDraftListResponse;
+import moadong.feedback.payload.response.LetterDraftResponse;
+import moadong.feedback.payload.response.LetterImageUploadResponse;
+import moadong.feedback.service.FeedbackAdminService;
+import moadong.feedback.service.LetterDraftService;
+import moadong.feedback.service.LetterImageUploadService;
+import moadong.global.payload.Response;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * 개발자 포털용 우체통 운영 API.
+ * <p>
+ * 피드백은 사용자가 쓴 개인적인 의견이므로 반드시 {@code /api/admin} 아래에 두어야 한다.
+ * {@code SecurityConfig} 가 이 경로만 ROLE_DEVELOPER로 막고 나머지는 permitAll 이다.
+ */
+@RestController
+@RequestMapping("/api/admin/feedback")
+@RequiredArgsConstructor
+@Tag(name = "Feedback_Admin", description = "모아동 우체통 운영 API")
+public class FeedbackAdminController {
+
+    private final FeedbackAdminService feedbackAdminService;
+    private final LetterDraftService letterDraftService;
+    private final LetterImageUploadService letterImageUploadService;
+
+    @GetMapping
+    @Operation(summary = "받은 피드백 목록", description = "전체 피드백을 최신순으로 조회하고 미답변 개수를 함께 내려줍니다.")
+    public ResponseEntity<?> getFeedbacks() {
+        AdminFeedbackListResponse response = feedbackAdminService.getFeedbacks();
+        return Response.ok(response);
+    }
+
+    @PostMapping("/{feedbackId}/reply")
+    @Operation(summary = "답장 발행", description = "해당 피드백을 보낸 사용자의 받은 편지함에 REPLY 편지를 생성하고 상태를 답장 완료로 바꿉니다.")
+    public ResponseEntity<?> reply(
+            @PathVariable String feedbackId,
+            @RequestBody @Valid FeedbackReplyRequest request
+    ) {
+        FeedbackReplyResponse response = feedbackAdminService.reply(feedbackId, request);
+        return Response.ok("답장이 발행되었습니다.", response);
+    }
+
+    @PostMapping("/letters")
+    @Operation(summary = "새 편지 발행", description = "UPDATE / STORY 편지를 전체 사용자에게 발행합니다.")
+    public ResponseEntity<?> createLetter(@RequestBody @Valid LetterCreateRequest request) {
+        LetterCreateResponse response = feedbackAdminService.createBroadcastLetter(request);
+        return Response.ok("편지가 발행되었습니다.", response);
+    }
+
+    @PostMapping(value = "/letters/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "편지 본문 이미지 업로드",
+            description = "이미지를 R2에 업로드하고 URL을 반환합니다. 반환된 URL을 본문에 마크다운 이미지로 삽입해 사용합니다.")
+    public ResponseEntity<?> uploadLetterImage(@RequestPart("file") MultipartFile file) {
+        LetterImageUploadResponse response = letterImageUploadService.upload(file);
+        return Response.ok("이미지가 업로드되었습니다.", response);
+    }
+
+    @PostMapping("/letters/drafts")
+    @Operation(summary = "편지 초안 저장", description = "발행하지 않은 편지를 임시저장합니다. 제목·본문이 비어 있어도 저장됩니다.")
+    public ResponseEntity<?> createDraft(@RequestBody LetterDraftRequest request) {
+        LetterDraftResponse response = letterDraftService.createDraft(request);
+        return Response.ok("임시저장되었습니다.", response);
+    }
+
+    @GetMapping("/letters/drafts")
+    @Operation(summary = "편지 초안 목록", description = "임시저장한 편지를 최근 수정순으로 조회합니다.")
+    public ResponseEntity<?> getDrafts() {
+        LetterDraftListResponse response = letterDraftService.getDrafts();
+        return Response.ok(response);
+    }
+
+    @PutMapping("/letters/drafts/{draftId}")
+    @Operation(summary = "편지 초안 이어쓰기", description = "임시저장한 편지를 덮어씁니다.")
+    public ResponseEntity<?> updateDraft(
+            @PathVariable String draftId,
+            @RequestBody LetterDraftRequest request
+    ) {
+        LetterDraftResponse response = letterDraftService.updateDraft(draftId, request);
+        return Response.ok("임시저장되었습니다.", response);
+    }
+
+    @DeleteMapping("/letters/drafts/{draftId}")
+    @Operation(summary = "편지 초안 삭제", description = "발행 완료 후 또는 작성을 취소할 때 초안을 지웁니다.")
+    public ResponseEntity<?> deleteDraft(@PathVariable String draftId) {
+        letterDraftService.deleteDraft(draftId);
+        return Response.ok("초안이 삭제되었습니다.", null);
+    }
+
+    @PatchMapping("/{feedbackId}/status")
+    @Operation(summary = "피드백 상태 변경", description = "답장 대기(WAITING) / 확인 중(IN_PROGRESS) / 답장 완료(REPLIED) 사이를 전환합니다.")
+    public ResponseEntity<?> updateStatus(
+            @PathVariable String feedbackId,
+            @RequestBody @Valid FeedbackStatusUpdateRequest request
+    ) {
+        feedbackAdminService.updateStatus(feedbackId, request);
+        return Response.ok("상태가 변경되었습니다.", null);
+    }
+}

--- a/backend/src/main/java/moadong/feedback/controller/StudentFeedbackController.java
+++ b/backend/src/main/java/moadong/feedback/controller/StudentFeedbackController.java
@@ -3,6 +3,7 @@ package moadong.feedback.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import moadong.feedback.enums.LetterCategory;
@@ -67,11 +68,21 @@ public class StudentFeedbackController {
     @SecurityRequirement(name = "BearerAuth")
     public ResponseEntity<?> createImageUploadUrls(
             @RequestHeader("Authorization") String authorization,
-            @RequestBody @Valid List<UploadUrlRequest> requests
+            @RequestBody @Valid List<UploadUrlRequest> requests,
+            HttpServletRequest httpServletRequest
     ) {
         String studentId = studentJwtService.extractStudentId(authorization);
-        List<PresignedUploadResponse> responses = feedbackImageService.createUploadUrls(studentId, requests);
+        List<PresignedUploadResponse> responses =
+                feedbackImageService.createUploadUrls(studentId, requests, clientIp(httpServletRequest));
         return Response.ok(responses);
+    }
+
+    private String clientIp(HttpServletRequest request) {
+        String forwardedFor = request.getHeader("X-Forwarded-For");
+        if (forwardedFor != null && !forwardedFor.isBlank()) {
+            return forwardedFor.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
     }
 
     @GetMapping("/received")

--- a/backend/src/main/java/moadong/feedback/controller/StudentFeedbackController.java
+++ b/backend/src/main/java/moadong/feedback/controller/StudentFeedbackController.java
@@ -1,0 +1,135 @@
+package moadong.feedback.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import moadong.feedback.enums.LetterCategory;
+import moadong.feedback.payload.request.FeedbackCreateRequest;
+import moadong.feedback.payload.response.FeedbackCreateResponse;
+import moadong.feedback.payload.response.ReceivedLetterDetailResponse;
+import moadong.feedback.payload.response.ReceivedLetterListResponse;
+import moadong.feedback.payload.response.SentFeedbackListResponse;
+import moadong.feedback.payload.response.SentFeedbackResponse;
+import moadong.feedback.service.FeedbackImageService;
+import moadong.feedback.service.FeedbackService;
+import moadong.global.payload.Response;
+import moadong.media.dto.PresignedUploadResponse;
+import moadong.media.dto.UploadUrlRequest;
+import moadong.user.service.StudentJwtService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * 모아동 우체통 사용자 API.
+ * <p>
+ * {@code /api/student} 는 {@code JwtAuthenticationFilter} 가 건너뛰는 경로라서,
+ * 학생 토큰을 컨트롤러에서 직접 파싱한다. ({@code StudentFcmController} 와 같은 방식)
+ */
+@RestController
+@RequestMapping("/api/student/feedback")
+@RequiredArgsConstructor
+@Tag(name = "Student Feedback", description = "모아동 우체통 사용자 API")
+public class StudentFeedbackController {
+
+    private final StudentJwtService studentJwtService;
+    private final FeedbackService feedbackService;
+    private final FeedbackImageService feedbackImageService;
+
+    @PostMapping
+    @Operation(summary = "피드백 보내기", description = "학생 토큰 sub(UUID) 기준으로 피드백을 저장합니다.")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> createFeedback(
+            @RequestHeader("Authorization") String authorization,
+            @RequestBody @Valid FeedbackCreateRequest request
+    ) {
+        String studentId = studentJwtService.extractStudentId(authorization);
+        FeedbackCreateResponse response = feedbackService.createFeedback(studentId, request);
+        return Response.ok("피드백이 전송되었습니다.", response);
+    }
+
+    @PostMapping("/images/upload-url")
+    @Operation(summary = "첨부 사진 업로드 URL 발급",
+            description = "R2에 직접 업로드할 presigned URL을 요청한 개수만큼 발급합니다. "
+                    + "업로드 후 받은 finalUrl을 피드백 전송 시 images에 담아 보냅니다. "
+                    + "4장을 넘게 요청하면 앞의 4건만 발급하고 마지막에 실패 항목이 붙습니다.")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> createImageUploadUrls(
+            @RequestHeader("Authorization") String authorization,
+            @RequestBody @Valid List<UploadUrlRequest> requests
+    ) {
+        String studentId = studentJwtService.extractStudentId(authorization);
+        List<PresignedUploadResponse> responses = feedbackImageService.createUploadUrls(studentId, requests);
+        return Response.ok(responses);
+    }
+
+    @GetMapping("/received")
+    @Operation(summary = "받은 편지 목록", description = "나에게 온 답장과 전체 발행 편지를 최신순으로 조회합니다. category는 선택입니다.")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> getReceivedLetters(
+            @RequestHeader("Authorization") String authorization,
+            @RequestParam(required = false) LetterCategory category
+    ) {
+        String studentId = studentJwtService.extractStudentId(authorization);
+        ReceivedLetterListResponse response = feedbackService.getReceivedLetters(studentId, category);
+        return Response.ok(response);
+    }
+
+    @GetMapping("/received/{letterId}")
+    @Operation(summary = "받은 편지 상세", description = "REPLY 편지면 원본 피드백(myFeedback)을 함께 내려줍니다.")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> getReceivedLetter(
+            @RequestHeader("Authorization") String authorization,
+            @PathVariable String letterId
+    ) {
+        String studentId = studentJwtService.extractStudentId(authorization);
+        ReceivedLetterDetailResponse response = feedbackService.getReceivedLetter(studentId, letterId);
+        return Response.ok(response);
+    }
+
+    @PatchMapping("/received/{letterId}/read")
+    @Operation(summary = "받은 편지 읽음 처리", description = "해당 편지를 읽은 것으로 표시합니다.")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> markLetterRead(
+            @RequestHeader("Authorization") String authorization,
+            @PathVariable String letterId
+    ) {
+        String studentId = studentJwtService.extractStudentId(authorization);
+        feedbackService.markLetterRead(studentId, letterId);
+        return Response.ok("편지를 읽음 처리했습니다.", null);
+    }
+
+    @GetMapping("/sent")
+    @Operation(summary = "보낸 편지 목록", description = "내가 보낸 피드백을 최신순으로 조회합니다.")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> getSentFeedbacks(
+            @RequestHeader("Authorization") String authorization
+    ) {
+        String studentId = studentJwtService.extractStudentId(authorization);
+        SentFeedbackListResponse response = feedbackService.getSentFeedbacks(studentId);
+        return Response.ok(response);
+    }
+
+    @GetMapping("/sent/{feedbackId}")
+    @Operation(summary = "보낸 편지 상세", description = "내가 보낸 피드백 하나를 조회합니다.")
+    @SecurityRequirement(name = "BearerAuth")
+    public ResponseEntity<?> getSentFeedback(
+            @RequestHeader("Authorization") String authorization,
+            @PathVariable String feedbackId
+    ) {
+        String studentId = studentJwtService.extractStudentId(authorization);
+        SentFeedbackResponse response = feedbackService.getSentFeedback(studentId, feedbackId);
+        return Response.ok(response);
+    }
+}

--- a/backend/src/main/java/moadong/feedback/entity/Feedback.java
+++ b/backend/src/main/java/moadong/feedback/entity/Feedback.java
@@ -8,13 +8,15 @@ import moadong.feedback.enums.FeedbackStatus;
 import moadong.feedback.enums.FeedbackType;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Version;
-import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.Instant;
 import java.util.List;
 
 @Document("feedbacks")
+@CompoundIndex(name = "student_created_at_idx", def = "{'studentId': 1, 'createdAt': -1}")
+@CompoundIndex(name = "created_at_idx", def = "{'createdAt': -1}")
 @Getter
 @Builder
 @AllArgsConstructor
@@ -33,8 +35,8 @@ public class Feedback {
 
     /**
      * 학생 임시 토큰의 sub(UUID). StudentUser 문서가 없을 수도 있으므로 참조 대신 값으로 보관한다.
+     * 조회는 항상 최신순 정렬과 함께라 student_created_at_idx가 담당한다.
      */
-    @Indexed
     private String studentId;
 
     private FeedbackType type;
@@ -60,6 +62,10 @@ public class Feedback {
         this.repliedAt = Instant.now();
     }
 
+    /**
+     * 운영자가 답장 대기 · 확인 중 사이를 오갈 때만 쓴다.
+     * REPLIED는 replyLetterId · repliedAt과 함께 설정돼야 하므로 {@link #markReplied}로만 전이한다.
+     */
     public void changeStatus(FeedbackStatus status) {
         this.status = status;
     }

--- a/backend/src/main/java/moadong/feedback/entity/Feedback.java
+++ b/backend/src/main/java/moadong/feedback/entity/Feedback.java
@@ -1,0 +1,66 @@
+package moadong.feedback.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import moadong.feedback.enums.FeedbackStatus;
+import moadong.feedback.enums.FeedbackType;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Version;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+import java.util.List;
+
+@Document("feedbacks")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Feedback {
+
+    @Id
+    private String id;
+
+    /**
+     * 운영자 둘이 동시에 답장을 발행하면 늦은 쪽이 충돌하도록 한다.
+     * {@code GlobalExceptionHandler}가 이 예외를 409로 변환한다.
+     */
+    @Version
+    private Long version;
+
+    /**
+     * 학생 임시 토큰의 sub(UUID). StudentUser 문서가 없을 수도 있으므로 참조 대신 값으로 보관한다.
+     */
+    @Indexed
+    private String studentId;
+
+    private FeedbackType type;
+
+    private String content;
+
+    @Builder.Default
+    private List<String> images = List.of();
+
+    @Builder.Default
+    private FeedbackStatus status = FeedbackStatus.WAITING;
+
+    @Builder.Default
+    private Instant createdAt = Instant.now();
+
+    private Instant repliedAt;
+
+    private String replyLetterId;
+
+    public void markReplied(String replyLetterId) {
+        this.status = FeedbackStatus.REPLIED;
+        this.replyLetterId = replyLetterId;
+        this.repliedAt = Instant.now();
+    }
+
+    public void changeStatus(FeedbackStatus status) {
+        this.status = status;
+    }
+}

--- a/backend/src/main/java/moadong/feedback/entity/Letter.java
+++ b/backend/src/main/java/moadong/feedback/entity/Letter.java
@@ -1,0 +1,102 @@
+package moadong.feedback.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import moadong.feedback.enums.LetterCategory;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+import java.util.Set;
+
+@Document("feedback_letters")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Letter {
+
+    private static final int PREVIEW_LENGTH = 60;
+
+    @Id
+    private String id;
+
+    private LetterCategory category;
+
+    /**
+     * REPLY 편지의 수신자. UPDATE / STORY 처럼 전체에게 발행하는 편지는 null이다.
+     */
+    @Indexed
+    private String recipientStudentId;
+
+    /**
+     * REPLY 편지가 답장하는 원본 피드백. 그 외 카테고리는 null이다.
+     */
+    private String feedbackId;
+
+    private String title;
+
+    private String body;
+
+    @Builder.Default
+    private Instant createdAt = Instant.now();
+
+    @Builder.Default
+    private Set<String> readStudentIds = Set.of();
+
+    public boolean isBroadcast() {
+        return recipientStudentId == null;
+    }
+
+    public boolean isReadableBy(String studentId) {
+        return isBroadcast() || recipientStudentId.equals(studentId);
+    }
+
+    public boolean isReadBy(String studentId) {
+        return readStudentIds != null && readStudentIds.contains(studentId);
+    }
+
+    /**
+     * 목록에 한 줄로 노출할 요약이자 답장 푸시의 본문. 마크다운 기호를 걷어낸 뒤 서버에서 잘라 내려준다.
+     * <p>
+     * 기호를 남기면 이미지 URL 한 줄이 요약 길이를 통째로 차지해 정작 내용이 보이지 않는다.
+     */
+    public String preview() {
+        String flattened = body == null ? "" : stripMarkdown(body).replaceAll("\\s+", " ").trim();
+        return flattened.length() <= PREVIEW_LENGTH
+                ? flattened
+                : flattened.substring(0, PREVIEW_LENGTH) + "...";
+    }
+
+    /**
+     * 이미지는 통째로, 링크는 표시 텍스트만 남기고 걷어낸다.
+     * 이미지 문법이 링크 문법을 포함하므로 반드시 이미지를 먼저 지운다.
+     */
+    private static String stripMarkdown(String markdown) {
+        return markdown
+                .replaceAll("!\\[[^\\]]*\\]\\([^)]*\\)", "")
+                .replaceAll("\\[([^\\]]*)\\]\\([^)]*\\)", "$1")
+                .replaceAll("\\*{1,2}", "");
+    }
+
+    public static Letter reply(String recipientStudentId, String feedbackId, String title, String body) {
+        return Letter.builder()
+                .category(LetterCategory.REPLY)
+                .recipientStudentId(recipientStudentId)
+                .feedbackId(feedbackId)
+                .title(title)
+                .body(body)
+                .build();
+    }
+
+    public static Letter broadcast(LetterCategory category, String title, String body) {
+        return Letter.builder()
+                .category(category)
+                .title(title)
+                .body(body)
+                .build();
+    }
+}

--- a/backend/src/main/java/moadong/feedback/entity/Letter.java
+++ b/backend/src/main/java/moadong/feedback/entity/Letter.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import moadong.feedback.enums.LetterCategory;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.Instant;
@@ -42,6 +43,19 @@ public class Letter {
     private String title;
 
     private String body;
+
+    /**
+     * 전체 발행 요청의 재시도를 걸러내기 위한 키. 클라이언트가 편지 한 건에 대해 같은 값을 재사용한다.
+     * 답장은 {@code FEEDBACK_ALREADY_REPLIED}로 막히므로 전체 발행 편지에만 쓴다.
+     * 조회로만 거르면 동시 요청이 둘 다 통과하므로 유니크 인덱스로 최종 방어한다.
+     */
+    @Indexed(unique = true, sparse = true)
+    private String idempotencyKey;
+
+    /**
+     * 전체 발행 시 푸시가 도달한 기기 수. 재시도로 같은 요청이 다시 와도 원래 결과를 그대로 돌려주기 위해 보관한다.
+     */
+    private int pushSuccessCount;
 
     @Builder.Default
     private Instant createdAt = Instant.now();
@@ -94,11 +108,16 @@ public class Letter {
                 .build();
     }
 
-    public static Letter broadcast(LetterCategory category, String title, String body) {
+    public static Letter broadcast(LetterCategory category, String title, String body, String idempotencyKey) {
         return Letter.builder()
                 .category(category)
                 .title(title)
                 .body(body)
+                .idempotencyKey(idempotencyKey)
                 .build();
+    }
+
+    public void recordPushResult(int successCount) {
+        this.pushSuccessCount = successCount;
     }
 }

--- a/backend/src/main/java/moadong/feedback/entity/Letter.java
+++ b/backend/src/main/java/moadong/feedback/entity/Letter.java
@@ -6,13 +6,15 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import moadong.feedback.enums.LetterCategory;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.Instant;
 import java.util.Set;
 
 @Document("feedback_letters")
+@CompoundIndex(name = "recipient_created_at_idx", def = "{'recipientStudentId': 1, 'createdAt': -1}")
+@CompoundIndex(name = "category_recipient_created_at_idx", def = "{'category': 1, 'recipientStudentId': 1, 'createdAt': -1}")
 @Getter
 @Builder
 @AllArgsConstructor
@@ -28,8 +30,8 @@ public class Letter {
 
     /**
      * REPLY 편지의 수신자. UPDATE / STORY 처럼 전체에게 발행하는 편지는 null이다.
+     * 받은 편지함 조회는 항상 최신순 정렬과 함께라 recipient_created_at_idx가 담당한다.
      */
-    @Indexed
     private String recipientStudentId;
 
     /**

--- a/backend/src/main/java/moadong/feedback/entity/LetterDraft.java
+++ b/backend/src/main/java/moadong/feedback/entity/LetterDraft.java
@@ -1,0 +1,51 @@
+package moadong.feedback.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import moadong.feedback.enums.LetterCategory;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+
+/**
+ * 발행 전 편지 초안. 발행된 편지({@link Letter})와 다른 컬렉션에 둔다.
+ * 같은 컬렉션에 상태 플래그로 섞으면 받은 편지함 쿼리에 조건 하나만 빠져도
+ * 쓰다 만 글이 전체 사용자에게 노출되기 때문이다.
+ * <p>
+ * 초안은 작성 도중 언제든 저장할 수 있어야 하므로 제목 · 본문이 비어 있어도 허용한다.
+ */
+@Document("feedback_letter_drafts")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class LetterDraft {
+
+    @Id
+    private String id;
+
+    private LetterCategory category;
+
+    private String title;
+
+    private String body;
+
+    private boolean sendPush;
+
+    @Builder.Default
+    private Instant createdAt = Instant.now();
+
+    @Builder.Default
+    private Instant updatedAt = Instant.now();
+
+    public void update(LetterCategory category, String title, String body, boolean sendPush) {
+        this.category = category;
+        this.title = title;
+        this.body = body;
+        this.sendPush = sendPush;
+        this.updatedAt = Instant.now();
+    }
+}

--- a/backend/src/main/java/moadong/feedback/enums/FeedbackStatus.java
+++ b/backend/src/main/java/moadong/feedback/enums/FeedbackStatus.java
@@ -1,0 +1,14 @@
+package moadong.feedback.enums;
+
+/**
+ * 운영자에게 노출되는 3단계 상태. 사용자에게는 {@link SentFeedbackStatus}로 축약해 내려간다.
+ */
+public enum FeedbackStatus {
+    WAITING,
+    IN_PROGRESS,
+    REPLIED;
+
+    public SentFeedbackStatus toSentStatus() {
+        return this == REPLIED ? SentFeedbackStatus.REPLIED : SentFeedbackStatus.PENDING;
+    }
+}

--- a/backend/src/main/java/moadong/feedback/enums/FeedbackType.java
+++ b/backend/src/main/java/moadong/feedback/enums/FeedbackType.java
@@ -1,0 +1,8 @@
+package moadong.feedback.enums;
+
+public enum FeedbackType {
+    BUG,
+    FEATURE,
+    QUESTION,
+    CHEER
+}

--- a/backend/src/main/java/moadong/feedback/enums/LetterCategory.java
+++ b/backend/src/main/java/moadong/feedback/enums/LetterCategory.java
@@ -1,0 +1,7 @@
+package moadong.feedback.enums;
+
+public enum LetterCategory {
+    REPLY,
+    UPDATE,
+    STORY
+}

--- a/backend/src/main/java/moadong/feedback/enums/SentFeedbackStatus.java
+++ b/backend/src/main/java/moadong/feedback/enums/SentFeedbackStatus.java
@@ -1,0 +1,6 @@
+package moadong.feedback.enums;
+
+public enum SentFeedbackStatus {
+    PENDING,
+    REPLIED
+}

--- a/backend/src/main/java/moadong/feedback/payload/request/FeedbackCreateRequest.java
+++ b/backend/src/main/java/moadong/feedback/payload/request/FeedbackCreateRequest.java
@@ -1,5 +1,6 @@
 package moadong.feedback.payload.request;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import moadong.feedback.enums.FeedbackType;
@@ -10,7 +11,7 @@ public record FeedbackCreateRequest(
         @NotNull(message = "피드백 유형은 필수입니다.")
         FeedbackType type,
 
-        @NotNull(message = "내용은 필수입니다.")
+        @NotBlank(message = "내용은 필수입니다.")
         @Size(min = 10, max = 300, message = "내용은 10자 이상 300자 이하로 입력해주세요.")
         String content,
 

--- a/backend/src/main/java/moadong/feedback/payload/request/FeedbackCreateRequest.java
+++ b/backend/src/main/java/moadong/feedback/payload/request/FeedbackCreateRequest.java
@@ -1,0 +1,20 @@
+package moadong.feedback.payload.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import moadong.feedback.enums.FeedbackType;
+
+import java.util.List;
+
+public record FeedbackCreateRequest(
+        @NotNull(message = "피드백 유형은 필수입니다.")
+        FeedbackType type,
+
+        @NotNull(message = "내용은 필수입니다.")
+        @Size(min = 10, max = 300, message = "내용은 10자 이상 300자 이하로 입력해주세요.")
+        String content,
+
+        // 미리 업로드한 사진의 최종 URL. 장수 · 소유 경로 · 실제 업로드 여부는 서버가 다시 검증한다.
+        List<String> images
+) {
+}

--- a/backend/src/main/java/moadong/feedback/payload/request/FeedbackReplyRequest.java
+++ b/backend/src/main/java/moadong/feedback/payload/request/FeedbackReplyRequest.java
@@ -1,0 +1,14 @@
+package moadong.feedback.payload.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record FeedbackReplyRequest(
+        @NotBlank(message = "제목은 필수입니다.")
+        String title,
+
+        @NotBlank(message = "본문은 필수입니다.")
+        String body,
+
+        boolean sendPush
+) {
+}

--- a/backend/src/main/java/moadong/feedback/payload/request/FeedbackStatusUpdateRequest.java
+++ b/backend/src/main/java/moadong/feedback/payload/request/FeedbackStatusUpdateRequest.java
@@ -1,0 +1,10 @@
+package moadong.feedback.payload.request;
+
+import jakarta.validation.constraints.NotNull;
+import moadong.feedback.enums.FeedbackStatus;
+
+public record FeedbackStatusUpdateRequest(
+        @NotNull(message = "상태는 필수입니다.")
+        FeedbackStatus status
+) {
+}

--- a/backend/src/main/java/moadong/feedback/payload/request/LetterCreateRequest.java
+++ b/backend/src/main/java/moadong/feedback/payload/request/LetterCreateRequest.java
@@ -1,0 +1,19 @@
+package moadong.feedback.payload.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import moadong.feedback.enums.LetterCategory;
+
+public record LetterCreateRequest(
+        @NotNull(message = "편지 분류는 필수입니다.")
+        LetterCategory category,
+
+        @NotBlank(message = "제목은 필수입니다.")
+        String title,
+
+        @NotBlank(message = "본문은 필수입니다.")
+        String body,
+
+        boolean sendPush
+) {
+}

--- a/backend/src/main/java/moadong/feedback/payload/request/LetterCreateRequest.java
+++ b/backend/src/main/java/moadong/feedback/payload/request/LetterCreateRequest.java
@@ -14,6 +14,9 @@ public record LetterCreateRequest(
         @NotBlank(message = "본문은 필수입니다.")
         String body,
 
-        boolean sendPush
+        boolean sendPush,
+
+        // 재시도 식별용. 같은 편지에 대해 같은 값을 보내면 중복 발행과 중복 푸시를 막는다.
+        String requestId
 ) {
 }

--- a/backend/src/main/java/moadong/feedback/payload/request/LetterDraftRequest.java
+++ b/backend/src/main/java/moadong/feedback/payload/request/LetterDraftRequest.java
@@ -1,0 +1,14 @@
+package moadong.feedback.payload.request;
+
+import moadong.feedback.enums.LetterCategory;
+
+/**
+ * 초안은 작성 도중 저장되므로 필수값 검증을 두지 않는다. 검증은 발행 시점에 한다.
+ */
+public record LetterDraftRequest(
+        LetterCategory category,
+        String title,
+        String body,
+        boolean sendPush
+) {
+}

--- a/backend/src/main/java/moadong/feedback/payload/response/AdminFeedbackListResponse.java
+++ b/backend/src/main/java/moadong/feedback/payload/response/AdminFeedbackListResponse.java
@@ -1,0 +1,10 @@
+package moadong.feedback.payload.response;
+
+import java.util.List;
+
+public record AdminFeedbackListResponse(
+        List<AdminFeedbackResponse> feedbacks,
+        // 사이드바 뱃지에 쓰이는 미답변(답장 완료가 아닌) 개수
+        long unansweredCount
+) {
+}

--- a/backend/src/main/java/moadong/feedback/payload/response/AdminFeedbackResponse.java
+++ b/backend/src/main/java/moadong/feedback/payload/response/AdminFeedbackResponse.java
@@ -1,0 +1,32 @@
+package moadong.feedback.payload.response;
+
+import moadong.feedback.entity.Feedback;
+import moadong.feedback.enums.FeedbackStatus;
+import moadong.feedback.enums.FeedbackType;
+
+import java.time.Instant;
+import java.util.List;
+
+public record AdminFeedbackResponse(
+        String id,
+        FeedbackType type,
+        String content,
+        List<String> images,
+        // 학생 UUID를 그대로 노출하지 않기 위한 표시용 익명 식별자 (예: user_8842)
+        String sender,
+        FeedbackStatus status,
+        Instant createdAt
+) {
+
+    public static AdminFeedbackResponse of(Feedback feedback, String sender) {
+        return new AdminFeedbackResponse(
+                feedback.getId(),
+                feedback.getType(),
+                feedback.getContent(),
+                feedback.getImages() == null ? List.of() : feedback.getImages(),
+                sender,
+                feedback.getStatus(),
+                feedback.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/moadong/feedback/payload/response/FeedbackCreateResponse.java
+++ b/backend/src/main/java/moadong/feedback/payload/response/FeedbackCreateResponse.java
@@ -1,0 +1,6 @@
+package moadong.feedback.payload.response;
+
+public record FeedbackCreateResponse(
+        String feedbackId
+) {
+}

--- a/backend/src/main/java/moadong/feedback/payload/response/FeedbackReplyResponse.java
+++ b/backend/src/main/java/moadong/feedback/payload/response/FeedbackReplyResponse.java
@@ -1,0 +1,7 @@
+package moadong.feedback.payload.response;
+
+public record FeedbackReplyResponse(
+        String letterId,
+        boolean pushSent
+) {
+}

--- a/backend/src/main/java/moadong/feedback/payload/response/LetterCreateResponse.java
+++ b/backend/src/main/java/moadong/feedback/payload/response/LetterCreateResponse.java
@@ -1,0 +1,9 @@
+package moadong.feedback.payload.response;
+
+public record LetterCreateResponse(
+        String letterId,
+        boolean pushSent,
+        // 발송에 성공한 기기 수. 운영자가 실제로 나갔는지 확인할 수 있어야 한다.
+        int pushSuccessCount
+) {
+}

--- a/backend/src/main/java/moadong/feedback/payload/response/LetterDraftListResponse.java
+++ b/backend/src/main/java/moadong/feedback/payload/response/LetterDraftListResponse.java
@@ -1,0 +1,8 @@
+package moadong.feedback.payload.response;
+
+import java.util.List;
+
+public record LetterDraftListResponse(
+        List<LetterDraftResponse> drafts
+) {
+}

--- a/backend/src/main/java/moadong/feedback/payload/response/LetterDraftResponse.java
+++ b/backend/src/main/java/moadong/feedback/payload/response/LetterDraftResponse.java
@@ -1,0 +1,27 @@
+package moadong.feedback.payload.response;
+
+import moadong.feedback.entity.LetterDraft;
+import moadong.feedback.enums.LetterCategory;
+
+import java.time.Instant;
+
+public record LetterDraftResponse(
+        String id,
+        LetterCategory category,
+        String title,
+        String body,
+        boolean sendPush,
+        Instant updatedAt
+) {
+
+    public static LetterDraftResponse from(LetterDraft draft) {
+        return new LetterDraftResponse(
+                draft.getId(),
+                draft.getCategory(),
+                draft.getTitle(),
+                draft.getBody(),
+                draft.isSendPush(),
+                draft.getUpdatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/moadong/feedback/payload/response/LetterImageUploadResponse.java
+++ b/backend/src/main/java/moadong/feedback/payload/response/LetterImageUploadResponse.java
@@ -1,0 +1,6 @@
+package moadong.feedback.payload.response;
+
+public record LetterImageUploadResponse(
+        String imageUrl
+) {
+}

--- a/backend/src/main/java/moadong/feedback/payload/response/ReceivedLetterDetailResponse.java
+++ b/backend/src/main/java/moadong/feedback/payload/response/ReceivedLetterDetailResponse.java
@@ -1,0 +1,30 @@
+package moadong.feedback.payload.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import moadong.feedback.entity.Letter;
+import moadong.feedback.enums.LetterCategory;
+
+import java.time.Instant;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ReceivedLetterDetailResponse(
+        String id,
+        LetterCategory category,
+        String title,
+        Instant createdAt,
+        String body,
+        // category = REPLY 일 때만 채워진다. 상세 화면의 "내가 보낸 편지" 인용 카드에 쓰인다.
+        SentFeedbackResponse myFeedback
+) {
+
+    public static ReceivedLetterDetailResponse of(Letter letter, SentFeedbackResponse myFeedback) {
+        return new ReceivedLetterDetailResponse(
+                letter.getId(),
+                letter.getCategory(),
+                letter.getTitle(),
+                letter.getCreatedAt(),
+                letter.getBody(),
+                myFeedback
+        );
+    }
+}

--- a/backend/src/main/java/moadong/feedback/payload/response/ReceivedLetterListResponse.java
+++ b/backend/src/main/java/moadong/feedback/payload/response/ReceivedLetterListResponse.java
@@ -1,0 +1,8 @@
+package moadong.feedback.payload.response;
+
+import java.util.List;
+
+public record ReceivedLetterListResponse(
+        List<ReceivedLetterSummaryResponse> letters
+) {
+}

--- a/backend/src/main/java/moadong/feedback/payload/response/ReceivedLetterSummaryResponse.java
+++ b/backend/src/main/java/moadong/feedback/payload/response/ReceivedLetterSummaryResponse.java
@@ -1,0 +1,29 @@
+package moadong.feedback.payload.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import moadong.feedback.entity.Letter;
+import moadong.feedback.enums.LetterCategory;
+
+import java.time.Instant;
+
+public record ReceivedLetterSummaryResponse(
+        String id,
+        LetterCategory category,
+        String title,
+        String preview,
+        Instant createdAt,
+        @JsonProperty("isRead")
+        boolean isRead
+) {
+
+    public static ReceivedLetterSummaryResponse from(Letter letter, String studentId) {
+        return new ReceivedLetterSummaryResponse(
+                letter.getId(),
+                letter.getCategory(),
+                letter.getTitle(),
+                letter.preview(),
+                letter.getCreatedAt(),
+                letter.isReadBy(studentId)
+        );
+    }
+}

--- a/backend/src/main/java/moadong/feedback/payload/response/SentFeedbackListResponse.java
+++ b/backend/src/main/java/moadong/feedback/payload/response/SentFeedbackListResponse.java
@@ -1,0 +1,8 @@
+package moadong.feedback.payload.response;
+
+import java.util.List;
+
+public record SentFeedbackListResponse(
+        List<SentFeedbackResponse> feedbacks
+) {
+}

--- a/backend/src/main/java/moadong/feedback/payload/response/SentFeedbackResponse.java
+++ b/backend/src/main/java/moadong/feedback/payload/response/SentFeedbackResponse.java
@@ -1,0 +1,29 @@
+package moadong.feedback.payload.response;
+
+import moadong.feedback.entity.Feedback;
+import moadong.feedback.enums.FeedbackType;
+import moadong.feedback.enums.SentFeedbackStatus;
+
+import java.time.Instant;
+import java.util.List;
+
+public record SentFeedbackResponse(
+        String id,
+        FeedbackType type,
+        String content,
+        List<String> images,
+        SentFeedbackStatus status,
+        Instant createdAt
+) {
+
+    public static SentFeedbackResponse from(Feedback feedback) {
+        return new SentFeedbackResponse(
+                feedback.getId(),
+                feedback.getType(),
+                feedback.getContent(),
+                feedback.getImages() == null ? List.of() : feedback.getImages(),
+                feedback.getStatus().toSentStatus(),
+                feedback.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/moadong/feedback/repository/FeedbackRepository.java
+++ b/backend/src/main/java/moadong/feedback/repository/FeedbackRepository.java
@@ -1,0 +1,18 @@
+package moadong.feedback.repository;
+
+import moadong.feedback.entity.Feedback;
+import moadong.feedback.enums.FeedbackStatus;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface FeedbackRepository extends MongoRepository<Feedback, String> {
+
+    List<Feedback> findByStudentIdOrderByCreatedAtDesc(String studentId);
+
+    List<Feedback> findAllByOrderByCreatedAtDesc();
+
+    long countByStatusNot(FeedbackStatus status);
+}

--- a/backend/src/main/java/moadong/feedback/repository/LetterDraftRepository.java
+++ b/backend/src/main/java/moadong/feedback/repository/LetterDraftRepository.java
@@ -1,0 +1,13 @@
+package moadong.feedback.repository;
+
+import moadong.feedback.entity.LetterDraft;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface LetterDraftRepository extends MongoRepository<LetterDraft, String> {
+
+    List<LetterDraft> findAllByOrderByUpdatedAtDesc();
+}

--- a/backend/src/main/java/moadong/feedback/repository/LetterRepository.java
+++ b/backend/src/main/java/moadong/feedback/repository/LetterRepository.java
@@ -1,0 +1,29 @@
+package moadong.feedback.repository;
+
+import moadong.feedback.entity.Letter;
+import moadong.feedback.enums.LetterCategory;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+import org.springframework.data.mongodb.repository.Update;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface LetterRepository extends MongoRepository<Letter, String> {
+
+    /**
+     * 받은 편지함 = 나에게 온 REPLY + 전체 발행 편지(recipientStudentId 없음).
+     */
+    @Query(value = "{ $or: [ { 'recipientStudentId': ?0 }, { 'recipientStudentId': null } ] }",
+            sort = "{ 'createdAt': -1 }")
+    List<Letter> findInboxByStudentId(String studentId);
+
+    @Query(value = "{ 'category': ?1, $or: [ { 'recipientStudentId': ?0 }, { 'recipientStudentId': null } ] }",
+            sort = "{ 'createdAt': -1 }")
+    List<Letter> findInboxByStudentIdAndCategory(String studentId, LetterCategory category);
+
+    @Query("{ '_id': ?0 }")
+    @Update("{ '$addToSet': { 'readStudentIds': ?1 } }")
+    long markRead(String letterId, String studentId);
+}

--- a/backend/src/main/java/moadong/feedback/repository/LetterRepository.java
+++ b/backend/src/main/java/moadong/feedback/repository/LetterRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.mongodb.repository.Update;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface LetterRepository extends MongoRepository<Letter, String> {
@@ -26,4 +27,6 @@ public interface LetterRepository extends MongoRepository<Letter, String> {
     @Query("{ '_id': ?0 }")
     @Update("{ '$addToSet': { 'readStudentIds': ?1 } }")
     long markRead(String letterId, String studentId);
+
+    Optional<Letter> findByIdempotencyKey(String idempotencyKey);
 }

--- a/backend/src/main/java/moadong/feedback/service/FeedbackAdminService.java
+++ b/backend/src/main/java/moadong/feedback/service/FeedbackAdminService.java
@@ -1,0 +1,163 @@
+package moadong.feedback.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import moadong.fcm.model.TokenPushPayload;
+import moadong.fcm.model.TokenPushResult;
+import moadong.fcm.payload.request.FcmAdminBatchSendRequest;
+import moadong.fcm.payload.response.FcmAdminBatchSendResponse;
+import moadong.fcm.port.PushNotificationPort;
+import moadong.fcm.service.FcmAdminService;
+import moadong.feedback.entity.Feedback;
+import moadong.feedback.entity.Letter;
+import moadong.feedback.enums.FeedbackStatus;
+import moadong.feedback.enums.LetterCategory;
+import moadong.feedback.payload.request.FeedbackReplyRequest;
+import moadong.feedback.payload.request.FeedbackStatusUpdateRequest;
+import moadong.feedback.payload.request.LetterCreateRequest;
+import moadong.feedback.payload.response.AdminFeedbackListResponse;
+import moadong.feedback.payload.response.AdminFeedbackResponse;
+import moadong.feedback.payload.response.FeedbackReplyResponse;
+import moadong.feedback.payload.response.LetterCreateResponse;
+import moadong.feedback.repository.FeedbackRepository;
+import moadong.feedback.repository.LetterRepository;
+import moadong.global.exception.ErrorCode;
+import moadong.global.exception.RestApiException;
+import moadong.user.repository.StudentUserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FeedbackAdminService {
+
+    private static final String REPLY_PUSH_TYPE = "FEEDBACK_REPLY";
+    private static final String LETTER_PUSH_TYPE = "FEEDBACK_LETTER";
+    private static final int SENDER_ID_LENGTH = 8;
+
+    private final FeedbackRepository feedbackRepository;
+    private final LetterRepository letterRepository;
+    private final StudentUserRepository studentUserRepository;
+    private final PushNotificationPort pushNotificationPort;
+    private final FcmAdminService fcmAdminService;
+
+    public AdminFeedbackListResponse getFeedbacks() {
+        List<AdminFeedbackResponse> feedbacks = feedbackRepository.findAllByOrderByCreatedAtDesc().stream()
+                .map(feedback -> AdminFeedbackResponse.of(feedback, anonymousSender(feedback.getStudentId())))
+                .toList();
+
+        return new AdminFeedbackListResponse(
+                feedbacks,
+                feedbackRepository.countByStatusNot(FeedbackStatus.REPLIED));
+    }
+
+    @Transactional
+    public FeedbackReplyResponse reply(String feedbackId, FeedbackReplyRequest request) {
+        Feedback feedback = feedbackRepository.findById(feedbackId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.FEEDBACK_NOT_FOUND));
+
+        if (feedback.getStatus() == FeedbackStatus.REPLIED) {
+            throw new RestApiException(ErrorCode.FEEDBACK_ALREADY_REPLIED);
+        }
+
+        Letter letter = letterRepository.save(Letter.reply(
+                feedback.getStudentId(), feedback.getId(), request.title(), request.body()));
+
+        feedback.markReplied(letter.getId());
+        feedbackRepository.save(feedback);
+
+        boolean pushSent = request.sendPush()
+                && sendReplyPush(feedback.getStudentId(), letter);
+
+        return new FeedbackReplyResponse(letter.getId(), pushSent);
+    }
+
+    public LetterCreateResponse createBroadcastLetter(LetterCreateRequest request) {
+        if (request.category() == LetterCategory.REPLY) {
+            throw new RestApiException(ErrorCode.LETTER_CATEGORY_NOT_BROADCASTABLE);
+        }
+
+        Letter letter = letterRepository.save(
+                Letter.broadcast(request.category(), request.title(), request.body()));
+
+        if (!request.sendPush()) {
+            return new LetterCreateResponse(letter.getId(), false, 0);
+        }
+
+        int successCount = sendBroadcastPush(letter);
+        return new LetterCreateResponse(letter.getId(), successCount > 0, successCount);
+    }
+
+    public void updateStatus(String feedbackId, FeedbackStatusUpdateRequest request) {
+        Feedback feedback = feedbackRepository.findById(feedbackId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.FEEDBACK_NOT_FOUND));
+
+        feedback.changeStatus(request.status());
+        feedbackRepository.save(feedback);
+    }
+
+    /**
+     * 전체 발행 편지 푸시. 대상 토큰 수집과 배치 발송은 기존 FCM 관리자 경로를 그대로 쓴다.
+     * 답장 푸시와 마찬가지로 실패가 편지 발행을 되돌리지는 않는다.
+     */
+    private int sendBroadcastPush(Letter letter) {
+        try {
+            FcmAdminBatchSendResponse result = fcmAdminService.sendToAll(new FcmAdminBatchSendRequest(
+                    letter.getTitle(),
+                    letter.preview(),
+                    Map.of("type", LETTER_PUSH_TYPE, "letterId", letter.getId())));
+            if (result.failureCount() > 0) {
+                log.warn("Broadcast push partially failed. letter={}, success={}, failure={}",
+                        letter.getId(), result.successCount(), result.failureCount());
+            }
+            return result.successCount();
+        } catch (RuntimeException e) {
+            log.error("Broadcast push failed. letter={}", letter.getId(), e);
+            return 0;
+        }
+    }
+
+    /**
+     * 푸시 실패가 답장 발행을 되돌리면 안 되므로 실패는 로그만 남기고 false를 반환한다.
+     */
+    private boolean sendReplyPush(String studentId, Letter letter) {
+        String fcmToken = studentUserRepository.findByStudentId(studentId)
+                .map(student -> student.getCurrentFcmToken())
+                .orElse(null);
+
+        if (!StringUtils.hasText(fcmToken)) {
+            log.info("Reply push skipped. no fcm token for feedback letter={}", letter.getId());
+            return false;
+        }
+
+        try {
+            TokenPushResult result = pushNotificationPort.sendToToken(new TokenPushPayload(
+                    fcmToken,
+                    letter.getTitle(),
+                    letter.preview(),
+                    Map.of("type", REPLY_PUSH_TYPE, "letterId", letter.getId())));
+            return result.success();
+        } catch (RuntimeException e) {
+            log.error("Reply push failed. letter={}", letter.getId(), e);
+            return false;
+        }
+    }
+
+    /**
+     * 학생 UUID 전체를 노출하지 않기 위한 표시용 식별자. 같은 학생은 항상 같은 값이 된다.
+     * <p>
+     * UUIDv4의 앞 8자리(32비트 난수)를 쓴다. 짧은 해시로 줄이면 서로 다른 학생이 같은 값으로 보여
+     * 운영자가 동일인의 반복 제보로 오해할 수 있다.
+     */
+    private String anonymousSender(String studentId) {
+        if (studentId == null || studentId.length() < SENDER_ID_LENGTH) {
+            return "user_unknown";
+        }
+        return "user_" + studentId.substring(0, SENDER_ID_LENGTH);
+    }
+}

--- a/backend/src/main/java/moadong/feedback/service/FeedbackAdminService.java
+++ b/backend/src/main/java/moadong/feedback/service/FeedbackAdminService.java
@@ -24,6 +24,7 @@ import moadong.feedback.repository.LetterRepository;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
 import moadong.user.repository.StudentUserRepository;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.StringUtils;
@@ -94,19 +95,28 @@ public class FeedbackAdminService {
             throw new RestApiException(ErrorCode.LETTER_CATEGORY_NOT_BROADCASTABLE);
         }
 
-        if (StringUtils.hasText(request.requestId())) {
-            Optional<Letter> published = letterRepository.findByIdempotencyKey(request.requestId());
+        // 빈 문자열을 그대로 저장하면 sparse 인덱스가 걸러주지 못해, 다음 발행이 중복 키로 실패한다.
+        String requestId = StringUtils.hasText(request.requestId()) ? request.requestId().trim() : null;
+
+        if (requestId != null) {
+            Optional<LetterCreateResponse> published = findPublished(requestId);
             if (published.isPresent()) {
-                Letter letter = published.get();
-                log.info("Broadcast letter republish ignored. letter={}, requestId={}",
-                        letter.getId(), request.requestId());
-                return new LetterCreateResponse(letter.getId(), letter.getPushSuccessCount() > 0,
-                        letter.getPushSuccessCount());
+                return published.get();
             }
         }
 
-        Letter letter = letterRepository.save(Letter.broadcast(
-                request.category(), request.title(), request.body(), request.requestId()));
+        Letter letter;
+        try {
+            letter = letterRepository.save(Letter.broadcast(
+                    request.category(), request.title(), request.body(), requestId));
+        } catch (DuplicateKeyException e) {
+            if (requestId == null) {
+                throw e;
+            }
+            // 동시 요청이 둘 다 조회를 통과한 경우. 유니크 인덱스가 중복 저장을 막았으니
+            // 먼저 저장한 쪽 결과를 그대로 돌려준다. 이쪽은 푸시를 보내지 않는다.
+            return findPublished(requestId).orElseThrow(() -> e);
+        }
 
         if (!request.sendPush()) {
             return new LetterCreateResponse(letter.getId(), false, 0);
@@ -133,6 +143,20 @@ public class FeedbackAdminService {
 
         feedback.changeStatus(request.status());
         feedbackRepository.save(feedback);
+    }
+
+    /**
+     * 이미 발행된 편지의 결과. 동시 요청에서 진 쪽은 이긴 쪽이 푸시를 마치기 전에 읽을 수 있어
+     * pushSuccessCount가 0으로 보일 수 있다. 편지가 중복 발행되지 않는 것이 목적이라 그대로 둔다.
+     */
+    private Optional<LetterCreateResponse> findPublished(String requestId) {
+        return letterRepository.findByIdempotencyKey(requestId)
+                .map(letter -> {
+                    log.info("Broadcast letter republish ignored. letter={}, requestId={}",
+                            letter.getId(), requestId);
+                    return new LetterCreateResponse(letter.getId(),
+                            letter.getPushSuccessCount() > 0, letter.getPushSuccessCount());
+                });
     }
 
     /**

--- a/backend/src/main/java/moadong/feedback/service/FeedbackAdminService.java
+++ b/backend/src/main/java/moadong/feedback/service/FeedbackAdminService.java
@@ -93,9 +93,17 @@ public class FeedbackAdminService {
         return new LetterCreateResponse(letter.getId(), successCount > 0, successCount);
     }
 
+    /**
+     * 답장 대기 · 확인 중 사이 전환만 허용한다. REPLIED는 답장 편지와 함께 설정돼야 하므로
+     * 직접 지정할 수도, 이미 답장한 피드백을 되돌릴 수도 없다.
+     */
     public void updateStatus(String feedbackId, FeedbackStatusUpdateRequest request) {
         Feedback feedback = feedbackRepository.findById(feedbackId)
                 .orElseThrow(() -> new RestApiException(ErrorCode.FEEDBACK_NOT_FOUND));
+
+        if (request.status() == FeedbackStatus.REPLIED || feedback.getStatus() == FeedbackStatus.REPLIED) {
+            throw new RestApiException(ErrorCode.FEEDBACK_STATUS_NOT_CHANGEABLE);
+        }
 
         feedback.changeStatus(request.status());
         feedbackRepository.save(feedback);

--- a/backend/src/main/java/moadong/feedback/service/FeedbackAdminService.java
+++ b/backend/src/main/java/moadong/feedback/service/FeedbackAdminService.java
@@ -25,11 +25,12 @@ import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
 import moadong.user.repository.StudentUserRepository;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.StringUtils;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -45,6 +46,7 @@ public class FeedbackAdminService {
     private final StudentUserRepository studentUserRepository;
     private final PushNotificationPort pushNotificationPort;
     private final FcmAdminService fcmAdminService;
+    private final TransactionTemplate transactionTemplate;
 
     public AdminFeedbackListResponse getFeedbacks() {
         List<AdminFeedbackResponse> feedbacks = feedbackRepository.findAllByOrderByCreatedAtDesc().stream()
@@ -56,40 +58,64 @@ public class FeedbackAdminService {
                 feedbackRepository.countByStatusNot(FeedbackStatus.REPLIED));
     }
 
-    @Transactional
+    /**
+     * 편지 저장과 상태 변경만 트랜잭션으로 묶고, 푸시는 커밋된 뒤에 보낸다.
+     * 트랜잭션 안에서 보내면 커밋이 실패했을 때 존재하지 않는 답장의 알림이 나간다.
+     */
     public FeedbackReplyResponse reply(String feedbackId, FeedbackReplyRequest request) {
-        Feedback feedback = feedbackRepository.findById(feedbackId)
-                .orElseThrow(() -> new RestApiException(ErrorCode.FEEDBACK_NOT_FOUND));
+        Letter letter = transactionTemplate.execute(status -> {
+            Feedback feedback = feedbackRepository.findById(feedbackId)
+                    .orElseThrow(() -> new RestApiException(ErrorCode.FEEDBACK_NOT_FOUND));
 
-        if (feedback.getStatus() == FeedbackStatus.REPLIED) {
-            throw new RestApiException(ErrorCode.FEEDBACK_ALREADY_REPLIED);
-        }
+            if (feedback.getStatus() == FeedbackStatus.REPLIED) {
+                throw new RestApiException(ErrorCode.FEEDBACK_ALREADY_REPLIED);
+            }
 
-        Letter letter = letterRepository.save(Letter.reply(
-                feedback.getStudentId(), feedback.getId(), request.title(), request.body()));
+            Letter saved = letterRepository.save(Letter.reply(
+                    feedback.getStudentId(), feedback.getId(), request.title(), request.body()));
 
-        feedback.markReplied(letter.getId());
-        feedbackRepository.save(feedback);
+            feedback.markReplied(saved.getId());
+            feedbackRepository.save(feedback);
+            return saved;
+        });
 
         boolean pushSent = request.sendPush()
-                && sendReplyPush(feedback.getStudentId(), letter);
+                && sendReplyPush(letter.getRecipientStudentId(), letter);
 
         return new FeedbackReplyResponse(letter.getId(), pushSent);
     }
 
+    /**
+     * requestId가 같은 재시도는 편지를 다시 만들지 않고 처음 결과를 그대로 돌려준다.
+     * 재시도로 전체 사용자에게 푸시가 두 번 나가는 것을 막는다.
+     */
     public LetterCreateResponse createBroadcastLetter(LetterCreateRequest request) {
         if (request.category() == LetterCategory.REPLY) {
             throw new RestApiException(ErrorCode.LETTER_CATEGORY_NOT_BROADCASTABLE);
         }
 
-        Letter letter = letterRepository.save(
-                Letter.broadcast(request.category(), request.title(), request.body()));
+        if (StringUtils.hasText(request.requestId())) {
+            Optional<Letter> published = letterRepository.findByIdempotencyKey(request.requestId());
+            if (published.isPresent()) {
+                Letter letter = published.get();
+                log.info("Broadcast letter republish ignored. letter={}, requestId={}",
+                        letter.getId(), request.requestId());
+                return new LetterCreateResponse(letter.getId(), letter.getPushSuccessCount() > 0,
+                        letter.getPushSuccessCount());
+            }
+        }
+
+        Letter letter = letterRepository.save(Letter.broadcast(
+                request.category(), request.title(), request.body(), request.requestId()));
 
         if (!request.sendPush()) {
             return new LetterCreateResponse(letter.getId(), false, 0);
         }
 
         int successCount = sendBroadcastPush(letter);
+        letter.recordPushResult(successCount);
+        letterRepository.save(letter);
+
         return new LetterCreateResponse(letter.getId(), successCount > 0, successCount);
     }
 

--- a/backend/src/main/java/moadong/feedback/service/FeedbackImageService.java
+++ b/backend/src/main/java/moadong/feedback/service/FeedbackImageService.java
@@ -10,7 +10,10 @@ import moadong.global.exception.RestApiException;
 import moadong.global.util.RandomStringUtil;
 import moadong.media.dto.PresignedUploadResponse;
 import moadong.media.dto.UploadUrlRequest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
@@ -40,10 +43,25 @@ public class FeedbackImageService {
     private static final int MAX_IMAGE_COUNT = 4;
     private static final String KEY_ROOT = "feedback/";
 
+    /**
+     * 학생 토큰은 {@code /auth/student}로 누구나 무제한 발급받을 수 있다. 제한이 없으면 피드백을 만들지 않고도
+     * presigned URL만 받아 공개 버킷에 임의 파일을 올릴 수 있어, studentId와 IP 양쪽에 창을 건다.
+     */
+    private static final String RATE_LIMIT_KEY_PREFIX = "feedback:image-upload-url:ratelimit:";
+    private static final long RATE_LIMIT_WINDOW_SECONDS = 600L;
+    private static final long RATE_LIMIT_MAX_REQUESTS = 40L;
+    private static final RedisScript<Long> RATE_LIMIT_SCRIPT = RedisScript.of(
+            "local c = redis.call('INCR', KEYS[1])\n"
+                    + "if c == 1 then redis.call('EXPIRE', KEYS[1], ARGV[1]) end\n"
+                    + "return c",
+            Long.class
+    );
+
     private final S3Client s3Client;
     private final S3Presigner s3Presigner;
     private final AwsProperties awsProperties;
     private final ServerProperties serverProperties;
+    private final StringRedisTemplate stringRedisTemplate;
 
     private String normalizedViewEndpoint;
 
@@ -60,12 +78,14 @@ public class FeedbackImageService {
      * 동아리 활동사진({@code generateFeedUploadUrls})과 같은 부분 성공 응답을 돌려준다.
      * 한 건이 실패해도 나머지는 발급되고, 실패 항목은 success=false로 표시된다.
      */
-    public List<PresignedUploadResponse> createUploadUrls(String studentId, List<UploadUrlRequest> requests) {
+    public List<PresignedUploadResponse> createUploadUrls(String studentId, List<UploadUrlRequest> requests,
+                                                         String clientIp) {
         if (requests == null || requests.isEmpty()) {
             return List.of();
         }
 
         int limit = Math.min(MAX_IMAGE_COUNT, requests.size());
+        validateRateLimit(studentId, clientIp, limit);
         List<PresignedUploadResponse> results = new ArrayList<>(limit + 1);
         for (int i = 0; i < limit; i++) {
             try {
@@ -78,6 +98,27 @@ public class FeedbackImageService {
             results.add(errorResponse(ErrorCode.TOO_MANY_FILES));
         }
         return results;
+    }
+
+    /**
+     * 발급하려는 장수만큼 카운트를 올린다. studentId는 새로 발급받아 우회할 수 있으므로 IP 창을 함께 건다.
+     */
+    private void validateRateLimit(String studentId, String clientIp, int issuedCount) {
+        for (String key : List.of(rateLimitKey("student", studentId), rateLimitKey("ip", clientIp))) {
+            Long count = null;
+            for (int i = 0; i < issuedCount; i++) {
+                count = stringRedisTemplate.execute(RATE_LIMIT_SCRIPT, List.of(key),
+                        String.valueOf(RATE_LIMIT_WINDOW_SECONDS));
+            }
+            if (count != null && count > RATE_LIMIT_MAX_REQUESTS) {
+                log.warn("Feedback image upload-url rate limited. key={}, count={}", key, count);
+                throw new RestApiException(ErrorCode.FEEDBACK_IMAGE_UPLOAD_RATE_LIMITED);
+            }
+        }
+    }
+
+    private String rateLimitKey(String scope, String value) {
+        return RATE_LIMIT_KEY_PREFIX + scope + ":" + (StringUtils.hasText(value) ? value : "unknown");
     }
 
     private PresignedUploadResponse errorResponse(ErrorCode errorCode) {

--- a/backend/src/main/java/moadong/feedback/service/FeedbackImageService.java
+++ b/backend/src/main/java/moadong/feedback/service/FeedbackImageService.java
@@ -56,7 +56,8 @@ public class FeedbackImageService {
      */
     private static final String RATE_LIMIT_KEY_PREFIX = "feedback:image-upload-url:ratelimit:";
     private static final long RATE_LIMIT_WINDOW_SECONDS = 600L;
-    private static final long RATE_LIMIT_MAX_REQUESTS = 40L;
+    /** 편지 한 건에 4장이므로 10분에 5번 작성할 수 있는 여유. 정상 사용은 닿지 않는다. */
+    private static final long RATE_LIMIT_MAX_REQUESTS = 20L;
     private static final RedisScript<Long> RATE_LIMIT_SCRIPT = RedisScript.of(
             "local c = redis.call('INCR', KEYS[1])\n"
                     + "if c == 1 then redis.call('EXPIRE', KEYS[1], ARGV[1]) end\n"

--- a/backend/src/main/java/moadong/feedback/service/FeedbackImageService.java
+++ b/backend/src/main/java/moadong/feedback/service/FeedbackImageService.java
@@ -27,6 +27,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import static moadong.media.util.ClubImageUtil.isImageExtension;
 
@@ -42,6 +43,12 @@ public class FeedbackImageService {
     /** 편지 1건당 첨부 가능한 사진 수. */
     private static final int MAX_IMAGE_COUNT = 4;
     private static final String KEY_ROOT = "feedback/";
+
+    /**
+     * {@code UploadUrlRequest}의 @Pattern은 {@code @Valid List<T>}에서 요소까지 내려가지 않아 동작하지 않는다.
+     * 서명에 들어가는 값이라 서버에서 직접 막는다.
+     */
+    private static final Pattern ALLOWED_CONTENT_TYPE = Pattern.compile("^image/(jpeg|jpg|png|gif|bmp|webp)$");
 
     /**
      * 학생 토큰은 {@code /auth/student}로 누구나 무제한 발급받을 수 있다. 제한이 없으면 피드백을 만들지 않고도
@@ -127,6 +134,11 @@ public class FeedbackImageService {
 
     private PresignedUploadResponse createUploadUrl(String studentId, UploadUrlRequest request) {
         if (!isImageExtension(request.fileName())) {
+            throw new RestApiException(ErrorCode.UNSUPPORTED_FILE_TYPE);
+        }
+        // contentType은 그대로 서명돼 R2가 응답 헤더로 되돌려준다. text/html이 통과하면
+        // 업로드한 파일이 우리 CDN 도메인에서 그대로 실행된다.
+        if (request.contentType() == null || !ALLOWED_CONTENT_TYPE.matcher(request.contentType()).matches()) {
             throw new RestApiException(ErrorCode.UNSUPPORTED_FILE_TYPE);
         }
 

--- a/backend/src/main/java/moadong/feedback/service/FeedbackImageService.java
+++ b/backend/src/main/java/moadong/feedback/service/FeedbackImageService.java
@@ -1,0 +1,182 @@
+package moadong.feedback.service;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import moadong.global.config.properties.AwsProperties;
+import moadong.global.config.properties.ServerProperties;
+import moadong.global.exception.ErrorCode;
+import moadong.global.exception.RestApiException;
+import moadong.global.util.RandomStringUtil;
+import moadong.media.dto.PresignedUploadResponse;
+import moadong.media.dto.UploadUrlRequest;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static moadong.media.util.ClubImageUtil.isImageExtension;
+
+/**
+ * 우체통 첨부 사진 업로드. 동아리 활동사진(`CloudflareImageService`)과 같은 presigned 방식이다.
+ * 클라이언트가 R2로 직접 올린 뒤, 피드백 저장 시점에 서버가 전량을 다시 검증한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FeedbackImageService {
+
+    /** 편지 1건당 첨부 가능한 사진 수. */
+    private static final int MAX_IMAGE_COUNT = 4;
+    private static final String KEY_ROOT = "feedback/";
+
+    private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
+    private final AwsProperties awsProperties;
+    private final ServerProperties serverProperties;
+
+    private String normalizedViewEndpoint;
+
+    @PostConstruct
+    private void init() {
+        String viewEndpoint = awsProperties.s3().viewEndpoint();
+        if (viewEndpoint == null || viewEndpoint.isEmpty()) {
+            throw new IllegalStateException("cloud.aws.s3.view-endpoint must be configured");
+        }
+        normalizedViewEndpoint = viewEndpoint.replaceAll("/+$", "");
+    }
+
+    /**
+     * 동아리 활동사진({@code generateFeedUploadUrls})과 같은 부분 성공 응답을 돌려준다.
+     * 한 건이 실패해도 나머지는 발급되고, 실패 항목은 success=false로 표시된다.
+     */
+    public List<PresignedUploadResponse> createUploadUrls(String studentId, List<UploadUrlRequest> requests) {
+        if (requests == null || requests.isEmpty()) {
+            return List.of();
+        }
+
+        int limit = Math.min(MAX_IMAGE_COUNT, requests.size());
+        List<PresignedUploadResponse> results = new ArrayList<>(limit + 1);
+        for (int i = 0; i < limit; i++) {
+            try {
+                results.add(createUploadUrl(studentId, requests.get(i)));
+            } catch (RestApiException e) {
+                results.add(errorResponse(e.getErrorCode()));
+            }
+        }
+        if (requests.size() > limit) {
+            results.add(errorResponse(ErrorCode.TOO_MANY_FILES));
+        }
+        return results;
+    }
+
+    private PresignedUploadResponse errorResponse(ErrorCode errorCode) {
+        return new PresignedUploadResponse(null, null, null, false, errorCode.getMessage());
+    }
+
+    private PresignedUploadResponse createUploadUrl(String studentId, UploadUrlRequest request) {
+        if (!isImageExtension(request.fileName())) {
+            throw new RestApiException(ErrorCode.UNSUPPORTED_FILE_TYPE);
+        }
+
+        String key = buildKey(studentId, request.fileName());
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(awsProperties.s3().bucket())
+                .key(key)
+                .contentType(request.contentType())
+                .build();
+
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(serverProperties.fileUrl().expirationTime()))
+                .putObjectRequest(putObjectRequest)
+                .build();
+
+        String presignedUrl = s3Presigner.presignPutObject(presignRequest).url().toString();
+        return new PresignedUploadResponse(
+                presignedUrl,
+                normalizedViewEndpoint + "/" + key,
+                Map.of("Content-Type", request.contentType()),
+                true,
+                null);
+    }
+
+    /**
+     * 피드백 저장 직전 최종 검증. 클라이언트가 준 URL을 그대로 믿지 않고
+     * 장수 · 경로 소유자 · 실제 업로드 여부 · 용량을 R2에서 다시 확인한다.
+     */
+    public List<String> validateImages(String studentId, List<String> imageUrls) {
+        if (imageUrls == null || imageUrls.isEmpty()) {
+            return List.of();
+        }
+        if (imageUrls.size() > MAX_IMAGE_COUNT) {
+            throw new RestApiException(ErrorCode.TOO_MANY_FILES);
+        }
+
+        imageUrls.forEach(imageUrl -> validateImage(studentId, imageUrl));
+        return List.copyOf(imageUrls);
+    }
+
+    private void validateImage(String studentId, String imageUrl) {
+        if (imageUrl == null || imageUrl.length() > serverProperties.fileUrl().maxLength()) {
+            throw new RestApiException(ErrorCode.INVALID_FILE_URL);
+        }
+
+        String key = extractKeyOrNull(imageUrl);
+        if (key == null || !key.startsWith(KEY_ROOT + studentId + "/")) {
+            throw new RestApiException(ErrorCode.INVALID_FILE_URL);
+        }
+
+        long contentLength;
+        try {
+            contentLength = s3Client.headObject(HeadObjectRequest.builder()
+                    .bucket(awsProperties.s3().bucket())
+                    .key(key)
+                    .build()).contentLength();
+        } catch (NoSuchKeyException e) {
+            throw new RestApiException(ErrorCode.FILE_NOT_FOUND);
+        } catch (S3Exception e) {
+            throw new RestApiException(ErrorCode.IMAGE_UPLOAD_FAILED);
+        }
+
+        if (contentLength > serverProperties.image().maxSize().toBytes()) {
+            deleteQuietly(key);
+            throw new RestApiException(ErrorCode.FILE_TOO_LARGE);
+        }
+    }
+
+    private void deleteQuietly(String key) {
+        try {
+            s3Client.deleteObject(DeleteObjectRequest.builder()
+                    .bucket(awsProperties.s3().bucket())
+                    .key(key)
+                    .build());
+        } catch (S3Exception e) {
+            log.warn("Failed to delete oversized feedback image from R2: key={}, error={}", key, e.getMessage());
+        }
+    }
+
+    /**
+     * studentId는 학생 토큰의 sub로, {@code StudentJwtService}가 UUID 형식을 검증한 값이라 경로에 그대로 쓸 수 있다.
+     */
+    private String buildKey(String studentId, String fileName) {
+        String extension = fileName.contains(".")
+                ? fileName.substring(fileName.lastIndexOf("."))
+                : "";
+        return KEY_ROOT + studentId + "/" + RandomStringUtil.generateRandomString(10) + extension;
+    }
+
+    private String extractKeyOrNull(String imageUrl) {
+        String prefix = normalizedViewEndpoint + "/";
+        return imageUrl.startsWith(prefix) ? imageUrl.substring(prefix.length()) : null;
+    }
+}

--- a/backend/src/main/java/moadong/feedback/service/FeedbackService.java
+++ b/backend/src/main/java/moadong/feedback/service/FeedbackService.java
@@ -1,0 +1,95 @@
+package moadong.feedback.service;
+
+import lombok.RequiredArgsConstructor;
+import moadong.feedback.entity.Feedback;
+import moadong.feedback.entity.Letter;
+import moadong.feedback.enums.LetterCategory;
+import moadong.feedback.payload.request.FeedbackCreateRequest;
+import moadong.feedback.payload.response.FeedbackCreateResponse;
+import moadong.feedback.payload.response.ReceivedLetterDetailResponse;
+import moadong.feedback.payload.response.ReceivedLetterListResponse;
+import moadong.feedback.payload.response.ReceivedLetterSummaryResponse;
+import moadong.feedback.payload.response.SentFeedbackListResponse;
+import moadong.feedback.payload.response.SentFeedbackResponse;
+import moadong.feedback.repository.FeedbackRepository;
+import moadong.feedback.repository.LetterRepository;
+import moadong.global.exception.ErrorCode;
+import moadong.global.exception.RestApiException;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FeedbackService {
+
+    private final FeedbackRepository feedbackRepository;
+    private final LetterRepository letterRepository;
+    private final FeedbackImageService feedbackImageService;
+
+    public FeedbackCreateResponse createFeedback(String studentId, FeedbackCreateRequest request) {
+        Feedback feedback = feedbackRepository.save(Feedback.builder()
+                .studentId(studentId)
+                .type(request.type())
+                .content(request.content())
+                .images(feedbackImageService.validateImages(studentId, request.images()))
+                .build());
+
+        return new FeedbackCreateResponse(feedback.getId());
+    }
+
+    public ReceivedLetterListResponse getReceivedLetters(String studentId, LetterCategory category) {
+        List<Letter> letters = category == null
+                ? letterRepository.findInboxByStudentId(studentId)
+                : letterRepository.findInboxByStudentIdAndCategory(studentId, category);
+
+        return new ReceivedLetterListResponse(letters.stream()
+                .map(letter -> ReceivedLetterSummaryResponse.from(letter, studentId))
+                .toList());
+    }
+
+    public ReceivedLetterDetailResponse getReceivedLetter(String studentId, String letterId) {
+        Letter letter = getReadableLetter(studentId, letterId);
+        return ReceivedLetterDetailResponse.of(letter, findOriginalFeedback(letter));
+    }
+
+    public SentFeedbackListResponse getSentFeedbacks(String studentId) {
+        return new SentFeedbackListResponse(
+                feedbackRepository.findByStudentIdOrderByCreatedAtDesc(studentId).stream()
+                        .map(SentFeedbackResponse::from)
+                        .toList());
+    }
+
+    public SentFeedbackResponse getSentFeedback(String studentId, String feedbackId) {
+        Feedback feedback = feedbackRepository.findById(feedbackId)
+                .filter(it -> it.getStudentId().equals(studentId))
+                .orElseThrow(() -> new RestApiException(ErrorCode.FEEDBACK_NOT_FOUND));
+
+        return SentFeedbackResponse.from(feedback);
+    }
+
+    public void markLetterRead(String studentId, String letterId) {
+        getReadableLetter(studentId, letterId);
+        letterRepository.markRead(letterId, studentId);
+    }
+
+    /**
+     * 전체 발행 편지는 누구나, REPLY 편지는 수신자만 읽을 수 있다.
+     * 남의 편지인지 없는 편지인지 구분되지 않도록 같은 에러로 응답한다.
+     */
+    private Letter getReadableLetter(String studentId, String letterId) {
+        return letterRepository.findById(letterId)
+                .filter(letter -> letter.isReadableBy(studentId))
+                .orElseThrow(() -> new RestApiException(ErrorCode.LETTER_NOT_FOUND));
+    }
+
+    private SentFeedbackResponse findOriginalFeedback(Letter letter) {
+        if (letter.getCategory() != LetterCategory.REPLY || letter.getFeedbackId() == null) {
+            return null;
+        }
+
+        return feedbackRepository.findById(letter.getFeedbackId())
+                .map(SentFeedbackResponse::from)
+                .orElse(null);
+    }
+}

--- a/backend/src/main/java/moadong/feedback/service/LetterDraftService.java
+++ b/backend/src/main/java/moadong/feedback/service/LetterDraftService.java
@@ -1,0 +1,51 @@
+package moadong.feedback.service;
+
+import lombok.RequiredArgsConstructor;
+import moadong.feedback.entity.LetterDraft;
+import moadong.feedback.payload.request.LetterDraftRequest;
+import moadong.feedback.payload.response.LetterDraftListResponse;
+import moadong.feedback.payload.response.LetterDraftResponse;
+import moadong.feedback.repository.LetterDraftRepository;
+import moadong.global.exception.ErrorCode;
+import moadong.global.exception.RestApiException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LetterDraftService {
+
+    private final LetterDraftRepository letterDraftRepository;
+
+    public LetterDraftResponse createDraft(LetterDraftRequest request) {
+        LetterDraft draft = letterDraftRepository.save(LetterDraft.builder()
+                .category(request.category())
+                .title(request.title())
+                .body(request.body())
+                .sendPush(request.sendPush())
+                .build());
+
+        return LetterDraftResponse.from(draft);
+    }
+
+    public LetterDraftListResponse getDrafts() {
+        return new LetterDraftListResponse(
+                letterDraftRepository.findAllByOrderByUpdatedAtDesc().stream()
+                        .map(LetterDraftResponse::from)
+                        .toList());
+    }
+
+    public LetterDraftResponse updateDraft(String draftId, LetterDraftRequest request) {
+        LetterDraft draft = letterDraftRepository.findById(draftId)
+                .orElseThrow(() -> new RestApiException(ErrorCode.LETTER_DRAFT_NOT_FOUND));
+
+        draft.update(request.category(), request.title(), request.body(), request.sendPush());
+        return LetterDraftResponse.from(letterDraftRepository.save(draft));
+    }
+
+    public void deleteDraft(String draftId) {
+        if (!letterDraftRepository.existsById(draftId)) {
+            throw new RestApiException(ErrorCode.LETTER_DRAFT_NOT_FOUND);
+        }
+        letterDraftRepository.deleteById(draftId);
+    }
+}

--- a/backend/src/main/java/moadong/feedback/service/LetterImageUploadService.java
+++ b/backend/src/main/java/moadong/feedback/service/LetterImageUploadService.java
@@ -1,0 +1,50 @@
+package moadong.feedback.service;
+
+import lombok.RequiredArgsConstructor;
+import moadong.feedback.payload.response.LetterImageUploadResponse;
+import moadong.global.config.properties.AwsProperties;
+import moadong.media.service.R2ImageUploadService;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+/**
+ * 편지 본문에 넣을 이미지 업로드. 운영자(ROLE_DEVELOPER)만 호출하므로
+ * 홍보 게시판 · 배너와 같은 멀티파트 방식이다. 업로드 후 받은 URL을 본문에 마크다운으로 삽입한다.
+ * <p>
+ * 사용자가 피드백에 첨부하는 사진({@link FeedbackImageService})과는 인증 주체가 달라 별개의 경로다.
+ */
+@Service
+@RequiredArgsConstructor
+public class LetterImageUploadService {
+
+    private final R2ImageUploadService r2ImageUploadService;
+    private final AwsProperties awsProperties;
+
+    public LetterImageUploadResponse upload(MultipartFile file) {
+        String imageUrl = r2ImageUploadService.upload(
+                file,
+                awsProperties.s3().bucket(),
+                awsProperties.s3().viewEndpoint(),
+                buildKey(file));
+        return new LetterImageUploadResponse(imageUrl);
+    }
+
+    private String buildKey(MultipartFile file) {
+        LocalDate today = LocalDate.now(ZoneOffset.UTC);
+        String originalFilename = (file != null) ? file.getOriginalFilename() : null;
+        String filename = StringUtils.cleanPath(originalFilename == null ? "" : originalFilename);
+        return "feedback/letters/" + today.getYear()
+                + "/" + String.format("%02d", today.getMonthValue())
+                + "/" + UUID.randomUUID() + "-" + sanitizeFilename(StringUtils.getFilename(filename));
+    }
+
+    private String sanitizeFilename(String filename) {
+        String safeName = StringUtils.hasText(filename) ? filename : "image";
+        return safeName.replaceAll("[^A-Za-z0-9._-]", "_");
+    }
+}

--- a/backend/src/main/java/moadong/global/exception/ErrorCode.java
+++ b/backend/src/main/java/moadong/global/exception/ErrorCode.java
@@ -96,6 +96,7 @@ public enum ErrorCode {
     LETTER_CATEGORY_NOT_BROADCASTABLE(HttpStatus.BAD_REQUEST, "904-4", "전체 발행은 UPDATE 또는 STORY 편지만 가능합니다."),
     LETTER_DRAFT_NOT_FOUND(HttpStatus.NOT_FOUND, "904-5", "편지 초안이 존재하지 않습니다."),
     FEEDBACK_STATUS_NOT_CHANGEABLE(HttpStatus.BAD_REQUEST, "904-6", "답장 완료 상태는 답장 발행으로만 설정되며 되돌릴 수 없습니다."),
+    FEEDBACK_IMAGE_UPLOAD_RATE_LIMITED(HttpStatus.TOO_MANY_REQUESTS, "904-7", "사진 업로드 요청이 너무 많습니다. 잠시 후 다시 시도해주세요."),
 
     // 950xx: Notion 연동 오류
     NOTION_CONFIG_MISSING(HttpStatus.INTERNAL_SERVER_ERROR, "950-1", "Notion 서버 환경변수가 설정되지 않았습니다."),

--- a/backend/src/main/java/moadong/global/exception/ErrorCode.java
+++ b/backend/src/main/java/moadong/global/exception/ErrorCode.java
@@ -89,6 +89,13 @@ public enum ErrorCode {
     STATISTICS_EVENT_INVALID(HttpStatus.BAD_REQUEST, "903-4", "통계 이벤트 요청이 올바르지 않습니다."),
     STATISTICS_EVENT_RATE_LIMITED(HttpStatus.TOO_MANY_REQUESTS, "903-5", "통계 이벤트 요청이 너무 많습니다."),
 
+    // 904xx: 우체통(피드백) 오류
+    FEEDBACK_NOT_FOUND(HttpStatus.NOT_FOUND, "904-1", "피드백이 존재하지 않습니다."),
+    LETTER_NOT_FOUND(HttpStatus.NOT_FOUND, "904-2", "편지가 존재하지 않습니다."),
+    FEEDBACK_ALREADY_REPLIED(HttpStatus.CONFLICT, "904-3", "이미 답장이 발행된 피드백입니다."),
+    LETTER_CATEGORY_NOT_BROADCASTABLE(HttpStatus.BAD_REQUEST, "904-4", "전체 발행은 UPDATE 또는 STORY 편지만 가능합니다."),
+    LETTER_DRAFT_NOT_FOUND(HttpStatus.NOT_FOUND, "904-5", "편지 초안이 존재하지 않습니다."),
+
     // 950xx: Notion 연동 오류
     NOTION_CONFIG_MISSING(HttpStatus.INTERNAL_SERVER_ERROR, "950-1", "Notion 서버 환경변수가 설정되지 않았습니다."),
     NOTION_TOKEN_EXCHANGE_FAILED(HttpStatus.BAD_REQUEST, "950-2", "Notion 토큰 교환에 실패했습니다."),

--- a/backend/src/main/java/moadong/global/exception/ErrorCode.java
+++ b/backend/src/main/java/moadong/global/exception/ErrorCode.java
@@ -95,6 +95,7 @@ public enum ErrorCode {
     FEEDBACK_ALREADY_REPLIED(HttpStatus.CONFLICT, "904-3", "이미 답장이 발행된 피드백입니다."),
     LETTER_CATEGORY_NOT_BROADCASTABLE(HttpStatus.BAD_REQUEST, "904-4", "전체 발행은 UPDATE 또는 STORY 편지만 가능합니다."),
     LETTER_DRAFT_NOT_FOUND(HttpStatus.NOT_FOUND, "904-5", "편지 초안이 존재하지 않습니다."),
+    FEEDBACK_STATUS_NOT_CHANGEABLE(HttpStatus.BAD_REQUEST, "904-6", "답장 완료 상태는 답장 발행으로만 설정되며 되돌릴 수 없습니다."),
 
     // 950xx: Notion 연동 오류
     NOTION_CONFIG_MISSING(HttpStatus.INTERNAL_SERVER_ERROR, "950-1", "Notion 서버 환경변수가 설정되지 않았습니다."),

--- a/backend/src/main/resources/static/dev/index.html
+++ b/backend/src/main/resources/static/dev/index.html
@@ -836,6 +836,8 @@
     let feedbackDrafts = [];
     let feedbackCurrentDraftId = '';
     let feedbackIsUploading = false;
+    // 발행이 실패해 다시 시도할 때 같은 값을 보내야 편지가 두 번 만들어지지 않는다.
+    let feedbackLetterRequestId = '';
     let fcmTokens = [];
     let fcmFilteredTokens = [];
     let fcmCurrentPage = 1;
@@ -3392,6 +3394,13 @@
       return feedbacks.find((feedback) => feedback.id === feedbackSelectedId) || null;
     }
 
+    function generateFeedbackRequestId() {
+      if (window.crypto && typeof window.crypto.randomUUID === 'function') {
+        return window.crypto.randomUUID();
+      }
+      return 'letter-' + Math.random().toString(36).slice(2) + '-' + performance.now().toString(36);
+    }
+
     function renderFeedbackQuoteImages(images) {
       const wrap = document.getElementById('feedbackQuoteImages');
       wrap.innerHTML = '';
@@ -3420,6 +3429,7 @@
       feedbackMode = 'letter';
       feedbackSelectedId = '';
       feedbackCurrentDraftId = '';
+      feedbackLetterRequestId = '';
       // 초안을 불러온 뒤 새 편지로 넘어오면 이전 분류·푸시 설정이 남는다.
       document.getElementById('feedbackLetterCategory').value = 'UPDATE';
       document.getElementById('feedbackSendPush').checked = false;
@@ -3639,8 +3649,17 @@
         ? API_BASE + '/api/admin/feedback/letters'
         : API_BASE + '/api/admin/feedback/' + encodeURIComponent(feedbackSelectedId) + '/reply';
       const sendPush = document.getElementById('feedbackSendPush').checked;
+      if (isLetterMode && !feedbackLetterRequestId) {
+        feedbackLetterRequestId = generateFeedbackRequestId();
+      }
       const payload = isLetterMode
-        ? { category: document.getElementById('feedbackLetterCategory').value, title, body, sendPush }
+        ? {
+            category: document.getElementById('feedbackLetterCategory').value,
+            title,
+            body,
+            sendPush,
+            requestId: feedbackLetterRequestId
+          }
         : { title, body, sendPush };
 
       feedbackIsPublishing = true;
@@ -3665,6 +3684,7 @@
         document.getElementById('feedbackReplyBody').value = '';
         feedbackSelectedId = '';
         feedbackCurrentDraftId = '';
+        feedbackLetterRequestId = '';
         feedbackMode = 'reply';
         await reloadFeedbackList();
       } catch (e) {

--- a/backend/src/main/resources/static/dev/index.html
+++ b/backend/src/main/resources/static/dev/index.html
@@ -157,9 +157,11 @@
     .feedback-layout { display: grid; grid-template-columns: minmax(0, 1fr) 370px; gap: 16px; align-items: start; }
     @media (max-width: 1100px) { .feedback-layout { grid-template-columns: 1fr; } }
     .feedback-quote { margin: 0 0 12px; padding: 12px; border: 1px solid #e5e7eb; border-radius: 8px; background: #f9fafb; font-size: 0.9rem; white-space: pre-wrap; }
-    .feedback-checkbox { display: flex; justify-content: flex-start; align-items: center; gap: 8px; margin: 12px 0; font-size: 0.9rem; text-align: left; }
-    .feedback-checkbox input { margin: 0; flex: none; }
-    .feedback-content-cell { max-width: 320px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    /* flex 대신 일반 인라인 흐름을 쓴다. 폭이 좁아져도 글자 단위로 세로로 쪼개지지 않는다. */
+    .feedback-checkbox { display: block; margin: 12px 0; font-size: 0.9rem; }
+    .feedback-checkbox input { margin: 0 8px 0 0; vertical-align: middle; }
+    .feedback-checkbox span { vertical-align: middle; }
+    .feedback-content-cell { max-width: 220px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     /* 유형 · 받은 날짜 · 상태는 짧은 한국어라 폭이 좁아지면 글자 단위로 쪼개진다. */
     #feedbackList th:nth-child(1), #feedbackList td:nth-child(1),
     #feedbackList th:nth-child(4), #feedbackList td:nth-child(4),

--- a/backend/src/main/resources/static/dev/index.html
+++ b/backend/src/main/resources/static/dev/index.html
@@ -157,9 +157,10 @@
     .feedback-layout { display: grid; grid-template-columns: minmax(0, 1fr) 370px; gap: 16px; align-items: start; }
     @media (max-width: 1100px) { .feedback-layout { grid-template-columns: 1fr; } }
     .feedback-quote { margin: 0 0 12px; padding: 12px; border: 1px solid #e5e7eb; border-radius: 8px; background: #f9fafb; font-size: 0.9rem; white-space: pre-wrap; }
-    /* flex 대신 일반 인라인 흐름을 쓴다. 폭이 좁아져도 글자 단위로 세로로 쪼개지지 않는다. */
+    /* 전역 `input` 규칙이 width:100% · display:block을 걸어 체크박스가 한 줄을 통째로 차지한다.
+       포털의 유일한 체크박스라 여기서만 되돌린다. */
     .feedback-checkbox { display: block; margin: 12px 0; font-size: 0.9rem; }
-    .feedback-checkbox input { margin: 0 8px 0 0; vertical-align: middle; }
+    .feedback-checkbox input { width: auto; max-width: none; display: inline-block; margin: 0 8px 0 0; padding: 0; vertical-align: middle; }
     .feedback-checkbox span { vertical-align: middle; }
     .feedback-content-cell { max-width: 220px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     /* 유형 · 받은 날짜 · 상태는 짧은 한국어라 폭이 좁아지면 글자 단위로 쪼개진다. */

--- a/backend/src/main/resources/static/dev/index.html
+++ b/backend/src/main/resources/static/dev/index.html
@@ -3420,6 +3420,9 @@
       feedbackMode = 'letter';
       feedbackSelectedId = '';
       feedbackCurrentDraftId = '';
+      // 초안을 불러온 뒤 새 편지로 넘어오면 이전 분류·푸시 설정이 남는다.
+      document.getElementById('feedbackLetterCategory').value = 'UPDATE';
+      document.getElementById('feedbackSendPush').checked = false;
       document.getElementById('feedbackReplyTitle').value = '';
       document.getElementById('feedbackReplyBody').value = '';
       document.getElementById('feedbackSaveResult').classList.add('hidden');
@@ -3431,6 +3434,7 @@
       feedbackMode = 'reply';
       feedbackSelectedId = '';
       feedbackCurrentDraftId = '';
+      document.getElementById('feedbackSendPush').checked = false;
       document.getElementById('feedbackReplyTitle').value = '';
       document.getElementById('feedbackReplyBody').value = '';
       document.getElementById('feedbackSaveResult').classList.add('hidden');

--- a/backend/src/main/resources/static/dev/index.html
+++ b/backend/src/main/resources/static/dev/index.html
@@ -575,7 +575,9 @@
             <span class="feedback-upload-help">업로드하면 본문 끝에 <code>![]( )</code> 로 삽입됩니다. 최대 10MB</span>
           </div>
           <label class="feedback-checkbox" id="feedbackSendPushRow">
-            <input type="checkbox" id="feedbackSendPush" checked>
+            <!-- 웹뷰 토큰 주입 전에는 답장 푸시 대상을 찾을 수 없어 기본 해제한다.
+                 전체 편지 발행은 studentId 매칭이 없어 지금도 발송되므로 그때 켜서 쓴다. -->
+            <input type="checkbox" id="feedbackSendPush">
             <span id="feedbackSendPushLabel">발행하면 이 유저에게 푸시 알림 보내기</span>
           </label>
           <div class="promotion-actions">

--- a/backend/src/main/resources/static/dev/index.html
+++ b/backend/src/main/resources/static/dev/index.html
@@ -153,6 +153,22 @@
     .promotion-actions button { margin: 0; }
     .promotion-help { margin-top: 8px; color: #666; font-size: 0.85rem; }
     .promotion-id { font-family: monospace; font-size: 0.85rem; color: #666; }
+    .nav-badge { display: inline-block; min-width: 18px; padding: 0 6px; margin-left: 6px; border-radius: 9px; background: #dc2626; color: #fff; font-size: 0.75rem; line-height: 18px; text-align: center; }
+    .feedback-layout { display: grid; grid-template-columns: minmax(0, 1fr) 370px; gap: 16px; align-items: start; }
+    @media (max-width: 1100px) { .feedback-layout { grid-template-columns: 1fr; } }
+    .feedback-quote { margin: 0 0 12px; padding: 12px; border: 1px solid #e5e7eb; border-radius: 8px; background: #f9fafb; font-size: 0.9rem; white-space: pre-wrap; }
+    .feedback-checkbox { display: flex; align-items: center; gap: 8px; margin: 12px 0; font-size: 0.9rem; }
+    .feedback-checkbox input { margin: 0; }
+    .feedback-content-cell { max-width: 320px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .feedback-quote-images { display: flex; flex-wrap: wrap; gap: 8px; margin: 0 0 12px; }
+    .feedback-quote-images a { line-height: 0; }
+    .feedback-quote-images img { width: 72px; height: 72px; object-fit: cover; border-radius: 6px; border: 1px solid #e5e7eb; }
+    .feedback-draft-row { display: flex; gap: 8px; align-items: center; margin-bottom: 12px; }
+    .feedback-draft-row select { flex: 1; min-width: 0; }
+    .feedback-draft-row button { margin: 0; }
+    .feedback-upload-row { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 12px; }
+    .feedback-upload-row button { margin: 0; }
+    .feedback-upload-help { color: #666; font-size: 0.8rem; }
     .promotion-upload-row { display: flex; align-items: end; gap: 12px; flex-wrap: wrap; margin-bottom: 12px; }
     .promotion-upload-row .form-row { flex: 1 1 240px; margin-bottom: 0; }
     .promotion-upload-row button { margin: 0; }
@@ -253,6 +269,7 @@
         <a href="#club">동아리 관리</a>
         <a href="#dict">단어사전</a>
         <a href="#promotion">홍보 게시판</a>
+        <a href="#feedback">받은 피드백 <span id="feedbackNavBadge" class="nav-badge hidden"></span></a>
         <a href="#banner">배너 이미지</a>
         <a href="#fcm">FCM 알림</a>
         <a href="#statistics-backfill">통계 Backfill</a>
@@ -496,6 +513,74 @@
       </div>
     </section>
 
+    <section id="feedback" class="hidden">
+      <div class="section-head">
+        <h2>받은 피드백</h2>
+        <div class="section-head-actions">
+          <button type="button" id="btnLoadFeedback">목록 새로고침</button>
+          <button type="button" id="btnNewFeedbackLetter">+ 새 편지 발행</button>
+        </div>
+      </div>
+      <div id="feedbackBanner" class="banner hidden"></div>
+      <div class="feedback-layout">
+        <div class="promotion-panel">
+          <h3>피드백 목록</h3>
+          <p id="feedbackSummary" class="promotion-summary">피드백 목록을 불러오세요.</p>
+          <div id="feedbackListLoading" class="hidden">목록 불러오는 중...</div>
+          <div class="table-wrap">
+            <table id="feedbackList">
+              <thead><tr><th>유형</th><th>내용</th><th>보낸 사람</th><th>받은 날짜</th><th>상태</th></tr></thead>
+              <tbody>
+                <tr><td colspan="5">피드백 목록을 불러오세요.</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div class="promotion-panel">
+          <h3 id="feedbackEditorTitle">답장 작성</h3>
+          <p id="feedbackSelectionSummary" class="promotion-summary">왼쪽 목록에서 답장할 피드백을 선택하세요.</p>
+          <div id="feedbackQuote" class="feedback-quote hidden"></div>
+          <div id="feedbackQuoteImages" class="feedback-quote-images hidden"></div>
+          <div class="feedback-draft-row hidden" id="feedbackDraftRow">
+            <select id="feedbackDraftSelect"></select>
+            <button type="button" id="btnLoadFeedbackDraft">불러오기</button>
+            <button type="button" id="btnDeleteFeedbackDraft">삭제</button>
+          </div>
+          <div class="form-row hidden" id="feedbackLetterCategoryRow">
+            <label for="feedbackLetterCategory">편지 분류</label>
+            <select id="feedbackLetterCategory">
+              <option value="UPDATE">업데이트</option>
+              <option value="STORY">이야기</option>
+            </select>
+          </div>
+          <div class="form-row">
+            <label for="feedbackReplyTitle">제목</label>
+            <input type="text" id="feedbackReplyTitle" placeholder="답장 제목">
+          </div>
+          <div class="form-row">
+            <label for="feedbackReplyBody">본문 (마크다운)</label>
+            <textarea id="feedbackReplyBody" rows="10" placeholder="답장 본문" style="max-width:100%;"></textarea>
+          </div>
+          <div class="feedback-upload-row" id="feedbackImageUploadRow">
+            <input type="file" id="feedbackImageFile" accept="image/jpeg,image/png,image/gif,image/bmp,image/webp" class="hidden">
+            <button type="button" id="btnUploadFeedbackImage">이미지 업로드</button>
+            <span class="feedback-upload-help">업로드하면 본문 끝에 <code>![]( )</code> 로 삽입됩니다. 최대 10MB</span>
+          </div>
+          <label class="feedback-checkbox" id="feedbackSendPushRow">
+            <input type="checkbox" id="feedbackSendPush" checked>
+            <span id="feedbackSendPushLabel">발행하면 이 유저에게 푸시 알림 보내기</span>
+          </label>
+          <div class="promotion-actions">
+            <button type="button" id="btnPublishFeedbackReply">답장 발행</button>
+            <button type="button" id="btnSaveFeedbackDraft" class="hidden">임시저장</button>
+            <button type="button" id="btnClearFeedbackSelection">선택 해제</button>
+          </div>
+          <div id="feedbackSaveResult" class="message-box hidden"></div>
+        </div>
+      </div>
+    </section>
+
     <section id="banner" class="hidden">
       <div class="section-head">
         <h2>배너 이미지 관리</h2>
@@ -730,7 +815,18 @@
     const DEFAULT_PROMOTION_MAP_CENTER = Object.freeze({ latitude: 35.2338, longitude: 129.0826 });
     const DEFAULT_PROMOTION_MAP_ZOOM = 4;
     const PROMOTION_FORM_IDS = ['promotionClubId', 'promotionTitle', 'promotionLocation', 'promotionEventStartDate', 'promotionEventEndDate', 'promotionDescription', 'promotionImages'];
-    const PORTAL_SECTION_IDS = ['api-docs', 'club', 'dict', 'promotion', 'banner', 'fcm', 'statistics-backfill', 'conversion-batch'];
+    const PORTAL_SECTION_IDS = ['api-docs', 'club', 'dict', 'promotion', 'feedback', 'banner', 'fcm', 'statistics-backfill', 'conversion-batch'];
+    const FEEDBACK_TYPE_LABELS = { BUG: '문제 신고', FEATURE: '기능 요청', QUESTION: '문의', CHEER: '응원' };
+    const FEEDBACK_STATUS_LABELS = { WAITING: '답장 대기', IN_PROGRESS: '확인 중', REPLIED: '답장 완료' };
+    let feedbacks = [];
+    let feedbackSelectedId = '';
+    let feedbackMode = 'reply';
+    let feedbackHasLoaded = false;
+    let feedbackIsLoading = false;
+    let feedbackIsPublishing = false;
+    let feedbackDrafts = [];
+    let feedbackCurrentDraftId = '';
+    let feedbackIsUploading = false;
     let fcmTokens = [];
     let fcmFilteredTokens = [];
     let fcmCurrentPage = 1;
@@ -794,6 +890,7 @@
       if (sectionId === 'club') loadClubsIfVisible();
       if (sectionId === 'dict') loadDictIfVisible();
       if (sectionId === 'promotion') loadPromotionIfVisible();
+      if (sectionId === 'feedback') loadFeedbackIfVisible();
       if (sectionId === 'banner') loadBannerIfVisible();
       if (sectionId === 'fcm') loadFcmTokensIfVisible();
     }
@@ -833,6 +930,7 @@
       document.getElementById('club').classList.toggle('hidden', true);
       document.getElementById('dict').classList.toggle('hidden', true);
       document.getElementById('promotion').classList.toggle('hidden', true);
+      document.getElementById('feedback').classList.toggle('hidden', true);
       document.getElementById('banner').classList.toggle('hidden', true);
       document.getElementById('fcm').classList.toggle('hidden', true);
       document.getElementById('statistics-backfill').classList.toggle('hidden', true);
@@ -3175,6 +3273,427 @@
 
     clearBannerState();
     if (getToken()) loadBannerIfVisible();
+
+    function clearFeedbackBanner() {
+      const banner = document.getElementById('feedbackBanner');
+      banner.textContent = '';
+      banner.className = 'banner hidden';
+    }
+
+    function setFeedbackBanner(message, type) {
+      const banner = document.getElementById('feedbackBanner');
+      banner.textContent = message;
+      banner.className = 'banner ' + (type || 'warn');
+      banner.classList.remove('hidden');
+    }
+
+    function formatFeedbackDate(value) {
+      if (!value) return '-';
+      const date = new Date(value);
+      if (Number.isNaN(date.getTime())) return '-';
+      return (date.getMonth() + 1) + '월 ' + date.getDate() + '일';
+    }
+
+    function loadFeedbackIfVisible() {
+      if (feedbackHasLoaded || feedbackIsLoading) return;
+      reloadFeedbackList();
+    }
+
+    function updateFeedbackNavBadge(count) {
+      const badge = document.getElementById('feedbackNavBadge');
+      badge.textContent = String(count);
+      badge.classList.toggle('hidden', !count);
+    }
+
+    async function reloadFeedbackList() {
+      if (feedbackIsLoading) return;
+      feedbackIsLoading = true;
+      document.getElementById('feedbackListLoading').classList.remove('hidden');
+      updateFeedbackEditorState();
+      try {
+        const res = await fetch(API_BASE + '/api/admin/feedback', { headers: headers() });
+        const data = await readJsonOrEmpty(res);
+        if (!res.ok) {
+          setFeedbackBanner(data.message || '피드백 목록 조회 실패 (HTTP ' + res.status + ')', res.status === 403 ? 'warn' : 'error');
+          feedbacks = [];
+          updateFeedbackNavBadge(0);
+        } else {
+          clearFeedbackBanner();
+          feedbacks = data.data?.feedbacks || [];
+          updateFeedbackNavBadge(data.data?.unansweredCount || 0);
+        }
+        feedbackHasLoaded = true;
+      } catch (e) {
+        setFeedbackBanner(e.message || '피드백 목록 조회 실패', 'error');
+        feedbacks = [];
+      } finally {
+        feedbackIsLoading = false;
+        document.getElementById('feedbackListLoading').classList.add('hidden');
+        renderFeedbackList();
+      }
+    }
+
+    function renderFeedbackList() {
+      const tbody = document.querySelector('#feedbackList tbody');
+      const summary = document.getElementById('feedbackSummary');
+      tbody.innerHTML = '';
+      if (!feedbacks.length) {
+        const tr = document.createElement('tr');
+        const td = document.createElement('td');
+        td.colSpan = 5;
+        td.textContent = feedbackHasLoaded ? '받은 피드백이 없습니다.' : '피드백 목록을 불러오세요.';
+        tr.appendChild(td);
+        tbody.appendChild(tr);
+        summary.textContent = feedbackHasLoaded ? '총 0개 피드백' : '피드백 목록을 불러오세요.';
+        updateFeedbackEditorState();
+        return;
+      }
+
+      summary.textContent = '총 ' + feedbacks.length + '개 피드백';
+      feedbacks.forEach((feedback) => {
+        const tr = document.createElement('tr');
+        tr.tabIndex = 0;
+        tr.setAttribute('role', 'button');
+        tr.setAttribute('aria-label', (FEEDBACK_TYPE_LABELS[feedback.type] || feedback.type) + ' 피드백 답장 선택');
+        const isSelected = feedback.id === feedbackSelectedId;
+        tr.classList.toggle('is-selected', isSelected);
+        tr.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+        tr.appendChild(document.createElement('td')).textContent = FEEDBACK_TYPE_LABELS[feedback.type] || feedback.type || '-';
+        const contentCell = tr.appendChild(document.createElement('td'));
+        contentCell.className = 'feedback-content-cell';
+        contentCell.textContent = feedback.content || '';
+        contentCell.title = feedback.content || '';
+        tr.appendChild(document.createElement('td')).textContent = feedback.sender || '-';
+        tr.appendChild(document.createElement('td')).textContent = formatFeedbackDate(feedback.createdAt);
+        tr.appendChild(document.createElement('td')).textContent = FEEDBACK_STATUS_LABELS[feedback.status] || feedback.status || '-';
+        const selectCurrentFeedback = () => selectFeedback(feedback.id);
+        tr.onclick = selectCurrentFeedback;
+        tr.onkeydown = (event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            selectCurrentFeedback();
+          }
+        };
+        tbody.appendChild(tr);
+      });
+      updateFeedbackEditorState();
+    }
+
+    function getSelectedFeedback() {
+      return feedbacks.find((feedback) => feedback.id === feedbackSelectedId) || null;
+    }
+
+    function renderFeedbackQuoteImages(images) {
+      const wrap = document.getElementById('feedbackQuoteImages');
+      wrap.innerHTML = '';
+      wrap.classList.toggle('hidden', !images.length);
+      images.forEach((imageUrl, index) => {
+        const link = document.createElement('a');
+        link.href = imageUrl;
+        link.target = '_blank';
+        link.rel = 'noopener';
+        const img = document.createElement('img');
+        img.src = imageUrl;
+        img.alt = '첨부 사진 ' + (index + 1);
+        link.appendChild(img);
+        wrap.appendChild(link);
+      });
+    }
+
+    function selectFeedback(feedbackId) {
+      feedbackMode = 'reply';
+      feedbackSelectedId = feedbackId;
+      document.getElementById('feedbackSaveResult').classList.add('hidden');
+      renderFeedbackList();
+    }
+
+    function enterFeedbackLetterMode() {
+      feedbackMode = 'letter';
+      feedbackSelectedId = '';
+      feedbackCurrentDraftId = '';
+      document.getElementById('feedbackReplyTitle').value = '';
+      document.getElementById('feedbackReplyBody').value = '';
+      document.getElementById('feedbackSaveResult').classList.add('hidden');
+      renderFeedbackList();
+      reloadFeedbackDrafts();
+    }
+
+    function clearFeedbackSelection() {
+      feedbackMode = 'reply';
+      feedbackSelectedId = '';
+      feedbackCurrentDraftId = '';
+      document.getElementById('feedbackReplyTitle').value = '';
+      document.getElementById('feedbackReplyBody').value = '';
+      document.getElementById('feedbackSaveResult').classList.add('hidden');
+      renderFeedbackList();
+    }
+
+    async function reloadFeedbackDrafts() {
+      try {
+        const res = await fetch(API_BASE + '/api/admin/feedback/letters/drafts', { headers: headers() });
+        const data = await readJsonOrEmpty(res);
+        feedbackDrafts = res.ok ? (data.data?.drafts || []) : [];
+      } catch (e) {
+        feedbackDrafts = [];
+      }
+      renderFeedbackDraftOptions();
+    }
+
+    function renderFeedbackDraftOptions() {
+      const select = document.getElementById('feedbackDraftSelect');
+      select.innerHTML = '';
+      if (!feedbackDrafts.length) {
+        const option = document.createElement('option');
+        option.value = '';
+        option.textContent = '임시저장한 편지 없음';
+        select.appendChild(option);
+      } else {
+        feedbackDrafts.forEach((draft) => {
+          const option = document.createElement('option');
+          option.value = draft.id;
+          option.textContent = (draft.title || '(제목 없음)') + ' · ' + formatFeedbackDate(draft.updatedAt);
+          select.appendChild(option);
+        });
+      }
+      if (feedbackCurrentDraftId) {
+        select.value = feedbackCurrentDraftId;
+      }
+      updateFeedbackEditorState();
+    }
+
+    function loadSelectedFeedbackDraft() {
+      const draftId = document.getElementById('feedbackDraftSelect').value;
+      const draft = feedbackDrafts.find((it) => it.id === draftId);
+      if (!draft) return;
+
+      feedbackCurrentDraftId = draft.id;
+      document.getElementById('feedbackLetterCategory').value = draft.category || 'UPDATE';
+      document.getElementById('feedbackReplyTitle').value = draft.title || '';
+      document.getElementById('feedbackReplyBody').value = draft.body || '';
+      document.getElementById('feedbackSendPush').checked = !!draft.sendPush;
+      setMessageBox('feedbackSaveResult', true, '임시저장한 편지를 불러왔습니다.');
+      updateFeedbackEditorState();
+    }
+
+    async function saveFeedbackDraft() {
+      const payload = {
+        category: document.getElementById('feedbackLetterCategory').value,
+        title: document.getElementById('feedbackReplyTitle').value,
+        body: document.getElementById('feedbackReplyBody').value,
+        sendPush: document.getElementById('feedbackSendPush').checked
+      };
+      const isUpdate = !!feedbackCurrentDraftId;
+      const url = API_BASE + '/api/admin/feedback/letters/drafts'
+        + (isUpdate ? '/' + encodeURIComponent(feedbackCurrentDraftId) : '');
+
+      try {
+        const res = await fetch(url, {
+          method: isUpdate ? 'PUT' : 'POST',
+          headers: headers(),
+          body: JSON.stringify(payload)
+        });
+        const data = await readJsonOrEmpty(res);
+        if (!res.ok) {
+          setMessageBox('feedbackSaveResult', false, data.message || '임시저장 실패 (HTTP ' + res.status + ')');
+          return;
+        }
+        feedbackCurrentDraftId = data.data?.id || feedbackCurrentDraftId;
+        setMessageBox('feedbackSaveResult', true, getApiSuccessMessage(data, '임시저장되었습니다.'));
+        await reloadFeedbackDrafts();
+      } catch (e) {
+        setMessageBox('feedbackSaveResult', false, e.message || '임시저장 실패');
+      }
+    }
+
+    async function deleteSelectedFeedbackDraft() {
+      const draftId = document.getElementById('feedbackDraftSelect').value;
+      if (!draftId) return;
+
+      try {
+        const res = await fetch(API_BASE + '/api/admin/feedback/letters/drafts/' + encodeURIComponent(draftId), {
+          method: 'DELETE',
+          headers: headers()
+        });
+        const data = await readJsonOrEmpty(res);
+        if (!res.ok) {
+          setMessageBox('feedbackSaveResult', false, data.message || '초안 삭제 실패 (HTTP ' + res.status + ')');
+          return;
+        }
+        if (feedbackCurrentDraftId === draftId) {
+          feedbackCurrentDraftId = '';
+        }
+        setMessageBox('feedbackSaveResult', true, getApiSuccessMessage(data, '초안이 삭제되었습니다.'));
+        await reloadFeedbackDrafts();
+      } catch (e) {
+        setMessageBox('feedbackSaveResult', false, e.message || '초안 삭제 실패');
+      }
+    }
+
+    async function uploadFeedbackLetterImage(file) {
+      feedbackIsUploading = true;
+      updateFeedbackEditorState();
+      try {
+        const formData = new FormData();
+        formData.append('file', file);
+        const res = await fetch(API_BASE + '/api/admin/feedback/letters/images', {
+          method: 'POST',
+          headers: buildBannerUploadHeaders(),
+          body: formData
+        });
+        const data = await readJsonOrEmpty(res);
+        if (!res.ok) {
+          setMessageBox('feedbackSaveResult', false, data.message || '이미지 업로드 실패 (HTTP ' + res.status + ')');
+          return;
+        }
+        const bodyInput = document.getElementById('feedbackReplyBody');
+        const markdown = '![' + (file.name || '이미지') + '](' + data.data.imageUrl + ')';
+        bodyInput.value = bodyInput.value.replace(/\s*$/, '') + '\n\n' + markdown + '\n';
+        setMessageBox('feedbackSaveResult', true, '이미지를 본문에 삽입했습니다.');
+      } catch (e) {
+        setMessageBox('feedbackSaveResult', false, e.message || '이미지 업로드 실패');
+      } finally {
+        feedbackIsUploading = false;
+        updateFeedbackEditorState();
+      }
+    }
+
+    function updateFeedbackEditorState() {
+      const isLetterMode = feedbackMode === 'letter';
+      const selected = getSelectedFeedback();
+      const busy = feedbackIsLoading || feedbackIsPublishing || feedbackIsUploading;
+      const alreadyReplied = !!selected && selected.status === 'REPLIED';
+
+      document.getElementById('feedbackEditorTitle').textContent = isLetterMode ? '새 편지 발행' : '답장 작성';
+      document.getElementById('feedbackLetterCategoryRow').classList.toggle('hidden', !isLetterMode);
+      document.getElementById('feedbackDraftRow').classList.toggle('hidden', !isLetterMode);
+      document.getElementById('feedbackImageUploadRow').classList.toggle('hidden', !isLetterMode);
+      document.getElementById('btnSaveFeedbackDraft').classList.toggle('hidden', !isLetterMode);
+      document.getElementById('feedbackSendPushLabel').textContent = isLetterMode
+        ? '발행 시 전체 유저에게 푸시 알림 보내기'
+        : '발행하면 이 유저에게 푸시 알림 보내기';
+
+      const quote = document.getElementById('feedbackQuote');
+      if (isLetterMode || !selected) {
+        quote.classList.add('hidden');
+        quote.textContent = '';
+      } else {
+        quote.classList.remove('hidden');
+        quote.textContent = [
+          FEEDBACK_TYPE_LABELS[selected.type] || selected.type,
+          selected.sender,
+          formatFeedbackDate(selected.createdAt)
+        ].join(' · ') + '\n\n' + (selected.content || '');
+      }
+      renderFeedbackQuoteImages(isLetterMode ? [] : (selected?.images || []));
+
+      const summary = document.getElementById('feedbackSelectionSummary');
+      if (isLetterMode) {
+        summary.textContent = feedbackCurrentDraftId
+          ? '임시저장한 편지를 이어서 작성 중입니다. 발행하면 초안은 삭제됩니다.'
+          : 'UPDATE / STORY 편지를 전체 사용자에게 발행합니다.';
+      } else if (!selected) {
+        summary.textContent = '왼쪽 목록에서 답장할 피드백을 선택하세요.';
+      } else if (alreadyReplied) {
+        summary.textContent = '이미 답장을 발행한 피드백입니다.';
+      } else {
+        summary.textContent = selected.sender + '에게 답장합니다.';
+      }
+
+      const btnPublish = document.getElementById('btnPublishFeedbackReply');
+      btnPublish.textContent = isLetterMode ? '편지 발행' : '답장 발행';
+      btnPublish.disabled = busy || (!isLetterMode && (!selected || alreadyReplied));
+      document.getElementById('btnLoadFeedback').disabled = busy;
+      document.getElementById('btnNewFeedbackLetter').disabled = busy;
+      document.getElementById('btnSaveFeedbackDraft').disabled = busy;
+      document.getElementById('btnUploadFeedbackImage').disabled = busy;
+
+      const hasDrafts = feedbackDrafts.length > 0;
+      document.getElementById('feedbackDraftSelect').disabled = busy || !hasDrafts;
+      document.getElementById('btnLoadFeedbackDraft').disabled = busy || !hasDrafts;
+      document.getElementById('btnDeleteFeedbackDraft').disabled = busy || !hasDrafts;
+    }
+
+    async function publishFeedbackLetter() {
+      const isLetterMode = feedbackMode === 'letter';
+      const title = document.getElementById('feedbackReplyTitle').value.trim();
+      const body = document.getElementById('feedbackReplyBody').value.trim();
+      if (!title || !body) {
+        setMessageBox('feedbackSaveResult', false, '제목과 본문을 모두 입력하세요.');
+        return;
+      }
+
+      const url = isLetterMode
+        ? API_BASE + '/api/admin/feedback/letters'
+        : API_BASE + '/api/admin/feedback/' + encodeURIComponent(feedbackSelectedId) + '/reply';
+      const sendPush = document.getElementById('feedbackSendPush').checked;
+      const payload = isLetterMode
+        ? { category: document.getElementById('feedbackLetterCategory').value, title, body, sendPush }
+        : { title, body, sendPush };
+
+      feedbackIsPublishing = true;
+      updateFeedbackEditorState();
+      try {
+        const res = await fetch(url, { method: 'POST', headers: headers(), body: JSON.stringify(payload) });
+        const data = await readJsonOrEmpty(res);
+        if (!res.ok) {
+          setMessageBox('feedbackSaveResult', false, data.message || '발행 실패 (HTTP ' + res.status + ')');
+          return;
+        }
+        setMessageBox('feedbackSaveResult', true, getApiSuccessMessage(data, isLetterMode ? '편지가 발행되었습니다.' : '답장이 발행되었습니다.'));
+        if (sendPush && data.data && data.data.pushSent === false) {
+          showToast((isLetterMode ? '편지는' : '답장은') + ' 발행됐지만 푸시는 전송되지 않았습니다.', 'error');
+        } else if (isLetterMode && sendPush && data.data) {
+          showToast('푸시 ' + (data.data.pushSuccessCount || 0) + '건 발송됨');
+        }
+        if (isLetterMode && feedbackCurrentDraftId) {
+          await discardFeedbackDraftAfterPublish(feedbackCurrentDraftId);
+        }
+        document.getElementById('feedbackReplyTitle').value = '';
+        document.getElementById('feedbackReplyBody').value = '';
+        feedbackSelectedId = '';
+        feedbackCurrentDraftId = '';
+        feedbackMode = 'reply';
+        await reloadFeedbackList();
+      } catch (e) {
+        setMessageBox('feedbackSaveResult', false, e.message || '발행 실패');
+      } finally {
+        feedbackIsPublishing = false;
+        updateFeedbackEditorState();
+      }
+    }
+
+    /**
+     * 발행된 편지의 초안이 남으면 운영자가 같은 편지를 또 발행할 수 있다.
+     * 삭제 실패는 발행 자체를 되돌리지 않으므로 안내만 한다.
+     */
+    async function discardFeedbackDraftAfterPublish(draftId) {
+      try {
+        const res = await fetch(API_BASE + '/api/admin/feedback/letters/drafts/' + encodeURIComponent(draftId), {
+          method: 'DELETE',
+          headers: headers()
+        });
+        if (!res.ok) {
+          showToast('편지는 발행됐지만 초안이 남아 있습니다. 목록에서 삭제해주세요.', 'error');
+        }
+      } catch (e) {
+        showToast('편지는 발행됐지만 초안이 남아 있습니다. 목록에서 삭제해주세요.', 'error');
+      }
+      await reloadFeedbackDrafts();
+    }
+
+    document.getElementById('btnLoadFeedback').onclick = () => reloadFeedbackList();
+    document.getElementById('btnNewFeedbackLetter').onclick = () => enterFeedbackLetterMode();
+    document.getElementById('btnClearFeedbackSelection').onclick = () => clearFeedbackSelection();
+    document.getElementById('btnPublishFeedbackReply').onclick = () => publishFeedbackLetter();
+    document.getElementById('btnSaveFeedbackDraft').onclick = () => saveFeedbackDraft();
+    document.getElementById('btnLoadFeedbackDraft').onclick = () => loadSelectedFeedbackDraft();
+    document.getElementById('btnDeleteFeedbackDraft').onclick = () => deleteSelectedFeedbackDraft();
+    document.getElementById('btnUploadFeedbackImage').onclick = () => document.getElementById('feedbackImageFile').click();
+    document.getElementById('feedbackImageFile').onchange = (event) => {
+      const file = event.target.files && event.target.files[0];
+      event.target.value = '';
+      if (file) uploadFeedbackLetterImage(file);
+    };
 
     async function readJsonOrEmpty(res) {
       try {

--- a/backend/src/main/resources/static/dev/index.html
+++ b/backend/src/main/resources/static/dev/index.html
@@ -157,9 +157,13 @@
     .feedback-layout { display: grid; grid-template-columns: minmax(0, 1fr) 370px; gap: 16px; align-items: start; }
     @media (max-width: 1100px) { .feedback-layout { grid-template-columns: 1fr; } }
     .feedback-quote { margin: 0 0 12px; padding: 12px; border: 1px solid #e5e7eb; border-radius: 8px; background: #f9fafb; font-size: 0.9rem; white-space: pre-wrap; }
-    .feedback-checkbox { display: flex; align-items: center; gap: 8px; margin: 12px 0; font-size: 0.9rem; }
-    .feedback-checkbox input { margin: 0; }
+    .feedback-checkbox { display: flex; justify-content: flex-start; align-items: center; gap: 8px; margin: 12px 0; font-size: 0.9rem; text-align: left; }
+    .feedback-checkbox input { margin: 0; flex: none; }
     .feedback-content-cell { max-width: 320px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    /* 유형 · 받은 날짜 · 상태는 짧은 한국어라 폭이 좁아지면 글자 단위로 쪼개진다. */
+    #feedbackList th:nth-child(1), #feedbackList td:nth-child(1),
+    #feedbackList th:nth-child(4), #feedbackList td:nth-child(4),
+    #feedbackList th:nth-child(5), #feedbackList td:nth-child(5) { white-space: nowrap; }
     .feedback-quote-images { display: flex; flex-wrap: wrap; gap: 8px; margin: 0 0 12px; }
     .feedback-quote-images a { line-height: 0; }
     .feedback-quote-images img { width: 72px; height: 72px; object-fit: cover; border-radius: 6px; border: 1px solid #e5e7eb; }

--- a/backend/src/test/java/moadong/feedback/entity/LetterPreviewTest.java
+++ b/backend/src/test/java/moadong/feedback/entity/LetterPreviewTest.java
@@ -1,0 +1,62 @@
+package moadong.feedback.entity;
+
+import moadong.feedback.enums.LetterCategory;
+import moadong.util.annotations.UnitTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@UnitTest
+class LetterPreviewTest {
+
+    private Letter letterWithBody(String body) {
+        return Letter.builder()
+                .id("letter-1")
+                .category(LetterCategory.REPLY)
+                .title("즐겨찾기한 동아리 알림, 이렇게 준비 중이에요")
+                .body(body)
+                .build();
+    }
+
+    @Test
+    void 미리보기는_마크다운_기호_없이_읽히는_문장이어야_한다() {
+        String body = """
+                **즐겨찾기 알림**, 이렇게 준비 중이에요!
+                ![준비 화면](https://cdn.moadong.com/feedback/abc123.png)
+                자세한 내용은 [공지](https://moadong.com/notice)를 확인해주세요.
+                """;
+
+        assertEquals("즐겨찾기 알림, 이렇게 준비 중이에요! 자세한 내용은 공지를 확인해주세요.",
+                letterWithBody(body).preview());
+    }
+
+    @Test
+    void 본문이_이미지로_시작해도_뒤의_내용이_보인다() {
+        String body = """
+                ![준비 화면](https://cdn.moadong.com/feedback/abc123.png)
+                알림 기능을 준비하고 있어요.
+                """;
+
+        assertEquals("알림 기능을 준비하고 있어요.", letterWithBody(body).preview());
+    }
+
+    @Test
+    void 긴_본문은_60자에서_잘린다() {
+        String preview = letterWithBody("가".repeat(100)).preview();
+
+        assertEquals("가".repeat(60) + "...", preview);
+    }
+
+    @Test
+    void 본문이_없으면_빈_문자열을_반환한다() {
+        assertEquals("", letterWithBody(null).preview());
+    }
+
+    @Test
+    void 이미지만_있는_본문은_URL을_노출하지_않는다() {
+        String preview = letterWithBody("![준비 화면](https://cdn.moadong.com/feedback/abc123.png)").preview();
+
+        assertTrue(preview.isEmpty(), "이미지만 있으면 보여줄 문장이 없다. 실제: " + preview);
+    }
+}

--- a/backend/src/test/java/moadong/feedback/payload/FeedbackSerializationTest.java
+++ b/backend/src/test/java/moadong/feedback/payload/FeedbackSerializationTest.java
@@ -1,0 +1,38 @@
+package moadong.feedback.payload;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import moadong.feedback.entity.Letter;
+import moadong.feedback.enums.LetterCategory;
+import moadong.util.annotations.UnitTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@UnitTest
+class FeedbackSerializationTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    @Test
+    void 받은_편지_요약은_isRead_키로_직렬화된다() throws Exception {
+        Letter letter = Letter.builder()
+                .id("letter-1")
+                .category(LetterCategory.UPDATE)
+                .title("업데이트")
+                .body("본문")
+                .readStudentIds(Set.of())
+                .build();
+
+        String json = objectMapper.writeValueAsString(
+                moadong.feedback.payload.response.ReceivedLetterSummaryResponse.from(letter, "student-1"));
+
+        assertTrue(json.contains("\"isRead\""), "프론트가 isRead 키를 읽는다. 실제 직렬화: " + json);
+        assertTrue(json.contains("\"createdAt\":\""), "createdAt은 ISO8601 문자열이어야 한다. 실제 직렬화: " + json);
+    }
+}

--- a/backend/src/test/java/moadong/feedback/service/FeedbackAdminServiceTest.java
+++ b/backend/src/test/java/moadong/feedback/service/FeedbackAdminServiceTest.java
@@ -1,0 +1,264 @@
+package moadong.feedback.service;
+
+import moadong.fcm.model.TokenPushPayload;
+import moadong.fcm.model.TokenPushResult;
+import moadong.fcm.payload.request.FcmAdminBatchSendRequest;
+import moadong.fcm.payload.response.FcmAdminBatchSendResponse;
+import moadong.fcm.port.PushNotificationPort;
+import moadong.fcm.service.FcmAdminService;
+import moadong.feedback.entity.Feedback;
+import moadong.feedback.entity.Letter;
+import moadong.feedback.enums.FeedbackStatus;
+import moadong.feedback.enums.FeedbackType;
+import moadong.feedback.enums.LetterCategory;
+import moadong.feedback.payload.request.FeedbackReplyRequest;
+import moadong.feedback.payload.request.LetterCreateRequest;
+import moadong.feedback.payload.response.AdminFeedbackListResponse;
+import moadong.feedback.payload.response.FeedbackReplyResponse;
+import moadong.feedback.payload.response.LetterCreateResponse;
+import moadong.feedback.repository.FeedbackRepository;
+import moadong.feedback.repository.LetterRepository;
+import moadong.global.exception.ErrorCode;
+import moadong.global.exception.RestApiException;
+import moadong.user.entity.StudentUser;
+import moadong.user.repository.StudentUserRepository;
+import moadong.util.annotations.UnitTest;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@UnitTest
+class FeedbackAdminServiceTest {
+
+    private static final String STUDENT_ID = "11111111-1111-1111-1111-111111111111";
+    private static final String OTHER_STUDENT_ID = "22222222-2222-2222-2222-222222222222";
+
+    @Mock
+    private FeedbackRepository feedbackRepository;
+
+    @Mock
+    private LetterRepository letterRepository;
+
+    @Mock
+    private StudentUserRepository studentUserRepository;
+
+    @Mock
+    private PushNotificationPort pushNotificationPort;
+
+    @Mock
+    private FcmAdminService fcmAdminService;
+
+    @InjectMocks
+    private FeedbackAdminService feedbackAdminService;
+
+    @Test
+    void 답장을_발행하면_REPLY_편지가_생기고_상태가_답장완료가_된다() {
+        givenWaitingFeedback();
+        givenSavedLetterId("letter-1");
+
+        FeedbackReplyResponse response = feedbackAdminService.reply(
+                "feedback-1", new FeedbackReplyRequest("답장 제목", "답장 본문", false));
+
+        ArgumentCaptor<Letter> letterCaptor = ArgumentCaptor.forClass(Letter.class);
+        verify(letterRepository).save(letterCaptor.capture());
+        assertEquals(LetterCategory.REPLY, letterCaptor.getValue().getCategory());
+        assertEquals(STUDENT_ID, letterCaptor.getValue().getRecipientStudentId());
+        assertEquals("feedback-1", letterCaptor.getValue().getFeedbackId());
+
+        ArgumentCaptor<Feedback> feedbackCaptor = ArgumentCaptor.forClass(Feedback.class);
+        verify(feedbackRepository).save(feedbackCaptor.capture());
+        assertEquals(FeedbackStatus.REPLIED, feedbackCaptor.getValue().getStatus());
+        assertEquals("letter-1", feedbackCaptor.getValue().getReplyLetterId());
+
+        assertEquals("letter-1", response.letterId());
+        assertFalse(response.pushSent());
+    }
+
+    @Test
+    void 서로_다른_학생은_서로_다른_보낸사람으로_표시된다() {
+        when(feedbackRepository.findAllByOrderByCreatedAtDesc()).thenReturn(List.of(
+                feedbackOf("feedback-1", STUDENT_ID),
+                feedbackOf("feedback-2", OTHER_STUDENT_ID)));
+        when(feedbackRepository.countByStatusNot(FeedbackStatus.REPLIED)).thenReturn(2L);
+
+        AdminFeedbackListResponse response = feedbackAdminService.getFeedbacks();
+
+        assertEquals("user_11111111", response.feedbacks().get(0).sender());
+        assertNotEquals(response.feedbacks().get(0).sender(), response.feedbacks().get(1).sender());
+        assertEquals(2L, response.unansweredCount());
+    }
+
+    @Test
+    void 이미_답장한_피드백에는_다시_답장할_수_없다() {
+        Feedback replied = Feedback.builder()
+                .id("feedback-1")
+                .studentId(STUDENT_ID)
+                .type(FeedbackType.BUG)
+                .content("버그가 있어요")
+                .status(FeedbackStatus.REPLIED)
+                .build();
+        when(feedbackRepository.findById("feedback-1")).thenReturn(Optional.of(replied));
+
+        RestApiException exception = assertThrows(RestApiException.class, () -> feedbackAdminService.reply(
+                "feedback-1", new FeedbackReplyRequest("답장 제목", "답장 본문", false)));
+
+        assertEquals(ErrorCode.FEEDBACK_ALREADY_REPLIED, exception.getErrorCode());
+        verify(letterRepository, never()).save(any());
+    }
+
+    @Test
+    void FCM_토큰이_있으면_답장_푸시를_보낸다() {
+        givenWaitingFeedback();
+        givenSavedLetterId("letter-1");
+        when(studentUserRepository.findByStudentId(STUDENT_ID)).thenReturn(Optional.of(StudentUser.builder()
+                .studentId(STUDENT_ID)
+                .currentFcmToken("fcm-token")
+                .build()));
+        when(pushNotificationPort.sendToToken(any())).thenReturn(new TokenPushResult(true, "message-1"));
+
+        FeedbackReplyResponse response = feedbackAdminService.reply(
+                "feedback-1", new FeedbackReplyRequest("답장 제목", "답장 본문", true));
+
+        ArgumentCaptor<TokenPushPayload> payloadCaptor = ArgumentCaptor.forClass(TokenPushPayload.class);
+        verify(pushNotificationPort).sendToToken(payloadCaptor.capture());
+        assertEquals("fcm-token", payloadCaptor.getValue().token());
+        assertEquals("답장 제목", payloadCaptor.getValue().title());
+        assertEquals("letter-1", payloadCaptor.getValue().data().get("letterId"));
+        assertTrue(response.pushSent());
+    }
+
+    @Test
+    void FCM_토큰이_없으면_푸시를_건너뛰고_답장은_발행된다() {
+        givenWaitingFeedback();
+        givenSavedLetterId("letter-1");
+        when(studentUserRepository.findByStudentId(STUDENT_ID)).thenReturn(Optional.empty());
+
+        FeedbackReplyResponse response = feedbackAdminService.reply(
+                "feedback-1", new FeedbackReplyRequest("답장 제목", "답장 본문", true));
+
+        verify(pushNotificationPort, never()).sendToToken(any());
+        assertEquals("letter-1", response.letterId());
+        assertFalse(response.pushSent());
+    }
+
+    @Test
+    void 푸시_발송이_실패해도_답장_발행은_유지된다() {
+        givenWaitingFeedback();
+        givenSavedLetterId("letter-1");
+        when(studentUserRepository.findByStudentId(STUDENT_ID)).thenReturn(Optional.of(StudentUser.builder()
+                .studentId(STUDENT_ID)
+                .currentFcmToken("fcm-token")
+                .build()));
+        when(pushNotificationPort.sendToToken(any())).thenThrow(new IllegalStateException("firebase down"));
+
+        FeedbackReplyResponse response = feedbackAdminService.reply(
+                "feedback-1", new FeedbackReplyRequest("답장 제목", "답장 본문", true));
+
+        verify(feedbackRepository).save(any());
+        assertEquals("letter-1", response.letterId());
+        assertFalse(response.pushSent());
+    }
+
+    @Test
+    void REPLY는_전체_발행할_수_없다() {
+        RestApiException exception = assertThrows(RestApiException.class,
+                () -> feedbackAdminService.createBroadcastLetter(
+                        new LetterCreateRequest(LetterCategory.REPLY, "제목", "본문", false)));
+
+        assertEquals(ErrorCode.LETTER_CATEGORY_NOT_BROADCASTABLE, exception.getErrorCode());
+        verify(letterRepository, never()).save(any());
+    }
+
+    @Test
+    void 전체_발행_편지는_수신자가_비어있다() {
+        givenSavedLetterId("letter-1");
+
+        feedbackAdminService.createBroadcastLetter(
+                new LetterCreateRequest(LetterCategory.UPDATE, "제목", "본문", false));
+
+        ArgumentCaptor<Letter> letterCaptor = ArgumentCaptor.forClass(Letter.class);
+        verify(letterRepository).save(letterCaptor.capture());
+        assertTrue(letterCaptor.getValue().isBroadcast());
+        verify(fcmAdminService, never()).sendToAll(any());
+    }
+
+    @Test
+    void 전체_발행_시_푸시를_켜면_전체_토큰으로_발송한다() {
+        givenSavedLetterId("letter-1");
+        when(fcmAdminService.sendToAll(any()))
+                .thenReturn(new FcmAdminBatchSendResponse(120, 1, 118, 2, List.of("bad-token")));
+
+        LetterCreateResponse response = feedbackAdminService.createBroadcastLetter(
+                new LetterCreateRequest(LetterCategory.UPDATE, "제목", "본문", true));
+
+        ArgumentCaptor<FcmAdminBatchSendRequest> pushCaptor =
+                ArgumentCaptor.forClass(FcmAdminBatchSendRequest.class);
+        verify(fcmAdminService).sendToAll(pushCaptor.capture());
+        assertEquals("제목", pushCaptor.getValue().title());
+        assertEquals("letter-1", pushCaptor.getValue().data().get("letterId"));
+        assertTrue(response.pushSent());
+        assertEquals(118, response.pushSuccessCount());
+    }
+
+    @Test
+    void 전체_발행_푸시가_실패해도_편지는_남는다() {
+        givenSavedLetterId("letter-1");
+        when(fcmAdminService.sendToAll(any())).thenThrow(new IllegalStateException("firebase down"));
+
+        LetterCreateResponse response = feedbackAdminService.createBroadcastLetter(
+                new LetterCreateRequest(LetterCategory.UPDATE, "제목", "본문", true));
+
+        verify(letterRepository).save(any());
+        assertEquals("letter-1", response.letterId());
+        assertFalse(response.pushSent());
+        assertEquals(0, response.pushSuccessCount());
+    }
+
+    private Feedback feedbackOf(String feedbackId, String studentId) {
+        return Feedback.builder()
+                .id(feedbackId)
+                .studentId(studentId)
+                .type(FeedbackType.CHEER)
+                .content("응원합니다 항상 잘 쓰고 있어요")
+                .status(FeedbackStatus.WAITING)
+                .build();
+    }
+
+    private void givenWaitingFeedback() {
+        when(feedbackRepository.findById("feedback-1")).thenReturn(Optional.of(Feedback.builder()
+                .id("feedback-1")
+                .studentId(STUDENT_ID)
+                .type(FeedbackType.FEATURE)
+                .content("즐겨찾기 알림이 있으면 좋겠어요")
+                .status(FeedbackStatus.WAITING)
+                .build()));
+    }
+
+    private void givenSavedLetterId(String letterId) {
+        when(letterRepository.save(any())).thenAnswer(invocation -> {
+            Letter letter = invocation.getArgument(0);
+            return Letter.builder()
+                    .id(letterId)
+                    .category(letter.getCategory())
+                    .recipientStudentId(letter.getRecipientStudentId())
+                    .feedbackId(letter.getFeedbackId())
+                    .title(letter.getTitle())
+                    .body(letter.getBody())
+                    .build();
+        });
+    }
+}

--- a/backend/src/test/java/moadong/feedback/service/FeedbackAdminServiceTest.java
+++ b/backend/src/test/java/moadong/feedback/service/FeedbackAdminServiceTest.java
@@ -12,6 +12,7 @@ import moadong.feedback.enums.FeedbackStatus;
 import moadong.feedback.enums.FeedbackType;
 import moadong.feedback.enums.LetterCategory;
 import moadong.feedback.payload.request.FeedbackReplyRequest;
+import moadong.feedback.payload.request.FeedbackStatusUpdateRequest;
 import moadong.feedback.payload.request.LetterCreateRequest;
 import moadong.feedback.payload.response.AdminFeedbackListResponse;
 import moadong.feedback.payload.response.FeedbackReplyResponse;
@@ -226,6 +227,58 @@ class FeedbackAdminServiceTest {
         assertEquals("letter-1", response.letterId());
         assertFalse(response.pushSent());
         assertEquals(0, response.pushSuccessCount());
+    }
+
+    @Test
+    void 상태를_확인_중으로_바꿀_수_있다() {
+        givenWaitingFeedback();
+        when(feedbackRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        feedbackAdminService.updateStatus("feedback-1",
+                new FeedbackStatusUpdateRequest(FeedbackStatus.IN_PROGRESS));
+
+        ArgumentCaptor<Feedback> captor = ArgumentCaptor.forClass(Feedback.class);
+        verify(feedbackRepository).save(captor.capture());
+        assertEquals(FeedbackStatus.IN_PROGRESS, captor.getValue().getStatus());
+    }
+
+    @Test
+    void 답장_완료_상태는_직접_지정할_수_없다() {
+        givenWaitingFeedback();
+
+        RestApiException exception = assertThrows(RestApiException.class, () -> feedbackAdminService.updateStatus(
+                "feedback-1", new FeedbackStatusUpdateRequest(FeedbackStatus.REPLIED)));
+
+        assertEquals(ErrorCode.FEEDBACK_STATUS_NOT_CHANGEABLE, exception.getErrorCode());
+        verify(feedbackRepository, never()).save(any());
+    }
+
+    @Test
+    void 이미_답장한_피드백의_상태는_되돌릴_수_없다() {
+        when(feedbackRepository.findById("feedback-1")).thenReturn(Optional.of(Feedback.builder()
+                .id("feedback-1")
+                .studentId(STUDENT_ID)
+                .type(FeedbackType.BUG)
+                .content("버그가 있어요")
+                .status(FeedbackStatus.REPLIED)
+                .replyLetterId("letter-1")
+                .build()));
+
+        RestApiException exception = assertThrows(RestApiException.class, () -> feedbackAdminService.updateStatus(
+                "feedback-1", new FeedbackStatusUpdateRequest(FeedbackStatus.WAITING)));
+
+        assertEquals(ErrorCode.FEEDBACK_STATUS_NOT_CHANGEABLE, exception.getErrorCode());
+        verify(feedbackRepository, never()).save(any());
+    }
+
+    @Test
+    void 없는_피드백의_상태는_변경할_수_없다() {
+        when(feedbackRepository.findById("feedback-1")).thenReturn(Optional.empty());
+
+        RestApiException exception = assertThrows(RestApiException.class, () -> feedbackAdminService.updateStatus(
+                "feedback-1", new FeedbackStatusUpdateRequest(FeedbackStatus.IN_PROGRESS)));
+
+        assertEquals(ErrorCode.FEEDBACK_NOT_FOUND, exception.getErrorCode());
     }
 
     private Feedback feedbackOf(String feedbackId, String studentId) {

--- a/backend/src/test/java/moadong/feedback/service/FeedbackAdminServiceTest.java
+++ b/backend/src/test/java/moadong/feedback/service/FeedbackAdminServiceTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -37,6 +38,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -279,6 +281,45 @@ class FeedbackAdminServiceTest {
         ArgumentCaptor<Letter> captor = ArgumentCaptor.forClass(Letter.class);
         verify(letterRepository).save(captor.capture());
         assertEquals("req-1", captor.getValue().getIdempotencyKey());
+    }
+
+    @Test
+    void 빈_requestId는_저장하지_않는다() {
+        // 빈 문자열을 저장하면 sparse 유니크 인덱스가 걸러주지 못해 다음 발행이 중복 키로 실패한다.
+        givenSavedLetterId("letter-1");
+
+        feedbackAdminService.createBroadcastLetter(
+                new LetterCreateRequest(LetterCategory.UPDATE, "제목", "본문", false, ""));
+        feedbackAdminService.createBroadcastLetter(
+                new LetterCreateRequest(LetterCategory.UPDATE, "제목", "본문", false, "   "));
+
+        ArgumentCaptor<Letter> captor = ArgumentCaptor.forClass(Letter.class);
+        verify(letterRepository, org.mockito.Mockito.times(2)).save(captor.capture());
+        captor.getAllValues().forEach(letter -> assertNull(letter.getIdempotencyKey()));
+        verify(letterRepository, never()).findByIdempotencyKey(any());
+    }
+
+    @Test
+    void 동시_발행이_충돌하면_먼저_저장된_편지를_돌려준다() {
+        Letter winner = Letter.builder()
+                .id("letter-1")
+                .category(LetterCategory.UPDATE)
+                .title("제목")
+                .body("본문")
+                .idempotencyKey("req-1")
+                .pushSuccessCount(118)
+                .build();
+        when(letterRepository.findByIdempotencyKey("req-1"))
+                .thenReturn(Optional.empty())
+                .thenReturn(Optional.of(winner));
+        when(letterRepository.save(any())).thenThrow(new DuplicateKeyException("duplicate idempotencyKey"));
+
+        LetterCreateResponse response = feedbackAdminService.createBroadcastLetter(
+                new LetterCreateRequest(LetterCategory.UPDATE, "제목", "본문", true, "req-1"));
+
+        assertEquals("letter-1", response.letterId());
+        assertEquals(118, response.pushSuccessCount());
+        verify(fcmAdminService, never()).sendToAll(any());
     }
 
     @Test

--- a/backend/src/test/java/moadong/feedback/service/FeedbackAdminServiceTest.java
+++ b/backend/src/test/java/moadong/feedback/service/FeedbackAdminServiceTest.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.List;
 import java.util.Optional;
@@ -63,11 +65,23 @@ class FeedbackAdminServiceTest {
     @Mock
     private FcmAdminService fcmAdminService;
 
+    @Mock
+    private TransactionTemplate transactionTemplate;
+
     @InjectMocks
     private FeedbackAdminService feedbackAdminService;
 
+    /** 답장 저장 구간을 트랜잭션 없이 그대로 실행시킨다. */
+    private void givenTransactionRunsInline() {
+        when(transactionTemplate.execute(any())).thenAnswer(invocation -> {
+            TransactionCallback<?> callback = invocation.getArgument(0);
+            return callback.doInTransaction(null);
+        });
+    }
+
     @Test
     void 답장을_발행하면_REPLY_편지가_생기고_상태가_답장완료가_된다() {
+        givenTransactionRunsInline();
         givenWaitingFeedback();
         givenSavedLetterId("letter-1");
 
@@ -112,6 +126,7 @@ class FeedbackAdminServiceTest {
                 .content("버그가 있어요")
                 .status(FeedbackStatus.REPLIED)
                 .build();
+        givenTransactionRunsInline();
         when(feedbackRepository.findById("feedback-1")).thenReturn(Optional.of(replied));
 
         RestApiException exception = assertThrows(RestApiException.class, () -> feedbackAdminService.reply(
@@ -123,6 +138,7 @@ class FeedbackAdminServiceTest {
 
     @Test
     void FCM_토큰이_있으면_답장_푸시를_보낸다() {
+        givenTransactionRunsInline();
         givenWaitingFeedback();
         givenSavedLetterId("letter-1");
         when(studentUserRepository.findByStudentId(STUDENT_ID)).thenReturn(Optional.of(StudentUser.builder()
@@ -144,6 +160,7 @@ class FeedbackAdminServiceTest {
 
     @Test
     void FCM_토큰이_없으면_푸시를_건너뛰고_답장은_발행된다() {
+        givenTransactionRunsInline();
         givenWaitingFeedback();
         givenSavedLetterId("letter-1");
         when(studentUserRepository.findByStudentId(STUDENT_ID)).thenReturn(Optional.empty());
@@ -158,6 +175,7 @@ class FeedbackAdminServiceTest {
 
     @Test
     void 푸시_발송이_실패해도_답장_발행은_유지된다() {
+        givenTransactionRunsInline();
         givenWaitingFeedback();
         givenSavedLetterId("letter-1");
         when(studentUserRepository.findByStudentId(STUDENT_ID)).thenReturn(Optional.of(StudentUser.builder()
@@ -178,7 +196,7 @@ class FeedbackAdminServiceTest {
     void REPLY는_전체_발행할_수_없다() {
         RestApiException exception = assertThrows(RestApiException.class,
                 () -> feedbackAdminService.createBroadcastLetter(
-                        new LetterCreateRequest(LetterCategory.REPLY, "제목", "본문", false)));
+                        new LetterCreateRequest(LetterCategory.REPLY, "제목", "본문", false, null)));
 
         assertEquals(ErrorCode.LETTER_CATEGORY_NOT_BROADCASTABLE, exception.getErrorCode());
         verify(letterRepository, never()).save(any());
@@ -189,7 +207,7 @@ class FeedbackAdminServiceTest {
         givenSavedLetterId("letter-1");
 
         feedbackAdminService.createBroadcastLetter(
-                new LetterCreateRequest(LetterCategory.UPDATE, "제목", "본문", false));
+                new LetterCreateRequest(LetterCategory.UPDATE, "제목", "본문", false, null));
 
         ArgumentCaptor<Letter> letterCaptor = ArgumentCaptor.forClass(Letter.class);
         verify(letterRepository).save(letterCaptor.capture());
@@ -204,7 +222,7 @@ class FeedbackAdminServiceTest {
                 .thenReturn(new FcmAdminBatchSendResponse(120, 1, 118, 2, List.of("bad-token")));
 
         LetterCreateResponse response = feedbackAdminService.createBroadcastLetter(
-                new LetterCreateRequest(LetterCategory.UPDATE, "제목", "본문", true));
+                new LetterCreateRequest(LetterCategory.UPDATE, "제목", "본문", true, null));
 
         ArgumentCaptor<FcmAdminBatchSendRequest> pushCaptor =
                 ArgumentCaptor.forClass(FcmAdminBatchSendRequest.class);
@@ -221,12 +239,46 @@ class FeedbackAdminServiceTest {
         when(fcmAdminService.sendToAll(any())).thenThrow(new IllegalStateException("firebase down"));
 
         LetterCreateResponse response = feedbackAdminService.createBroadcastLetter(
-                new LetterCreateRequest(LetterCategory.UPDATE, "제목", "본문", true));
+                new LetterCreateRequest(LetterCategory.UPDATE, "제목", "본문", true, null));
 
-        verify(letterRepository).save(any());
+        verify(letterRepository, org.mockito.Mockito.atLeastOnce()).save(any());
         assertEquals("letter-1", response.letterId());
         assertFalse(response.pushSent());
         assertEquals(0, response.pushSuccessCount());
+    }
+
+    @Test
+    void 같은_requestId로_다시_발행하면_편지도_푸시도_반복되지_않는다() {
+        Letter published = Letter.builder()
+                .id("letter-1")
+                .category(LetterCategory.UPDATE)
+                .title("제목")
+                .body("본문")
+                .idempotencyKey("req-1")
+                .pushSuccessCount(118)
+                .build();
+        when(letterRepository.findByIdempotencyKey("req-1")).thenReturn(Optional.of(published));
+
+        LetterCreateResponse response = feedbackAdminService.createBroadcastLetter(
+                new LetterCreateRequest(LetterCategory.UPDATE, "제목", "본문", true, "req-1"));
+
+        assertEquals("letter-1", response.letterId());
+        assertEquals(118, response.pushSuccessCount());
+        verify(letterRepository, never()).save(any());
+        verify(fcmAdminService, never()).sendToAll(any());
+    }
+
+    @Test
+    void 처음_발행할_때는_requestId를_편지에_남긴다() {
+        givenSavedLetterId("letter-1");
+        when(letterRepository.findByIdempotencyKey("req-1")).thenReturn(Optional.empty());
+
+        feedbackAdminService.createBroadcastLetter(
+                new LetterCreateRequest(LetterCategory.UPDATE, "제목", "본문", false, "req-1"));
+
+        ArgumentCaptor<Letter> captor = ArgumentCaptor.forClass(Letter.class);
+        verify(letterRepository).save(captor.capture());
+        assertEquals("req-1", captor.getValue().getIdempotencyKey());
     }
 
     @Test

--- a/backend/src/test/java/moadong/feedback/service/FeedbackImageServiceTest.java
+++ b/backend/src/test/java/moadong/feedback/service/FeedbackImageServiceTest.java
@@ -142,6 +142,19 @@ class FeedbackImageServiceTest {
     }
 
     @Test
+    void 이미지가_아닌_contentType은_서명하지_않는다() {
+        // 서명된 contentType이 R2 응답 헤더가 되므로, text/html이 통과하면 CDN에서 그대로 실행된다.
+        List<PresignedUploadResponse> responses = createUploadUrls(List.of(
+                new UploadUrlRequest("evil.png", "text/html"),
+                new UploadUrlRequest("evil2.png", "application/javascript")));
+
+        assertFalse(responses.get(0).success());
+        assertFalse(responses.get(1).success());
+        assertEquals(ErrorCode.UNSUPPORTED_FILE_TYPE.getMessage(), responses.get(0).failureReason());
+        verify(s3Presigner, never()).presignPutObject(any(PutObjectPresignRequest.class));
+    }
+
+    @Test
     void 발급_요청이_창_한도를_넘으면_거부한다() {
         when(stringRedisTemplate.execute(any(RedisScript.class), any(), any())).thenReturn(41L);
 

--- a/backend/src/test/java/moadong/feedback/service/FeedbackImageServiceTest.java
+++ b/backend/src/test/java/moadong/feedback/service/FeedbackImageServiceTest.java
@@ -13,6 +13,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.util.unit.DataSize;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
@@ -40,12 +42,16 @@ class FeedbackImageServiceTest {
     private static final String OTHER_STUDENT_ID = "22222222-2222-2222-2222-222222222222";
     private static final String VIEW_ENDPOINT = "https://cdn.moadong.com";
     private static final long MAX_IMAGE_BYTES = 5L * 1024 * 1024;
+    private static final String CLIENT_IP = "203.0.113.10";
 
     @Mock
     private S3Client s3Client;
 
     @Mock
     private S3Presigner s3Presigner;
+
+    @Mock
+    private StringRedisTemplate stringRedisTemplate;
 
     private FeedbackImageService feedbackImageService;
 
@@ -61,8 +67,13 @@ class FeedbackImageServiceTest {
                 new ServerProperties.Image(DataSize.ofBytes(MAX_IMAGE_BYTES)),
                 new ServerProperties.FileUrl(200, 10));
 
-        feedbackImageService = new FeedbackImageService(s3Client, s3Presigner, awsProperties, serverProperties);
+        feedbackImageService = new FeedbackImageService(
+                s3Client, s3Presigner, awsProperties, serverProperties, stringRedisTemplate);
         ReflectionTestUtils.invokeMethod(feedbackImageService, "init");
+    }
+
+    private List<PresignedUploadResponse> createUploadUrls(List<UploadUrlRequest> requests) {
+        return feedbackImageService.createUploadUrls(STUDENT_ID, requests, CLIENT_IP);
     }
 
     private String myImageUrl(String fileName) {
@@ -82,7 +93,7 @@ class FeedbackImageServiceTest {
             return presigned;
         });
 
-        List<PresignedUploadResponse> responses = feedbackImageService.createUploadUrls(STUDENT_ID, List.of(
+        List<PresignedUploadResponse> responses = createUploadUrls(List.of(
                 new UploadUrlRequest("a.jpg", "image/jpeg"),
                 new UploadUrlRequest("b.png", "image/png")));
 
@@ -101,7 +112,7 @@ class FeedbackImageServiceTest {
             return presigned;
         });
 
-        List<PresignedUploadResponse> responses = feedbackImageService.createUploadUrls(STUDENT_ID, List.of(
+        List<PresignedUploadResponse> responses = createUploadUrls(List.of(
                 new UploadUrlRequest("a.jpg", "image/jpeg"),
                 new UploadUrlRequest("bad.txt", "image/jpeg")));
 
@@ -118,7 +129,7 @@ class FeedbackImageServiceTest {
             return presigned;
         });
 
-        List<PresignedUploadResponse> responses = feedbackImageService.createUploadUrls(STUDENT_ID, List.of(
+        List<PresignedUploadResponse> responses = createUploadUrls(List.of(
                 new UploadUrlRequest("a.jpg", "image/jpeg"),
                 new UploadUrlRequest("b.jpg", "image/jpeg"),
                 new UploadUrlRequest("c.jpg", "image/jpeg"),
@@ -128,6 +139,37 @@ class FeedbackImageServiceTest {
         assertEquals(5, responses.size());
         assertEquals(4, responses.stream().filter(PresignedUploadResponse::success).count());
         assertEquals(ErrorCode.TOO_MANY_FILES.getMessage(), responses.get(4).failureReason());
+    }
+
+    @Test
+    void 발급_요청이_창_한도를_넘으면_거부한다() {
+        when(stringRedisTemplate.execute(any(RedisScript.class), any(), any())).thenReturn(41L);
+
+        RestApiException exception = assertThrows(RestApiException.class,
+                () -> createUploadUrls(List.of(new UploadUrlRequest("a.jpg", "image/jpeg"))));
+
+        assertEquals(ErrorCode.FEEDBACK_IMAGE_UPLOAD_RATE_LIMITED, exception.getErrorCode());
+        verify(s3Presigner, never()).presignPutObject(any(PutObjectPresignRequest.class));
+    }
+
+    @Test
+    void 발급_요청은_studentId와_IP_양쪽_창을_모두_센다() {
+        when(s3Presigner.presignPutObject(any(PutObjectPresignRequest.class))).thenAnswer(invocation -> {
+            PresignedPutObjectRequest presigned = org.mockito.Mockito.mock(PresignedPutObjectRequest.class);
+            when(presigned.url()).thenReturn(new java.net.URL("https://r2.example.com/upload?sig=abc"));
+            return presigned;
+        });
+
+        createUploadUrls(List.of(new UploadUrlRequest("a.jpg", "image/jpeg")));
+
+        ArgumentCaptor<List> keysCaptor = ArgumentCaptor.forClass(List.class);
+        verify(stringRedisTemplate, org.mockito.Mockito.times(2))
+                .execute(any(RedisScript.class), keysCaptor.capture(), any());
+        List<String> countedKeys = keysCaptor.getAllValues().stream()
+                .map(keys -> (String) keys.get(0))
+                .toList();
+        assertTrue(countedKeys.get(0).endsWith("student:" + STUDENT_ID), countedKeys.toString());
+        assertTrue(countedKeys.get(1).endsWith("ip:" + CLIENT_IP), countedKeys.toString());
     }
 
     @Test

--- a/backend/src/test/java/moadong/feedback/service/FeedbackImageServiceTest.java
+++ b/backend/src/test/java/moadong/feedback/service/FeedbackImageServiceTest.java
@@ -1,0 +1,224 @@
+package moadong.feedback.service;
+
+import moadong.global.config.properties.AwsProperties;
+import moadong.global.config.properties.ServerProperties;
+import moadong.global.exception.ErrorCode;
+import moadong.global.exception.RestApiException;
+import moadong.media.dto.PresignedUploadResponse;
+import moadong.media.dto.UploadUrlRequest;
+import moadong.util.annotations.UnitTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.util.unit.DataSize;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@UnitTest
+class FeedbackImageServiceTest {
+
+    private static final String STUDENT_ID = "11111111-1111-1111-1111-111111111111";
+    private static final String OTHER_STUDENT_ID = "22222222-2222-2222-2222-222222222222";
+    private static final String VIEW_ENDPOINT = "https://cdn.moadong.com";
+    private static final long MAX_IMAGE_BYTES = 5L * 1024 * 1024;
+
+    @Mock
+    private S3Client s3Client;
+
+    @Mock
+    private S3Presigner s3Presigner;
+
+    private FeedbackImageService feedbackImageService;
+
+    @BeforeEach
+    void setUp() {
+        AwsProperties awsProperties = new AwsProperties(
+                new AwsProperties.Credentials("access", "secret"),
+                // 후행 슬래시가 정규화되는지도 함께 확인한다.
+                new AwsProperties.S3("moadong-bucket", "https://r2.example.com", VIEW_ENDPOINT + "/"));
+        ServerProperties serverProperties = new ServerProperties(
+                "moadong.com",
+                new ServerProperties.Feed(5),
+                new ServerProperties.Image(DataSize.ofBytes(MAX_IMAGE_BYTES)),
+                new ServerProperties.FileUrl(200, 10));
+
+        feedbackImageService = new FeedbackImageService(s3Client, s3Presigner, awsProperties, serverProperties);
+        ReflectionTestUtils.invokeMethod(feedbackImageService, "init");
+    }
+
+    private String myImageUrl(String fileName) {
+        return VIEW_ENDPOINT + "/feedback/" + STUDENT_ID + "/" + fileName;
+    }
+
+    private void givenObjectSize(long contentLength) {
+        when(s3Client.headObject(any(HeadObjectRequest.class)))
+                .thenReturn(HeadObjectResponse.builder().contentLength(contentLength).build());
+    }
+
+    @Test
+    void 업로드_URL은_요청한_개수만큼_발급된다() {
+        when(s3Presigner.presignPutObject(any(PutObjectPresignRequest.class))).thenAnswer(invocation -> {
+            PresignedPutObjectRequest presigned = org.mockito.Mockito.mock(PresignedPutObjectRequest.class);
+            when(presigned.url()).thenReturn(new java.net.URL("https://r2.example.com/upload?sig=abc"));
+            return presigned;
+        });
+
+        List<PresignedUploadResponse> responses = feedbackImageService.createUploadUrls(STUDENT_ID, List.of(
+                new UploadUrlRequest("a.jpg", "image/jpeg"),
+                new UploadUrlRequest("b.png", "image/png")));
+
+        assertEquals(2, responses.size());
+        assertTrue(responses.get(0).success());
+        assertTrue(responses.get(0).finalUrl().startsWith(VIEW_ENDPOINT + "/feedback/" + STUDENT_ID + "/"));
+        assertTrue(responses.get(0).finalUrl().endsWith(".jpg"));
+        assertTrue(responses.get(1).finalUrl().endsWith(".png"));
+    }
+
+    @Test
+    void 지원하지_않는_확장자는_그_항목만_실패한다() {
+        when(s3Presigner.presignPutObject(any(PutObjectPresignRequest.class))).thenAnswer(invocation -> {
+            PresignedPutObjectRequest presigned = org.mockito.Mockito.mock(PresignedPutObjectRequest.class);
+            when(presigned.url()).thenReturn(new java.net.URL("https://r2.example.com/upload?sig=abc"));
+            return presigned;
+        });
+
+        List<PresignedUploadResponse> responses = feedbackImageService.createUploadUrls(STUDENT_ID, List.of(
+                new UploadUrlRequest("a.jpg", "image/jpeg"),
+                new UploadUrlRequest("bad.txt", "image/jpeg")));
+
+        assertTrue(responses.get(0).success());
+        assertFalse(responses.get(1).success());
+        assertEquals(ErrorCode.UNSUPPORTED_FILE_TYPE.getMessage(), responses.get(1).failureReason());
+    }
+
+    @Test
+    void 상한을_넘게_요청하면_앞의_4건만_발급하고_실패_항목을_덧붙인다() {
+        when(s3Presigner.presignPutObject(any(PutObjectPresignRequest.class))).thenAnswer(invocation -> {
+            PresignedPutObjectRequest presigned = org.mockito.Mockito.mock(PresignedPutObjectRequest.class);
+            when(presigned.url()).thenReturn(new java.net.URL("https://r2.example.com/upload?sig=abc"));
+            return presigned;
+        });
+
+        List<PresignedUploadResponse> responses = feedbackImageService.createUploadUrls(STUDENT_ID, List.of(
+                new UploadUrlRequest("a.jpg", "image/jpeg"),
+                new UploadUrlRequest("b.jpg", "image/jpeg"),
+                new UploadUrlRequest("c.jpg", "image/jpeg"),
+                new UploadUrlRequest("d.jpg", "image/jpeg"),
+                new UploadUrlRequest("e.jpg", "image/jpeg")));
+
+        assertEquals(5, responses.size());
+        assertEquals(4, responses.stream().filter(PresignedUploadResponse::success).count());
+        assertEquals(ErrorCode.TOO_MANY_FILES.getMessage(), responses.get(4).failureReason());
+    }
+
+    @Test
+    void 사진이_없으면_빈_목록을_반환한다() {
+        assertTrue(feedbackImageService.validateImages(STUDENT_ID, null).isEmpty());
+        assertTrue(feedbackImageService.validateImages(STUDENT_ID, List.of()).isEmpty());
+        verify(s3Client, never()).headObject(any(HeadObjectRequest.class));
+    }
+
+    @Test
+    void 정상적인_사진은_그대로_통과한다() {
+        givenObjectSize(1024);
+        List<String> images = List.of(myImageUrl("aaaaaaaaaa.jpg"), myImageUrl("bbbbbbbbbb.png"));
+
+        assertEquals(images, feedbackImageService.validateImages(STUDENT_ID, images));
+    }
+
+    @Test
+    void 사진이_4장을_넘으면_거부한다() {
+        List<String> images = List.of(
+                myImageUrl("a.jpg"), myImageUrl("b.jpg"), myImageUrl("c.jpg"),
+                myImageUrl("d.jpg"), myImageUrl("e.jpg"));
+
+        RestApiException exception = assertThrows(RestApiException.class,
+                () -> feedbackImageService.validateImages(STUDENT_ID, images));
+
+        assertEquals(ErrorCode.TOO_MANY_FILES, exception.getErrorCode());
+        verify(s3Client, never()).headObject(any(HeadObjectRequest.class));
+    }
+
+    @Test
+    void 남의_경로에_있는_사진은_첨부할_수_없다() {
+        String othersUrl = VIEW_ENDPOINT + "/feedback/" + OTHER_STUDENT_ID + "/aaaaaaaaaa.jpg";
+
+        RestApiException exception = assertThrows(RestApiException.class,
+                () -> feedbackImageService.validateImages(STUDENT_ID, List.of(othersUrl)));
+
+        assertEquals(ErrorCode.INVALID_FILE_URL, exception.getErrorCode());
+        verify(s3Client, never()).headObject(any(HeadObjectRequest.class));
+    }
+
+    @Test
+    void 다른_도메인의_URL은_첨부할_수_없다() {
+        String foreignUrl = "https://evil.example.com/feedback/" + STUDENT_ID + "/aaaaaaaaaa.jpg";
+
+        RestApiException exception = assertThrows(RestApiException.class,
+                () -> feedbackImageService.validateImages(STUDENT_ID, List.of(foreignUrl)));
+
+        assertEquals(ErrorCode.INVALID_FILE_URL, exception.getErrorCode());
+    }
+
+    @Test
+    void 다른_기능의_경로로_우회할_수_없다() {
+        String clubFeedUrl = VIEW_ENDPOINT + "/someClubId/feed/aaaaaaaaaa.jpg";
+
+        RestApiException exception = assertThrows(RestApiException.class,
+                () -> feedbackImageService.validateImages(STUDENT_ID, List.of(clubFeedUrl)));
+
+        assertEquals(ErrorCode.INVALID_FILE_URL, exception.getErrorCode());
+    }
+
+    @Test
+    void 실제로_업로드되지_않은_사진은_거부한다() {
+        when(s3Client.headObject(any(HeadObjectRequest.class))).thenThrow(NoSuchKeyException.builder().build());
+
+        RestApiException exception = assertThrows(RestApiException.class,
+                () -> feedbackImageService.validateImages(STUDENT_ID, List.of(myImageUrl("aaaaaaaaaa.jpg"))));
+
+        assertEquals(ErrorCode.FILE_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    void 용량을_초과한_사진은_R2에서_삭제하고_거부한다() {
+        givenObjectSize(MAX_IMAGE_BYTES + 1);
+
+        RestApiException exception = assertThrows(RestApiException.class,
+                () -> feedbackImageService.validateImages(STUDENT_ID, List.of(myImageUrl("aaaaaaaaaa.jpg"))));
+
+        assertEquals(ErrorCode.FILE_TOO_LARGE, exception.getErrorCode());
+        ArgumentCaptor<DeleteObjectRequest> deleteCaptor = ArgumentCaptor.forClass(DeleteObjectRequest.class);
+        verify(s3Client).deleteObject(deleteCaptor.capture());
+        assertEquals("feedback/" + STUDENT_ID + "/aaaaaaaaaa.jpg", deleteCaptor.getValue().key());
+    }
+
+    @Test
+    void URL이_너무_길면_거부한다() {
+        String longUrl = myImageUrl("a".repeat(200) + ".jpg");
+
+        RestApiException exception = assertThrows(RestApiException.class,
+                () -> feedbackImageService.validateImages(STUDENT_ID, List.of(longUrl)));
+
+        assertEquals(ErrorCode.INVALID_FILE_URL, exception.getErrorCode());
+    }
+}

--- a/backend/src/test/java/moadong/feedback/service/FeedbackImageServiceTest.java
+++ b/backend/src/test/java/moadong/feedback/service/FeedbackImageServiceTest.java
@@ -156,7 +156,7 @@ class FeedbackImageServiceTest {
 
     @Test
     void 발급_요청이_창_한도를_넘으면_거부한다() {
-        when(stringRedisTemplate.execute(any(RedisScript.class), any(), any())).thenReturn(41L);
+        when(stringRedisTemplate.execute(any(RedisScript.class), any(), any())).thenReturn(21L);
 
         RestApiException exception = assertThrows(RestApiException.class,
                 () -> createUploadUrls(List.of(new UploadUrlRequest("a.jpg", "image/jpeg"))));

--- a/backend/src/test/java/moadong/feedback/service/FeedbackServiceTest.java
+++ b/backend/src/test/java/moadong/feedback/service/FeedbackServiceTest.java
@@ -1,0 +1,241 @@
+package moadong.feedback.service;
+
+import moadong.feedback.entity.Feedback;
+import moadong.feedback.entity.Letter;
+import moadong.feedback.enums.FeedbackStatus;
+import moadong.feedback.enums.FeedbackType;
+import moadong.feedback.enums.LetterCategory;
+import moadong.feedback.enums.SentFeedbackStatus;
+import moadong.feedback.payload.request.FeedbackCreateRequest;
+import moadong.feedback.payload.response.ReceivedLetterDetailResponse;
+import moadong.feedback.payload.response.ReceivedLetterListResponse;
+import moadong.feedback.repository.FeedbackRepository;
+import moadong.feedback.repository.LetterRepository;
+import moadong.global.exception.ErrorCode;
+import moadong.global.exception.RestApiException;
+import moadong.util.annotations.UnitTest;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@UnitTest
+class FeedbackServiceTest {
+
+    private static final String STUDENT_ID = "11111111-1111-1111-1111-111111111111";
+    private static final String OTHER_STUDENT_ID = "22222222-2222-2222-2222-222222222222";
+
+    @Mock
+    private FeedbackRepository feedbackRepository;
+
+    @Mock
+    private LetterRepository letterRepository;
+
+    @Mock
+    private FeedbackImageService feedbackImageService;
+
+    @InjectMocks
+    private FeedbackService feedbackService;
+
+    @Test
+    void 피드백_저장_시_사진은_검증을_거친_결과가_들어간다() {
+        List<String> requested = List.of("https://cdn.moadong.com/feedback/" + STUDENT_ID + "/a.jpg");
+        when(feedbackImageService.validateImages(STUDENT_ID, requested)).thenReturn(requested);
+        when(feedbackRepository.save(any(Feedback.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        feedbackService.createFeedback(STUDENT_ID,
+                new FeedbackCreateRequest(FeedbackType.BUG, "사진과 함께 버그를 신고합니다", requested));
+
+        ArgumentCaptor<Feedback> captor = ArgumentCaptor.forClass(Feedback.class);
+        verify(feedbackRepository).save(captor.capture());
+        assertEquals(requested, captor.getValue().getImages());
+    }
+
+    @Test
+    void 사진_검증에_실패하면_피드백이_저장되지_않는다() {
+        List<String> requested = List.of("https://evil.example.com/a.jpg");
+        when(feedbackImageService.validateImages(STUDENT_ID, requested))
+                .thenThrow(new RestApiException(ErrorCode.INVALID_FILE_URL));
+
+        assertThrows(RestApiException.class, () -> feedbackService.createFeedback(STUDENT_ID,
+                new FeedbackCreateRequest(FeedbackType.BUG, "사진과 함께 버그를 신고합니다", requested)));
+
+        verify(feedbackRepository, never()).save(any(Feedback.class));
+    }
+
+    @Test
+    void 받은_편지_목록은_학생별로_읽음_여부를_계산한다() {
+        Letter read = Letter.builder()
+                .id("letter-read")
+                .category(LetterCategory.UPDATE)
+                .title("업데이트")
+                .body("본문")
+                .readStudentIds(Set.of(STUDENT_ID))
+                .build();
+        Letter unread = Letter.builder()
+                .id("letter-unread")
+                .category(LetterCategory.STORY)
+                .title("이야기")
+                .body("본문")
+                .readStudentIds(Set.of(OTHER_STUDENT_ID))
+                .build();
+        when(letterRepository.findInboxByStudentId(STUDENT_ID)).thenReturn(List.of(read, unread));
+
+        ReceivedLetterListResponse response = feedbackService.getReceivedLetters(STUDENT_ID, null);
+
+        assertTrue(response.letters().get(0).isRead());
+        assertFalse(response.letters().get(1).isRead());
+    }
+
+    @Test
+    void 목록_요약은_본문을_잘라서_내려준다() {
+        String longBody = "가".repeat(100);
+        Letter letter = Letter.builder()
+                .id("letter-1")
+                .category(LetterCategory.STORY)
+                .title("이야기")
+                .body(longBody)
+                .readStudentIds(Set.of())
+                .build();
+        when(letterRepository.findInboxByStudentId(STUDENT_ID)).thenReturn(List.of(letter));
+
+        ReceivedLetterListResponse response = feedbackService.getReceivedLetters(STUDENT_ID, null);
+
+        assertEquals("가".repeat(60) + "...", response.letters().get(0).preview());
+    }
+
+    @Test
+    void 답장_편지_상세는_원본_피드백을_동봉한다() {
+        Letter reply = Letter.builder()
+                .id("letter-1")
+                .category(LetterCategory.REPLY)
+                .recipientStudentId(STUDENT_ID)
+                .feedbackId("feedback-1")
+                .title("답장")
+                .body("본문")
+                .build();
+        Feedback original = Feedback.builder()
+                .id("feedback-1")
+                .studentId(STUDENT_ID)
+                .type(FeedbackType.FEATURE)
+                .content("즐겨찾기 알림이 있으면 좋겠어요")
+                .status(FeedbackStatus.REPLIED)
+                .build();
+        when(letterRepository.findById("letter-1")).thenReturn(Optional.of(reply));
+        when(feedbackRepository.findById("feedback-1")).thenReturn(Optional.of(original));
+
+        ReceivedLetterDetailResponse response = feedbackService.getReceivedLetter(STUDENT_ID, "letter-1");
+
+        assertEquals("feedback-1", response.myFeedback().id());
+        assertEquals(SentFeedbackStatus.REPLIED, response.myFeedback().status());
+    }
+
+    @Test
+    void 전체_발행_편지_상세는_myFeedback_없이_내려간다() {
+        Letter broadcast = Letter.builder()
+                .id("letter-1")
+                .category(LetterCategory.UPDATE)
+                .title("업데이트")
+                .body("본문")
+                .build();
+        when(letterRepository.findById("letter-1")).thenReturn(Optional.of(broadcast));
+
+        ReceivedLetterDetailResponse response = feedbackService.getReceivedLetter(STUDENT_ID, "letter-1");
+
+        assertNull(response.myFeedback());
+    }
+
+    @Test
+    void 남의_답장_편지는_조회할_수_없다() {
+        Letter reply = Letter.builder()
+                .id("letter-1")
+                .category(LetterCategory.REPLY)
+                .recipientStudentId(OTHER_STUDENT_ID)
+                .feedbackId("feedback-1")
+                .title("답장")
+                .body("본문")
+                .build();
+        when(letterRepository.findById("letter-1")).thenReturn(Optional.of(reply));
+
+        RestApiException exception = assertThrows(RestApiException.class,
+                () -> feedbackService.getReceivedLetter(STUDENT_ID, "letter-1"));
+
+        assertEquals(ErrorCode.LETTER_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    void 남의_피드백_상세는_조회할_수_없다() {
+        Feedback feedback = Feedback.builder()
+                .id("feedback-1")
+                .studentId(OTHER_STUDENT_ID)
+                .type(FeedbackType.BUG)
+                .content("버그가 있어요")
+                .build();
+        when(feedbackRepository.findById("feedback-1")).thenReturn(Optional.of(feedback));
+
+        RestApiException exception = assertThrows(RestApiException.class,
+                () -> feedbackService.getSentFeedback(STUDENT_ID, "feedback-1"));
+
+        assertEquals(ErrorCode.FEEDBACK_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    void 읽을_수_없는_편지는_읽음_처리되지_않는다() {
+        Letter reply = Letter.builder()
+                .id("letter-1")
+                .category(LetterCategory.REPLY)
+                .recipientStudentId(OTHER_STUDENT_ID)
+                .title("답장")
+                .body("본문")
+                .build();
+        when(letterRepository.findById("letter-1")).thenReturn(Optional.of(reply));
+
+        assertThrows(RestApiException.class, () -> feedbackService.markLetterRead(STUDENT_ID, "letter-1"));
+
+        verify(letterRepository, never()).markRead("letter-1", STUDENT_ID);
+    }
+
+    @Test
+    void 읽음_처리는_학생을_읽은_목록에_추가한다() {
+        Letter broadcast = Letter.builder()
+                .id("letter-1")
+                .category(LetterCategory.UPDATE)
+                .title("업데이트")
+                .body("본문")
+                .build();
+        when(letterRepository.findById("letter-1")).thenReturn(Optional.of(broadcast));
+
+        feedbackService.markLetterRead(STUDENT_ID, "letter-1");
+
+        verify(letterRepository).markRead("letter-1", STUDENT_ID);
+    }
+
+    @Test
+    void 답장_전_피드백은_사용자에게_PENDING으로_보인다() {
+        Feedback feedback = Feedback.builder()
+                .id("feedback-1")
+                .studentId(STUDENT_ID)
+                .type(FeedbackType.QUESTION)
+                .content("궁금한 게 있어요")
+                .status(FeedbackStatus.IN_PROGRESS)
+                .build();
+        when(feedbackRepository.findByStudentIdOrderByCreatedAtDesc(STUDENT_ID)).thenReturn(List.of(feedback));
+
+        assertEquals(SentFeedbackStatus.PENDING,
+                feedbackService.getSentFeedbacks(STUDENT_ID).feedbacks().get(0).status());
+    }
+}

--- a/backend/src/test/java/moadong/feedback/service/LetterDraftServiceTest.java
+++ b/backend/src/test/java/moadong/feedback/service/LetterDraftServiceTest.java
@@ -1,0 +1,90 @@
+package moadong.feedback.service;
+
+import moadong.feedback.entity.LetterDraft;
+import moadong.feedback.enums.LetterCategory;
+import moadong.feedback.payload.request.LetterDraftRequest;
+import moadong.feedback.payload.response.LetterDraftResponse;
+import moadong.feedback.repository.LetterDraftRepository;
+import moadong.global.exception.ErrorCode;
+import moadong.global.exception.RestApiException;
+import moadong.util.annotations.UnitTest;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@UnitTest
+class LetterDraftServiceTest {
+
+    @Mock
+    private LetterDraftRepository letterDraftRepository;
+
+    @InjectMocks
+    private LetterDraftService letterDraftService;
+
+    @Test
+    void 제목과_본문이_비어있어도_임시저장된다() {
+        when(letterDraftRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        LetterDraftResponse response = letterDraftService.createDraft(
+                new LetterDraftRequest(null, null, null, false));
+
+        assertNull(response.title());
+        assertNull(response.body());
+        verify(letterDraftRepository).save(any(LetterDraft.class));
+    }
+
+    @Test
+    void 이어쓰기는_기존_초안을_덮어쓴다() {
+        LetterDraft draft = LetterDraft.builder()
+                .id("draft-1")
+                .category(LetterCategory.UPDATE)
+                .title("쓰다 만 제목")
+                .body("쓰다 만 본문")
+                .build();
+        when(letterDraftRepository.findById("draft-1")).thenReturn(Optional.of(draft));
+        when(letterDraftRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        letterDraftService.updateDraft("draft-1",
+                new LetterDraftRequest(LetterCategory.STORY, "완성된 제목", "완성된 본문", true));
+
+        ArgumentCaptor<LetterDraft> captor = ArgumentCaptor.forClass(LetterDraft.class);
+        verify(letterDraftRepository).save(captor.capture());
+        assertEquals(LetterCategory.STORY, captor.getValue().getCategory());
+        assertEquals("완성된 제목", captor.getValue().getTitle());
+        assertTrue(captor.getValue().isSendPush());
+    }
+
+    @Test
+    void 없는_초안은_이어쓸_수_없다() {
+        when(letterDraftRepository.findById("draft-1")).thenReturn(Optional.empty());
+
+        RestApiException exception = assertThrows(RestApiException.class, () -> letterDraftService.updateDraft(
+                "draft-1", new LetterDraftRequest(LetterCategory.UPDATE, "제목", "본문", false)));
+
+        assertEquals(ErrorCode.LETTER_DRAFT_NOT_FOUND, exception.getErrorCode());
+        verify(letterDraftRepository, never()).save(any());
+    }
+
+    @Test
+    void 없는_초안은_삭제할_수_없다() {
+        when(letterDraftRepository.existsById("draft-1")).thenReturn(false);
+
+        RestApiException exception = assertThrows(RestApiException.class,
+                () -> letterDraftService.deleteDraft("draft-1"));
+
+        assertEquals(ErrorCode.LETTER_DRAFT_NOT_FOUND, exception.getErrorCode());
+        verify(letterDraftRepository, never()).deleteById(any());
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈



## 📝작업 내용

프론트가 MSW 목으로 먼저 구현한 **모아동 우체통**의 백엔드입니다. `feedback` 도메인이 없던 상태에서 전부 신규로 만들었습니다.

### 사용자 API — 경로가 `/api/student/feedback` 입니다 ⚠️

전달 문서는 `/api/feedback`을 가정했지만 **그대로 두면 매 요청 500**입니다.

`JwtAuthenticationFilter:33`이 `/api/student`, `/auth/student`, `/api/v2/fcm`만 건너뜁니다. `/api/feedback`에 학생 토큰을 붙이면 필터가 동작하고 → `CustomUserDetailService`가 UUID를 사용자로 조회하다 `USER_NOT_EXIST`를 던지는데 → 필터는 `extractUsername` 구간만 try/catch라 이 예외가 안 잡히고 → 필터 체인이라 `GlobalExceptionHandler`도 못 탑니다.

그래서 `StudentFcmController`와 같은 방식(필터 제외 경로 + `StudentJwtService`로 직접 파싱)으로 맞췄습니다.

| 메서드 | 경로 |
|---|---|
| POST | `/api/student/feedback` |
| POST | `/api/student/feedback/images/upload-url` |
| GET | `/api/student/feedback/received?category=` |
| GET | `/api/student/feedback/received/{letterId}` |
| PATCH | `/api/student/feedback/received/{letterId}/read` |
| GET | `/api/student/feedback/sent` |
| GET | `/api/student/feedback/sent/{feedbackId}` |

### 운영 API — 전부 `/api/admin` 아래

피드백은 개인적인 의견이라 `SecurityConfig`의 `hasRole('DEVELOPER')` 안쪽에 두는 게 필수입니다. 다른 경로면 `anyRequest().permitAll()`에 걸려 인증 없이 뚫립니다.

`GET /api/admin/feedback` · `POST .../{id}/reply` · `PATCH .../{id}/status` · `POST .../letters` · `POST .../letters/images` · 초안 CRUD 4개

### 첨부 사진

동아리 활동사진(`generateFeedUploadUrls`)과 같은 presigned 방식이며 **요청/응답 배열 형태도 동일**해서 프론트가 `uploadToStorage`를 그대로 재사용합니다. 저장 시점에 **장수·소유 경로·실제 업로드 여부·용량을 R2에서 다시 검증**합니다. key가 `feedback/{studentId}/`라 경로 자체가 권한 경계입니다.

규격은 기존 규약대로 6종(jpeg·jpg·png·gif·bmp·webp) · 10MB입니다. 시안의 "PNG·JPG·최대 5MB" 문구는 오기이며 `application.yml`과 프론트 `MAX_FILE_SIZE` 모두 10MB로 이미 일치합니다.

### 개발자 포털

사이드바에 `받은 피드백` 추가. 좌측 테이블 · 우측 답장 패널(원문 인용 + 첨부 썸네일), 새 편지 발행 시 이미지 업로드 · 임시저장 · 전체 푸시. 로컬 구동으로 목록·답장·첨부 썸네일 렌더까지 확인했습니다.

## 중점적으로 리뷰받고 싶은 부분

1. **`/api/student/feedback` 경로 선택** — 위 500 이슈 때문인데, `shouldNotFilter`에 `/api/feedback`을 추가하는 쪽이 나을지 의견 주세요. 프론트 계약이 바뀌는 지점입니다.
2. **초안을 별도 컬렉션(`feedback_letter_drafts`)에 둔 것** — `Letter`에 상태 플래그로 두면 받은 편지함 쿼리에 조건 하나만 빠져도 미발행 글이 전체 사용자에게 노출됩니다. 물리 분리로 그 사고를 구조적으로 막았습니다.
3. **브로드캐스트 편지의 `readStudentIds`** — 편지 문서 안에 읽은 사람 UUID를 모읍니다. 지금 규모(수천)에선 문제없지만 1만 명이면 조회 1회에 편지당 360KB를 끌어옵니다. 커지면 projection으로 분리해야 합니다.

## 논의하고 싶은 부분

**공개 버킷** — 첨부 사진이 활동사진·로고와 같은 공개 버킷에 올라갑니다. key가 랜덤이라 URL을 모르면 못 열지만 알면 누구나 열립니다. 정책적으로 괜찮은지만 확인 부탁드립니다.

## 🫡 참고사항

### 확정된 결정 (논의 완료)

- **보낸 사람 식별자** = `user_` + 학생 UUID 앞 8자리 (`user_a3f9c2d1`). 시안의 4자리는 1만 버킷이라 제보자 200명에서 충돌 확률 86%, 500명이면 사실상 100%입니다. 서로 다른 학생이 같은 ID로 보이면 운영자가 동일인의 반복 제보로 오해합니다. 학번은 서버가 알지도 못하고 개인정보라 노출하지 않습니다.
- **운영 상태 3단계 / 사용자 2단계** — DB에 `WAITING`/`IN_PROGRESS`/`REPLIED`, 사용자 응답은 `PENDING`/`REPLIED`로 축약.
- **`sendToAll` 필드 제외** — 대상 선택 UI가 없어 의미가 미정이라 넣지 않았습니다.
- **답장 본문도 마크다운** — 서버는 이미 그렇게 취급 중이라 코드 변경 없습니다.

### 답장 푸시는 웹뷰 토큰 주입 전까지 동작하지 않습니다

우체통 출시를 앱 릴리즈에 묶지 않기로 하면서, 앱 웹뷰 안에서도 웹이 자체 UUID를 발급하게 됩니다. 앱 `@access_token`의 UUID(= FCM 등록 주체)와 달라져 `StudentUser`를 찾을 수 없습니다.

```
앱 AsyncStorage @access_token → UUID-A → FCM v2 등록 (StudentUser 존재)
웹뷰 안 웹이 자체 발급        → UUID-B → Feedback.studentId = UUID-B
```

그래서 포털 푸시 체크박스를 **기본 해제**로 두었습니다(`75744f8a`). 켜둔 채 발행하면 실패가 아닌데 매번 "푸시는 전송되지 않았습니다" 경고가 뜹니다. 발송 코드는 그대로 두었고, 주입이 들어오면 체크만 켜면 동작합니다.

**전체 편지 발행(`UPDATE`/`STORY`) 푸시는 지금도 정상 동작합니다.** 전체 토큰 멀티캐스트라 studentId 매칭이 없습니다. 답장만 안 됩니다.

### 후속 작업 — 신원 이관 API 검토 필요

위 순서(우체통 먼저 출시 → 나중에 앱에 주입 추가) 때문에, 주입이 들어오는 시점에 studentId가 바뀌어 **그 사이에 쌓인 편지함이 유실**됩니다. 유실 규모는 `출시 ~ 주입 릴리즈` 기간 × 사용량이라 미룰수록 커집니다.

필요해지면 범위는 피드백 도메인 3곳입니다 — `Feedback.studentId`, `Letter.recipientStudentId`, `Letter.readStudentIds`. FCM 쪽(`StudentUser`, `StudentFcmToken`)은 주입 토큰으로 이미 등록돼 있으므로 건드리면 안 됩니다. 두 토큰의 서명을 모두 검증해야 남의 편지함 흡수를 막을 수 있습니다.

이번 PR 범위 밖입니다. 주입 릴리즈 시점이 정해지면 별도로 올리겠습니다.

### 테스트

신규 43개 전부 통과. 전체 328개 / 20실패인데, 실패 20개는 작업 전과 동일한 `@SpringBootTest` 컨텍스트 로딩 실패입니다(워크스페이스에 `application.yml` 미생성). 피드백 관련 클래스는 없습니다.

`FeedbackServiceTest` 11 · `FeedbackImageServiceTest` 12 · `FeedbackAdminServiceTest` 10 · `LetterPreviewTest` 5 · `LetterDraftServiceTest` 4 · `FeedbackSerializationTest` 1

### 배포 후 첫 확인

학생 토큰을 붙인 `GET /api/student/feedback/sent` 한 번. `/api/student`가 필터에서 제외된다는 전제는 코드로만 확인했고 실행 검증을 못 했습니다. 이게 틀리면 사용자 API 전체가 500입니다.

### 알려진 제약 (이번 범위 밖)

- **고아 파일** — presigned 발급 후 저장하지 않으면 R2에 객체가 남습니다. **기존 활동사진·로고·커버도 동일**하며 `listObjectsV2` 호출이 코드에 아예 없어 정리 수단 자체가 없습니다. 새로 생긴 문제가 아닙니다.
- **웹 브라우저 직접 접속** — 앱 웹뷰가 아닌 순수 브라우저는 별도 UUID를 갖습니다. 시크릿 모드·사이트 데이터 삭제로 편지함이 유실됩니다. 로그인이 없는 구조의 본질적 한계입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 학생이 피드백을 작성하고 이미지 첨부, 제출 내역 및 답변 상태를 확인할 수 있습니다.
  * 받은 편지를 카테고리별로 조회하고, 상세 내용 확인 및 읽음 처리를 지원합니다.
  * 운영자가 피드백에 답장하고 상태를 관리하거나 전체 편지를 발행할 수 있습니다.
  * 편지 초안 저장·수정·삭제, 이미지 업로드, 푸시 알림 설정을 지원합니다.
* **개선**
  * 편지 미리보기와 중복 발행 방지 기능을 제공합니다.
  * 이미지 형식·용량·업로드 횟수 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->