### PR TITLE
[feature] 어드민 지원서 상세 모바일 페이지 구현

### DIFF
--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPage.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPage.tsx
@@ -5,6 +5,7 @@ import PrevApplicantButton from '@/assets/images/icons/prev_applicant.svg';
 import Header from '@/components/common/Header/Header';
 import Spinner from '@/components/common/Spinner/Spinner';
 import { AVAILABLE_STATUSES } from '@/constants/status';
+import useDevice from '@/hooks/useDevice';
 import {
   useGetApplicants,
   useUpdateApplicant,
@@ -17,6 +18,7 @@ import { ApplicationStatus } from '@/types/applicants';
 import { Question } from '@/types/application';
 import { asApplicantId } from '@/types/branded';
 import mapStatusToGroup from '@/utils/mapStatusToGroup';
+import ApplicantDetailPageMobile from './ApplicantDetailPageMobile';
 import * as Styled from './ApplicantDetailPage.styles';
 
 const getStatusColor = (status: ApplicationStatus | undefined): string => {
@@ -41,7 +43,7 @@ const isApplicationStatus = (value: unknown): value is ApplicationStatus => {
   );
 };
 
-const ApplicantDetailPage = () => {
+const ApplicantDetailPageDesktop = () => {
   const { questionId, applicationFormId } = useParams<{
     questionId: string;
     applicationFormId: string;
@@ -217,6 +219,16 @@ const ApplicantDetailPage = () => {
       </Styled.ApplicantInfoContainer>
     </>
   );
+};
+
+const ApplicantDetailPage = () => {
+  const { isMobile, isTablet } = useDevice();
+
+  if (isMobile || isTablet) {
+    return <ApplicantDetailPageMobile />;
+  }
+
+  return <ApplicantDetailPageDesktop />;
 };
 
 export default ApplicantDetailPage;

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPage.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPage.tsx
@@ -1,25 +1,19 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import NextApplicantButton from '@/assets/images/icons/next_applicant.svg';
 import PrevApplicantButton from '@/assets/images/icons/prev_applicant.svg';
 import Header from '@/components/common/Header/Header';
 import Spinner from '@/components/common/Spinner/Spinner';
 import { AVAILABLE_STATUSES } from '@/constants/status';
-import {
-  useGetApplicants,
-  useUpdateApplicant,
-} from '@/hooks/Queries/useApplicants';
-import { useGetApplication } from '@/hooks/Queries/useApplication';
 import useDevice from '@/hooks/useDevice';
 import QuestionAnswerer from '@/pages/ApplicationFormPage/components/QuestionAnswerer/QuestionAnswerer';
 import QuestionContainer from '@/pages/ApplicationFormPage/components/QuestionContainer/QuestionContainer';
-import { useAdminClubId } from '@/store/useAdminClubStore';
 import { ApplicationStatus } from '@/types/applicants';
 import { Question } from '@/types/application';
-import { asApplicantId } from '@/types/branded';
 import mapStatusToGroup from '@/utils/mapStatusToGroup';
 import * as Styled from './ApplicantDetailPage.styles';
 import ApplicantDetailPageMobile from './ApplicantDetailPageMobile';
+import { useApplicantDetail } from './hooks/useApplicantDetail';
 
 const getStatusColor = (status: ApplicationStatus | undefined): string => {
   switch (status) {
@@ -43,66 +37,32 @@ const isApplicationStatus = (value: unknown): value is ApplicationStatus => {
   );
 };
 
-const ApplicantDetailPageDesktop = () => {
+const ApplicantDetailPage = () => {
   const { questionId, applicationFormId } = useParams<{
     questionId: string;
     applicationFormId: string;
   }>();
-
   const navigate = useNavigate();
-  const [applicantMemo, setAppMemo] = useState('');
-  const [applicantStatus, setApplicantStatus] = useState<ApplicationStatus>(
-    ApplicationStatus.SUBMITTED,
-  );
-  const { clubId } = useAdminClubId();
-  const {
-    data: applicantsData,
-    isLoading: isApplicantsLoading,
-    isError: isApplicantsError,
-  } = useGetApplicants(applicationFormId ?? undefined);
-
-  const applicantIndex =
-    applicantsData?.applicants.findIndex((a) => a.id === questionId) ?? -1;
-  const applicant = applicantsData?.applicants[applicantIndex];
+  const { isMobile, isTablet } = useDevice();
 
   const {
-    data: formData,
+    applicantsData,
+    isApplicantsLoading,
+    isApplicantsError,
+    formData,
     isLoading,
     isError,
-  } = useGetApplication(clubId!, applicationFormId ?? undefined);
-  const { mutate: updateApplicant } = useUpdateApplicant(
-    applicationFormId ?? undefined,
-  );
+    applicant,
+    applicantIndex,
+    applicantMemo,
+    setApplicantMemo,
+    applicantStatus,
+    setApplicantStatus,
+    updateApplicantDetail,
+    getAnswerByQuestionId,
+  } = useApplicantDetail(applicationFormId, questionId);
 
-  useEffect(() => {
-    if (applicant) {
-      setAppMemo(applicant.memo);
-      setApplicantStatus(mapStatusToGroup(applicant.status).status);
-    }
-  }, [applicant, applicant?.status, applicant?.memo]);
-
-  const updateApplicantDetail = (memo: string, status: ApplicationStatus) => {
-    if (!questionId) return;
-
-    updateApplicant(
-      [
-        {
-          memo,
-          status,
-          applicantId: asApplicantId(questionId),
-        },
-      ],
-      {
-        onError: () => {
-          alert('지원자 정보 수정에 실패했습니다.');
-        },
-      },
-    );
-  };
-
-  if (!applicationFormId) {
-    return <div>지원서 정보를 불러올 수 없습니다.</div>;
-  }
+  if (!applicationFormId) return <div>지원서 정보를 불러올 수 없습니다.</div>;
   if (isLoading || isApplicantsLoading) return <Spinner />;
   if (isApplicantsError)
     return <div>지원자 데이터를 불러오는 중 오류가 발생했습니다.</div>;
@@ -111,41 +71,48 @@ const ApplicantDetailPageDesktop = () => {
   if (!formData) return <div>지원서 정보가 없습니다.</div>;
   if (!applicant) return <div>해당 지원자를 찾을 수 없습니다.</div>;
 
-  // 답변 매핑 함수
-  const getAnswerByQuestionId = (qId: number) => {
-    return applicant.answers
-      .filter((ans) => ans.id === qId)
-      .map((ans) => ans.value);
+  const handlePrev = () => {
+    const prev = applicantsData.applicants[applicantIndex - 1];
+    if (!prev) return;
+    navigate(`/admin/applicants-list/${applicationFormId}/${prev.id}`);
   };
 
-  const handleMemoChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setAppMemo(e.target.value);
+  const handleNext = () => {
+    const next = applicantsData.applicants[applicantIndex + 1];
+    if (!next) return;
+    navigate(`/admin/applicants-list/${applicationFormId}/${next.id}`);
+  };
+
+  const handleStatusChange = (status: ApplicationStatus) => {
+    setApplicantStatus(status);
+    updateApplicantDetail(applicantMemo, status);
   };
 
   const handleMemoBlur = () => {
     updateApplicantDetail(applicantMemo, applicantStatus);
   };
 
-  const handleStatusChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const rawStatus = e.target.value;
-    if (!isApplicationStatus(rawStatus)) return;
-    setApplicantStatus(rawStatus);
-    updateApplicantDetail(applicantMemo, rawStatus);
-  };
-
-  const previousApplicant = () => {
-    const previousData = applicantsData?.applicants[applicantIndex - 1];
-    if (applicantIndex < 0 || !previousData) return;
-
-    navigate(`/admin/applicants-list/${applicationFormId}/${previousData.id}`);
-  };
-
-  const nextApplicant = () => {
-    const nextData = applicantsData?.applicants[applicantIndex + 1];
-    if (applicantIndex < 0 || !nextData) return;
-
-    navigate(`/admin/applicants-list/${applicationFormId}/${nextData.id}`);
-  };
+  if (isMobile || isTablet) {
+    return (
+      <ApplicantDetailPageMobile
+        applicantsData={applicantsData}
+        formData={formData}
+        applicantIndex={applicantIndex}
+        applicantMemo={applicantMemo}
+        setApplicantMemo={setApplicantMemo}
+        applicantStatus={applicantStatus}
+        onStatusChange={handleStatusChange}
+        onMemoBlur={handleMemoBlur}
+        onPrev={handlePrev}
+        onNext={handleNext}
+        onSelect={(id) =>
+          navigate(`/admin/applicants-list/${applicationFormId}/${id}`)
+        }
+        onBack={() => navigate(`/admin/applicants-list/${applicationFormId}`)}
+        getAnswerByQuestionId={getAnswerByQuestionId}
+      />
+    );
+  }
 
   return (
     <>
@@ -154,7 +121,7 @@ const ApplicantDetailPageDesktop = () => {
         <Styled.HeaderContainer>
           <Styled.ApplicantContainer>
             <Styled.NavigationButton
-              onClick={previousApplicant}
+              onClick={handlePrev}
               src={PrevApplicantButton}
               alt='이전 지원자'
             />
@@ -167,14 +134,14 @@ const ApplicantDetailPageDesktop = () => {
                 )
               }
             >
-              {applicantsData?.applicants.map((a) => (
+              {applicantsData.applicants.map((a) => (
                 <option key={a.id} value={a.id}>
                   {a.answers[0].value}
                 </option>
               ))}
             </select>
             <Styled.NavigationButton
-              onClick={nextApplicant}
+              onClick={handleNext}
               src={NextApplicantButton}
               alt='다음 지원자'
             />
@@ -182,7 +149,11 @@ const ApplicantDetailPageDesktop = () => {
           <Styled.StatusSelect
             id='statusSelect'
             value={applicantStatus}
-            onChange={handleStatusChange}
+            onChange={(e) => {
+              const rawStatus = e.target.value;
+              if (!isApplicationStatus(rawStatus)) return;
+              handleStatusChange(rawStatus);
+            }}
             $backgroundColor={getStatusColor(applicantStatus)}
           >
             {AVAILABLE_STATUSES.map((status) => (
@@ -196,11 +167,11 @@ const ApplicantDetailPageDesktop = () => {
         <Styled.MemoContainer>
           <Styled.MemoLabel>메모</Styled.MemoLabel>
           <Styled.MemoTextarea
-            onChange={handleMemoChange}
+            onChange={(e) => setApplicantMemo(e.target.value)}
             onBlur={handleMemoBlur}
             placeholder='메모를 입력해주세요'
             value={applicantMemo}
-          ></Styled.MemoTextarea>
+          />
         </Styled.MemoContainer>
       </Styled.Wrapper>
 
@@ -219,16 +190,6 @@ const ApplicantDetailPageDesktop = () => {
       </Styled.ApplicantInfoContainer>
     </>
   );
-};
-
-const ApplicantDetailPage = () => {
-  const { isMobile, isTablet } = useDevice();
-
-  if (isMobile || isTablet) {
-    return <ApplicantDetailPageMobile />;
-  }
-
-  return <ApplicantDetailPageDesktop />;
 };
 
 export default ApplicantDetailPage;

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPage.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPage.tsx
@@ -5,12 +5,12 @@ import PrevApplicantButton from '@/assets/images/icons/prev_applicant.svg';
 import Header from '@/components/common/Header/Header';
 import Spinner from '@/components/common/Spinner/Spinner';
 import { AVAILABLE_STATUSES } from '@/constants/status';
-import useDevice from '@/hooks/useDevice';
 import {
   useGetApplicants,
   useUpdateApplicant,
 } from '@/hooks/Queries/useApplicants';
 import { useGetApplication } from '@/hooks/Queries/useApplication';
+import useDevice from '@/hooks/useDevice';
 import QuestionAnswerer from '@/pages/ApplicationFormPage/components/QuestionAnswerer/QuestionAnswerer';
 import QuestionContainer from '@/pages/ApplicationFormPage/components/QuestionContainer/QuestionContainer';
 import { useAdminClubId } from '@/store/useAdminClubStore';
@@ -18,8 +18,8 @@ import { ApplicationStatus } from '@/types/applicants';
 import { Question } from '@/types/application';
 import { asApplicantId } from '@/types/branded';
 import mapStatusToGroup from '@/utils/mapStatusToGroup';
-import ApplicantDetailPageMobile from './ApplicantDetailPageMobile';
 import * as Styled from './ApplicantDetailPage.styles';
+import ApplicantDetailPageMobile from './ApplicantDetailPageMobile';
 
 const getStatusColor = (status: ApplicationStatus | undefined): string => {
   switch (status) {

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPageMobile.styles.ts
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPageMobile.styles.ts
@@ -1,66 +1,26 @@
 import styled from 'styled-components';
-import PrevApplicant from '@/assets/images/icons/prev_applicant.svg?react';
+import { media } from '@/styles/mediaQuery';
 import { colors } from '@/styles/theme/colors';
 import { setTypography, typography } from '@/styles/theme/typography';
 
-export const PageWrapper = styled.div`
+export const Container = styled.div`
+  width: 100%;
+  max-width: 500px;
+  min-height: 100vh;
+  margin: 0 auto;
+  background: ${colors.base.white};
+  box-shadow: 0px 2px 12px rgba(0, 0, 0, 0.04);
+
+  ${media.mobile} {
+    max-width: 100%;
+    margin: 0;
+    box-shadow: none;
+  }
+`;
+
+export const Content = styled.div`
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
-  background: ${colors.base.white};
-`;
-
-export const Header = styled.header`
-  position: sticky;
-  top: 0;
-  z-index: 10;
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  padding: 10px 20px;
-  width: 100%;
-  height: 48px;
-  background: ${colors.base.white};
-  border-bottom: 1px solid ${colors.gray[300]};
-  box-sizing: border-box;
-`;
-
-export const BackButton = styled.button`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  padding: 0;
-  border: none;
-  background: transparent;
-  cursor: pointer;
-`;
-
-export const BackIcon = styled(PrevApplicant)`
-  width: 24px;
-  height: 24px;
-  color: ${colors.base.black};
-
-  & circle {
-    display: none;
-  }
-  & path {
-    stroke: currentColor;
-    stroke-width: 2;
-  }
-`;
-
-export const HeaderTitle = styled.h1`
-  ${setTypography(typography.title.title5)}
-  color: ${colors.base.black};
-  letter-spacing: -0.02em;
-`;
-
-export const HeaderSpacer = styled.div`
-  width: 24px;
-  height: 24px;
 `;
 
 export const TopSection = styled.div`
@@ -125,7 +85,6 @@ export const MemoLabel = styled.span`
 `;
 
 export const MemoInput = styled.input`
-  flex: 1;
   width: 100%;
   border: none;
   background: transparent;

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPageMobile.styles.ts
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPageMobile.styles.ts
@@ -27,7 +27,7 @@ export const TopSection = styled.div`
   display: flex;
   flex-direction: column;
   gap: 6px;
-  padding: 10px 20px;
+  padding: 16px 20px;
   box-sizing: border-box;
 `;
 
@@ -109,6 +109,6 @@ export const AnswerList = styled.div`
   display: flex;
   flex-direction: column;
   gap: 10px;
-  padding: 10px 20px;
+  padding: 16px 20px 19px;
   box-sizing: border-box;
 `;

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPageMobile.styles.ts
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPageMobile.styles.ts
@@ -1,0 +1,155 @@
+import styled from 'styled-components';
+import PrevApplicant from '@/assets/images/icons/prev_applicant.svg?react';
+import { colors } from '@/styles/theme/colors';
+import { setTypography, typography } from '@/styles/theme/typography';
+
+export const PageWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: ${colors.base.white};
+`;
+
+export const Header = styled.header`
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 20px;
+  width: 100%;
+  height: 48px;
+  background: ${colors.base.white};
+  border-bottom: 1px solid ${colors.gray[300]};
+  box-sizing: border-box;
+`;
+
+export const BackButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+`;
+
+export const BackIcon = styled(PrevApplicant)`
+  width: 24px;
+  height: 24px;
+  color: ${colors.base.black};
+
+  & circle {
+    display: none;
+  }
+  & path {
+    stroke: currentColor;
+    stroke-width: 2;
+  }
+`;
+
+export const HeaderTitle = styled.h1`
+  ${setTypography(typography.title.title5)}
+  color: ${colors.base.black};
+  letter-spacing: -0.02em;
+`;
+
+export const HeaderSpacer = styled.div`
+  width: 24px;
+  height: 24px;
+`;
+
+export const TopSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 20px;
+  box-sizing: border-box;
+`;
+
+export const StatusTabRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  height: 32px;
+`;
+
+export const StatusTab = styled.button<{ $isSelected: boolean }>`
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 6px 12px;
+  height: 32px;
+  border: none;
+  border-radius: 10px;
+  box-sizing: border-box;
+  cursor: pointer;
+  background: ${({ $isSelected }) =>
+    $isSelected
+      ? `linear-gradient(0deg, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.2)), ${colors.gray[800]}`
+      : colors.gray[100]};
+  ${({ $isSelected }) =>
+    $isSelected
+      ? setTypography(typography.button.button1)
+      : setTypography(typography.paragraph.p6)}
+  color: ${({ $isSelected }) =>
+    $isSelected ? colors.base.white : colors.gray[600]};
+  letter-spacing: -0.02em;
+  text-align: center;
+`;
+
+export const MemoContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding: 14px 18px;
+  width: 100%;
+  background: ${colors.gray[50]};
+  border: 1px solid ${colors.gray[200]};
+  border-radius: 14px;
+  box-sizing: border-box;
+`;
+
+export const MemoLabel = styled.span`
+  ${setTypography(typography.paragraph.p7)}
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  color: ${colors.gray[600]};
+`;
+
+export const MemoInput = styled.input`
+  flex: 1;
+  width: 100%;
+  border: none;
+  background: transparent;
+  outline: none;
+  ${setTypography(typography.paragraph.p3)}
+  letter-spacing: -0.02em;
+  color: ${colors.gray[900]};
+
+  &::placeholder {
+    color: ${colors.gray[500]};
+  }
+`;
+
+export const Divider = styled.div`
+  width: 100%;
+  height: 6px;
+  background: ${colors.gray[100]};
+  flex-shrink: 0;
+`;
+
+export const AnswerList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 10px 20px;
+  box-sizing: border-box;
+`;

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPageMobile.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPageMobile.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import Spinner from '@/components/common/Spinner/Spinner';
+import WebviewTopBar from '@/components/common/WebviewTopBar/WebviewTopBar';
 import { AVAILABLE_STATUSES } from '@/constants/status';
 import {
   useGetApplicants,
@@ -91,8 +92,9 @@ const ApplicantDetailPageMobile = () => {
   };
 
   const getAnswerByQuestionId = (qId: number) =>
-    applicant?.answers.filter((ans) => ans.id === qId).map((ans) => ans.value) ??
-    [];
+    applicant?.answers
+      .filter((ans) => ans.id === qId)
+      .map((ans) => ans.value) ?? [];
 
   if (!applicationFormId) return <div>지원서 정보를 불러올 수 없습니다.</div>;
   if (isLoading || isApplicantsLoading) return <Spinner />;
@@ -109,66 +111,58 @@ const ApplicantDetailPageMobile = () => {
   }));
 
   return (
-    <Styled.PageWrapper>
-      <Styled.Header>
-        <Styled.BackButton
-          onClick={() => navigate(-1)}
-          aria-label='뒤로가기'
-        >
-          <Styled.BackIcon />
-        </Styled.BackButton>
-        <Styled.HeaderTitle>지원서 상세</Styled.HeaderTitle>
-        <Styled.HeaderSpacer />
-      </Styled.Header>
-
-      <Styled.TopSection>
-        <ApplicantNavHeader
-          applicants={applicantNavItems}
-          currentIndex={applicantIndex}
-          onPrev={handlePrev}
-          onNext={handleNext}
-          onSelect={handleSelectApplicant}
-        />
-
-        <Styled.StatusTabRow>
-          {AVAILABLE_STATUSES.map((status) => {
-            const { label } = mapStatusToGroup(status);
-            return (
-              <Styled.StatusTab
-                key={status}
-                $isSelected={applicantStatus === status}
-                onClick={() => handleStatusChange(status)}
-              >
-                {label}
-              </Styled.StatusTab>
-            );
-          })}
-        </Styled.StatusTabRow>
-
-        <Styled.MemoContainer>
-          <Styled.MemoLabel>메모</Styled.MemoLabel>
-          <Styled.MemoInput
-            value={applicantMemo}
-            onChange={(e) => setApplicantMemo(e.target.value)}
-            onBlur={handleMemoBlur}
-            placeholder='메모를 입력해주세요'
+    <Styled.Container>
+      <WebviewTopBar title='지원서 상세' />
+      <Styled.Content>
+        <Styled.TopSection>
+          <ApplicantNavHeader
+            applicants={applicantNavItems}
+            currentIndex={applicantIndex}
+            onPrev={handlePrev}
+            onNext={handleNext}
+            onSelect={handleSelectApplicant}
           />
-        </Styled.MemoContainer>
-      </Styled.TopSection>
 
-      <Styled.Divider />
+          <Styled.StatusTabRow>
+            {AVAILABLE_STATUSES.map((status) => {
+              const { label } = mapStatusToGroup(status);
+              return (
+                <Styled.StatusTab
+                  key={status}
+                  $isSelected={applicantStatus === status}
+                  onClick={() => handleStatusChange(status)}
+                >
+                  {label}
+                </Styled.StatusTab>
+              );
+            })}
+          </Styled.StatusTabRow>
 
-      <Styled.AnswerList>
-        {formData.questions?.map((q: Question, i: number) => (
-          <AnswerCard
-            key={q.id}
-            index={i + 1}
-            question={q}
-            answers={getAnswerByQuestionId(q.id)}
-          />
-        ))}
-      </Styled.AnswerList>
-    </Styled.PageWrapper>
+          <Styled.MemoContainer>
+            <Styled.MemoLabel>메모</Styled.MemoLabel>
+            <Styled.MemoInput
+              value={applicantMemo}
+              onChange={(e) => setApplicantMemo(e.target.value)}
+              onBlur={handleMemoBlur}
+              placeholder='메모를 입력해주세요'
+            />
+          </Styled.MemoContainer>
+        </Styled.TopSection>
+
+        <Styled.Divider />
+
+        <Styled.AnswerList>
+          {formData.questions?.map((q: Question, i: number) => (
+            <AnswerCard
+              key={q.id}
+              index={i + 1}
+              question={q}
+              answers={getAnswerByQuestionId(q.id)}
+            />
+          ))}
+        </Styled.AnswerList>
+      </Styled.Content>
+    </Styled.Container>
   );
 };
 

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPageMobile.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPageMobile.tsx
@@ -149,7 +149,7 @@ const ApplicantDetailPageMobile = () => {
               value={applicantMemo}
               onChange={(e) => setApplicantMemo(e.target.value)}
               onBlur={handleMemoBlur}
-              placeholder='메모를 입력해주세요'
+              placeholder='메모할 내용을 입력해주세요'
             />
           </Styled.MemoContainer>
         </Styled.TopSection>

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPageMobile.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPageMobile.tsx
@@ -1,0 +1,175 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import Spinner from '@/components/common/Spinner/Spinner';
+import { AVAILABLE_STATUSES } from '@/constants/status';
+import {
+  useGetApplicants,
+  useUpdateApplicant,
+} from '@/hooks/Queries/useApplicants';
+import { useGetApplication } from '@/hooks/Queries/useApplication';
+import { useAdminClubId } from '@/store/useAdminClubStore';
+import { ApplicationStatus } from '@/types/applicants';
+import { Question } from '@/types/application';
+import { asApplicantId } from '@/types/branded';
+import mapStatusToGroup from '@/utils/mapStatusToGroup';
+import AnswerCard from './components/mobile/AnswerCard/AnswerCard';
+import ApplicantNavHeader from './components/mobile/ApplicantNavHeader/ApplicantNavHeader';
+import * as Styled from './ApplicantDetailPageMobile.styles';
+
+const ApplicantDetailPageMobile = () => {
+  const { questionId, applicationFormId } = useParams<{
+    questionId: string;
+    applicationFormId: string;
+  }>();
+  const navigate = useNavigate();
+
+  const [applicantMemo, setApplicantMemo] = useState('');
+  const [applicantStatus, setApplicantStatus] = useState<ApplicationStatus>(
+    ApplicationStatus.SUBMITTED,
+  );
+
+  const { clubId } = useAdminClubId();
+
+  const {
+    data: applicantsData,
+    isLoading: isApplicantsLoading,
+    isError: isApplicantsError,
+  } = useGetApplicants(applicationFormId ?? undefined);
+
+  const applicantIndex =
+    applicantsData?.applicants.findIndex((a) => a.id === questionId) ?? -1;
+  const applicant = applicantsData?.applicants[applicantIndex];
+
+  const {
+    data: formData,
+    isLoading,
+    isError,
+  } = useGetApplication(clubId!, applicationFormId ?? undefined);
+
+  const { mutate: updateApplicant } = useUpdateApplicant(
+    applicationFormId ?? undefined,
+  );
+
+  useEffect(() => {
+    if (applicant) {
+      setApplicantMemo(applicant.memo);
+      setApplicantStatus(mapStatusToGroup(applicant.status).status);
+    }
+  }, [applicant, applicant?.status, applicant?.memo]);
+
+  const updateApplicantDetail = (memo: string, status: ApplicationStatus) => {
+    if (!questionId) return;
+    updateApplicant(
+      [{ memo, status, applicantId: asApplicantId(questionId) }],
+      { onError: () => alert('지원자 정보 수정에 실패했습니다.') },
+    );
+  };
+
+  const handlePrev = () => {
+    const prev = applicantsData?.applicants[applicantIndex - 1];
+    if (!prev) return;
+    navigate(`/admin/applicants-list/${applicationFormId}/${prev.id}`);
+  };
+
+  const handleNext = () => {
+    const next = applicantsData?.applicants[applicantIndex + 1];
+    if (!next) return;
+    navigate(`/admin/applicants-list/${applicationFormId}/${next.id}`);
+  };
+
+  const handleSelectApplicant = (id: string) => {
+    navigate(`/admin/applicants-list/${applicationFormId}/${id}`);
+  };
+
+  const handleStatusChange = (status: ApplicationStatus) => {
+    setApplicantStatus(status);
+    updateApplicantDetail(applicantMemo, status);
+  };
+
+  const handleMemoBlur = () => {
+    updateApplicantDetail(applicantMemo, applicantStatus);
+  };
+
+  const getAnswerByQuestionId = (qId: number) =>
+    applicant?.answers.filter((ans) => ans.id === qId).map((ans) => ans.value) ??
+    [];
+
+  if (!applicationFormId) return <div>지원서 정보를 불러올 수 없습니다.</div>;
+  if (isLoading || isApplicantsLoading) return <Spinner />;
+  if (isApplicantsError)
+    return <div>지원자 데이터를 불러오는 중 오류가 발생했습니다.</div>;
+  if (!applicantsData) return <div>지원자 데이터를 불러올 수 없습니다.</div>;
+  if (isError) return <div>지원서 정보를 불러오는 중 오류가 발생했습니다.</div>;
+  if (!formData) return <div>지원서 정보가 없습니다.</div>;
+  if (!applicant) return <div>해당 지원자를 찾을 수 없습니다.</div>;
+
+  const applicantNavItems = applicantsData.applicants.map((a) => ({
+    id: a.id,
+    name: a.answers[0]?.value ?? '-',
+  }));
+
+  return (
+    <Styled.PageWrapper>
+      <Styled.Header>
+        <Styled.BackButton
+          onClick={() => navigate(-1)}
+          aria-label='뒤로가기'
+        >
+          <Styled.BackIcon />
+        </Styled.BackButton>
+        <Styled.HeaderTitle>지원서 상세</Styled.HeaderTitle>
+        <Styled.HeaderSpacer />
+      </Styled.Header>
+
+      <Styled.TopSection>
+        <ApplicantNavHeader
+          applicants={applicantNavItems}
+          currentIndex={applicantIndex}
+          onPrev={handlePrev}
+          onNext={handleNext}
+          onSelect={handleSelectApplicant}
+        />
+
+        <Styled.StatusTabRow>
+          {AVAILABLE_STATUSES.map((status) => {
+            const { label } = mapStatusToGroup(status);
+            return (
+              <Styled.StatusTab
+                key={status}
+                $isSelected={applicantStatus === status}
+                onClick={() => handleStatusChange(status)}
+              >
+                {label}
+              </Styled.StatusTab>
+            );
+          })}
+        </Styled.StatusTabRow>
+
+        <Styled.MemoContainer>
+          <Styled.MemoLabel>메모</Styled.MemoLabel>
+          <Styled.MemoInput
+            value={applicantMemo}
+            onChange={(e) => setApplicantMemo(e.target.value)}
+            onBlur={handleMemoBlur}
+            placeholder='메모를 입력해주세요'
+          />
+        </Styled.MemoContainer>
+      </Styled.TopSection>
+
+      <Styled.Divider />
+
+      <Styled.AnswerList>
+        {formData.questions?.map((q: Question, i: number) => (
+          <AnswerCard
+            key={q.id}
+            index={i + 1}
+            question={q}
+            answers={getAnswerByQuestionId(q.id)}
+          />
+        ))}
+      </Styled.AnswerList>
+    </Styled.PageWrapper>
+  );
+};
+
+export default ApplicantDetailPageMobile;

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPageMobile.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPageMobile.tsx
@@ -13,9 +13,9 @@ import { ApplicationStatus } from '@/types/applicants';
 import { Question } from '@/types/application';
 import { asApplicantId } from '@/types/branded';
 import mapStatusToGroup from '@/utils/mapStatusToGroup';
+import * as Styled from './ApplicantDetailPageMobile.styles';
 import AnswerCard from './components/mobile/AnswerCard/AnswerCard';
 import ApplicantNavHeader from './components/mobile/ApplicantNavHeader/ApplicantNavHeader';
-import * as Styled from './ApplicantDetailPageMobile.styles';
 
 const ApplicantDetailPageMobile = () => {
   const { questionId, applicationFormId } = useParams<{
@@ -114,9 +114,7 @@ const ApplicantDetailPageMobile = () => {
     <Styled.Container>
       <WebviewTopBar
         title='지원서 상세'
-        onBack={() =>
-          navigate(`/admin/applicants-list/${applicationFormId}`)
-        }
+        onBack={() => navigate(`/admin/applicants-list/${applicationFormId}`)}
       />
       <Styled.Content>
         <Styled.TopSection>

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPageMobile.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPageMobile.tsx
@@ -112,7 +112,12 @@ const ApplicantDetailPageMobile = () => {
 
   return (
     <Styled.Container>
-      <WebviewTopBar title='지원서 상세' />
+      <WebviewTopBar
+        title='지원서 상세'
+        onBack={() =>
+          navigate(`/admin/applicants-list/${applicationFormId}`)
+        }
+      />
       <Styled.Content>
         <Styled.TopSection>
           <ApplicantNavHeader

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPageMobile.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/ApplicantDetailPageMobile.tsx
@@ -1,110 +1,43 @@
-import { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
-import Spinner from '@/components/common/Spinner/Spinner';
 import WebviewTopBar from '@/components/common/WebviewTopBar/WebviewTopBar';
 import { AVAILABLE_STATUSES } from '@/constants/status';
-import {
-  useGetApplicants,
-  useUpdateApplicant,
-} from '@/hooks/Queries/useApplicants';
-import { useGetApplication } from '@/hooks/Queries/useApplication';
-import { useAdminClubId } from '@/store/useAdminClubStore';
-import { ApplicationStatus } from '@/types/applicants';
-import { Question } from '@/types/application';
-import { asApplicantId } from '@/types/branded';
+import { ApplicantsInfo, ApplicationStatus } from '@/types/applicants';
+import { ApplicationFormData, Question } from '@/types/application';
 import mapStatusToGroup from '@/utils/mapStatusToGroup';
 import * as Styled from './ApplicantDetailPageMobile.styles';
 import AnswerCard from './components/mobile/AnswerCard/AnswerCard';
 import ApplicantNavHeader from './components/mobile/ApplicantNavHeader/ApplicantNavHeader';
 
-const ApplicantDetailPageMobile = () => {
-  const { questionId, applicationFormId } = useParams<{
-    questionId: string;
-    applicationFormId: string;
-  }>();
-  const navigate = useNavigate();
+interface ApplicantDetailPageMobileProps {
+  applicantsData: ApplicantsInfo;
+  formData: ApplicationFormData;
+  applicantIndex: number;
+  applicantMemo: string;
+  setApplicantMemo: (value: string) => void;
+  applicantStatus: ApplicationStatus;
+  onStatusChange: (status: ApplicationStatus) => void;
+  onMemoBlur: () => void;
+  onPrev: () => void;
+  onNext: () => void;
+  onSelect: (id: string) => void;
+  onBack: () => void;
+  getAnswerByQuestionId: (qId: number) => string[];
+}
 
-  const [applicantMemo, setApplicantMemo] = useState('');
-  const [applicantStatus, setApplicantStatus] = useState<ApplicationStatus>(
-    ApplicationStatus.SUBMITTED,
-  );
-
-  const { clubId } = useAdminClubId();
-
-  const {
-    data: applicantsData,
-    isLoading: isApplicantsLoading,
-    isError: isApplicantsError,
-  } = useGetApplicants(applicationFormId ?? undefined);
-
-  const applicantIndex =
-    applicantsData?.applicants.findIndex((a) => a.id === questionId) ?? -1;
-  const applicant = applicantsData?.applicants[applicantIndex];
-
-  const {
-    data: formData,
-    isLoading,
-    isError,
-  } = useGetApplication(clubId!, applicationFormId ?? undefined);
-
-  const { mutate: updateApplicant } = useUpdateApplicant(
-    applicationFormId ?? undefined,
-  );
-
-  useEffect(() => {
-    if (applicant) {
-      setApplicantMemo(applicant.memo);
-      setApplicantStatus(mapStatusToGroup(applicant.status).status);
-    }
-  }, [applicant, applicant?.status, applicant?.memo]);
-
-  const updateApplicantDetail = (memo: string, status: ApplicationStatus) => {
-    if (!questionId) return;
-    updateApplicant(
-      [{ memo, status, applicantId: asApplicantId(questionId) }],
-      { onError: () => alert('지원자 정보 수정에 실패했습니다.') },
-    );
-  };
-
-  const handlePrev = () => {
-    const prev = applicantsData?.applicants[applicantIndex - 1];
-    if (!prev) return;
-    navigate(`/admin/applicants-list/${applicationFormId}/${prev.id}`);
-  };
-
-  const handleNext = () => {
-    const next = applicantsData?.applicants[applicantIndex + 1];
-    if (!next) return;
-    navigate(`/admin/applicants-list/${applicationFormId}/${next.id}`);
-  };
-
-  const handleSelectApplicant = (id: string) => {
-    navigate(`/admin/applicants-list/${applicationFormId}/${id}`);
-  };
-
-  const handleStatusChange = (status: ApplicationStatus) => {
-    setApplicantStatus(status);
-    updateApplicantDetail(applicantMemo, status);
-  };
-
-  const handleMemoBlur = () => {
-    updateApplicantDetail(applicantMemo, applicantStatus);
-  };
-
-  const getAnswerByQuestionId = (qId: number) =>
-    applicant?.answers
-      .filter((ans) => ans.id === qId)
-      .map((ans) => ans.value) ?? [];
-
-  if (!applicationFormId) return <div>지원서 정보를 불러올 수 없습니다.</div>;
-  if (isLoading || isApplicantsLoading) return <Spinner />;
-  if (isApplicantsError)
-    return <div>지원자 데이터를 불러오는 중 오류가 발생했습니다.</div>;
-  if (!applicantsData) return <div>지원자 데이터를 불러올 수 없습니다.</div>;
-  if (isError) return <div>지원서 정보를 불러오는 중 오류가 발생했습니다.</div>;
-  if (!formData) return <div>지원서 정보가 없습니다.</div>;
-  if (!applicant) return <div>해당 지원자를 찾을 수 없습니다.</div>;
-
+const ApplicantDetailPageMobile = ({
+  applicantsData,
+  formData,
+  applicantIndex,
+  applicantMemo,
+  setApplicantMemo,
+  applicantStatus,
+  onStatusChange,
+  onMemoBlur,
+  onPrev,
+  onNext,
+  onSelect,
+  onBack,
+  getAnswerByQuestionId,
+}: ApplicantDetailPageMobileProps) => {
   const applicantNavItems = applicantsData.applicants.map((a) => ({
     id: a.id,
     name: a.answers[0]?.value ?? '-',
@@ -112,18 +45,15 @@ const ApplicantDetailPageMobile = () => {
 
   return (
     <Styled.Container>
-      <WebviewTopBar
-        title='지원서 상세'
-        onBack={() => navigate(`/admin/applicants-list/${applicationFormId}`)}
-      />
+      <WebviewTopBar title='지원서 상세' onBack={onBack} />
       <Styled.Content>
         <Styled.TopSection>
           <ApplicantNavHeader
             applicants={applicantNavItems}
             currentIndex={applicantIndex}
-            onPrev={handlePrev}
-            onNext={handleNext}
-            onSelect={handleSelectApplicant}
+            onPrev={onPrev}
+            onNext={onNext}
+            onSelect={onSelect}
           />
 
           <Styled.StatusTabRow>
@@ -133,7 +63,7 @@ const ApplicantDetailPageMobile = () => {
                 <Styled.StatusTab
                   key={status}
                   $isSelected={applicantStatus === status}
-                  onClick={() => handleStatusChange(status)}
+                  onClick={() => onStatusChange(status)}
                 >
                   {label}
                 </Styled.StatusTab>
@@ -146,7 +76,7 @@ const ApplicantDetailPageMobile = () => {
             <Styled.MemoInput
               value={applicantMemo}
               onChange={(e) => setApplicantMemo(e.target.value)}
-              onBlur={handleMemoBlur}
+              onBlur={onMemoBlur}
               placeholder='메모할 내용을 입력해주세요'
             />
           </Styled.MemoContainer>

--- a/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/hooks/useApplicantDetail.ts
+++ b/frontend/src/pages/AdminPage/tabs/ApplicantsTab/ApplicantDetailPage/hooks/useApplicantDetail.ts
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react';
+import {
+  useGetApplicants,
+  useUpdateApplicant,
+} from '@/hooks/Queries/useApplicants';
+import { useGetApplication } from '@/hooks/Queries/useApplication';
+import { useAdminClubId } from '@/store/useAdminClubStore';
+import { ApplicationStatus } from '@/types/applicants';
+import { asApplicantId } from '@/types/branded';
+import mapStatusToGroup from '@/utils/mapStatusToGroup';
+
+export const useApplicantDetail = (
+  applicationFormId: string | undefined,
+  questionId: string | undefined,
+) => {
+  const [applicantMemo, setApplicantMemo] = useState('');
+  const [applicantStatus, setApplicantStatus] = useState<ApplicationStatus>(
+    ApplicationStatus.SUBMITTED,
+  );
+
+  const { clubId } = useAdminClubId();
+
+  const {
+    data: applicantsData,
+    isLoading: isApplicantsLoading,
+    isError: isApplicantsError,
+  } = useGetApplicants(applicationFormId);
+
+  const applicantIndex =
+    applicantsData?.applicants.findIndex((a) => a.id === questionId) ?? -1;
+  const applicant = applicantsData?.applicants[applicantIndex];
+
+  const {
+    data: formData,
+    isLoading,
+    isError,
+  } = useGetApplication(clubId!, applicationFormId);
+
+  const { mutate: updateApplicant } = useUpdateApplicant(applicationFormId);
+
+  useEffect(() => {
+    if (applicant) {
+      setApplicantMemo(applicant.memo);
+      setApplicantStatus(mapStatusToGroup(applicant.status).status);
+    }
+  }, [applicant, applicant?.status, applicant?.memo]);
+
+  const updateApplicantDetail = (memo: string, status: ApplicationStatus) => {
+    if (!questionId) return;
+    updateApplicant(
+      [{ memo, status, applicantId: asApplicantId(questionId) }],
+      { onError: () => alert('지원자 정보 수정에 실패했습니다.') },
+    );
+  };
+
+  const getAnswerByQuestionId = (qId: number) =>
+    applicant?.answers
+      .filter((ans) => ans.id === qId)
+      .map((ans) => ans.value) ?? [];
+
+  return {
+    applicantsData,
+    isApplicantsLoading,
+    isApplicantsError,
+    formData,
+    isLoading,
+    isError,
+    applicant,
+    applicantIndex,
+    applicantMemo,
+    setApplicantMemo,
+    applicantStatus,
+    setApplicantStatus,
+    updateApplicantDetail,
+    getAnswerByQuestionId,
+  };
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> #1923 (MOA-1061)

## 📝작업 내용

### 1. 지원서 상세 모바일 페이지 구현 (`ApplicantDetailPageMobile`)

지원자 현황 목록에서 지원자를 클릭 시 진입하는 **지원서 상세 페이지 모바일 버전**을 신규 구현했습니다.

**구조:**

| 영역 | 내용 |
|---|---|
| 탑바 | `WebviewTopBar` 공통 컴포넌트 — 뒤로가기 클릭 시 지원자 현황 목록으로 이동 |
| 지원자 선택 | `ApplicantNavHeader` — 이전/다음 이동 + 이름 드롭다운 (이름 클릭 시 열림) |
| 상태 탭 | 검토 전 · 면접예정 · 합격 · 불합격 — 탭 클릭 시 즉시 저장 |
| 메모 | 입력 후 blur 시 저장 |
| 답변 카드 목록 | `AnswerCard` 반복 렌더링 (단답형 · 장문형 · 선택형) |

> 📸 **이미지 — 지원서 상세 화면**
>
> | 기본 상태 | 지원자 드롭다운 열린 상태 |
> |---|---|
> | <img width="287" height="538" alt="image" src="https://github.com/user-attachments/assets/8af8b897-171e-4133-ad73-09e9e304a22c" /> | <img width="286" height="537" alt="image" src="https://github.com/user-attachments/assets/0f43100b-624e-4d30-997f-93b411affaa6" /> |

---

### 2. 데스크탑 분기 처리

`ApplicantDetailPage`에 `useDevice` 분기를 추가해 모바일/태블릿에서는 `ApplicantDetailPageMobile`, 그 외에서는 기존 데스크탑 컴포넌트가 렌더링됩니다. 라우팅 변경 없이 동일한 URL에서 동작합니다.

---

### 3. 뒤로가기 동작 개선

이전/다음 지원자로 이동했던 히스토리와 무관하게, 뒤로가기 시 **항상 지원자 현황 목록**(`/admin/applicants-list/:applicationFormId`)으로 이동합니다.

---

### 4. 태블릿 레이아웃

`ApplicantsTabMobile`과 동일한 `Container` 패턴 적용:
- 태블릿: `max-width 500px`, `margin: 0 auto`, 카드 섀도우
- 모바일: 풀 너비, 섀도우 없음

---

### 5. 기존 컴포넌트 재사용

| 컴포넌트 | 용도 |
|---|---|
| `WebviewTopBar` | 공통 모바일 탑바 |
| `ApplicantNavHeader` | 지원자 이전/다음/드롭다운 |
| `AnswerCard` | 답변 카드 (단답·장문·선택형) |

---

## 중점적으로 리뷰받고 싶은 부분(선택)

- `ApplicantDetailPage` 내부에서 `ApplicantDetailPageDesktop`으로 이름을 바꾸고 래퍼 컴포넌트로 분기하는 방식이 적절한지

## 🫡 참고사항

- 데이터 로직(`useGetApplicants`, `useGetApplication`, `useUpdateApplicant`)은 데스크탑과 동일하게 사용
- 스타일 토큰은 기존 `colors`, `typography`, `media` 그대로 사용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 모바일·태블릿 환경에 맞춘 지원자 상세 화면을 제공합니다.
  - 지원자 상세 화면에서 이전·다음 지원자로 빠르게 이동할 수 있습니다.
  - 지원자 상태와 메모를 화면에서 수정하고 저장할 수 있습니다.
  - 지원서 질문별 답변을 보기 쉽게 확인할 수 있습니다.

- **개선 사항**
  - 모바일 화면에서 상태 탭, 메모 입력 영역, 답변 목록의 사용성이 향상되었습니다.
  - 상태 및 메모 저장 실패 시 안내 메시지를 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->