### PR TITLE
[fix] 클럽 상세 select가 logo에 undefined를 넣지 않게 한다

### DIFF
--- a/frontend/src/hooks/Queries/CLAUDE.md
+++ b/frontend/src/hooks/Queries/CLAUDE.md
@@ -34,3 +34,21 @@ API를 래핑하는 React Query 훅 (useClub, useApplication, useApplicants 등)
 `960-3`은 재시도해도 같은 결과라 "다시 시도" UI를 띄우지 않는다.
 Google OAuth 동의 화면이 테스트 모드면 refresh token이 7일 뒤 만료되므로,
 프로덕션 게시 전까지는 이 상태가 정상적으로 자주 발생한다.
+
+## 클럽 로고 (`useClub`)
+
+로고가 없을 때 백엔드가 주는 값이 엔드포인트마다 다르다.
+
+| 훅 | 백엔드 DTO | 로고 없을 때 |
+| --- | --- | --- |
+| `useGetClubDetail` | `ClubDetailedResult` | `""` (null 폴백이 있어 null은 오지 않음) |
+| `useGetCardList` | `ClubSearchResult` | `null` 가능 (로고 삭제 시 `updateLogo(null)`) |
+
+상세는 `""`가 보장되므로 `select`에서 `undefined`로 바꾸지 않는다.
+`Club['logo']` 타입이 `string`인 것과 어긋나고, 소비자가 이미 전부
+`logo || 기본이미지` 가드를 갖고 있어 얻는 것도 없다.
+
+목록은 `null`이 올 수 있는데 타입은 `string`이라 아직 어긋나 있다.
+`convertGoogleDriveUrl`이 null을 받으면 내부 `try/catch`가 삼켜
+`console.error`만 남기고 null을 그대로 돌려주니, 무가드 프로퍼티
+접근을 새로 추가하지 말 것.

--- a/frontend/src/hooks/Queries/useClub.ts
+++ b/frontend/src/hooks/Queries/useClub.ts
@@ -40,11 +40,11 @@ export const useGetClubDetail = (
     select: (data) =>
       ({
         ...data,
-        logo: data.logo ? convertGoogleDriveUrl(data.logo) : undefined,
+        logo: data.logo ? convertGoogleDriveUrl(data.logo) : '',
         feeds: Array.isArray(data.feeds)
           ? data.feeds.map(convertGoogleDriveUrl)
           : [],
-      }) as ClubDetail,
+      }),
   });
 };
 

--- a/frontend/src/hooks/Queries/useClub.ts
+++ b/frontend/src/hooks/Queries/useClub.ts
@@ -37,14 +37,13 @@ export const useGetClubDetail = (
     staleTime: options?.staleTime ?? 60 * 1000,
     gcTime: options?.gcTime,
     enabled: !!clubParam && (options?.enabled ?? true),
-    select: (data) =>
-      ({
-        ...data,
-        logo: data.logo ? convertGoogleDriveUrl(data.logo) : '',
-        feeds: Array.isArray(data.feeds)
-          ? data.feeds.map(convertGoogleDriveUrl)
-          : [],
-      }),
+    select: (data) => ({
+      ...data,
+      logo: data.logo ? convertGoogleDriveUrl(data.logo) : '',
+      feeds: Array.isArray(data.feeds)
+        ? data.feeds.map(convertGoogleDriveUrl)
+        : [],
+    }),
   });
 };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

없음 (#1936 리뷰 중 발견한 별건)

## 📝작업 내용

`useGetClubDetail`의 `select`가 `logo`에 `undefined`를 넣고 있었는데, `Club['logo']` 타입은 `string`입니다. 끝에 붙은 `as ClubDetail` 캐스트가 이 불일치를 가리고 있어 타입 체크에 걸리지 않았습니다.

```diff
   select: (data) =>
     ({
       ...data,
-      logo: data.logo ? convertGoogleDriveUrl(data.logo) : undefined,
+      logo: data.logo ? convertGoogleDriveUrl(data.logo) : '',
       feeds: Array.isArray(data.feeds)
         ? data.feeds.map(convertGoogleDriveUrl)
         : [],
-    }) as ClubDetail,
+    }),
```

`''`로 맞추니 타입이 실제 값과 일치해서 **`as ClubDetail` 캐스트도 같이 제거**할 수 있었습니다.

## 왜 타입을 넓히지 않고 `''`로 좁혔나

`undefined`는 백엔드가 준 값이 아니라 **프론트 `select`가 만들어낸 값**이기 때문입니다. 백엔드를 확인했습니다.

`ClubDetailedResult.java:65`

```java
.logo(clubRecruitmentInformation.getLogo() == null ? ""
        : clubRecruitmentInformation.getLogo())
```

null 폴백이 있어 **상세 응답은 최소 `""`를 보장**합니다. 프로덕션에서도 확인했습니다 — 로고가 없는 동아리(`@SIC`)의 상세 응답은 `logo: ""` 입니다.

따라서 `Club['logo']`를 `string | undefined`로 넓히는 건 실제 계약보다 넓게 잡는 것이라, 만들어내던 `undefined`를 없애는 쪽을 골랐습니다.

## 회귀가 없다고 보는 근거

`logo`를 받는 소비자가 전부 이미 falsy 가드를 갖고 있어 `''`와 `undefined`의 동작이 동일합니다. (동작 경로를 하나씩 확인했고, 타입 통과만으로 판단하지 않았습니다.)

| 소비자 | 선언 | 처리 |
| --- | --- | --- |
| `ClubProfileCard` | `logo?: string` | `logo \|\| DefaultLogo` |
| `MapModal` → `InteractiveMapView` | `clubLogo?: string` | 그대로 전달 |
| `ClubLogoEditor` | `clubLogo?: string \| null` | `!clubLogo \|\| clubLogo.trim() === ''` |

## 🫡 참고사항

`src/hooks/Queries/CLAUDE.md`에 로고 계약을 정리해 뒀습니다. `undefined`로 되돌리는 변경이 다시 들어오는 걸 막으려는 목적입니다.

### 검증

- `npx tsc --noEmit` → 통과 (에러 0). 캐스트를 제거한 상태에서 통과하므로 타입이 실제로 맞다는 확인이기도 합니다
- `npm run test` → **51 suites / 428 tests 전부 통과**
- `npx eslint useClub.ts` → 에러 0 / 경고 2. 둘 다 mutation `onError`의 기존 `console.error`(131, 151번 줄)이고, git stash로 변경 전과 비교해 **개수·내용 동일**함을 확인했습니다
- 브라우저에서 상세 페이지 렌더링까지는 확인하지 않았습니다

### 남은 문제 (이 PR 범위 밖)

목록 쪽은 아직 타입이 어긋나 있습니다. `ClubSearchResult.java:24`가 `logoUrl = (info != null) ? info.getLogo() : null` 이고 로고 삭제 시 `CloudflareImageService:68`이 `updateLogo(null)`로 저장하므로 **목록 응답은 `logo: null`이 가능**한데 타입은 `string`입니다.

null이 오면 `useGetCardList`의 무가드 `convertGoogleDriveUrl(club.logo)`에서 `url.match`가 TypeError를 내고, 함수 내부 `try/catch`가 이를 삼켜 `console.error`만 남기고 null을 그대로 반환합니다.

**지금 프로덕션에는 null이 없어서(69개 중 URL 65 / `""` 4 / null 0) 발현되지 않고 있습니다.** 다만 백엔드 목록 DTO를 상세처럼 `""` 폴백으로 맞출지, 프론트에서 가드를 넣을지는 레포 두 개에 걸치는 결정이라 이 PR에 섞지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 클럽 상세 정보에서 로고가 없을 때 일관되게 빈 문자열로 표시되도록 수정했습니다.

* **문서**
  * 클럽 로고 처리 규칙과 Google Drive 로고 URL 처리 기준을 문서화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->