### PR TITLE
[fix] PR #1895 리뷰 중 긴급 건 수정

### DIFF
--- a/frontend/src/hooks/useNavigator.test.ts
+++ b/frontend/src/hooks/useNavigator.test.ts
@@ -128,6 +128,8 @@ describe('useNavigator - 사용자가 링크를 클릭했을 때', () => {
         expect(mockRequestOpenExternalUrl).toHaveBeenCalled();
         expect(window.open).toHaveBeenCalledWith(
           'itms-apps://itunes.apple.com/app/123456',
+          '_blank',
+          'noopener',
         );
       });
     });

--- a/frontend/src/pages/AdminPage/tabs/CalendarSyncTab/components/AddEventSheet/AddEventSheet.styles.ts
+++ b/frontend/src/pages/AdminPage/tabs/CalendarSyncTab/components/AddEventSheet/AddEventSheet.styles.ts
@@ -26,13 +26,6 @@ export const SaveArea = styled.div`
   padding: 10px 24px calc(20px + env(safe-area-inset-bottom));
 `;
 
-export const MonthLabel = styled.h4`
-  margin: 0;
-  font-size: 1.05rem;
-  font-weight: 700;
-  color: ${colors.gray[900]};
-`;
-
 /** 버튼 영역이 투명이라 배경을 깔지 않으면 뒤 내용과 겹쳐 읽히지 않는다 */
 export const ErrorText = styled.p`
   margin: 0;

--- a/frontend/src/pages/AdminPage/tabs/CalendarSyncTab/components/AddEventSheet/AddEventSheet.tsx
+++ b/frontend/src/pages/AdminPage/tabs/CalendarSyncTab/components/AddEventSheet/AddEventSheet.tsx
@@ -11,7 +11,7 @@ import type {
   CustomEventType,
   RecurrenceFrequency,
 } from '@/types/club';
-import { dateFromKey, formatMonthLabel } from '@/utils/calendarSyncUtils';
+import { dateFromKey } from '@/utils/calendarSyncUtils';
 import CalendarLinkPanel from '../CalendarLinkPanel/CalendarLinkPanel';
 import ColorBar from '../ColorBar/ColorBar';
 import DatePickerSheet from '../DatePickerSheet/DatePickerSheet';
@@ -203,8 +203,7 @@ const AddEventSheet = ({
             setEventType(nextType);
           }}
         />
-        <Styled.MonthLabel>{formatMonthLabel(month)}</Styled.MonthLabel>
-
+        {/* 달을 넘길 수단이 헤더뿐이라, 헤더를 숨기면 initialDate가 속한 달에만 갇힌다 */}
         {eventType === 'SINGLE' && (
           <MiniCalendar
             month={month}
@@ -215,7 +214,6 @@ const AddEventSheet = ({
               trackDateSelected(dateKey);
               setSelectedDate(dateKey);
             }}
-            showHeader={false}
             accentColor={color}
           />
         )}
@@ -228,7 +226,6 @@ const AddEventSheet = ({
             rangeStart={rangeStart}
             rangeEnd={rangeEnd}
             onSelectDate={handleRangeSelect}
-            showHeader={false}
             accentColor={color}
           />
         )}
@@ -240,7 +237,6 @@ const AddEventSheet = ({
             mode='multi'
             selectedDates={multiDates}
             onSelectDate={handleMultiSelect}
-            showHeader={false}
             accentColor={color}
           />
         )}

--- a/frontend/src/pages/AdminPage/tabs/CalendarSyncTab/components/ColorBar/ColorBar.styles.ts
+++ b/frontend/src/pages/AdminPage/tabs/CalendarSyncTab/components/ColorBar/ColorBar.styles.ts
@@ -7,13 +7,23 @@ export const Container = styled.div`
   padding: 4px 0;
 `;
 
+/** 색 막대는 8px로 보이되, 모바일에서 누를 수 있도록 버튼 자체는 24px을 확보한다 */
 export const ColorChip = styled.button<{ $color: string; $selected: boolean }>`
   flex: ${({ $selected }) => ($selected ? 3 : 1)};
-  height: 8px;
+  height: 24px;
+  display: flex;
+  align-items: center;
   border: none;
-  border-radius: 4px;
-  background: ${({ $color }) => $color};
+  background: none;
   cursor: pointer;
   padding: 0;
   transition: flex 0.2s ease;
+
+  &::after {
+    content: '';
+    width: 100%;
+    height: 8px;
+    border-radius: 4px;
+    background: ${({ $color }) => $color};
+  }
 `;


### PR DESCRIPTION
## 개요

[#1895](https://github.com/Moadong/moadong/pull/1895) CodeRabbit 리뷰 28건 중, 실제로 재현되는 긴급 건만 골라 수정했습니다.

## 수정한 것

### 1. 일정 추가 시트에서 달을 넘길 수 없음 (🟠 Major)

`AddEventSheet`의 SINGLE·PERIOD·MULTI 달력이 `MiniCalendar`를 `showHeader={false}`로 그립니다. `MiniCalendar`는 헤더의 이전/다음/오늘 버튼에서만 `onMonthChange`를 부르고(`MiniCalendar.tsx:76-92`), 현재 달이 아닌 셀은 `disabled`입니다(`:127`). 위에 있던 `Styled.MonthLabel`은 정적 텍스트라 이동 수단이 못 됩니다.

→ 3월 셀에서 시트를 열면 4월 일정을 만들 수 없었습니다. 헤더를 살리고 중복되는 정적 월 라벨을 걷어냈습니다.

### 2. 색상 선택 버튼 터치 영역 8px (🟠 Major)

`ColorBar`의 버튼 높이가 색 막대 높이(8px)와 같아 모바일에서 색을 고르기 어려웠습니다. 막대는 가상 요소로 8px을 유지하고 버튼만 24px을 확보했습니다.

### 3. 실패하고 있던 테스트 (🟠 Major)

`useNavigator.test.ts`의 `itms-apps://` 폴백 테스트가 `window.open(url)` 한 인자를 기대하는데 구현은 `(url, '_blank', 'noopener')`를 넘겨 실패 중이었습니다. **`frontend-ci.yml`은 prettier·lint·audit:tracking·build만 돌리고 jest를 돌리지 않아 CI가 초록이었습니다.**

## 미룬 것

| 리뷰 | 판단 |
| --- | --- |
| `CalendarSyncTab` 연결 해제 확인 창 건너뜀 | **stale** — 해당 코드가 리팩터링돼 사라짐 |
| `ProviderPopover` Escape 스택 통합 | **stale** — 컴포넌트가 현재 어디서도 쓰이지 않는 dead code (삭제는 별건으로) |
| `BottomSheet` / `DisconnectConfirmModal` 포커스 트랩 | 접근성 heavy lift, 별도 PR |
| `parseDateKey`가 `2026-02-30`을 통과시킴 | 서버가 생성하는 값이라 실사용 경로 없음 |
| 나머지 🟡 Minor (스토리 args, import 순서, keyframes 네이밍 등) | 릴리즈 블로커 아님 |

## 검증

- `npm run typecheck` — 통과
- `npx jest` — 43 suites / 366 tests 전부 통과 (수정 전 1건 실패)
- `npx prettier --check`, `npx eslint` (변경 파일) — 통과

> 참고: 프론트엔드 CI에 jest 단계가 없어 테스트가 깨져도 드러나지 않습니다. `frontend-ci.yml`에 `npm run test` 추가를 별도로 제안합니다.
