### PR TITLE
[feature] 모달·바텀시트 포커스 트랩 추가

### DIFF
--- a/frontend/src/components/common/BottomSheet/BottomSheet.styles.ts
+++ b/frontend/src/components/common/BottomSheet/BottomSheet.styles.ts
@@ -34,6 +34,8 @@ export const Sheet = styled.div<{
   width: 100%;
   max-width: 500px;
   max-height: calc(100dvh - 80px);
+  /* 열릴 때 포커스를 받으므로 시트 전체를 두르는 기본 포커스 링을 지운다 */
+  outline: none;
   ${({ $stacked }) =>
     $stacked &&
     css`

--- a/frontend/src/components/common/BottomSheet/BottomSheet.tsx
+++ b/frontend/src/components/common/BottomSheet/BottomSheet.tsx
@@ -1,5 +1,6 @@
 import { MouseEvent, PointerEvent, ReactNode, useRef, useState } from 'react';
 import useBodyScrollLock from '@/hooks/useBodyScrollLock';
+import useFocusTrap from '@/hooks/useFocusTrap';
 import useTopmostEscape from '@/hooks/useTopmostEscape';
 import Portal from '../Portal/Portal';
 import * as Styled from './BottomSheet.styles';
@@ -26,8 +27,12 @@ const BottomSheet = ({
   background,
   stacked,
 }: BottomSheetProps) => {
+  const sheetRef = useRef<HTMLDivElement>(null);
+
   useBodyScrollLock(isOpen);
   useTopmostEscape(isOpen, onClose);
+  // 모달 위에 시트를 겹쳐 열 때 아래 모달이 포커스를 도로 뺏지 않도록 함께 쌓는다
+  useFocusTrap(isOpen, sheetRef);
 
   /** 드래그 중에만 값을 갖는다. 놓으면 null이 되어 제자리로 돌아간다. */
   const [dragOffset, setDragOffset] = useState<number | null>(null);
@@ -62,6 +67,8 @@ const BottomSheet = ({
     <Portal>
       <Styled.Overlay onClick={closeOnBackdrop ? onClose : undefined}>
         <Styled.Sheet
+          ref={sheetRef}
+          tabIndex={-1}
           role='dialog'
           aria-modal='true'
           $background={background}

--- a/frontend/src/components/common/Modal/Modal.styles.ts
+++ b/frontend/src/components/common/Modal/Modal.styles.ts
@@ -9,8 +9,21 @@ export const Overlay = styled.div`
   background: rgba(0, 0, 0, 0.6);
   display: flex;
   justify-content: center;
+  /*
+   * 내용이 화면보다 길면 가운데 정렬은 위아래로 똑같이 넘쳐 상단이 잘린다.
+   * safe는 넘칠 때만 위쪽 기준으로 붙여 제목이 잘려나가지 않게 한다.
+   *
+   * overflow: hidden은 스크롤바만 감출 뿐 스크롤은 되는 상자라, 화면 밖 요소로
+   * 포커스가 가면 브라우저가 이 상자를 스크롤해 모달을 위로 밀어버린다.
+   * 되돌릴 스크롤바가 없어 잘린 상단은 다시 못 본다. clip은 스크롤 상자를
+   * 만들지 않아 이 밀림이 아예 일어나지 않는다.
+   *
+   * 두 속성 모두 미지원 브라우저를 위해 기존 값을 앞에 남겨둔다.
+   */
   align-items: center;
+  align-items: safe center;
   overflow: hidden;
+  overflow: clip;
   transition: background-color 0.2s ease;
   touch-action: none;
 `;

--- a/frontend/src/components/common/Modal/Modal.tsx
+++ b/frontend/src/components/common/Modal/Modal.tsx
@@ -1,5 +1,6 @@
-import { MouseEvent, ReactNode } from 'react';
+import { MouseEvent, ReactNode, useRef } from 'react';
 import useBodyScrollLock from '@/hooks/useBodyScrollLock';
+import useFocusTrap from '@/hooks/useFocusTrap';
 import useTopmostEscape from '@/hooks/useTopmostEscape';
 import Portal from '../Portal/Portal';
 import * as Styled from './Modal.styles';
@@ -17,8 +18,11 @@ const Modal = ({
   children,
   closeOnBackdrop = true,
 }: ModalProps) => {
+  const contentRef = useRef<HTMLDivElement>(null);
+
   useBodyScrollLock(isOpen);
   useTopmostEscape(isOpen, onClose);
+  useFocusTrap(isOpen, contentRef);
 
   if (!isOpen) return null;
 
@@ -26,6 +30,8 @@ const Modal = ({
     <Portal>
       <Styled.Overlay onClick={closeOnBackdrop ? onClose : undefined}>
         <Styled.ContentWrapper
+          ref={contentRef}
+          tabIndex={-1}
           onClick={(e: MouseEvent<HTMLDivElement>) => e.stopPropagation()}
         >
           {children}

--- a/frontend/src/hooks/useFocusTrap.test.tsx
+++ b/frontend/src/hooks/useFocusTrap.test.tsx
@@ -1,0 +1,117 @@
+import '@testing-library/jest-dom';
+import { useRef } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import useFocusTrap from './useFocusTrap';
+
+const Overlay = ({ isOpen, name }: { isOpen: boolean; name: string }) => {
+  const ref = useRef<HTMLDivElement>(null);
+  useFocusTrap(isOpen, ref);
+
+  if (!isOpen) return null;
+
+  return (
+    <div ref={ref} tabIndex={-1} data-testid={name}>
+      <button>{name} 첫</button>
+      <button>{name} 끝</button>
+    </div>
+  );
+};
+
+/** preventDefault로 브라우저 기본 이동을 막았으면 false를 돌려준다 */
+const pressTab = (shiftKey = false) =>
+  fireEvent.keyDown(document, { key: 'Tab', shiftKey });
+
+describe('useFocusTrap', () => {
+  it('열리면 컨테이너로 포커스가 들어간다', () => {
+    render(<Overlay isOpen name='모달' />);
+
+    expect(screen.getByTestId('모달')).toHaveFocus();
+  });
+
+  it('안쪽 요소의 onFocus를 건드리지 않는다', () => {
+    const onFocus = jest.fn();
+    const Sneaky = () => {
+      const ref = useRef<HTMLDivElement>(null);
+      useFocusTrap(true, ref);
+      return (
+        <div ref={ref} tabIndex={-1}>
+          <button onFocus={onFocus}>부수효과</button>
+        </div>
+      );
+    };
+    render(<Sneaky />);
+
+    expect(onFocus).not.toHaveBeenCalled();
+  });
+
+  it('마지막 요소에서 Tab을 누르면 첫 요소로 돌아온다', () => {
+    render(<Overlay isOpen name='모달' />);
+    screen.getByRole('button', { name: '모달 끝' }).focus();
+
+    expect(pressTab()).toBe(false);
+    expect(screen.getByRole('button', { name: '모달 첫' })).toHaveFocus();
+  });
+
+  it('첫 요소에서 Shift+Tab을 누르면 마지막 요소로 간다', () => {
+    render(<Overlay isOpen name='모달' />);
+    screen.getByRole('button', { name: '모달 첫' }).focus();
+
+    expect(pressTab(true)).toBe(false);
+    expect(screen.getByRole('button', { name: '모달 끝' })).toHaveFocus();
+  });
+
+  it('열자마자 Shift+Tab을 눌러도 배경으로 나가지 않는다', () => {
+    render(<Overlay isOpen name='모달' />);
+
+    expect(pressTab(true)).toBe(false);
+    expect(screen.getByRole('button', { name: '모달 끝' })).toHaveFocus();
+  });
+
+  it('배경으로 빠져나간 포커스를 다시 안으로 데려온다', () => {
+    render(<Overlay isOpen name='모달' />);
+    (document.activeElement as HTMLElement).blur();
+    expect(document.body).toHaveFocus();
+
+    pressTab();
+    expect(screen.getByRole('button', { name: '모달 첫' })).toHaveFocus();
+  });
+
+  it('닫히면 열기 전 포커스로 복원한다', () => {
+    const Scene = ({ isOpen }: { isOpen: boolean }) => (
+      <>
+        <button>배경</button>
+        <Overlay isOpen={isOpen} name='모달' />
+      </>
+    );
+
+    const { rerender } = render(<Scene isOpen={false} />);
+    const background = screen.getByRole('button', { name: '배경' });
+    background.focus();
+
+    rerender(<Scene isOpen />);
+    expect(screen.getByTestId('모달')).toHaveFocus();
+
+    rerender(<Scene isOpen={false} />);
+    expect(background).toHaveFocus();
+  });
+
+  it('겹쳐 열리면 가장 위 하나만 가둔다', () => {
+    const Nested = ({ inner }: { inner: boolean }) => (
+      <>
+        <Overlay isOpen name='바깥' />
+        {inner && <Overlay isOpen name='안쪽' />}
+      </>
+    );
+
+    const { rerender } = render(<Nested inner />);
+    expect(screen.getByTestId('안쪽')).toHaveFocus();
+
+    // 바깥이 아니라 안쪽 요소끼리 순환한다
+    screen.getByRole('button', { name: '안쪽 끝' }).focus();
+    pressTab();
+    expect(screen.getByRole('button', { name: '안쪽 첫' })).toHaveFocus();
+
+    rerender(<Nested inner={false} />);
+    expect(screen.getByTestId('바깥')).toHaveFocus();
+  });
+});

--- a/frontend/src/hooks/useFocusTrap.ts
+++ b/frontend/src/hooks/useFocusTrap.ts
@@ -1,0 +1,98 @@
+import { RefObject, useEffect } from 'react';
+
+/**
+ * 열린 오버레이 안에 포커스를 가둔다.
+ *
+ * 오버레이는 #root 뒤에 붙는 별도 포털이라 배경이 그대로 탭 순서에 남는다.
+ * aria-modal은 접근성 트리만 바꿀 뿐 포커스 순서를 막지 못해서, 열려 있는 채로
+ * Tab을 누르면 뒤에 깔린 요소로 새어나간다. 그래서 열릴 때 안으로 옮기고,
+ * Tab을 안에서 순환시키고, 닫힐 때 열기 전 자리로 돌려놓는다.
+ *
+ * 오버레이가 겹칠 때 각자 가두면 아래 오버레이가 위에 열린 것의 포커스를 뺏는다.
+ * useTopmostEscape와 같은 이유로 열린 순서를 쌓아두고 맨 위 하나만 가둔다.
+ */
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+const stack: HTMLElement[] = [];
+
+const getFocusable = (container: HTMLElement) =>
+  Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+
+const handleKeyDown = (event: KeyboardEvent) => {
+  if (event.key !== 'Tab') return;
+
+  const container = stack[stack.length - 1];
+  if (!container) return;
+
+  /** 안에 잡을 것이 없으면 컨테이너 자신에 묶어둔다 */
+  const focusable = getFocusable(container);
+  const first = focusable[0] ?? container;
+  const last = focusable[focusable.length - 1] ?? container;
+
+  const active = document.activeElement;
+
+  // 배경을 클릭하면 포커스가 body로 빠진다. 다음 Tab에서 다시 데려온다.
+  if (!container.contains(active)) {
+    event.preventDefault();
+    (event.shiftKey ? last : first).focus();
+    return;
+  }
+
+  /** 열린 직후 포커스를 받는 컨테이너는 첫 요소 앞자리로 친다 */
+  const atStart = active === container || active === first;
+
+  // 사이 요소들은 브라우저 기본 이동에 맡기고 양 끝만 이어붙인다
+  if (event.shiftKey && atStart) {
+    event.preventDefault();
+    last.focus();
+  } else if (!event.shiftKey && active === last) {
+    event.preventDefault();
+    first.focus();
+  }
+};
+
+const useFocusTrap = (
+  isOpen: boolean,
+  containerRef: RefObject<HTMLElement | null>,
+) => {
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!isOpen || !container) return;
+
+    const previouslyFocused = document.activeElement;
+
+    if (stack.length === 0) {
+      document.addEventListener('keydown', handleKeyDown);
+    }
+    stack.push(container);
+
+    // 첫 요소를 바로 잡으면 그 요소의 onFocus가 딸려 실행된다(스와이프 행이 열리는 식).
+    // 컨테이너를 잡아 두면 아무것도 건드리지 않으면서 Tab이 자연스럽게 안쪽으로 들어간다.
+    container.focus();
+
+    return () => {
+      stack.splice(stack.indexOf(container), 1);
+      if (stack.length === 0) {
+        document.removeEventListener('keydown', handleKeyDown);
+      }
+
+      // 모달에서 페이지를 떠나면 열기 전 요소가 이미 사라져 있다.
+      // 스크롤 잠금이 풀리며 돌려놓은 위치를 흔들지 않도록 preventScroll으로 되돌린다.
+      if (
+        previouslyFocused instanceof HTMLElement &&
+        previouslyFocused.isConnected
+      ) {
+        previouslyFocused.focus({ preventScroll: true });
+      }
+    };
+  }, [isOpen, containerRef]);
+};
+
+export default useFocusTrap;


### PR DESCRIPTION
## 문제

Modal이 포커스를 안쪽으로 옮기지도, 가두지도 않았습니다. 열린 상태에서 Tab을 누르면 배경의 조작 가능한 요소로 포커스가 새어나갑니다.

`index.html`에서 `#modal-root`는 `#root` **뒤에** 붙고, 모달이 열릴 때 `#root`에 `inert`나 `aria-hidden`을 거는 코드는 없습니다. 그래서:

- 모달 첫 요소에서 **Shift+Tab** → 곧장 배경 요소로
- 모달 마지막 요소에서 **Tab** → 문서 끝 → 브라우저 UI → 다시 문서 처음(배경)으로

`aria-modal='true'`는 접근성 트리에만 영향을 주고 순차 키보드 포커스 순서를 바꾸지 않아 이걸 막지 못합니다. 게다가 Modal 자체가 아니라 소비자가 각자 붙이고 있어 `MapModal`, `PhotoModal`, `DayEventsModal`, `PersonalInfoConsentModal`, `ResponsiveSheet`(데스크톱)에는 아예 없습니다.

특히 `PersonalInfoConsentModal`은 `closeOnBackdrop={false}` + `onClose={() => {}}`로 ESC·배경 클릭 모두 막아둔 강제 동의 모달인데, Tab으로는 배경 관리자 페이지를 자유롭게 조작할 수 있어 모달의 목적 자체가 깨집니다.

## 변경

기존 `useBodyScrollLock` / `useTopmostEscape`와 같은 패턴으로 훅을 분리했습니다.

**신규** `src/hooks/useFocusTrap.ts`
- 모듈 스택에 컨테이너를 쌓고 document 리스너 하나로 **맨 위 하나만** 가둡니다 (`useTopmostEscape`와 동일한 이유·동일한 구조)
- 열릴 때 컨테이너로 포커스 이동 → Tab/Shift+Tab 양끝 순환 → 닫힐 때 열기 전 포커스 복원
- 복원은 `isConnected` 가드 + `preventScroll`로 처리합니다. 모달에서 페이지를 떠나면 열기 전 요소가 이미 사라져 있고, `useBodyScrollLock`이 되돌린 스크롤 위치를 흔들면 안 되기 때문입니다

**수정** `Modal.tsx`, `BottomSheet.tsx`, `BottomSheet.styles.ts`
- 공개 API(`isOpen`, `onClose`, `children`, `closeOnBackdrop`) **변경 없음**

## 설계 판단 2가지 (리뷰 포인트)

### 1. "첫 포커서블"이 아니라 컨테이너로 포커스

`SwipeableEventRow.tsx:65`의 삭제 버튼이 DOM상 첫 포커서블인데 `onFocus`에 행을 여는 부수효과가 걸려 있습니다. 첫 요소를 잡으면 `DayEventsModal`을 여는 순간 첫 일정 행이 스르륵 열립니다.

컨테이너(`tabIndex={-1}`)를 잡으면 아무것도 건드리지 않고 Tab이 자연스럽게 안으로 들어갑니다(Radix Dialog 등의 기본 동작). 대신 컨테이너에서 Shift+Tab이 배경으로 새지 않도록 컨테이너를 "첫 요소 앞자리"로 처리하는 분기를 넣었습니다.

### 2. BottomSheet까지 포함 

실제로 오버레이가 겹치는 곳은 `DayEventsModal`(Modal) 위의 `DeleteScopeSheet`(→ `ResponsiveSheet` → 모바일 BottomSheet / 데스크톱 Modal)입니다. Modal에만 넣으면 시트가 위에 뜬 동안 Tab이 아래 모달로 끌려 내려가는 **새 버그**가 생깁니다. 스택을 공유해야 해서 BottomSheet에도 한 줄 넣었습니다.

## 검증

| 항목 | 결과 |
| --- | --- |
| `npm run typecheck` | 통과 |
| `npx jest` 전체 | 51 suites / 425 tests 통과 (신규 8개 포함) |
| `npm run lint` (변경 파일) | 이슈 없음 |
| `npm run build-storybook` | 성공 |

**실제 브라우저 (Playwright + Storybook)**

- 열림 → 컨테이너로 포커스 이동
- Tab 6회: `컨테이너 → B → 닫기 → A → B → 닫기 → A`, **배경 유출 0**
- Shift+Tab 4회: 역방향 wrap 정상, 유출 0
- 열자마자 Shift+Tab → 마지막 요소로 wrap (배경으로 안 나감)
- 배경 클릭으로 포커스가 body로 빠진 뒤 Tab → 모달 안으로 복귀
- ESC로 닫기 → 열기 전 버튼으로 포커스 복원
- 포커서블 0개인 시트에서 Tab/Shift+Tab → 시트 안 유지

**사용처 10곳**(`ResponsiveSheet`, `SatisfactionModal`, `MapModal`, `ApplicationSelectModal`, `PhotoModal`, `DisconnectConfirmModal`, `DayEventsModal`, `PersonalInfoConsentModal`, `FeedbackConfirmModal`, `ModalLayout`)을 모두 읽고 확인했습니다. 첫 포커스가 컨테이너라 어느 곳도 자동 활성화·부수효과가 없습니다.

Chromatic 회귀는 이 PR의 스냅샷 확인 부탁드립니다.

## 검증 중 잡은 회귀

BottomSheet의 `Sheet`에 `outline: none`이 없어서, 키보드로 열면 시트 전체에 `outline: auto 1px` 포커스 링이 그려졌습니다(`:focus-visible` 매칭 확인). Modal의 `ContentWrapper`엔 이미 있던 속성이라 동일하게 추가했고, 재확인 결과 `outline-style: none`입니다.

## 손대지 않은 것 (후속 제안)

1. **BottomSheet 스토리가 로드 시 아무것도 렌더하지 않습니다** — 기존 버그입니다. `Portal`은 렌더 중에 `#modal-root`를 찾는데 `.storybook/preview.tsx`는 `useEffect`에서 만듭니다. 첫 렌더에 root가 없어 `null`을 반환하고, `isOpen`이 처음부터 `true`라 재렌더가 안 일어나 영영 안 뜹니다. **Chromatic이 BottomSheet를 스냅샷하지 못하고 있다**는 뜻입니다. 이 PR과 무관해 그대로 뒀습니다.
2. **스크린리더 라벨링 공백** — 위에 적은 5개 모달에 `role`/`aria-modal`이 없습니다. 포커스는 해결됐지만 안내는 여전히 약합니다. 5개 파일을 건드려야 해서 분리했습니다.
3. BottomSheet 실사용처는 전부 관리자 캘린더 탭(로그인 필요)이라 실제 앱에서는 확인하지 못했습니다. Storybook + 단위 테스트로만 검증했습니다.


