### PR TITLE
[refactor] 서버 에러 문구 추출 로직을 API 유틸로 분리한다

### DIFF
--- a/frontend/src/apis/CLAUDE.md
+++ b/frontend/src/apis/CLAUDE.md
@@ -7,6 +7,7 @@ API는 `src/apis/utils/apiHelpers.ts`의 헬퍼 함수를 사용하는 일관된
 - `handleResponse<T>()` - 응답 파싱, `{ data: {...} }` 형식 자동 언래핑
 - `secureFetch()` - 인증된 요청, **401 시 토큰 자동 갱신** (`src/apis/auth/secureFetch.ts`)
 - `studentFetch()` - 익명 학생 토큰 요청 (`src/apis/auth/studentFetch.ts`). 우체통 전용
+- `getServerErrorMessage(error, fallback)` - 서버 원본 에러 문구 추출 (`src/apis/utils/getServerErrorMessage.ts`). `handleResponse`가 `error.message`를 호출부 기본 문구로 덮어쓰기 때문에 원본은 `error.data.message`에 남는다. 그걸 되꺼내는 짝. 폴백 문구는 화면마다 달라 인자로 받는다
 - `fetchWithTimeout()` - 타임아웃(기본 10s) 붙은 fetch 래퍼 (`src/apis/utils/fetchWithTimeout.ts`). 타임아웃/네트워크 실패를 `NetworkError`로 변환, 호출부 signal 병합 지원. API 호출은 raw `fetch` 대신 이걸 사용 (예외: SSE 스트림, S3 presigned 업로드)
 
 - 도메인별 API 함수는 이 디렉토리에 둔다 (club, auth, application, applicants). 페이지나 컴포넌트 안에 직접 분산시키지 않는다.

--- a/frontend/src/apis/utils/getServerErrorMessage.test.ts
+++ b/frontend/src/apis/utils/getServerErrorMessage.test.ts
@@ -1,0 +1,77 @@
+import { ApiError, NetworkError } from '@/errors';
+import { getServerErrorMessage } from './getServerErrorMessage';
+
+const FALLBACK = '전송에 실패했어요. 잠시 후 다시 시도해주세요.';
+
+/** handleResponse가 실제로 만드는 형태. message는 호출부 기본 문구로 덮인 뒤다 */
+const createApiError = (data: unknown) =>
+  new ApiError(
+    400,
+    'Bad Request',
+    '601-2',
+    data,
+    '피드백 전송에 실패했습니다.',
+  );
+
+describe('getServerErrorMessage', () => {
+  it('ApiError의 data.message가 있으면 그것을 반환한다', () => {
+    const error = createApiError({
+      statuscode: '601-2',
+      message: '이미지 파일을 찾을 수 없습니다.',
+    });
+
+    expect(getServerErrorMessage(error, FALLBACK)).toBe(
+      '이미지 파일을 찾을 수 없습니다.',
+    );
+  });
+
+  it('덮어써진 error.message가 아니라 data.message를 본다', () => {
+    const error = createApiError({
+      message: '이미지 파일을 찾을 수 없습니다.',
+    });
+
+    expect(getServerErrorMessage(error, FALLBACK)).not.toBe(error.message);
+  });
+
+  it('data가 없으면 폴백을 반환한다', () => {
+    expect(getServerErrorMessage(createApiError(undefined), FALLBACK)).toBe(
+      FALLBACK,
+    );
+  });
+
+  it('data에 message가 없으면 폴백을 반환한다', () => {
+    expect(
+      getServerErrorMessage(createApiError({ statuscode: '601-2' }), FALLBACK),
+    ).toBe(FALLBACK);
+  });
+
+  it('ApiError가 아닌 일반 Error면 폴백을 반환한다', () => {
+    expect(getServerErrorMessage(new Error('boom'), FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('NetworkError처럼 data가 없는 에러도 폴백을 반환한다', () => {
+    expect(getServerErrorMessage(new NetworkError(), FALLBACK)).toBe(FALLBACK);
+  });
+
+  // data는 서버 JSON 그대로라 객체라는 보장이 없다
+  it.each([
+    ['문자열', '이미지 파일을 찾을 수 없습니다.'],
+    ['숫자', 500],
+    ['배열', [{ message: '이미지 파일을 찾을 수 없습니다.' }]],
+    ['null', null],
+    ['message가 문자열이 아닌 객체', { message: 601 }],
+    ['message가 빈 문자열인 객체', { message: '' }],
+  ])('data가 %s면 폴백을 반환한다', (_, data) => {
+    expect(getServerErrorMessage(createApiError(data), FALLBACK)).toBe(
+      FALLBACK,
+    );
+  });
+
+  it('폴백은 화면마다 다르게 넘길 수 있다', () => {
+    const error = createApiError(undefined);
+
+    expect(getServerErrorMessage(error, '저장에 실패했어요.')).toBe(
+      '저장에 실패했어요.',
+    );
+  });
+});

--- a/frontend/src/apis/utils/getServerErrorMessage.ts
+++ b/frontend/src/apis/utils/getServerErrorMessage.ts
@@ -1,0 +1,24 @@
+import { ApiError } from '@/errors';
+
+/**
+ * 서버가 내려준 문구를 그대로 꺼낸다.
+ * `handleResponse`가 error.message를 호출부 기본 문구로 덮어쓰기 때문에 원본은 data에 남는다.
+ * 사진이 R2에 없다(601-2), 10자 미만이다 같은 실패는 사용자가 고칠 수 있는 것이라
+ * "실패했어요"보다 이유를 보여주는 편이 낫다.
+ *
+ * 폴백은 화면마다 달라서 인자로 받는다.
+ */
+export const getServerErrorMessage = (
+  error: unknown,
+  fallback: string,
+): string => {
+  if (!(error instanceof ApiError)) return fallback;
+
+  const body = error.data;
+  if (typeof body !== 'object' || body === null) return fallback;
+
+  const { message } = body as { message?: unknown };
+
+  // 빈 문자열이면 빈 토스트가 뜬다. handleResponse도 같은 이유로 truthy 검사를 한다.
+  return typeof message === 'string' && message !== '' ? message : fallback;
+};

--- a/frontend/src/pages/FeedbackPage/FeedbackWritePage.tsx
+++ b/frontend/src/pages/FeedbackPage/FeedbackWritePage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router-dom';
+import { getServerErrorMessage } from '@/apis/utils/getServerErrorMessage';
 import AttachErrorIcon from '@/assets/images/icons/feedback/feedback_image_attach_error.svg?react';
 import AttachMaxIcon from '@/assets/images/icons/feedback/feedback_image_attach_max.svg?react';
 import AttachIcon from '@/assets/images/icons/feedback/feedback_image_attach.svg?react';
@@ -16,7 +17,6 @@ import {
   FEEDBACK_TYPE_ORDER,
 } from '@/constants/feedback';
 import { ALLOWED_IMAGE_TYPES, MAX_FILE_SIZE } from '@/constants/uploadLimit';
-import { ApiError } from '@/errors';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import useTrackPageView from '@/hooks/Mixpanel/useTrackPageView';
 import { useCreateFeedback } from '@/hooks/Queries/useFeedback';
@@ -48,20 +48,6 @@ type AttachError = 'count' | 'size' | 'type' | null;
 const ALLOWED_TYPES: readonly string[] = ALLOWED_IMAGE_TYPES;
 
 const SUBMIT_ERROR_FALLBACK = '전송에 실패했어요. 잠시 후 다시 시도해주세요.';
-
-/**
- * 서버가 내려준 문구를 그대로 보여준다.
- * `handleResponse`가 error.message를 호출부 기본 문구로 덮어쓰기 때문에 원본은 data에 있다.
- * 사진이 R2에 없다(601-2), 10자 미만이다 같은 실패는 사용자가 고칠 수 있는 것이라
- * "실패했어요"보다 이유를 보여주는 편이 낫다.
- */
-const toSubmitErrorMessage = (error: unknown) => {
-  if (!(error instanceof ApiError)) return SUBMIT_ERROR_FALLBACK;
-
-  const body = error.data as { message?: string } | undefined;
-
-  return body?.message ?? SUBMIT_ERROR_FALLBACK;
-};
 
 const ATTACH_ERROR_LABEL: Record<NonNullable<AttachError>, string> = {
   count: `최대 ${FEEDBACK_IMAGE_MAX_COUNT}장까지 첨부할 수 있어요.`,
@@ -210,7 +196,7 @@ const FeedbackWritePage = () => {
 
           // 모달을 닫아 토스트가 보이게 한다. 작성한 내용과 사진은 그대로 남아 다시 시도할 수 있다.
           setOpenedModal(null);
-          setSubmitError(toSubmitErrorMessage(error));
+          setSubmitError(getServerErrorMessage(error, SUBMIT_ERROR_FALLBACK));
         },
       },
     );


### PR DESCRIPTION
## #️⃣연관된 이슈

> 스택 PR — base가 `develop-fe`가 아니라 **`feat/feedback-error-toast`(#1914)** 입니다. #1914가 먼저 머지되어야 합니다. (#1914가 이 함수를 만듭니다)

## 📝작업 내용

#1914에서 `FeedbackWritePage.tsx` 안에 모듈 private으로 만든 `toSubmitErrorMessage`를 `src/apis/utils/getServerErrorMessage.ts`로 옮기고 테스트를 붙였습니다.

**옮긴 이유** — 이 함수가 아는 지식이 우체통이 아니라 API 레이어의 것입니다. `handleResponse`가 `customErrorMessage`로 `error.message`를 덮어쓰기 때문에 서버 원본 문구가 `error.data`에 남는데, 이 함수는 그걸 되꺼내는 짝입니다. `develop-fe`에 전역 `Toast`가 들어와서 다른 화면에서도 곧 필요해집니다.

폴백 문구는 화면마다 달라서 인자로 받습니다. `FeedbackWritePage`는 기존 `SUBMIT_ERROR_FALLBACK`을 그대로 넘깁니다.

```ts
setSubmitError(getServerErrorMessage(error, SUBMIT_ERROR_FALLBACK));
```

호출부 변경은 `+2 −16`이고, 이제 안 쓰게 된 `ApiError` import를 지웠습니다.

## 중점적으로 리뷰받고 싶은 부분

**캐스팅을 런타임 검사로 바꾼 것**

원본은 `error.data as { message?: string } | undefined`였습니다. `data`는 서버 JSON 그대로라 객체라는 보장이 없어서, 문자열이 오면 `'문자열'.message`가 `undefined`인 덕에 *우연히* 폴백으로 떨어졌습니다. 공용 유틸이 되는 만큼 실제로 검사하게 했습니다.

```ts
if (typeof body !== 'object' || body === null) return fallback;
const { message } = body as { message?: unknown };
return typeof message === 'string' && message !== '' ? message : fallback;
```

빈 문자열도 폴백으로 넘깁니다. 호출부가 `isOpen={submitError !== null}`이라 `message: ''`가 오면 **빈 토스트가 뜹니다.** `handleResponse`도 `if (body?.message)`로 같은 truthy 검사를 하고 있어 API 레이어와 일관됩니다.

동작이 바뀌는 건 이 두 경우뿐이고, 둘 다 기존에는 화면이 깨지던 쪽입니다.

