### PR TITLE
[fix] PR #1896 리뷰 중 긴급 이슈 수정 (반복 일정 삭제 버그 + 통계 수집 API 검증)

### DIFF
--- a/backend/src/main/java/moadong/analytics/controller/ClubDetailDurationController.java
+++ b/backend/src/main/java/moadong/analytics/controller/ClubDetailDurationController.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import moadong.analytics.payload.request.ClubDetailDurationRecordRequest;
 import moadong.analytics.service.ClubDetailDurationService;
+import moadong.global.payload.Response;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,22 +19,29 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Analytics", description = "사용자 행동 통계 수집 API")
 public class ClubDetailDurationController {
 
+    /** IPv6 최대 표기 길이. */
+    private static final int MAX_IP_LENGTH = 45;
+
     private final ClubDetailDurationService clubDetailDurationService;
 
     @PostMapping("/duration")
     @Operation(summary = "동아리 상세 페이지 체류 시간 기록")
-    public ResponseEntity<Void> recordDuration(
+    public ResponseEntity<?> recordDuration(
             @RequestBody ClubDetailDurationRecordRequest request,
             HttpServletRequest httpServletRequest
     ) {
         clubDetailDurationService.record(request, clientIp(httpServletRequest));
-        return ResponseEntity.noContent().build();
+        return Response.ok("체류 시간이 기록되었습니다.");
     }
 
     private String clientIp(HttpServletRequest request) {
         String forwardedFor = request.getHeader("X-Forwarded-For");
         if (forwardedFor != null && !forwardedFor.isBlank()) {
-            return forwardedFor.split(",")[0].trim();
+            String candidate = forwardedFor.split(",")[0].trim();
+            // 헤더는 호출자가 조작할 수 있으므로 IP 길이를 벗어난 값은 요청 제한 키로 쓰지 않는다.
+            if (!candidate.isEmpty() && candidate.length() <= MAX_IP_LENGTH) {
+                return candidate;
+            }
         }
         return request.getRemoteAddr();
     }

--- a/backend/src/main/java/moadong/analytics/service/ClubDetailDurationService.java
+++ b/backend/src/main/java/moadong/analytics/service/ClubDetailDurationService.java
@@ -28,6 +28,8 @@ public class ClubDetailDurationService {
 
     private static final long MIN_DURATION_SECONDS = 1L;
     private static final long MAX_DURATION_SECONDS = 3600L;
+    /** clubId는 24자 Mongo id, sessionId/visitorId는 36자 UUID이므로 64자면 충분하다. */
+    private static final int MAX_ID_LENGTH = 64;
     private static final String RATE_LIMIT_KEY_PREFIX = "analytics:club-detail-duration:ratelimit:";
     private static final long RATE_LIMIT_WINDOW_SECONDS = 60L;
     private static final long RATE_LIMIT_MAX_REQUESTS = 120L;
@@ -63,9 +65,9 @@ public class ClubDetailDurationService {
 
     private void validate(ClubDetailDurationRecordRequest request) {
         if (request == null
-                || isBlank(request.clubId())
-                || isBlank(request.sessionId())
-                || isBlank(request.visitorId())
+                || isInvalidId(request.clubId())
+                || isInvalidId(request.sessionId())
+                || isInvalidId(request.visitorId())
                 || request.durationSeconds() == null
                 || request.durationSeconds() < MIN_DURATION_SECONDS
                 || request.durationSeconds() > MAX_DURATION_SECONDS) {
@@ -147,7 +149,10 @@ public class ClubDetailDurationService {
         return leftAt.atZone(AnalyticsTime.KST).toLocalDate();
     }
 
-    private boolean isBlank(String value) {
-        return value == null || value.isBlank();
+    /**
+     * 인증 없는 공개 API이므로 식별자 길이를 제한해 Redis 키와 Mongo 질의에 임의 길이 값이 들어가지 않게 한다.
+     */
+    private boolean isInvalidId(String value) {
+        return value == null || value.isBlank() || value.length() > MAX_ID_LENGTH;
     }
 }

--- a/backend/src/main/java/moadong/calendar/custom/service/CustomCalendarEventService.java
+++ b/backend/src/main/java/moadong/calendar/custom/service/CustomCalendarEventService.java
@@ -97,7 +97,7 @@ public class CustomCalendarEventService {
             return;
         }
 
-        LocalDate newRecurrenceEnd = targetDate.minusDays(1);
+        LocalDate newRecurrenceEnd = earlierOfExistingEnd(event, targetDate.minusDays(1));
         if (newRecurrenceEnd.isBefore(parseRequiredDate(event.getStart()))) {
             customCalendarEventRepository.delete(event);
             return;
@@ -163,6 +163,19 @@ public class CustomCalendarEventService {
                         event.getColor()
                 ))
                 .toList();
+    }
+
+    /**
+     * THIS_AND_FOLLOWING 삭제는 종료일을 앞당기기만 해야 한다.
+     * 기준일이 기존 종료일보다 뒤면 종료일을 그대로 두어 발생일이 늘어나지 않게 한다.
+     */
+    private LocalDate earlierOfExistingEnd(CustomCalendarEvent event, LocalDate newRecurrenceEnd) {
+        String existingEnd = event.getRecurrence().end();
+        if (!StringUtils.hasText(existingEnd)) {
+            return newRecurrenceEnd;
+        }
+        LocalDate parsedExistingEnd = parseRequiredDate(existingEnd);
+        return parsedExistingEnd.isBefore(newRecurrenceEnd) ? parsedExistingEnd : newRecurrenceEnd;
     }
 
     private boolean isRecurring(CustomCalendarEvent event) {

--- a/backend/src/main/java/moadong/calendar/custom/service/CustomEventOccurrenceExpander.java
+++ b/backend/src/main/java/moadong/calendar/custom/service/CustomEventOccurrenceExpander.java
@@ -58,13 +58,14 @@ public class CustomEventOccurrenceExpander {
             return List.of(start.toString());
         }
 
-        LocalDate windowLimit = LocalDate.now().plusYears(FUTURE_WINDOW_YEARS);
+        LocalDate today = LocalDate.now();
+        LocalDate windowLimit = today.plusYears(FUTURE_WINDOW_YEARS);
         LocalDate recurrenceEnd = parseOrNull(recurrence.end());
         LocalDate windowEnd = (recurrenceEnd != null && recurrenceEnd.isBefore(windowLimit))
                 ? recurrenceEnd
                 : windowLimit;
-        LocalDate visibleStart = recurrenceEnd == null && start.isBefore(LocalDate.now())
-                ? LocalDate.now()
+        LocalDate visibleStart = recurrenceEnd == null && start.isBefore(today)
+                ? today
                 : start;
 
         if (windowEnd.isBefore(visibleStart)) {

--- a/backend/src/test/java/moadong/analytics/controller/ClubDetailDurationControllerTest.java
+++ b/backend/src/test/java/moadong/analytics/controller/ClubDetailDurationControllerTest.java
@@ -3,6 +3,7 @@ package moadong.analytics.controller;
 import jakarta.servlet.http.HttpServletRequest;
 import moadong.analytics.payload.request.ClubDetailDurationRecordRequest;
 import moadong.analytics.service.ClubDetailDurationService;
+import moadong.global.payload.Response;
 import moadong.util.annotations.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -28,7 +29,7 @@ class ClubDetailDurationControllerTest {
     private ClubDetailDurationController clubDetailDurationController;
 
     @Test
-    void 체류_시간_기록_요청은_204를_반환한다() {
+    void 체류_시간_기록_요청은_200과_공통_응답을_반환한다() {
         // given
         ClubDetailDurationRecordRequest request = new ClubDetailDurationRecordRequest(
                 "club-id",
@@ -42,10 +43,33 @@ class ClubDetailDurationControllerTest {
         when(httpServletRequest.getHeader("X-Forwarded-For")).thenReturn("203.0.113.1, 10.0.0.1");
 
         // when
-        ResponseEntity<Void> response = clubDetailDurationController.recordDuration(request, httpServletRequest);
+        ResponseEntity<?> response = clubDetailDurationController.recordDuration(request, httpServletRequest);
 
         // then
-        assertEquals(204, response.getStatusCode().value());
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals("200", ((Response<?>) response.getBody()).statuscode());
         verify(clubDetailDurationService).record(request, "203.0.113.1");
+    }
+
+    @Test
+    void 비정상적으로_긴_X_Forwarded_For_값은_무시하고_remoteAddr을_사용한다() {
+        // given
+        ClubDetailDurationRecordRequest request = new ClubDetailDurationRecordRequest(
+                "club-id",
+                "테스트동아리",
+                "session-id",
+                "visitor-id",
+                Instant.parse("2026-08-06T01:00:00Z"),
+                Instant.parse("2026-08-06T01:00:10Z"),
+                10L
+        );
+        when(httpServletRequest.getHeader("X-Forwarded-For")).thenReturn("x".repeat(500));
+        when(httpServletRequest.getRemoteAddr()).thenReturn("10.0.0.1");
+
+        // when
+        clubDetailDurationController.recordDuration(request, httpServletRequest);
+
+        // then
+        verify(clubDetailDurationService).record(request, "10.0.0.1");
     }
 }

--- a/backend/src/test/java/moadong/calendar/custom/service/CustomCalendarEventServiceTest.java
+++ b/backend/src/test/java/moadong/calendar/custom/service/CustomCalendarEventServiceTest.java
@@ -413,6 +413,22 @@ class CustomCalendarEventServiceTest {
     }
 
     @Test
+    @DisplayName("THIS_AND_FOLLOWING 기준일이 기존 종료일보다 뒤면 종료일을 연장하지 않는다")
+    void delete_thisAndFollowingAfterRecurrenceEnd_keepsRecurrenceEnd() {
+        givenAuthenticatedClub();
+        givenSaveReturnsArgument();
+        CustomEventRecurrence recurrence = new CustomEventRecurrence("WEEKLY", null, "2026-03-31", null);
+        CustomCalendarEvent event = storedEvent("RECURRING", "2026-03-06", null, null, recurrence);
+        when(customCalendarEventRepository.findByIdAndClubId(EVENT_ID, CLUB_ID)).thenReturn(Optional.of(event));
+
+        customCalendarEventService.delete(user, EVENT_ID, "THIS_AND_FOLLOWING", "2027-01-01");
+
+        ArgumentCaptor<CustomCalendarEvent> captor = ArgumentCaptor.forClass(CustomCalendarEvent.class);
+        verify(customCalendarEventRepository).save(captor.capture());
+        assertThat(captor.getValue().getRecurrence().end()).isEqualTo("2026-03-31");
+    }
+
+    @Test
     @DisplayName("THIS_AND_FOLLOWING 기준일이 시작일이면 이벤트를 삭제한다")
     void delete_thisAndFollowingFromStart_deletesEvent() {
         givenAuthenticatedClub();

--- a/backend/src/test/java/moadong/calendar/custom/service/CustomEventOccurrenceExpanderTest.java
+++ b/backend/src/test/java/moadong/calendar/custom/service/CustomEventOccurrenceExpanderTest.java
@@ -155,9 +155,9 @@ class CustomEventOccurrenceExpanderTest {
     @DisplayName("반복 종료일이 없으면 오늘 기준 1년까지만 전개한다")
     void expand_unboundedRecurrenceStopsAtWindowLimit() {
         CustomEventRecurrence recurrence = new CustomEventRecurrence("MONTHLY", null, null, null);
-        LocalDate windowLimit = LocalDate.now().plusYears(1);
 
         List<String> occurrences = expander.expand(event("RECURRING", "2026-03-01", null, null, recurrence));
+        LocalDate windowLimit = LocalDate.now().plusYears(1);
 
         assertThat(occurrences).isNotEmpty();
         assertThat(occurrences).allSatisfy(date ->

--- a/docs/spec/club-detail-duration-analytics-spec.md
+++ b/docs/spec/club-detail-duration-analytics-spec.md
@@ -111,11 +111,12 @@ B 방문자: 30초
 
 성공 응답:
 
-- HTTP `204 No Content`
+- HTTP `200`
+- 공통 `Response<T>` 래퍼(`statuscode`, `message`, `data`)를 사용한다.
 
 중복 세션 응답:
 
-- HTTP `204 No Content`
+- HTTP `200`
 - 이미 처리한 `sessionId + clubId`는 다시 집계하지 않는다.
 
 실패 응답:
@@ -132,7 +133,7 @@ B 방문자: 30초
 
 검증:
 
-- `clubId`, `sessionId`, `visitorId`는 blank일 수 없다.
+- `clubId`, `sessionId`, `visitorId`는 blank일 수 없고 64자를 넘을 수 없다.
 - `durationSeconds`는 `1` 이상 `3600` 이하이다.
 - `enteredAt`과 `leftAt`이 모두 있으면 `leftAt`은 `enteredAt`보다 이전일 수 없다.
 - `clubId`는 존재하는 동아리여야 한다.
@@ -141,7 +142,8 @@ B 방문자: 30초
 
 - Redis window counter로 `clubId + clientIp` 단위 요청 수를 제한한다.
 - 기준값은 60초당 120회다.
-- `X-Forwarded-For`가 있으면 첫 번째 IP를 사용하고, 없으면 `remoteAddr`를 사용한다.
+- `X-Forwarded-For`가 있으면 첫 번째 IP를 사용하고, 없거나 IP 길이(45자)를 넘으면 `remoteAddr`를 사용한다.
+- `X-Forwarded-For`는 호출자가 조작할 수 있으므로, 인그레스에서 이 헤더를 덮어쓰도록 설정되어 있어야 요청 제한이 실제로 동작한다.
 
 날짜 기준:
 


### PR DESCRIPTION
## 배경

[#1896](https://github.com/Moadong/moadong/pull/1896) 릴리즈 PR의 CodeRabbit 리뷰 9건 중, **릴리즈를 막을 만한 4건만**  수정했습니다.

## 수정한 것

### 1. `THIS_AND_FOLLOWING` 삭제가 오히려 반복 일정을 늘리던 버그

`CustomCalendarEventService.delete()`가 기존 `recurrence.end`와 비교 없이 종료일을 덮어썼습니다.

- 종료일이 `2026-03-31`인 이벤트에 `scope=THIS_AND_FOLLOWING&date=2027-01-01` 요청
- → 새 종료일이 `2026-12-31`이 되어 **삭제 요청이 발생일을 9개월치 추가**

두 값 중 이른 날짜를 선택하도록 수정하고 회귀 테스트를 추가했습니다.

### 2. 수집 API 식별자 길이 미검증

`POST /api/analytics/club-detail/duration`은 인증 없는 공개 API인데 `clubId`/`sessionId`/`visitorId`에 blank 검사만 있어, 임의 길이 문자열이 Redis 요청 제한 키와 Mongo 질의에 그대로 들어갔습니다. 64자 상한을 추가했습니다 (실제값: Mongo id 24자, UUID 36자).

### 3. `X-Forwarded-For` 값 길이 미검증

호출자가 조작 가능한 헤더가 길이 제한 없이 Redis 키에 붙었습니다. IPv6 최대 표기(45자)를 넘으면 무시하고 `getRemoteAddr()`을 쓰도록 했습니다.

### 4. `Response<T>` 공통 계약 위반

`ResponseEntity<Void>` + 204를 반환하고 있었습니다. 프론트가 아직 이 API를 호출하지 않아(`frontend/`에 `visitorId` 참조 0건) 지금이 계약을 맞출 수 있는 시점이라 200 + `Response.ok`로 변경하고 스펙 문서도 갱신했습니다.

부수적으로 `CustomEventOccurrenceExpander`가 `windowLimit`/`visibleStart`를 각각 `LocalDate.now()`로 계산하던 부분을 한 번으로 모았습니다 

