### PR TITLE
[feature] 모달·바텀시트 포커스 트랩 추가

### DIFF
--- a/frontend/src/components/common/BottomSheet/BottomSheet.styles.ts
+++ b/frontend/src/components/common/BottomSheet/BottomSheet.styles.ts
@@ -34,6 +34,8 @@ export const Sheet = styled.div<{
   width: 100%;
   max-width: 500px;
   max-height: calc(100dvh - 80px);
+  /* 열릴 때 포커스를 받으므로 시트 전체를 두르는 기본 포커스 링을 지운다 */
+  outline: none;
   ${({ $stacked }) =>
     $stacked &&
     css`

--- a/frontend/src/components/common/BottomSheet/BottomSheet.tsx
+++ b/frontend/src/components/common/BottomSheet/BottomSheet.tsx
@@ -1,5 +1,6 @@
 import { MouseEvent, PointerEvent, ReactNode, useRef, useState } from 'react';
 import useBodyScrollLock from '@/hooks/useBodyScrollLock';
+import useFocusTrap from '@/hooks/useFocusTrap';
 import useTopmostEscape from '@/hooks/useTopmostEscape';
 import Portal from '../Portal/Portal';
 import * as Styled from './BottomSheet.styles';
@@ -26,8 +27,12 @@ const BottomSheet = ({
   background,
   stacked,
 }: BottomSheetProps) => {
+  const sheetRef = useRef<HTMLDivElement>(null);
+
   useBodyScrollLock(isOpen);
   useTopmostEscape(isOpen, onClose);
+  // 모달 위에 시트를 겹쳐 열 때 아래 모달이 포커스를 도로 뺏지 않도록 함께 쌓는다
+  useFocusTrap(isOpen, sheetRef);
 
   /** 드래그 중에만 값을 갖는다. 놓으면 null이 되어 제자리로 돌아간다. */
   const [dragOffset, setDragOffset] = useState<number | null>(null);
@@ -62,6 +67,8 @@ const BottomSheet = ({
     <Portal>
       <Styled.Overlay onClick={closeOnBackdrop ? onClose : undefined}>
         <Styled.Sheet
+          ref={sheetRef}
+          tabIndex={-1}
           role='dialog'
           aria-modal='true'
           $background={background}

--- a/frontend/src/components/common/Modal/Modal.styles.ts
+++ b/frontend/src/components/common/Modal/Modal.styles.ts
@@ -9,8 +9,21 @@ export const Overlay = styled.div`
   background: rgba(0, 0, 0, 0.6);
   display: flex;
   justify-content: center;
+  /*
+   * 내용이 화면보다 길면 가운데 정렬은 위아래로 똑같이 넘쳐 상단이 잘린다.
+   * safe는 넘칠 때만 위쪽 기준으로 붙여 제목이 잘려나가지 않게 한다.
+   *
+   * overflow: hidden은 스크롤바만 감출 뿐 스크롤은 되는 상자라, 화면 밖 요소로
+   * 포커스가 가면 브라우저가 이 상자를 스크롤해 모달을 위로 밀어버린다.
+   * 되돌릴 스크롤바가 없어 잘린 상단은 다시 못 본다. clip은 스크롤 상자를
+   * 만들지 않아 이 밀림이 아예 일어나지 않는다.
+   *
+   * 두 속성 모두 미지원 브라우저를 위해 기존 값을 앞에 남겨둔다.
+   */
   align-items: center;
+  align-items: safe center;
   overflow: hidden;
+  overflow: clip;
   transition: background-color 0.2s ease;
   touch-action: none;
 `;

--- a/frontend/src/components/common/Modal/Modal.tsx
+++ b/frontend/src/components/common/Modal/Modal.tsx
@@ -1,5 +1,6 @@
-import { MouseEvent, ReactNode } from 'react';
+import { MouseEvent, ReactNode, useRef } from 'react';
 import useBodyScrollLock from '@/hooks/useBodyScrollLock';
+import useFocusTrap from '@/hooks/useFocusTrap';
 import useTopmostEscape from '@/hooks/useTopmostEscape';
 import Portal from '../Portal/Portal';
 import * as Styled from './Modal.styles';
@@ -17,8 +18,11 @@ const Modal = ({
   children,
   closeOnBackdrop = true,
 }: ModalProps) => {
+  const contentRef = useRef<HTMLDivElement>(null);
+
   useBodyScrollLock(isOpen);
   useTopmostEscape(isOpen, onClose);
+  useFocusTrap(isOpen, contentRef);
 
   if (!isOpen) return null;
 
@@ -26,6 +30,8 @@ const Modal = ({
     <Portal>
       <Styled.Overlay onClick={closeOnBackdrop ? onClose : undefined}>
         <Styled.ContentWrapper
+          ref={contentRef}
+          tabIndex={-1}
           onClick={(e: MouseEvent<HTMLDivElement>) => e.stopPropagation()}
         >
           {children}

--- a/frontend/src/hooks/useFocusTrap.test.tsx
+++ b/frontend/src/hooks/useFocusTrap.test.tsx
@@ -1,0 +1,117 @@
+import '@testing-library/jest-dom';
+import { useRef } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import useFocusTrap from './useFocusTrap';
+
+const Overlay = ({ isOpen, name }: { isOpen: boolean; name: string }) => {
+  const ref = useRef<HTMLDivElement>(null);
+  useFocusTrap(isOpen, ref);
+
+  if (!isOpen) return null;
+
+  return (
+    <div ref={ref} tabIndex={-1} data-testid={name}>
+      <button>{name} 첫</button>
+      <button>{name} 끝</button>
+    </div>
+  );
+};
+
+/** preventDefault로 브라우저 기본 이동을 막았으면 false를 돌려준다 */
+const pressTab = (shiftKey = false) =>
+  fireEvent.keyDown(document, { key: 'Tab', shiftKey });
+
+describe('useFocusTrap', () => {
+  it('열리면 컨테이너로 포커스가 들어간다', () => {
+    render(<Overlay isOpen name='모달' />);
+
+    expect(screen.getByTestId('모달')).toHaveFocus();
+  });
+
+  it('안쪽 요소의 onFocus를 건드리지 않는다', () => {
+    const onFocus = jest.fn();
+    const Sneaky = () => {
+      const ref = useRef<HTMLDivElement>(null);
+      useFocusTrap(true, ref);
+      return (
+        <div ref={ref} tabIndex={-1}>
+          <button onFocus={onFocus}>부수효과</button>
+        </div>
+      );
+    };
+    render(<Sneaky />);
+
+    expect(onFocus).not.toHaveBeenCalled();
+  });
+
+  it('마지막 요소에서 Tab을 누르면 첫 요소로 돌아온다', () => {
+    render(<Overlay isOpen name='모달' />);
+    screen.getByRole('button', { name: '모달 끝' }).focus();
+
+    expect(pressTab()).toBe(false);
+    expect(screen.getByRole('button', { name: '모달 첫' })).toHaveFocus();
+  });
+
+  it('첫 요소에서 Shift+Tab을 누르면 마지막 요소로 간다', () => {
+    render(<Overlay isOpen name='모달' />);
+    screen.getByRole('button', { name: '모달 첫' }).focus();
+
+    expect(pressTab(true)).toBe(false);
+    expect(screen.getByRole('button', { name: '모달 끝' })).toHaveFocus();
+  });
+
+  it('열자마자 Shift+Tab을 눌러도 배경으로 나가지 않는다', () => {
+    render(<Overlay isOpen name='모달' />);
+
+    expect(pressTab(true)).toBe(false);
+    expect(screen.getByRole('button', { name: '모달 끝' })).toHaveFocus();
+  });
+
+  it('배경으로 빠져나간 포커스를 다시 안으로 데려온다', () => {
+    render(<Overlay isOpen name='모달' />);
+    (document.activeElement as HTMLElement).blur();
+    expect(document.body).toHaveFocus();
+
+    pressTab();
+    expect(screen.getByRole('button', { name: '모달 첫' })).toHaveFocus();
+  });
+
+  it('닫히면 열기 전 포커스로 복원한다', () => {
+    const Scene = ({ isOpen }: { isOpen: boolean }) => (
+      <>
+        <button>배경</button>
+        <Overlay isOpen={isOpen} name='모달' />
+      </>
+    );
+
+    const { rerender } = render(<Scene isOpen={false} />);
+    const background = screen.getByRole('button', { name: '배경' });
+    background.focus();
+
+    rerender(<Scene isOpen />);
+    expect(screen.getByTestId('모달')).toHaveFocus();
+
+    rerender(<Scene isOpen={false} />);
+    expect(background).toHaveFocus();
+  });
+
+  it('겹쳐 열리면 가장 위 하나만 가둔다', () => {
+    const Nested = ({ inner }: { inner: boolean }) => (
+      <>
+        <Overlay isOpen name='바깥' />
+        {inner && <Overlay isOpen name='안쪽' />}
+      </>
+    );
+
+    const { rerender } = render(<Nested inner />);
+    expect(screen.getByTestId('안쪽')).toHaveFocus();
+
+    // 바깥이 아니라 안쪽 요소끼리 순환한다
+    screen.getByRole('button', { name: '안쪽 끝' }).focus();
+    pressTab();
+    expect(screen.getByRole('button', { name: '안쪽 첫' })).toHaveFocus();
+
+    rerender(<Nested inner={false} />);
+    expect(screen.getByTestId('바깥')).toHaveFocus();
+  });
+});

--- a/frontend/src/hooks/useFocusTrap.ts
+++ b/frontend/src/hooks/useFocusTrap.ts
@@ -1,0 +1,98 @@
+import { RefObject, useEffect } from 'react';
+
+/**
+ * 열린 오버레이 안에 포커스를 가둔다.
+ *
+ * 오버레이는 #root 뒤에 붙는 별도 포털이라 배경이 그대로 탭 순서에 남는다.
+ * aria-modal은 접근성 트리만 바꿀 뿐 포커스 순서를 막지 못해서, 열려 있는 채로
+ * Tab을 누르면 뒤에 깔린 요소로 새어나간다. 그래서 열릴 때 안으로 옮기고,
+ * Tab을 안에서 순환시키고, 닫힐 때 열기 전 자리로 돌려놓는다.
+ *
+ * 오버레이가 겹칠 때 각자 가두면 아래 오버레이가 위에 열린 것의 포커스를 뺏는다.
+ * useTopmostEscape와 같은 이유로 열린 순서를 쌓아두고 맨 위 하나만 가둔다.
+ */
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+const stack: HTMLElement[] = [];
+
+const getFocusable = (container: HTMLElement) =>
+  Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+
+const handleKeyDown = (event: KeyboardEvent) => {
+  if (event.key !== 'Tab') return;
+
+  const container = stack[stack.length - 1];
+  if (!container) return;
+
+  /** 안에 잡을 것이 없으면 컨테이너 자신에 묶어둔다 */
+  const focusable = getFocusable(container);
+  const first = focusable[0] ?? container;
+  const last = focusable[focusable.length - 1] ?? container;
+
+  const active = document.activeElement;
+
+  // 배경을 클릭하면 포커스가 body로 빠진다. 다음 Tab에서 다시 데려온다.
+  if (!container.contains(active)) {
+    event.preventDefault();
+    (event.shiftKey ? last : first).focus();
+    return;
+  }
+
+  /** 열린 직후 포커스를 받는 컨테이너는 첫 요소 앞자리로 친다 */
+  const atStart = active === container || active === first;
+
+  // 사이 요소들은 브라우저 기본 이동에 맡기고 양 끝만 이어붙인다
+  if (event.shiftKey && atStart) {
+    event.preventDefault();
+    last.focus();
+  } else if (!event.shiftKey && active === last) {
+    event.preventDefault();
+    first.focus();
+  }
+};
+
+const useFocusTrap = (
+  isOpen: boolean,
+  containerRef: RefObject<HTMLElement | null>,
+) => {
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!isOpen || !container) return;
+
+    const previouslyFocused = document.activeElement;
+
+    if (stack.length === 0) {
+      document.addEventListener('keydown', handleKeyDown);
+    }
+    stack.push(container);
+
+    // 첫 요소를 바로 잡으면 그 요소의 onFocus가 딸려 실행된다(스와이프 행이 열리는 식).
+    // 컨테이너를 잡아 두면 아무것도 건드리지 않으면서 Tab이 자연스럽게 안쪽으로 들어간다.
+    container.focus();
+
+    return () => {
+      stack.splice(stack.indexOf(container), 1);
+      if (stack.length === 0) {
+        document.removeEventListener('keydown', handleKeyDown);
+      }
+
+      // 모달에서 페이지를 떠나면 열기 전 요소가 이미 사라져 있다.
+      // 스크롤 잠금이 풀리며 돌려놓은 위치를 흔들지 않도록 preventScroll으로 되돌린다.
+      if (
+        previouslyFocused instanceof HTMLElement &&
+        previouslyFocused.isConnected
+      ) {
+        previouslyFocused.focus({ preventScroll: true });
+      }
+    };
+  }, [isOpen, containerRef]);
+};
+
+export default useFocusTrap;


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

모달이 열려 있어도 **Tab이 배경으로 새어나갑니다.** `#modal-root`는 `index.html`에서 `#root` 뒤에 붙는데 모달이 열릴 때 `#root`를 `inert` 처리하지 않아, 모달 첫 요소에서 Shift+Tab을 누르면 곧장 배경 요소로 갑니다. `aria-modal`은 접근성 트리만 바꿀 뿐 키보드 포커스 순서를 막지 못합니다.

특히 `PersonalInfoConsentModal`은 ESC·배경 클릭을 모두 막아둔 강제 동의 모달인데, Tab으로는 뒤의 관리자 페이지를 그대로 조작할 수 있어 모달의 목적 자체가 깨집니다.

`useFocusTrap` 훅을 추가해 **열릴 때 포커스를 안으로 옮기고, Tab/Shift+Tab을 안에서 순환시키고, 닫힐 때 열기 전 자리로 되돌립니다.** 기존 `useBodyScrollLock`·`useTopmostEscape`와 같은 패턴이고, 오버레이가 겹칠 때 맨 위 하나만 가두는 스택 구조도 `useTopmostEscape`를 그대로 따랐습니다. 공용 `Modal`에 걸어 하위 모달 10곳이 함께 혜택을 보며, 공개 API(`isOpen`, `onClose`, `children`, `closeOnBackdrop`)는 그대로입니다.

### 함께 고친 것 — 긴 모달에서 모달이 위로 밀리는 문제

작업 중 제보받은 증상입니다. 원인은 포커스 트랩이 아니라 `Modal.styles.ts`의 `Overlay`였습니다.

`overflow: hidden`은 스크롤바만 감출 뿐 스크롤은 되는 상자입니다. 내용이 화면보다 길면 `align-items: center` 때문에 위아래로 똑같이 넘치고, 화면 밖 요소로 포커스가 가는 순간 브라우저가 이 Overlay를 스크롤해 모달을 밀어 올립니다. 스크롤바가 없으니 잘려나간 상단은 되돌릴 수 없습니다. 저장 버튼이 카드 중간에 떠 보이던 것도 같은 원인입니다 — 카드가 내부 스크롤을 안 하면 `position: sticky`의 기준이 Overlay가 됩니다.

```css
align-items: safe center;  /* 넘칠 때만 위쪽 기준 → 제목이 안 잘림 */
overflow: clip;            /* 스크롤 상자를 안 만듦 → 밀림 자체가 불가능 */
```

둘 다 미지원 브라우저를 위해 기존 값(`center`, `hidden`)을 앞줄에 남겨 구형은 지금과 동일하게 동작합니다.

`.focus()` 호출이 아니라 **브라우저의 기본 Tab 이동**이 일으키므로 이 PR 이전부터 있던 문제입니다. 다만 포커스가 모달 안을 순환하게 되면서 훨씬 쉽게 닿아 함께 담았습니다.

## 중점적으로 리뷰받고 싶은 부분

**첫 포커서블이 아니라 컨테이너를 잡습니다.** `SwipeableEventRow`의 삭제 버튼이 DOM상 첫 포커서블인데 `onFocus`에 행을 여는 부수효과가 걸려 있어, 첫 요소를 잡으면 `DayEventsModal`을 여는 순간 첫 일정 행이 스르륵 열립니다. 컨테이너(`tabIndex={-1}`)를 잡으면 아무것도 건드리지 않고 Tab이 자연스럽게 안으로 들어갑니다(Radix Dialog 등의 기본 동작). 대신 컨테이너에서 Shift+Tab이 배경으로 새지 않도록 "첫 요소 앞자리"로 처리하는 분기가 하나 있습니다.

**BottomSheet까지 건드렸습니다.** 모달 위에 시트를 겹쳐 여는 화면이 있어서(`DayEventsModal` 위의 `DeleteScopeSheet`), Modal에만 걸면 시트가 떠 있는 동안 Tab이 아래 모달로 **BottomSheet까지 건드렸습니다.** 모달 위에 시트를 겹쳐 여는 화면이 있어서(`DayEventsModal` 위의 `DeleteScopeSheet`), Modal에만 걸면 시트가 떠 있는 동안 Tab이 아래 모달로 끌려 내려가는 새 버그가 생깁니다. 스택을 공유해야 해서 한 줄 넣었고, 시트가 포커스를 받게 되면서 생긴 포커스 링을 `outline: none`으로 지웠습니다.
끌려 내려가는 새 버그가 생깁니다. 스택을 공유해야 해서 한 줄 넣었고, 시트가 포커스를 받게 되면서 생긴 포커스 링을 `outline: none`으로 지웠습니다.

## 논의하고 싶은 부분

`ResponsiveSheet`의 `DesktopCard`엔 이미 `max-height: calc(100dvh - 120px); overflow-y: auto`가 있습니다. 이게 제대로 걸리면 카드가 화면을 넘칠 수 없어 위의 "모달이 밀리는" 증상 자체가 나지 않아야 합니다 — 실제로 그 스타일 그대로는 재현되지 않았고, `max-height`를 제거해야 재현됐습니다.