### PR TITLE
[feature] 동아리 일정 관리 메뉴 프로덕션 노출

### DIFF
--- a/frontend/src/constants/adminTabs.ts
+++ b/frontend/src/constants/adminTabs.ts
@@ -15,10 +15,7 @@ export const ADMIN_TABS: TabCategory[] = [
       { label: '기본 정보 수정', path: '/admin/club-info' },
       { label: '소개 정보 수정', path: '/admin/club-intro' },
       { label: '활동 사진 수정', path: '/admin/photo-edit' },
-      ...(import.meta.env.DEV ||
-      (typeof __VERCEL_PREVIEW__ !== 'undefined' && __VERCEL_PREVIEW__)
-        ? [{ label: '동아리 일정 관리', path: '/admin/calendar-sync' }]
-        : []),
+      { label: '동아리 일정 관리', path: '/admin/calendar-sync' },
     ],
   },
   {


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

관리자 페이지 사이드바/설정탭의 **동아리 일정 관리** 메뉴에 걸려 있던 dev·preview 전용 게이팅을 제거해 프로덕션에서도 노출되도록 했습니다.

```diff
       { label: '활동 사진 수정', path: '/admin/photo-edit' },
-      ...(import.meta.env.DEV ||
-      (typeof __VERCEL_PREVIEW__ !== 'undefined' && __VERCEL_PREVIEW__)
-        ? [{ label: '동아리 일정 관리', path: '/admin/calendar-sync' }]
-        : []),
+      { label: '동아리 일정 관리', path: '/admin/calendar-sync' },
     ],
```

- 데스크탑 사이드바(`SideBar.tsx`)와 모바일 설정탭(`SettingsTab.tsx`)이 동일하게 `ADMIN_TABS`를 참조하므로 양쪽 모두 노출됩니다.
- `/admin/calendar-sync` 라우트는 기존에도 조건 없이 등록돼 있어(`AdminRoutes.tsx`) 별도 변경이 없습니다.

### 검증

- `npm run typecheck` 통과
- `npm run test` 통과 (43 suites / 366 tests)

## 중점적으로 리뷰받고 싶은 부분(선택)

**공개 페이지 "행사일정" 탭과의 정합성**입니다. `ClubDetailPage`의 행사일정 탭은 원래부터 게이팅이 없어 프로덕션에서도 노출 중이었고, 관리자가 연동할 수단이 없어 빈 상태만 보이고 있었습니다. 이번 변경으로 그 불일치가 해소되는 게 맞는지 확인 부탁드립니다.

## 논의하고 싶은 부분(선택)

- **Google OAuth 앱 인증 완료 여부**: 미완료 상태로 배포되면 동아리 관리자가 Google 계정 연동 시 "이 앱은 Google에서 확인하지 않았습니다" 경고 화면을 보게 됩니다. 인증 완료 후 머지하는 게 안전해 보입니다.

## 🫡 참고사항

`__VERCEL_PREVIEW__`(`config/vite.config.ts`의 define, `vite-env.d.ts`의 선언)는 이 변경으로 참조처가 없어졌습니다. 향후 다른 preview 전용 플래그에 재사용할 수 있어 이번 PR에서는 남겨뒀습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 동아리 일정 관리 탭이 모든 환경에서 항상 표시되도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
