### PR TITLE
[fix] 우체통 아이콘 크기와 안내 문구 줄바꿈을 시안에 맞춘다

### DIFF
--- a/frontend/src/pages/FeedbackPage/FeedbackWritePage.styles.ts
+++ b/frontend/src/pages/FeedbackPage/FeedbackWritePage.styles.ts
@@ -50,6 +50,8 @@ export const Description = styled.p`
   ${setTypography(typography.paragraph.p6)};
   color: ${colors.gray[800]};
   letter-spacing: -0.28px;
+  /* 기본값은 한글을 음절 단위로 끊는다. 두 줄 이상이면 어절 단위로 넘겨야 한다 */
+  word-break: keep-all;
 `;
 
 export const ContentField = styled.div`
@@ -102,6 +104,16 @@ export const AttachButton = styled.label<{ $disabled?: boolean }>`
 
   /* 시안: 최대 등록 수를 채우면 비활성화한다 */
   ${({ $disabled }) => $disabled && 'pointer-events: none; cursor: default;'}
+`;
+
+/** 시안(11435:18150): 40px 프레임 안에 35.556×27.777 글리프. 내보낸 SVG엔 여백이 없어 박스로 채운다 */
+export const AttachIconBox = styled.span`
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
 `;
 
 export const AttachLabel = styled.span<{

--- a/frontend/src/pages/FeedbackPage/FeedbackWritePage.tsx
+++ b/frontend/src/pages/FeedbackPage/FeedbackWritePage.tsx
@@ -237,7 +237,9 @@ const FeedbackWritePage = () => {
         </Styled.ContentField>
 
         <Styled.AttachButton $disabled={isAttachFull}>
-          <attachState.Icon width={40} height={40} aria-hidden />
+          <Styled.AttachIconBox>
+            <attachState.Icon width={36} height={28} aria-hidden />
+          </Styled.AttachIconBox>
           <Styled.AttachLabel $variant={attachState.variant}>
             {attachState.label}
           </Styled.AttachLabel>

--- a/frontend/src/pages/FeedbackPage/components/FeedbackTag.styles.ts
+++ b/frontend/src/pages/FeedbackPage/components/FeedbackTag.styles.ts
@@ -1,6 +1,16 @@
 import styled from 'styled-components';
 import { setTypography, typography } from '@/styles/theme/typography';
 
+/** 시안(11274:13733): 18px 프레임 안에 15px 글리프. 내보낸 SVG엔 여백이 없어 박스로 채운다 */
+export const IconBox = styled.span`
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+`;
+
 export const Tag = styled.span<{ $backgroundColor: string; $color: string }>`
   display: inline-flex;
   align-items: center;

--- a/frontend/src/pages/FeedbackPage/components/FeedbackTag.tsx
+++ b/frontend/src/pages/FeedbackPage/components/FeedbackTag.tsx
@@ -15,7 +15,11 @@ const FeedbackTag = ({
   Icon,
 }: FeedbackTagProps) => (
   <Styled.Tag $backgroundColor={backgroundColor} $color={color}>
-    {Icon && <Icon width={18} height={18} aria-hidden />}
+    {Icon && (
+      <Styled.IconBox>
+        <Icon width={15} height={15} aria-hidden />
+      </Styled.IconBox>
+    )}
     {label}
   </Styled.Tag>
 );

--- a/frontend/src/pages/FeedbackPage/components/FeedbackTypeCard.styles.ts
+++ b/frontend/src/pages/FeedbackPage/components/FeedbackTypeCard.styles.ts
@@ -8,7 +8,8 @@ export const Card = styled.button<{ $backgroundColor: string }>`
   gap: 12px;
   width: 100%;
   height: 64px;
-  padding: 18px;
+  /* 시안 패딩은 18px이지만 border 5px이 박스 안에 그려진다. 5+13이라야 내용이 18px에서 시작한다 */
+  padding: 13px;
   border: 5px solid ${({ $backgroundColor }) => $backgroundColor};
   border-radius: 5px 20px 20px 20px;
   background: linear-gradient(
@@ -19,9 +20,12 @@ export const Card = styled.button<{ $backgroundColor: string }>`
   cursor: pointer;
 `;
 
+/** 시안(11274:1398): 26px 프레임 안에 21.667px 글리프. 내보낸 SVG엔 여백이 없어 박스로 채운다 */
 export const IconBox = styled.span`
   display: flex;
   flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
   width: 26px;
   height: 26px;
 `;

--- a/frontend/src/pages/FeedbackPage/components/FeedbackTypeCard.tsx
+++ b/frontend/src/pages/FeedbackPage/components/FeedbackTypeCard.tsx
@@ -18,7 +18,7 @@ const FeedbackTypeCard = ({ type, onClick }: FeedbackTypeCardProps) => {
       onClick={() => onClick(type)}
     >
       <Styled.IconBox>
-        <Icon width={26} height={26} aria-hidden />
+        <Icon width={22} height={22} aria-hidden />
       </Styled.IconBox>
       <Styled.Label>{cardLabel}</Styled.Label>
       <Styled.Chevron>


### PR DESCRIPTION
## #️⃣연관된 이슈

없음 (시안 대조 중 발견)

## 📝작업 내용

Figma 시안([피드백 유형 선택](https://www.figma.com/design/LB4VudDhuIGjFayrm1kge1/%EB%AA%A8%EC%95%84%EB%8F%99?node-id=11366-18712), [피드백 작성](https://www.figma.com/design/LB4VudDhuIGjFayrm1kge1/%EB%AA%A8%EC%95%84%EB%8F%99?node-id=11366-20633))과 대조해 우체통 화면의 아이콘 크기·패딩·줄바꿈을 맞췄습니다.

### 1. 아이콘이 시안보다 20% 컸다

시안의 아이콘 컴포넌트(`Component 12`)는 **프레임**과 그 안의 **글리프**가 다른 크기이고, 비율은 어디서나 5/6입니다.

| 위치 | 시안 프레임 | 시안 글리프 |
| --- | --- | --- |
| 유형 선택 카드 | 26×26 | 21.667×21.667 |
| 작성 화면 태그 | 18×18 | 15×15 |
| 사진 첨부 | 40×40 | 35.556×27.777 |

내보낸 SVG는 **여백 없는 글리프만** 담고 있는데(`feedback_type_*.svg`의 viewBox가 21.667), 이걸 프레임 크기로 그려서 글리프가 전부 커졌습니다. 박스를 프레임 크기로 두고 글리프만 시안 값으로 그리도록 고쳤습니다.

### 2. 첨부 아이콘 비율 왜곡

크기가 아니라 비율 문제였습니다. 원본이 `35.556 × 27.777`(정사각형 아님)인데 Figma 내보내기에 붙는 `preserveAspectRatio="none"` 상태로 40×40을 강제해서 **세로가 1.44배** 늘어나 있었습니다.

### 3. 카드 좌측 여백 5px 초과

`padding: 18px → 13px`은 값을 줄인 게 아니라 복원입니다. `box-sizing: border-box`라 `border: 5px`이 박스 안쪽에 그려지므로 `5 + 13`이라야 내용이 시안의 18px 지점에서 시작합니다. 기존엔 23px이었습니다.

### 4. 안내 문구가 어절 중간에서 잘림

`word-break` 기본값은 한글을 음절 단위로 끊습니다. "제안하고 싶으신 … 자유롭게 **적** / **어주세요**"처럼 잘려서 `keep-all`로 어절 단위 줄바꿈으로 바꿨습니다.

## 중점적으로 리뷰받고 싶은 부분

**아이콘 박스를 감싸는 방식이 적절한지**가 궁금합니다. SVG 자체에 여백이 없어서 `IconBox`(카드·태그) / `AttachIconBox`(첨부)로 프레임 크기를 만들었는데, 대안으로 **SVG 자체를 프레임 크기(여백 포함)로 다시 내보내는** 방법도 있습니다. 후자면 래퍼가 사라지지만 에셋 4~7개를 다시 받아야 합니다. 장기적으로 어느 쪽이 나을지 의견 주세요.

## 논의하고 싶은 부분

**아직 안 고친 것 2가지**입니다. 이번 PR 범위와 성격이 달라 남겨뒀습니다.

1. **카드 테두리가 시안은 그라데이션인데 코드는 단색입니다.** 시안은 `GRADIENT_LINEAR` stroke(`#FFF0F4 32.2% → #FFFFFF`), 코드는 `border: 5px solid ${backgroundColor}`. CSS에서 그라데이션 테두리는 `border-image`나 래퍼가 필요해 단순 값 교체가 아니고, 흰 배경 위 연한 그라데이션이라 육안 차이는 작습니다.
2. **카드 높이는 시안 64px을 유지했습니다.** 시안 stroke가 `CENTER` 정렬이라 엄밀히는 위아래 2.5px씩 바깥으로 번져 시각적 높이가 69px인데, CSS border는 안쪽에 그려집니다. 내부 여백·아이콘·라벨 위치는 전부 시안과 같고 카드 외곽만 5px 작습니다.

`Title`(제목)에는 `keep-all`을 넣지 않았습니다. 현재 문안은 375px에서 어절 중간이 잘리지 않아 보이는 문제가 없습니다. 문안이 길어질 여지가 있으면 같이 넣어두는 편이 안전한데, 필요하면 알려주세요.

## 🫡 참고사항

**검증 방법**: 렌더된 DOM에서 `getBoundingClientRect()`로 실측했습니다(375px 뷰포트).

| 항목 | 시안 | 실측 |
| --- | --- | --- |
| 카드 | 337×64 | 337.00×64.00 |
| 카드 아이콘 좌측 오프셋 | 18 | 18.00 |
| 카드 아이콘 박스 / 글리프 | 26 / 21.667 | 26.00 / 22.00 |
| 카드 라벨 좌측 오프셋 | 56 | 56.00 |
| 셰브론 우측 오프셋 | 18 | 18.00 |
| 태그 아이콘 박스 / 글리프 | 18 / 15 | 18.00 / 15.00 |
| 태그 좌측 패딩 | 8 | 8.00 |
| 첨부 아이콘 박스 / 글리프 | 40 / 35.556×27.777 | 40.00 / 36.00×28.00 |

줄바꿈은 `Range.getBoundingClientRect()`로 문자별 y좌표를 재서 실제 줄 나눔을 추출했습니다.

- 신규 기능: `…자유롭게 적` / `어주세요` → `…자유롭게` / `적어주세요`
- 궁금한 점: `…내용을 작성해` / `주세요.`

두 화면의 모든 텍스트 노드를 훑어 2줄 이상으로 넘어가는 것을 확인했고, 어절 중간에서 끊기는 곳은 없습니다. 가로 오버플로도 없습니다.

`npm run typecheck` 통과. 테스트·스토리는 해당 컴포넌트에 없어 추가하지 않았습니다(수치 스타일 변경).

**#1914와의 관계**: `FeedbackWritePage.tsx`를 함께 수정하지만 서로 다른 구역(#1914는 4·16·47·123·200·300행대, 이 PR은 239행대)이라 충돌하지 않습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **스타일 개선**
  - 피드백 작성 화면의 한글 설명이 어절 단위로 자연스럽게 줄바꿈됩니다.
  - 첨부 아이콘과 피드백 유형 아이콘의 크기 및 정렬을 조정해 UI가 더 균형 있게 표시됩니다.
  - 피드백 유형 카드의 여백과 아이콘 배치를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->