### PR TITLE
[fix] 목록 로고가 null일 때 URL 변환을 건너뛴다

### DIFF
--- a/frontend/src/hooks/Queries/useClub.ts
+++ b/frontend/src/hooks/Queries/useClub.ts
@@ -88,7 +88,8 @@ export const useGetCardList = ({
       totalCount: data.totalCount,
       clubs: data.clubs.map((club) => ({
         ...club,
-        logo: convertGoogleDriveUrl(club.logo),
+        // 로고를 지운 동아리는 목록 응답에 logo가 null로 온다 (타입은 string이지만)
+        logo: club.logo ? convertGoogleDriveUrl(club.logo) : '',
       })),
     }),
   });


### PR DESCRIPTION
## 무엇을

동아리 목록의 로고 URL 변환에 null 가드를 넣습니다. 한 줄입니다.

```ts
- logo: convertGoogleDriveUrl(club.logo),
+ logo: club.logo ? convertGoogleDriveUrl(club.logo) : '',
```

## 왜

로고를 삭제한 동아리는 목록 응답의 `logo`가 `null`로 옵니다. 백엔드 `ClubSearchResult`가 `info.getLogo()`를 그대로 내려주고, 삭제 시 `updateLogo(null)`로 저장하기 때문입니다. 프론트 타입은 `logo: string`이라 이 경우가 가려져 있습니다.

`convertGoogleDriveUrl(null)`은 `url.match`에서 TypeError를 냅니다. 함수 내부 `try/catch`가 삼켜서 화면은 안 깨지지만 `console.error`가 남습니다.

**상세 쪽은 이미 같은 가드가 있습니다**(`useClub.ts:43`). 목록만 빠져 있어서 맞춥니다.

## 영향

없습니다. `ClubCard.tsx:138`이 `club.logo || default_profile_image`라 `null`이든 `''`이든 기본 로고가 뜹니다. 이 PR은 콘솔 에러만 없앱니다.

`''`을 쓴 건 선언 타입(`string`)을 지키기 위해서고, 백엔드가 나중에 목록 DTO를 상세처럼 `""` 폴백으로 맞추더라도 이 가드는 그대로 유효합니다.

## 지금 하는 이유

현재 프로덕션에는 null이 없습니다(69개 중 URL 65 / `""` 4 / null 0). 다만 로고 삭제는 이미 라이브라(`ClubLogoEditor`의 `useDeleteLogo`) 누가 한 번 누르면 그날 생깁니다.