### PR TITLE
[fix] 학생 토큰 재발급에 기존 sub를 실어 보낸다

### DIFF
--- a/frontend/src/apis/CLAUDE.md
+++ b/frontend/src/apis/CLAUDE.md
@@ -26,6 +26,7 @@ API는 `src/apis/utils/apiHelpers.ts`의 헬퍼 함수를 사용하는 일관된
 - `POST /auth/student`로 발급, localStorage `studentAccessToken`에 저장
 - 만료가 없어 refresh 흐름이 없다. 저장된 토큰이 무효할 때(서명 키 교체 등)만 401에서 한 번 재발급 후 재시도
 - 발급은 `issueStudentTokenOnce()`로 합친다. 발급마다 새 UUID라 동시 요청이 각자 발급받으면 학생 신원이 갈린다
+- **재발급에는 거부된 토큰의 `sub`를 실어 보낸다** (`{ sub }`). 신원이 토큰 안에만 있어서, 안 보내면 서명 키를 한 번 교체할 때 전 사용자가 같은 날 편지함을 잃는다. 서버는 UUIDv4 형식만 받으므로 `getTokenSubject()`가 형식을 확인하고, 아니면 sub 없이 새 신원으로 발급받는다
 
 ## 실시간 업데이트 (SSE)
 

--- a/frontend/src/apis/auth/studentFetch.test.ts
+++ b/frontend/src/apis/auth/studentFetch.test.ts
@@ -18,6 +18,15 @@ const issued = (accessToken: string) =>
 const authHeaderOf = (call: [RequestInfo, RequestInit?]) =>
   (call[1]?.headers as Record<string, string>)?.Authorization;
 
+const bodyOf = (call: [RequestInfo, RequestInit?]) =>
+  JSON.parse((call[1]?.body as string) ?? '{}');
+
+/** 서명은 검증하지 않으므로 payload만 맞으면 된다 */
+const tokenWithSubject = (sub: string) =>
+  `header.${btoa(JSON.stringify({ sub }))}.signature`;
+
+const STUDENT_SUB = '3f2504e0-4f89-41d3-9a0c-0305e82c3301';
+
 let fetchMock: jest.Mock;
 let studentFetch: (typeof import('./studentFetch'))['studentFetch'];
 
@@ -62,6 +71,8 @@ describe('studentFetch', () => {
       await studentFetch('/api/student/feedback/sent');
 
       expect(fetchMock.mock.calls[0][0]).toContain('/auth/student');
+      // 이어 붙일 신원이 없으므로 sub 없이 요청한다
+      expect(bodyOf(fetchMock.mock.calls[0])).toEqual({});
       expect(authHeaderOf(fetchMock.mock.calls[1])).toBe('Bearer new-token');
       expect(localStorage.getItem(STORAGE_KEYS.STUDENT_ACCESS_TOKEN)).toBe(
         'new-token',
@@ -113,6 +124,50 @@ describe('studentFetch', () => {
       // 주입 토큰을 건너뛰고 방금 발급받은 토큰으로 한 번에 나간다
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(authHeaderOf(fetchMock.mock.calls[0])).toBe('Bearer fresh');
+    });
+
+    // 서명 키를 교체하면 전 사용자의 토큰이 한 번에 무효가 된다.
+    // sub를 다시 보내지 않으면 그 자리에서 새 신원이 되고 편지함이 비어 보인다.
+    it('거부된 토큰의 sub로 재발급해 신원을 잇는다', async () => {
+      localStorage.setItem(
+        STORAGE_KEYS.STUDENT_ACCESS_TOKEN,
+        tokenWithSubject(STUDENT_SUB),
+      );
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({}, 401))
+        .mockResolvedValueOnce(issued('fresh'))
+        .mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+      await studentFetch('/api/student/feedback/sent');
+
+      expect(fetchMock.mock.calls[1][0]).toContain('/auth/student');
+      expect(bodyOf(fetchMock.mock.calls[1])).toEqual({ sub: STUDENT_SUB });
+    });
+
+    it('주입 토큰이 거부돼도 그 sub로 발급해 앱과 신원을 맞춘다', async () => {
+      window.__MOADONG_STUDENT_TOKEN__ = tokenWithSubject(STUDENT_SUB);
+      localStorage.setItem(STORAGE_KEYS.STUDENT_ACCESS_TOKEN, 'old-web-token');
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({}, 401))
+        .mockResolvedValueOnce(issued('fresh'))
+        .mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+      await studentFetch('/api/student/feedback/sent');
+
+      expect(bodyOf(fetchMock.mock.calls[1])).toEqual({ sub: STUDENT_SUB });
+    });
+
+    // UUIDv4가 아니면 서버가 400을 준다. 새 신원으로 가는 편이 낫다
+    it('sub를 읽을 수 없는 토큰이면 sub 없이 발급한다', async () => {
+      localStorage.setItem(STORAGE_KEYS.STUDENT_ACCESS_TOKEN, 'not-a-jwt');
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({}, 401))
+        .mockResolvedValueOnce(issued('fresh'))
+        .mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+      await studentFetch('/api/student/feedback/sent');
+
+      expect(bodyOf(fetchMock.mock.calls[1])).toEqual({});
     });
 
     it('앱이 새 토큰을 주입하면 다시 그것을 우선 쓴다', async () => {

--- a/frontend/src/apis/auth/studentFetch.ts
+++ b/frontend/src/apis/auth/studentFetch.ts
@@ -10,13 +10,44 @@ declare global {
   }
 }
 
+/** 서버가 sub로 받아주는 형식. 다른 값은 400이라 보내봐야 새 신원이 된다 */
+const UUID_V4 =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * 토큰이 담고 있는 신원(sub)을 서명 검증 없이 읽는다.
+ * 우체통 신원은 토큰 안에만 있어서, 서버가 토큰을 거부해도(서명 키 교체) 여기서 꺼낸 sub로
+ * 같은 신원을 다시 발급받을 수 있다. 값의 진위는 어차피 서버가 판단한다.
+ */
+const getTokenSubject = (token: string) => {
+  try {
+    const payload = token.split('.')[1];
+    if (!payload) return undefined;
+
+    const base64 = payload.replace(/-/g, '+').replace(/_/g, '/');
+    const { sub } = JSON.parse(
+      atob(base64.padEnd(Math.ceil(base64.length / 4) * 4, '=')),
+    );
+
+    return typeof sub === 'string' && UUID_V4.test(sub) ? sub : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
 /**
  * 우체통은 로그인 없이 쓰지만 '내가 보낸 편지'를 구분해야 해서 익명 학생 토큰을 쓴다.
  * 토큰에 만료가 없으므로 관리자용 secureFetch와 달리 refresh 흐름이 없다.
+ *
+ * sub를 함께 보내면 서버가 그 신원으로 다시 발급한다. 안 보내면 새 신원이라 편지함이 비어 보인다.
  */
-const issueStudentToken = async () => {
+const issueStudentToken = async (sub?: string) => {
   const response = await fetchWithTimeout(`${API_BASE_URL}/auth/student`, {
     method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ sub }),
   });
   const data = await handleResponse<{ accessToken: string }>(
     response,
@@ -39,8 +70,10 @@ let issuing: Promise<string> | null = null;
  * 목록 화면처럼 요청이 동시에 나가면 각자 발급받게 되는데, 발급마다 새 UUID라
  * 학생 신원이 갈리고 마지막에 저장된 것만 남는다. 그러면 먼저 보낸 편지가 조회되지 않는다.
  */
-const issueStudentTokenOnce = () => {
-  issuing ??= issueStudentToken().finally(() => {
+const issueStudentTokenOnce = (sub?: string) => {
+  // 합쳐진 발급은 먼저 시작한 쪽의 sub를 따른다. 동시에 401을 받는 요청들은
+  // 같은 토큰을 쓰고 있었으므로 sub도 같다.
+  issuing ??= issueStudentToken(sub).finally(() => {
     issuing = null;
   });
 
@@ -103,10 +136,12 @@ export const studentFetch = async (
   if (wasInjected) rejectedInjectedToken = token;
 
   const storedToken = localStorage.getItem(STORAGE_KEYS.STUDENT_ACCESS_TOKEN);
+  // 거부된 토큰의 sub로 재발급해 신원을 잇는다. 이게 없으면 서명 키를 한 번 교체할 때
+  // 전 사용자가 같은 날 편지함을 잃는다.
   const reissuedToken =
     !wasInjected && storedToken && storedToken !== token
       ? storedToken
-      : await issueStudentTokenOnce();
+      : await issueStudentTokenOnce(getTokenSubject(token));
 
   return fetchWithTimeout(
     input,


### PR DESCRIPTION
## #️⃣연관된 이슈

> 백엔드 #1926 (`develop/be`)의 프론트 짝

## 📝작업 내용

우체통은 로그인이 없어 **신원이 학생 토큰의 `sub`(= `studentId`)에만** 있습니다. 지금은 401로 토큰이 거부되면 `sub` 없이 재발급받아 그 자리에서 새 신원이 됩니다. 토큰에 만료가 없어 평소엔 안 나지만, **서명 키를 한 번 교체하면 전 사용자의 토큰이 동시에 무효가 되고 그날 모두의 편지함이 사라집니다.** `Feedback.studentId`에는 `StudentFcmToken.updateStudentId` 같은 복구 장치가 없습니다.

거부된 토큰에서 `sub`를 꺼내 발급 요청 본문(`{ sub }`)에 실어 보내도록 고쳤습니다.

- `getTokenSubject()` — JWT payload를 서명 검증 없이 디코딩해 `sub`를 읽습니다. 진위는 어차피 서버가 판단합니다.
- 서버가 UUIDv4만 받으므로(#1926) 형식을 확인하고, 아니면 `sub` 없이 새 신원으로 발급받습니다. 형식이 어긋난 값을 보내면 400이라 재시도 자체가 죽습니다.
- 앱이 주입한 토큰이 거부된 경우에도 그 `sub`로 발급해 앱과 신원을 맞춥니다.

테스트 3개를 더했고(거부된 토큰의 sub 사용 / 주입 토큰 거부 시에도 그 sub 사용 / sub를 못 읽으면 sub 없이 발급), 기존 "둘 다 없으면 새로 발급" 케이스에 본문이 비어 있다는 검증을 추가했습니다.

## 중점적으로 리뷰받고 싶은 부분

**발급 합치기와 sub** — `issueStudentTokenOnce(sub)`는 먼저 시작한 쪽의 sub를 따릅니다. 동시에 401을 받는 요청들은 같은 토큰을 쓰고 있었으므로 sub도 같다고 보고 그대로 뒀는데, 이 가정이 괜찮은지 봐주세요.

## 🫡 참고사항

**#1926이 머지되기 전에는 무동작입니다.** 현재 서버는 `@RequestBody`가 없어 본문을 그대로 무시하므로 회귀 없이 먼저 머지해도 됩니다. 반대로 #1926만 머지되면 웹/웹뷰 사용자는 여전히 편지함을 잃습니다 — 웹은 지금까지 sub를 보낸 적이 없기 때문입니다.

**저장소가 통째로 날아가는 경우는 여전히 못 살립니다** (브라우저 데이터 삭제, 시크릿 모드). 로그인이 없는 구조의 한계이고, 핸드오프 문서 §8-1의 httpOnly 쿠키가 별도 건으로 남아 있습니다.

**앱(`moadong-react-native`)도 짝이 필요합니다.** 재발급 sub를 저장소 값이 아니라 토큰 속 sub 우선으로 바꾸는 것과, `sub`가 신원 증명이 된 이상 UUID 생성을 `Math.random`에서 CSPRNG로 옮기는 것입니다. 아직 PR이 없습니다.

