### PR TITLE
[fix] 편지 푸시에 웹뷰 라우팅 정보 추가

### DIFF
--- a/backend/src/main/java/moadong/feedback/service/FeedbackAdminService.java
+++ b/backend/src/main/java/moadong/feedback/service/FeedbackAdminService.java
@@ -2,6 +2,7 @@ package moadong.feedback.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import moadong.fcm.enums.FcmAction;
 import moadong.fcm.model.TokenPushPayload;
 import moadong.fcm.model.TokenPushResult;
 import moadong.fcm.payload.request.FcmAdminBatchSendRequest;
@@ -40,6 +41,11 @@ public class FeedbackAdminService {
 
     private static final String REPLY_PUSH_TYPE = "FEEDBACK_REPLY";
     private static final String LETTER_PUSH_TYPE = "FEEDBACK_LETTER";
+    /**
+     * 웹뷰가 웹 주소 뒤에 그대로 이어붙이는 경로라 프론트 라우트({@code /feedback/letters/:letterId})와
+     * 정확히 같아야 한다. 단수(letter)로 바꾸거나 {@code /webview} 접두사를 붙이면 매칭이 실패해 빈 화면이 뜬다.
+     */
+    private static final String LETTER_DETAIL_PATH_PREFIX = "/feedback/letters/";
     private static final int SENDER_ID_LENGTH = 8;
 
     private final FeedbackRepository feedbackRepository;
@@ -168,7 +174,7 @@ public class FeedbackAdminService {
             FcmAdminBatchSendResponse result = fcmAdminService.sendToAll(new FcmAdminBatchSendRequest(
                     letter.getTitle(),
                     letter.preview(),
-                    Map.of("type", LETTER_PUSH_TYPE, "letterId", letter.getId())));
+                    letterNavigationData(LETTER_PUSH_TYPE, letter)));
             if (result.failureCount() > 0) {
                 log.warn("Broadcast push partially failed. letter={}, success={}, failure={}",
                         letter.getId(), result.successCount(), result.failureCount());
@@ -198,12 +204,25 @@ public class FeedbackAdminService {
                     fcmToken,
                     letter.getTitle(),
                     letter.preview(),
-                    Map.of("type", REPLY_PUSH_TYPE, "letterId", letter.getId())));
+                    letterNavigationData(REPLY_PUSH_TYPE, letter)));
             return result.success();
         } catch (RuntimeException e) {
             log.error("Reply push failed. letter={}", letter.getId(), e);
             return false;
         }
+    }
+
+    /**
+     * 푸시를 탭했을 때 편지 상세로 이동시키는 데이터. 앱은 action이 NAVIGATE_WEBVIEW인 경우에만
+     * path를 웹뷰로 넘기므로, 둘 중 하나라도 빠지면 앱 홈만 열린다.
+     */
+    private Map<String, String> letterNavigationData(String pushType, Letter letter) {
+        return Map.of(
+                "type", pushType,
+                "letterId", letter.getId(),
+                "action", FcmAction.NAVIGATE_WEBVIEW.name(),
+                "path", LETTER_DETAIL_PATH_PREFIX + letter.getId()
+        );
     }
 
     /**

--- a/backend/src/test/java/moadong/feedback/service/FeedbackAdminServiceTest.java
+++ b/backend/src/test/java/moadong/feedback/service/FeedbackAdminServiceTest.java
@@ -157,6 +157,8 @@ class FeedbackAdminServiceTest {
         assertEquals("fcm-token", payloadCaptor.getValue().token());
         assertEquals("답장 제목", payloadCaptor.getValue().title());
         assertEquals("letter-1", payloadCaptor.getValue().data().get("letterId"));
+        assertEquals("NAVIGATE_WEBVIEW", payloadCaptor.getValue().data().get("action"));
+        assertEquals("/feedback/letters/letter-1", payloadCaptor.getValue().data().get("path"));
         assertTrue(response.pushSent());
     }
 
@@ -231,6 +233,8 @@ class FeedbackAdminServiceTest {
         verify(fcmAdminService).sendToAll(pushCaptor.capture());
         assertEquals("제목", pushCaptor.getValue().title());
         assertEquals("letter-1", pushCaptor.getValue().data().get("letterId"));
+        assertEquals("NAVIGATE_WEBVIEW", pushCaptor.getValue().data().get("action"));
+        assertEquals("/feedback/letters/letter-1", pushCaptor.getValue().data().get("path"));
         assertTrue(response.pushSent());
         assertEquals(118, response.pushSuccessCount());
     }


### PR DESCRIPTION
## 문제

답장 푸시를 탭해도 편지 상세로 가지 못하고 앱 홈만 열립니다.

앱은 `hooks/use-fcm.ts:34`에서 `data.action === 'NAVIGATE_WEBVIEW'` 하나로만 분기하는데, `FeedbackAdminService`가 싣는 건 `type`과 `letterId`뿐이라 이 분기에 걸리지 않습니다. 구독 알림에서 정한 규약(`ClubNotificationPayloadFactory` — path/action/clubId)을 우체통이 따르지 않은 결과입니다.

전체 발행 편지 푸시(`sendBroadcastPush`)도 같은 문제가 있어 함께 고칩니다.

## 변경

답장·전체 발행 양쪽이 같은 데이터를 만들어야 해서 `letterNavigationData(pushType, letter)` 하나로 묶었습니다. `type`만 다르고 나머지 세 필드는 동일합니다.

```java
private Map<String, String> letterNavigationData(String pushType, Letter letter) {
    return Map.of(
            "type", pushType,
            "letterId", letter.getId(),
            "action", FcmAction.NAVIGATE_WEBVIEW.name(),
            "path", LETTER_DETAIL_PATH_PREFIX + letter.getId()   // "/feedback/letters/"
    );
}
```

`action`은 리터럴 대신 `FcmAction.NAVIGATE_WEBVIEW.name()`을 씁니다 — `ClubNotificationPayloadFactory`와 같은 방식이고, enum이 바뀌면 컴파일에서 잡힙니다. 나가는 문자열은 동일합니다.

## 경로가 왜 이 형태인지

`/feedback/letters/{letterId}` — **복수형이고 `/webview` 접두사가 없습니다.** 프론트 라우트와 대조했습니다:

```
origin/develop-fe:frontend/src/routes/AppRoutes.tsx:196:      path: '/feedback/letters/:letterId',
origin/develop-fe:frontend/src/pages/FeedbackPage/FeedbackListPage.tsx:133:  navigate(`/feedback/letters/${letterId}`);
```

앱은 `clubDetail`이 아닌 path를 범용 웹뷰로 넘기고(`use-fcm.ts`), `app/webview/[slug].tsx:73`이 `${webviewUrl}${path}`로 웹 주소 뒤에 그대로 이어붙입니다. 그래서 웹 라우트와 글자 단위로 같아야 하고, 단수(`letter`)로 넣으면 매칭에 실패해 빈 화면이 뜹니다.

구독 알림의 `/webview/clubDetail/{clubId}`는 네이티브 동아리 상세로 빠지는 특수 분기 전용이라 우체통에는 해당하지 않습니다. 이 점을 경로 상수 주석에 남겼습니다 — 다음 사람이 구독 알림에 맞추려다 되돌리는 게 재발 경로라서요.

`/feedback/sent/:feedbackId`(내가 보낸 편지)와 헷갈릴 여지가 있는데, 백엔드가 싣는 건 받은 편지 id(`letter.getId()`)라 `/feedback/letters/`가 맞습니다.

## 테스트

기존 payload 검증 두 곳에 `action`/`path` 단언을 추가했습니다 — 답장 푸시(`TokenPushPayload`), 전체 발행 푸시(`FcmAdminBatchSendRequest`). 오타나 단수형 회귀가 테스트에서 걸립니다.

`./gradlew test --tests "moadong.feedback.service.FeedbackAdminServiceTest" --rerun-tasks` → BUILD SUCCESSFUL

## 앱·프론트 수정 불필요

기존 `NAVIGATE_WEBVIEW` 분기가 그대로 처리합니다. 앱 재릴리즈도 필요 없습니다.

## 확인 방법

운영 포털에서 답장을 발행한 뒤 기기에서 푸시를 탭했을 때 받은 편지 상세가 열리면 성공입니다. 