### PR TITLE
[feature] 기기 언어 설정(device_locale) Mixpanel 수집

### DIFF
--- a/frontend/src/utils/CLAUDE.md
+++ b/frontend/src/utils/CLAUDE.md
@@ -7,6 +7,7 @@
 - `debounce.ts` - 디바운스 함수
 - `validateSocialLink.ts` - SNS 링크 유효성 검사
 - `isInAppWebView.ts` - 인앱 WebView 감지 (UA의 `MoadongApp`)
+- `getDeviceLocale.ts` - 기기 언어 설정 조회 (앱 주입 `window.deviceLocale` → `navigator.language` 폴백)
 - `webviewBridge.ts` - 네이티브 앱과 통신
 - `initSDK.ts` - 외부 SDK 초기화
 
@@ -18,4 +19,6 @@
 - **Kakao SDK**: 카카오 공유 기능
 - **Naver Map**: 동아리방 위치 지도 (네이버 클라우드 플랫폼)
 
-Mixpanel·Sentry·Channel.io는 `initSDK.ts`에서 초기화. Naver Map은 `loadNaverMapScript.ts`로 동적 로드(SDK init 아님). 각각 환경 변수 필요 (→ [frontend/CLAUDE.md](../../CLAUDE.md) 환경 변수 참고).
+Mixpanel·Sentry·Channel.io는 `initSDK.ts`에서 초기화.
+Mixpanel Super Property는 `initializeMixpanel()`에서 `mixpanel.register()`로 1회 등록한다 (`$os_version`, `device_locale`).
+`device_locale`은 앱이 웹뷰 콘텐츠 로드 **전에** `window.deviceLocale`을 주입해야 정확하며, 주입이 없으면 `navigator.language`로 폴백한다. Naver Map은 `loadNaverMapScript.ts`로 동적 로드(SDK init 아님). 각각 환경 변수 필요 (→ [frontend/CLAUDE.md](../../CLAUDE.md) 환경 변수 참고).

--- a/frontend/src/utils/getDeviceLocale.test.ts
+++ b/frontend/src/utils/getDeviceLocale.test.ts
@@ -35,6 +35,14 @@ describe('getDeviceLocale', () => {
     expect(getDeviceLocale('')).toBe('ko-KR');
   });
 
+  it('주입값이 공백뿐이면 navigator.language로 폴백한다', () => {
+    expect(getDeviceLocale('   ')).toBe('ko-KR');
+  });
+
+  it('주입값에 언어 정보가 없으면 navigator.language로 폴백한다', () => {
+    expect(getDeviceLocale('@calendar=gregorian')).toBe('ko-KR');
+  });
+
   it('locale을 알 수 없으면 null을 반환한다', () => {
     mockNavigatorLanguage('');
     expect(getDeviceLocale()).toBeNull();

--- a/frontend/src/utils/getDeviceLocale.test.ts
+++ b/frontend/src/utils/getDeviceLocale.test.ts
@@ -1,0 +1,42 @@
+import getDeviceLocale from '@/utils/getDeviceLocale';
+
+const mockNavigatorLanguage = (language: string) => {
+  Object.defineProperty(navigator, 'language', {
+    value: language,
+    configurable: true,
+  });
+};
+
+describe('getDeviceLocale', () => {
+  beforeEach(() => {
+    mockNavigatorLanguage('ko-KR');
+    delete window.deviceLocale;
+  });
+
+  it('앱이 주입한 window.deviceLocale을 우선 사용한다', () => {
+    window.deviceLocale = 'zh-CN';
+    expect(getDeviceLocale()).toBe('zh-CN');
+  });
+
+  it('iOS 형식의 언더스코어를 하이픈으로 정규화한다', () => {
+    expect(getDeviceLocale('vi_VN')).toBe('vi-VN');
+  });
+
+  it('iOS 식별자의 확장 정보를 제거한다', () => {
+    expect(getDeviceLocale('ko_KR@calendar=gregorian')).toBe('ko-KR');
+  });
+
+  it('주입값이 없으면 navigator.language로 폴백한다', () => {
+    mockNavigatorLanguage('en-US');
+    expect(getDeviceLocale()).toBe('en-US');
+  });
+
+  it('주입값이 빈 문자열이면 navigator.language로 폴백한다', () => {
+    expect(getDeviceLocale('')).toBe('ko-KR');
+  });
+
+  it('locale을 알 수 없으면 null을 반환한다', () => {
+    mockNavigatorLanguage('');
+    expect(getDeviceLocale()).toBeNull();
+  });
+});

--- a/frontend/src/utils/getDeviceLocale.ts
+++ b/frontend/src/utils/getDeviceLocale.ts
@@ -12,15 +12,12 @@ declare global {
  * 앱이 주입한 window.deviceLocale을 우선 사용하고, 없으면 navigator.language로 폴백
  * iOS의 "ko_KR@calendar=gregorian" 같은 형식을 "ko-KR"로 정규화해 Mixpanel 값이 갈라지지 않게 한다
  */
+const normalizeLocale = (locale: string | undefined): string | null =>
+  locale?.split('@')[0].replace(/_/g, '-').trim() || null;
+
 const getDeviceLocale = (
   rawLocale: string | undefined = window.deviceLocale,
-): string | null => {
-  const locale = rawLocale || navigator.language;
-  if (!locale) {
-    return null;
-  }
-
-  return locale.split('@')[0].replace(/_/g, '-').trim() || null;
-};
+): string | null =>
+  normalizeLocale(rawLocale) || normalizeLocale(navigator.language);
 
 export default getDeviceLocale;

--- a/frontend/src/utils/getDeviceLocale.ts
+++ b/frontend/src/utils/getDeviceLocale.ts
@@ -1,0 +1,26 @@
+declare global {
+  interface Window {
+    // 앱이 웹뷰 로드 전에 주입하는 기기 언어 설정
+    // Android: Locale.getDefault().toLanguageTag() → "ko-KR"
+    // iOS: Locale.current.identifier → "ko_KR"
+    deviceLocale?: string;
+  }
+}
+
+/**
+ * 기기 언어 설정을 BCP 47 형식으로 반환
+ * 앱이 주입한 window.deviceLocale을 우선 사용하고, 없으면 navigator.language로 폴백
+ * iOS의 "ko_KR@calendar=gregorian" 같은 형식을 "ko-KR"로 정규화해 Mixpanel 값이 갈라지지 않게 한다
+ */
+const getDeviceLocale = (
+  rawLocale: string | undefined = window.deviceLocale,
+): string | null => {
+  const locale = rawLocale || navigator.language;
+  if (!locale) {
+    return null;
+  }
+
+  return locale.split('@')[0].replace(/_/g, '-').trim() || null;
+};
+
+export default getDeviceLocale;

--- a/frontend/src/utils/initSDK.ts
+++ b/frontend/src/utils/initSDK.ts
@@ -2,6 +2,7 @@ import * as ChannelService from '@channel.io/channel-web-sdk-loader';
 import Clarity from '@microsoft/clarity';
 import * as Sentry from '@sentry/react';
 import mixpanel from 'mixpanel-browser';
+import getDeviceLocale from '@/utils/getDeviceLocale';
 import getIOSVersion from '@/utils/getIOSVersion';
 
 const LOCALHOST_HOSTNAME = 'localhost';
@@ -20,6 +21,12 @@ export function initializeMixpanel() {
   const iosVersion = getIOSVersion();
   if (iosVersion) {
     mixpanel.register({ $os_version: iosVersion });
+  }
+
+  // 외국인 유학생 등 비한국어 사용자 식별용 — 이후 모든 이벤트에 자동 포함
+  const deviceLocale = getDeviceLocale();
+  if (deviceLocale) {
+    mixpanel.register({ device_locale: deviceLocale });
   }
 
   if (window.location.hostname === LOCALHOST_HOSTNAME) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> 외국인 유학생 수요 파악을 위한 device_locale 수집

## 📝작업 내용

Mixpanel Super Property로 `device_locale`을 등록해 사용자의 기기 언어 설정을 수집합니다. 회원가입 기능이 없어 국적/언어 속성을 얻을 방법이 없던 문제를 기기 언어로 대신합니다.

- `getDeviceLocale.ts` 추가 — 앱이 주입한 `window.deviceLocale` 우선, 없으면 `navigator.language` 폴백
- `initializeMixpanel()`에서 `mixpanel.register({ device_locale })` 1회 등록 (기존 `$os_version` 등록과 동일한 위치)
- 값 정규화: iOS `Locale.current.identifier`는 `ko_KR` / `ko_KR@calendar=gregorian` 형식이라 Android의 `ko-KR`과 Mixpanel 값이 갈라집니다. `@` 뒤 확장을 제거하고 `_`를 `-`로 치환해 BCP 47로 통일합니다.

Super Property라 등록 이후 모든 이벤트에 자동 포함되며, Mixpanel 대시보드 사전 설정은 필요 없습니다.

## 중점적으로 리뷰받고 싶은 부분(선택)

**등록 시점**입니다. `initializeMixpanel()`은 번들 로드 시점에 1회만 실행되므로, 앱이 `window.deviceLocale`을 콘텐츠 로드 **이후**(`injectedJavaScript` / `onPageFinished`)에 주입하면 이미 폴백값이 등록된 뒤라 반영되지 않습니다. 앱 연동 시 반드시 `injectedJavaScriptBeforeContentLoaded`를 써야 합니다.

## 🫡 참고사항

**앱(RN) 작업은 이 PR에 포함되지 않았고, 없어도 동작합니다.** `navigator.language`가 iOS·Android 웹뷰 모두 기기 언어 설정을 따라가므로 웹 배포만으로 수집이 시작됩니다. 앱 주입은 정확도 개선이라 다음 릴리즈에 붙여도 순서 의존성이 없습니다.

다만 앱 네이티브 Mixpanel(`mixpanel-react-native`)은 별도 인스턴스라, **구독 버튼·알림 권한 다이얼로그 등 앱 전용 이벤트에는 `device_locale`이 붙지 않습니다.** 다음 릴리즈에 `registerSuperProperties` 추가가 필요합니다(`expo-localization` 설치 동반).

**지표 해석 주의:** 중국인 유학생이 폰을 한국어로 쓰면 `ko-KR`로 잡힙니다. `ko` 외 locale 사용자는 확실히 외국인이지만 그 역은 성립하지 않아, 실제 유학생 수의 **하한선**으로만 읽어야 합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 기기 언어 설정을 자동으로 감지해 분석 데이터에 `device_locale`로 기록합니다.
  * 시스템 로케일 형식을 정규화하고, 감지할 수 없는 경우 안전하게 처리합니다.
  * 운영체제 버전 정보와 함께 기기 로케일이 공통 분석 속성으로 한 번 등록됩니다.

* **테스트**
  * 다양한 로케일 형식, 우선순위, 폴백 및 빈 값 처리에 대한 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->