### PR TITLE
[fix] 학생 토큰 재발급 시 기존 sub를 받아 신원 유지

### DIFF
--- a/backend/src/main/java/moadong/global/RegexConstants.java
+++ b/backend/src/main/java/moadong/global/RegexConstants.java
@@ -3,6 +3,7 @@ package moadong.global;
 public final class RegexConstants {
     public static final String PHONE_NUMBER = "\\d{2,3}-\\d{3,4}-\\d{4}";
     public static final String EMAIL = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
+    public static final String UUID_V4 = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$";
     private RegexConstants() {
         throw new UnsupportedOperationException("이 클래스는 인스턴스로 만들면 안됩니다!");
     }

--- a/backend/src/main/java/moadong/user/controller/StudentAuthController.java
+++ b/backend/src/main/java/moadong/user/controller/StudentAuthController.java
@@ -2,12 +2,15 @@ package moadong.user.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import moadong.global.payload.Response;
+import moadong.user.payload.request.StudentIssueRequest;
 import moadong.user.payload.response.StudentIssueResponse;
 import moadong.user.service.UserCommandService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,9 +23,11 @@ public class StudentAuthController {
     private final UserCommandService userCommandService;
 
     @PostMapping
-    @Operation(summary = "학생 임시 JWT 발급", description = "랜덤 UUID를 sub로 사용하는 만료 없는 JWT를 발급합니다.")
-    public ResponseEntity<?> issueStudentToken() {
-        StudentIssueResponse response = userCommandService.issueStudentAccessToken();
+    @Operation(summary = "학생 임시 JWT 발급", description = "만료 없는 JWT를 발급합니다. 본문에 기존 sub(UUIDv4)를 담으면 같은 신원으로 재발급하고, 본문이 없으면 랜덤 UUID로 새 신원을 만듭니다.")
+    public ResponseEntity<?> issueStudentToken(
+            @Valid @RequestBody(required = false) StudentIssueRequest request) {
+        StudentIssueResponse response = userCommandService.issueStudentAccessToken(
+                StudentIssueRequest.resolveStudentId(request));
         return Response.ok(response);
     }
 }

--- a/backend/src/main/java/moadong/user/payload/request/StudentIssueRequest.java
+++ b/backend/src/main/java/moadong/user/payload/request/StudentIssueRequest.java
@@ -1,0 +1,25 @@
+package moadong.user.payload.request;
+
+import jakarta.validation.constraints.Pattern;
+import java.util.Locale;
+import java.util.UUID;
+import moadong.global.RegexConstants;
+
+public record StudentIssueRequest(
+        @Pattern(regexp = RegexConstants.UUID_V4, message = "sub는 UUIDv4 형식이어야 합니다.")
+        String sub
+) {
+
+    /**
+     * 재발급 요청의 sub를 studentId로 되돌린다.
+     * 본문이 없거나(이미 배포된 웹) sub가 없으면 새 신원을 만들고,
+     * sub가 있으면 소문자로 정규화해 같은 신원을 유지한다.
+     * (Feedback.studentId는 문자열 그대로 비교하므로 대소문자가 갈리면 편지함이 둘로 나뉜다.)
+     */
+    public static String resolveStudentId(StudentIssueRequest request) {
+        if (request == null || request.sub() == null) {
+            return UUID.randomUUID().toString();
+        }
+        return request.sub().toLowerCase(Locale.ROOT);
+    }
+}

--- a/backend/src/main/java/moadong/user/service/UserCommandService.java
+++ b/backend/src/main/java/moadong/user/service/UserCommandService.java
@@ -3,7 +3,6 @@ package moadong.user.service;
 import com.mongodb.MongoWriteException;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Date;
-import java.util.UUID;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -113,8 +112,7 @@ public class UserCommandService {
         }
     }
 
-    public StudentIssueResponse issueStudentAccessToken() {
-        String studentId = UUID.randomUUID().toString();
+    public StudentIssueResponse issueStudentAccessToken(String studentId) {
         String accessToken = jwtProvider.generateAccessTokenWithoutExpiration(studentId);
         return new StudentIssueResponse(accessToken);
     }

--- a/backend/src/test/java/moadong/unit/user/StudentAuthControllerTest.java
+++ b/backend/src/test/java/moadong/unit/user/StudentAuthControllerTest.java
@@ -1,0 +1,115 @@
+package moadong.unit.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import moadong.global.RegexConstants;
+import moadong.global.exception.GlobalExceptionHandler;
+import moadong.user.controller.StudentAuthController;
+import moadong.user.payload.response.StudentIssueResponse;
+import moadong.user.service.UserCommandService;
+import moadong.util.annotations.UnitTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@UnitTest
+class StudentAuthControllerTest {
+
+    private static final String STUDENT_ID = "3f2a1b4c-5d6e-4f7a-8b9c-0d1e2f3a4b5c";
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private UserCommandService userCommandService;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new StudentAuthController(userCommandService))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void 본문_없이_요청하면_새_신원으로_발급된다() throws Exception {
+        when(userCommandService.issueStudentAccessToken(anyString()))
+                .thenReturn(new StudentIssueResponse("token"));
+
+        mockMvc.perform(post("/auth/student"))
+                .andExpect(status().isOk());
+
+        assertThat(capturedStudentId()).matches(RegexConstants.UUID_V4);
+    }
+
+    @Test
+    void 본문에_sub가_없으면_새_신원으로_발급된다() throws Exception {
+        when(userCommandService.issueStudentAccessToken(anyString()))
+                .thenReturn(new StudentIssueResponse("token"));
+
+        mockMvc.perform(post("/auth/student")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"iat\":1700000000}"))
+                .andExpect(status().isOk());
+
+        assertThat(capturedStudentId()).matches(RegexConstants.UUID_V4);
+    }
+
+    @Test
+    void 본문의_sub가_studentId로_사용된다() throws Exception {
+        when(userCommandService.issueStudentAccessToken(anyString()))
+                .thenReturn(new StudentIssueResponse("token"));
+
+        mockMvc.perform(post("/auth/student")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"sub\":\"" + STUDENT_ID + "\",\"iat\":1700000000}"))
+                .andExpect(status().isOk());
+
+        assertThat(capturedStudentId()).isEqualTo(STUDENT_ID);
+    }
+
+    @Test
+    void 대문자_sub는_소문자로_정규화된다() throws Exception {
+        when(userCommandService.issueStudentAccessToken(anyString()))
+                .thenReturn(new StudentIssueResponse("token"));
+
+        mockMvc.perform(post("/auth/student")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"sub\":\"" + STUDENT_ID.toUpperCase() + "\"}"))
+                .andExpect(status().isOk());
+
+        assertThat(capturedStudentId()).isEqualTo(STUDENT_ID);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "moadong-admin",
+            "507f1f77bcf86cd799439011",
+            "",
+            "3f2a1b4c-5d6e-1f7a-8b9c-0d1e2f3a4b5c"
+    })
+    void UUIDv4가_아닌_sub는_거부된다(String sub) throws Exception {
+        mockMvc.perform(post("/auth/student")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"sub\":\"" + sub + "\"}"))
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(userCommandService);
+    }
+
+    private String capturedStudentId() {
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(userCommandService).issueStudentAccessToken(captor.capture());
+        return captor.getValue();
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

`POST /auth/student`(`StudentAuthController.issueStudentToken`)에 `@RequestBody`가 없어서, 호출할 때마다 `UUID.randomUUID()`로 새 `studentId`가 발급됐습니다. 앱은 이미 `{ sub, iat }`를 보내고 있는데 서버가 무시하고 있었습니다.

우체통은 로그인이 없어 사용자 신원이 JWT의 `sub`(= `studentId`)에만 있습니다. 토큰에 만료가 없어 평소엔 재발급이 나지 않지만, **서명 키를 한 번 교체하면 전 사용자의 토큰이 동시에 무효가 되고 그 자리에서 모두 새 신원을 받습니다.** `Feedback.studentId`에는 `StudentFcmToken.updateStudentId` 같은 복구 장치가 없어, 그 순간 모든 사용자의 편지함이 사라집니다.

선택 본문 `{ "sub": "..." }`를 받아 같은 신원으로 재발급하도록 고쳤습니다.

| 파일 | 변경 |
| --- | --- |
| `user/payload/request/StudentIssueRequest.java` (신규) | `sub` 검증 + `resolveStudentId()`(본문/sub 없으면 새 UUID, 있으면 소문자 정규화) |
| `global/RegexConstants.java` | `UUID_V4` 상수 추가 |
| `user/controller/StudentAuthController.java` | `@Valid @RequestBody(required = false)`로 본문 수신 후 studentId 전달 |
| `user/service/UserCommandService.java` | `issueStudentAccessToken(String studentId)` — 서명만 담당, 내부 UUID 생성 제거 |

**하위 호환**
- 이미 배포된 웹은 본문 없이 POST → `required = false`로 그대로 200, 새 신원 발급
- 앱은 `{ sub, iat }` 전송 → `iat` 같은 모르는 필드는 무시 (Spring Boot 기본값, `src/main`에 ObjectMapper 커스터마이징 없음을 확인)

**`sub` 검증 (UUIDv4만 허용, 위반 시 400)**
충돌 방지보다 **권한 상승 차단**이 목적입니다. `JwtAuthenticationFilter`가 `sub`로 `UserDetails`를 조회하므로, 임의 문자열을 허용하면 관리자 계정 아이디를 `sub`로 요구해 그 계정의 서명된 토큰을 받아낼 수 있습니다. 버전 니블 `4`와 변형 니블 `[89abAB]`를 강제해 ObjectId 형태·UUIDv1 등을 모두 거부합니다.

**소문자 정규화**
`Feedback.studentId`는 문자열 그대로 비교하므로, 같은 사용자가 대소문자만 다르게 보내면 편지함이 둘로 갈립니다.

## 중점적으로 리뷰받고 싶은 부분(선택)

- `resolveStudentId()`를 요청 record의 static 메서드로 둔 위치가 적절한지 (본문 자체가 null일 수 있어 인스턴스 메서드로 두기 어려웠습니다). 서비스로 내리는 편이 나을까요?
- `UUID_V4`를 `RegexConstants`에 둘지, `UploadUrlRequest`처럼 인라인으로 둘지

## 🫡 참고사항

**테스트** — `moadong/unit/user` 기존 컨벤션(`@UnitTest`, `MockMvcBuilders.standaloneSetup`)으로 `StudentAuthControllerTest` 추가. 서비스는 mock, `ArgumentCaptor<String>`로 실제 studentId를 검증합니다.

- 본문 없이 POST → 200 + UUIDv4 새 신원 (현재 배포된 웹 회귀 방지)
- `{"iat":...}`만 → 200 + UUIDv4 새 신원
- `{ sub, iat }` → 그 `sub`가 studentId
- 대문자 `sub` → 소문자로 정규화
- `moadong-admin` / 24자리 ObjectId / 빈 문자열 / UUIDv1 → 400, 서비스 호출 없음

```
./gradlew test --tests "moadong.unit.user.StudentAuthControllerTest"
→ tests="8" skipped="0" failures="0" errors="0"
```
`moadong.unit.user.*` 6개 클래스 전체도 실패 없음. (전체 `./gradlew test`는 Firebase 빈 없음 / Mongo 연결 거부로 컨텍스트 로딩 실패가 나는데, 이 변경과 무관한 기존 로컬 환경 문제입니다.)

**클라이언트 (별도 PR)** — 웹은 401로 거부된 토큰에서 `sub`를 꺼내 재발급 본문에 싣도록, 앱은 재발급 `sub`를 토큰 안의 값 우선으로 쓰고 UUID 생성을 `crypto.getRandomValues`로 교체하도록 수정되었습니다.

