### PR TITLE
[fix] 관리자 평균 체류 시간 카드 제거

### DIFF
--- a/frontend/src/pages/AdminPage/tabs/StatisticsTab/components/MetricSummary.test.tsx
+++ b/frontend/src/pages/AdminPage/tabs/StatisticsTab/components/MetricSummary.test.tsx
@@ -26,12 +26,11 @@ describe('MetricSummary', () => {
     );
 
     expect(screen.getByText('상세 조회수')).toBeInTheDocument();
-    expect(screen.getByText('평균 체류 시간')).toBeInTheDocument();
+    expect(screen.queryByText('평균 체류 시간')).not.toBeInTheDocument();
     expect(screen.getByText('고유 방문자')).toBeInTheDocument();
     expect(screen.getByText('인당 평균 체류 시간')).toBeInTheDocument();
     expect(screen.getByText('지원자 수')).toBeInTheDocument();
     expect(screen.getByText('1,234')).toBeInTheDocument();
-    expect(screen.getByText('1분 5초')).toBeInTheDocument();
     expect(screen.getByText('98')).toBeInTheDocument();
     expect(screen.getByText('2분 23초')).toBeInTheDocument();
   });

--- a/frontend/src/pages/AdminPage/tabs/StatisticsTab/components/MetricSummary.tsx
+++ b/frontend/src/pages/AdminPage/tabs/StatisticsTab/components/MetricSummary.tsx
@@ -53,12 +53,6 @@ const MetricSummary = ({
         </div>
       </Styled.MetricCard>
       <Styled.MetricCard>
-        <Styled.MetricLabel>평균 체류 시간</Styled.MetricLabel>
-        <Styled.MetricValue>
-          {formatDuration(data.averageDetailDurationSeconds)}
-        </Styled.MetricValue>
-      </Styled.MetricCard>
-      <Styled.MetricCard>
         <Styled.MetricLabel>고유 방문자</Styled.MetricLabel>
         <div>
           <Styled.MetricValue>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #1918

## 📝작업 내용

관리자 통계 요약에서 세션 기준 \평균 체류 시간\ 카드를 제거했습니다.

- 기존 \평균 체류 시간\은 \verageDetailDurationSeconds\를 표시하고 있었습니다.
- 현재 관리자 화면에서는 \인당 평균 체류 시간\이 대표 지표로 더 적합해, 혼동을 줄이기 위해 세션 기준 평균 카드만 숨겼습니다.
- \상세 조회수\, \고유 방문자\, \인당 평균 체류 시간\, \지원자 수\ 카드는 그대로 유지했습니다.
- \MetricSummary\ 테스트도 제거된 카드가 노출되지 않도록 갱신했습니다.

## 중점적으로 리뷰받고 싶은 부분(선택)

- 관리자 통계 요약에서 \인당 평균 체류 시간\만 체류 시간 대표 지표로 남기는 방향이 적절한지 확인 부탁드립니다.
- 추이 그래프는 이번 PR에서 변경하지 않았습니다.

## 논의하고 싶은 부분(선택)

- 추후 일자별 \인당 평균 체류 시간\ 추이가 필요하면 trend API 응답에 \verageDetailDurationSecondsPerVisitor\를 추가한 뒤 그래프 라인을 별도 PR에서 확장하는 방향이 좋겠습니다.

## 🫡 참고사항

검증:

- \
pm.cmd test -- MetricSummary.test.tsx --runInBand\ 통과


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 통계 요약 화면에서 **평균 체류 시간** 지표 카드가 제거되었습니다.
  * 상세 조회수와 고유 방문자 등 다른 통계 지표는 기존과 동일하게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->