### PR TITLE
[feature] ClubCard 이벤트에 로고 유무(has_logo) 속성 추가

### DIFF
--- a/frontend/src/pages/MainPage/components/ClubCard/ClubCard.tsx
+++ b/frontend/src/pages/MainPage/components/ClubCard/ClubCard.tsx
@@ -58,6 +58,7 @@ const ClubCard = ({
         club_id: club.id,
         club_name: club.name,
         recruitment_status: club.recruitmentStatus,
+        has_logo: Boolean(club.logo),
         page,
         scroll_y: capturedScrollY,
         card_top_in_viewport: capturedTop,
@@ -98,7 +99,7 @@ const ClubCard = ({
       document.removeEventListener('visibilitychange', handleVisibilityChange);
       fireImpressionEvent();
     };
-  }, [club.id, club.name, club.recruitmentStatus, page]);
+  }, [club.id, club.name, club.recruitmentStatus, club.logo, page]);
 
   const handleClick = () => {
     setIsClicked(true);
@@ -106,6 +107,7 @@ const ClubCard = ({
       club_id: club.id,
       club_name: club.name,
       recruitment_status: club.recruitmentStatus,
+      has_logo: Boolean(club.logo),
       page,
       card_index: index,
       scroll_y: Math.round(window.scrollY),

--- a/frontend/src/pages/MainPage/components/ClubCard/ClubCard.tsx
+++ b/frontend/src/pages/MainPage/components/ClubCard/ClubCard.tsx
@@ -99,7 +99,7 @@ const ClubCard = ({
       document.removeEventListener('visibilitychange', handleVisibilityChange);
       fireImpressionEvent();
     };
-  }, [club.id, club.name, club.recruitmentStatus, club.logo, page]);
+  }, [club.id, club.name, club.recruitmentStatus, page]);
 
   const handleClick = () => {
     setIsClicked(true);


### PR DESCRIPTION
## #️⃣연관된 이슈

없음 (Mixpanel 속성 추가 요청)

## 📝작업 내용

메인페이지에서 **동아리 로고 유무에 따른 클릭률(CTR) 차이**를 분석하기 위해 Mixpanel 이벤트에 `has_logo` (Boolean) 속성을 추가했습니다.

| 이벤트 | 추가 속성 |
| --- | --- |
| `ClubCard Clicked` | `has_logo: Boolean(club.logo)` |
| `ClubCard Viewed` | `has_logo: Boolean(club.logo)` |

요청에는 `ClubCard Clicked`만 있었지만, **CTR = 클릭 / 노출**이라 분모인 `ClubCard Viewed`에도 같은 속성이 있어야 `has_logo`별 클릭률을 계산할 수 있어 함께 넣었습니다. 클릭 이벤트에만 넣으면 Mixpanel에서 로고 유무별 "클릭 수"만 나뉘고 "클릭률"은 나오지 않습니다.

`ClubCard Viewed`가 useEffect 내부 클로저에서 `club.logo`를 읽게 되어 deps 배열에도 `club.logo`를 추가했습니다. 기존 deps가 이벤트에 담기는 필드를 하나씩 나열하는 방식이라 같은 규칙을 따랐습니다.

기존 이벤트명·속성 구조는 그대로이고, 속성만 추가됐습니다. `ClubCard`는 메인/구독/소개 페이지가 공유하는 컴포넌트라 세 곳 모두 자동 반영됩니다.

### 판별 기준

`Club.logo`는 `string` 타입(nullable 아님)이라 로고 미등록 시 빈 문자열입니다. `Boolean("")` → `false`이므로 미등록 케이스가 정상적으로 걸립니다. 카드 렌더링도 `club.logo || default_profile_image` 기준을 쓰기 때문에, **"기본 이미지가 보이는 카드 = `has_logo: false`"** 로 화면과 정확히 일치합니다.

## 중점적으로 리뷰받고 싶은 부분(선택)

- `ClubCard Viewed`까지 확장한 판단이 적절한지
- deps 배열에 `club.logo`를 넣은 것이 impression 이벤트 발화에 영향이 없는지 (로고 URL은 세션 중 바뀌지 않아 실질 재실행은 없다고 봤습니다)

## 🫡 참고사항

**검증**

- `npx tsc --noEmit` → 통과 (에러 0)
- `npx eslint ClubCard.tsx` → 에러 0 / 경고 1. 이 경고(`SS_COUNT_KEY`, `SS_LAST_KEY`, `trackEvent` 누락)는 **변경 전에도 있던 기존 경고**이며 git stash로 원본과 비교해 확인했습니다. 이번 변경으로 새로 생긴 경고는 없습니다.
- 브라우저에서 실제 이벤트 전송까지는 확인하지 않았습니다. 배포 후 Mixpanel Live View에서 확인 필요합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 클럽 카드 노출 및 클릭 이벤트에 로고 존재 여부 정보가 기록됩니다.
  * 클럽 로고 변경 시 노출 추적 정보가 최신 상태로 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
