### PR TITLE
[fix] 릴리즈 리뷰 후속 — 헤더 유실·중복 전송·문서 불일치 정리

### DIFF
--- a/docs/spec/moadong-letterbox-handoff.md
+++ b/docs/spec/moadong-letterbox-handoff.md
@@ -3,7 +3,7 @@
 작성일: 2026-08-10 (백엔드 1차 회신 반영)
 작성 배경: 프론트(React)에서 우체통 화면을 MSW 목으로 먼저 구현했다. **응답 형태를 프론트가 임의로 정했으므로**, 실제 API가 이 문서와 다르면 프론트를 그에 맞춰 고쳐야 한다.
 
-### 백엔드 회신 1차 (→ 프론트 반영 완료)
+## 백엔드 회신 1차 (→ 프론트 반영 완료)
 
 | 변경 | 프론트 대응 |
 |---|---|
@@ -344,7 +344,7 @@ issueStudentToken()  →  StudentIssueResponse(String accessToken)
 - `sendToAll`이 체크박스라는 건 **전체 발행이 아닌 경우도 상정했다**는 뜻인데, 시안에 대상 선택 UI는 없다 → §5 참조.
 
 **에디터 툴바 = 지원해야 할 마크다운 문법의 정의다.**
-```
+```text
 H2 · H3 · B · I · 링크 · 인용 · 목록 · 구분선 · 이미지
 ```
 
@@ -380,7 +380,7 @@ spring.servlet.multipart.max-file-size: "10MB"
 ⑭의 `임시저장` 버튼용. 전부 `/api/admin/feedback` 아래라 `ROLE_DEVELOPER`가 필요하다.
 **포털 전용이므로 React 프론트는 호출하지 않는다.**
 
-```
+```text
 POST   /api/admin/feedback/letters/drafts
 GET    /api/admin/feedback/letters/drafts
 PUT    /api/admin/feedback/letters/drafts/{draftId}
@@ -409,7 +409,7 @@ DELETE /api/admin/feedback/letters/drafts/{draftId}
 #### 초안이 사용자에게 노출될 수 없는 구조
 
 컬렉션이 물리적으로 분리돼 있다.
-```
+```text
 Letter.java:15       @Document("feedback_letters")
 LetterDraft.java:20  @Document("feedback_letter_drafts")
 ```
@@ -440,14 +440,14 @@ LetterDraft.java:20  @Document("feedback_letter_drafts")
 ## 5. 미결 — 정해야 할 것
 
 1. ~~**이미지 업로드**~~ ✅ **백엔드·프론트 모두 완료.** 브라우저에서 실제 흐름까지 확인했다.
-   ```
+   ```text
    POST /images/upload-url  →  PUT ×2 (presignedUrl)  →  POST /feedback (images: [finalUrl])
    ```
    사진이 없으면 `upload-url` 호출 없이 `images`를 생략한다.
 2. ~~**읽음 처리 API**~~ ✅ `PATCH .../read` 신설, 프론트 호출부 연결 완료
 3. ~~**운영 상태 3단계 vs 사용자 2단계**~~ ✅ 운영 3단계 + 전이 API 추가, 사용자 응답은 `PENDING`/`REPLIED` 2단계 유지. 프론트 영향 없음
 4. ~~**보낸 사람 식별자**~~ ✅ **익명 ID로 확정, 구현 완료.**
-   ```
+   ```text
    user_a3f9c2d1     // "user_" + 학생 토큰 sub(UUID)의 앞 8자리
    ```
    학번은 내리지 않는다 — 서버가 학번을 알지 못하고(`StudentUser.studentId`가 랜덤 UUID), 알더라도 운영 화면에 노출할 이유가 없다.
@@ -467,7 +467,7 @@ LetterDraft.java:20  @Document("feedback_letter_drafts")
 
    **남는 실질적 이슈 2가지** — 백엔드 결정을 따르되 확인이 필요하다.
    - ⑬ 답장 패널에 툴바가 없으므로 **운영자가 마크다운을 손으로 입력**해야 한다. 포털에 툴바를 넣을지 정해야 한다.
-   - 서식 없이 쓴 평문에 `*`, `#`, `- `가 섞이면 **의도치 않게 서식으로 먹는다.** (예: `*중요*` → 이탤릭)
+   - 서식 없이 쓴 평문에 `*`, `#`, 줄머리 `-`(뒤에 공백)가 섞이면 **의도치 않게 서식으로 먹는다.** (예: `*중요*` → 이탤릭)
 
 ### 문서에 명시 안 된 것 (프론트가 가정한 대로 두면 되는지 확인 필요)
 
@@ -482,7 +482,7 @@ LetterDraft.java:20  @Document("feedback_letter_drafts")
 
 ## 6. 프론트 현황 (참고)
 
-`develop-fe` 계열 `feature/letterbox` 브랜치에 구현 완료. 전부 MSW 목으로 동작한다.
+`develop-fe`에 머지 완료. **실제 API를 호출한다** — MSW 목은 제거됐다.
 
 | 화면 | 라우트 |
 |---|---|
@@ -495,11 +495,11 @@ LetterDraft.java:20  @Document("feedback_letter_drafts")
 
 진입점: 메뉴 페이지 `모아동 우체통` 카드 → `/feedback`
 
-목 데이터: `frontend/src/mocks/data/feedbackMock.ts`
-핸들러: `frontend/src/mocks/handlers/index.ts`
+API: `frontend/src/apis/feedback.ts` (학생 토큰을 붙이는 `frontend/src/apis/auth/studentFetch.ts` 경유)
+쿼리 훅: `frontend/src/hooks/Queries/useFeedback.ts`
 타입: `frontend/src/types/feedback.ts` ← **이 문서의 계약과 1:1 대응**
 
-실제 API가 나오면 `frontend/src/apis/feedback.ts`와 위 타입만 고치면 된다.
+실제 응답이 이 문서와 다르면 위 API 모듈과 타입을 고치면 된다.
 
 로딩·에러 UI, Mixpanel 트래킹(`PAGE_VIEW` 6종 + `USER_EVENT` 4종), 테스트(`feedback` API 6 · `formatTimeAgo` 4), `FeedbackTag` 스토리까지 붙어 있다.
 
@@ -507,9 +507,9 @@ LetterDraft.java:20  @Document("feedback_letter_drafts")
 
 우체통 흐름과 **독립적**이라 미뤄둔 것들이다. 없어도 편지를 읽고 쓰는 흐름은 끊기지 않는다.
 
-- **⑩ 만족도 모달 (`11170:1014`)** · **⑪ App Store 리뷰 이동 (`11177:1014`)** — 메인 화면에 뜨는 리뷰 유도 퍼널이다. 만족한 유저만 스토어로, 불만인 유저는 우체통으로 보내는 평점 방어 장치. 노출 조건(앱 3회 접속 또는 동아리 3회 조회)의 카운팅 저장소와 스토어 딥링크가 필요해 별도 작업으로 뺐다.
+- ~~**⑩ 만족도 모달 (`11170:1014`)** · **⑪ App Store 리뷰 이동 (`11177:1014`)**~~ ✅ `SatisfactionModal` + `useSatisfactionSurvey`로 구현했다. 만족하면 스토어 리뷰로, 아니면 `/feedback/write`로 보낸다.
+- ~~**사진 그리드 (보낸 편지 상세)**~~ ✅ presigned 업로드(`uploadFeedbackImages`)와 함께 붙였다.
 - **⑫ 답장 도착 푸시** — 앱·웹 토큰 주입까지 끝났다. 앱 릴리즈 후 우체통을 배포하면 동작한다 (§7).
-- **사진 그리드 (보낸 편지 상세)** — 이미지 업로드가 생기면 함께.
 
 ## 7. ⑫ 답장 도착 푸시 — 앱 릴리즈 후 배포 (결정)
 
@@ -544,7 +544,7 @@ LetterDraft.java:20  @Document("feedback_letter_drafts")
 웹뷰의 localStorage는 앱의 AsyncStorage와 별개라, 웹뷰는 앱과 **다른 studentId**를 자체 발급한다.
 그 studentId에는 `StudentUser`가 없으므로 `currentFcmToken`을 못 찾고 아래 로그만 남는다.
 
-```
+```text
 Reply push skipped. no fcm token for feedback letter={}
 ```
 
@@ -640,7 +640,7 @@ Reply push skipped. no fcm token for feedback letter={}
 사파리 ITP는 스크립트가 쓸 수 있는 저장소(localStorage 포함)를 **마지막 상호작용 후
 7일**에 비운다. 우체통 사용 패턴이 정확히 여기 걸린다.
 
-```
+```text
 피드백 보냄 → (며칠~몇 주) → 답장 도착 → 열어보러 옴
                     ↑
             그 사이 방문이 없으면 localStorage 소멸 → 보낸 편지도 받은 편지도 사라짐
@@ -655,7 +655,7 @@ Reply push skipped. no fcm token for feedback letter={}
 
 **제안: 서버가 발급하는 httpOnly 쿠키를 1차 신원으로 둔다.**
 
-```
+```text
 Set-Cookie: studentId=...; HttpOnly; Secure; SameSite=Lax; Max-Age=63072000
 ```
 
@@ -671,7 +671,7 @@ localStorage의 `sub`로 재발급이 가능해지면 **`sub`를 훔친 스크�
 
 프론트는 **쿠키 1차 · localStorage 2차**로 둔다. 둘 중 하나만 살아남아도 신원이 이어진다.
 
-```
+```text
 쿠키에 신원이 있으면 그대로 사용
 없으면 localStorage의 sub로 재발급 요청 (8-2)
 둘 다 없으면 신규 발급 후 양쪽에 저장

--- a/docs/spec/moadong-letterbox-handoff.md
+++ b/docs/spec/moadong-letterbox-handoff.md
@@ -731,13 +731,11 @@ UUIDv4(36자, 하이픈 포함)와 구조적으로 충돌할 수 없다. 이 제
 `sub`가 곧 인증 수단이 되므로 두 가지가 따라붙었다.
 
 - ~~서버에서 UUIDv4 형식을 검증해야 임의 문자열로 의도적 충돌을 막을 수 있다~~ ✅ 위 참조.
-- ⚠️ **앱의 UUID 생성이 `Math.random()` 기반이다 — 아직 안 고쳤다.**
-  `moadong-react-native/services/auth-token-storage.ts`의 `generateUuidV4()`가
-  `Math.floor(Math.random() * 16)`으로 UUID를 만들고, `issueAccessToken()`이 그 값을
-  `sub`로 보낸다. 서버가 `sub`를 무시하던 때는 버려지는 값이었지만 **이제는 인증 수단이다.**
-  `Math.random()`은 CSPRNG가 아니라 예측 가능한 시드 기반 PRNG이므로, 예측된 `sub`로
-  서버가 정당하게 서명한 토큰을 받아 그 사람의 편지함을 열 수 있다.
-  노출 범위는 해당 학생의 편지함(받은 편지·보낸 편지)이고, UUIDv4는 `userId`와 충돌하지
-  않으므로 관리자 권한으로는 번지지 않는다.
-  → `expo-crypto`의 `randomUUID()` 등 CSPRNG로 교체해야 한다. **앱 레포 작업이다.**
-  웹은 스스로 UUID를 만들지 않고 서버가 발급한 토큰에서 읽은 `sub`만 보내므로 해당 없다.
+- ~~앱의 UUID 생성이 `Math.random()` 기반이다. CSPRNG로 교체해야 한다~~
+  ✅ 앱 PR [#32](https://github.com/Moadong/moadong-react-native/pull/32) (2026-08-18 머지)에서
+  `crypto.getRandomValues` 기반으로 교체했다(`react-native-get-random-values` 폴리필).
+  같은 PR에서 `resolveAuthSubject()`를 추가해, 저장된 토큰이 있으면 그 `payload.sub`를
+  다시 보내고 신규 설치에서만 `@auth_subject`를 쓴다. 서버가 `sub`를 무시하던 시절의
+  기존 설치는 `@auth_subject`와 토큰 안 신원이 서로 다른데, 편지함이 달린 쪽은 토큰이므로
+  이 처리가 필요했다.
+  웹은 애초에 스스로 UUID를 만들지 않고 서버가 발급한 토큰에서 읽은 `sub`만 보낸다.

--- a/docs/spec/moadong-letterbox-handoff.md
+++ b/docs/spec/moadong-letterbox-handoff.md
@@ -444,6 +444,11 @@ LetterDraft.java:20  @Document("feedback_letter_drafts")
    POST /images/upload-url  →  PUT ×2 (presignedUrl)  →  POST /feedback (images: [finalUrl])
    ```
    사진이 없으면 `upload-url` 호출 없이 `images`를 생략한다.
+   `PresignedUploadResponse.requiredHeaders`는 `Content-Type` 하나로 고정이고
+   백엔드에 확장 계획이 없다(`CloudflareImageService`가 `putObjectRequest.contentType()`만
+   지정하므로 서명 대상은 host + Content-Type뿐). 프론트는 이 필드를 읽지 않고
+   `file.type`을 직접 보내는데, presign 요청에도 같은 `file.type`을 실으므로 값이 어긋나지
+   않는다. **두 지점이 갈라지면 R2가 403을 낸다** — 한쪽만 고치지 말 것.
 2. ~~**읽음 처리 API**~~ ✅ `PATCH .../read` 신설, 프론트 호출부 연결 완료
 3. ~~**운영 상태 3단계 vs 사용자 2단계**~~ ✅ 운영 3단계 + 전이 API 추가, 사용자 응답은 `PENDING`/`REPLIED` 2단계 유지. 프론트 영향 없음
 4. ~~**보낸 사람 식별자**~~ ✅ **익명 ID로 확정, 구현 완료.**
@@ -677,12 +682,33 @@ localStorage의 `sub`로 재발급이 가능해지면 **`sub`를 훔친 스크�
 둘 다 없으면 신규 발급 후 양쪽에 저장
 ```
 
-### 8-2. `/auth/student`가 `sub`를 버린다
+### 8-2. ~~`/auth/student`가 `sub`를 버린다~~ ✅ 해결
 
-`StudentAuthController.issueStudentToken()`에 `@RequestBody`가 없어서
-`UserCommandService.issueStudentAccessToken()`이 매번 `UUID.randomUUID()`로 새로 만든다.
-앱은 `{ sub, iat }`를 보내고 있는데(`services/api.ts`, `auth-token.service.ts`) 서버가 무시한다.
-의도된 동작이 아니다.
+**백엔드가 `sub`를 받도록 고쳤다.** 아래는 확정된 계약이다.
+
+| 요청 본문 | 동작 |
+|---|---|
+| 없음 / `{}` / `{"sub": null}` | 새 UUID 발급 (하위 호환 — 본문 없이 POST하는 기존 클라이언트도 그대로 동작) |
+| `{"sub": "<UUIDv4>"}` | **소문자로 정규화한 뒤** 그 값을 `sub`로 발급 |
+| UUIDv4가 아닌 값 | 400 |
+
+`StudentIssueRequest`가 `@Pattern(regexp = RegexConstants.UUID_V4)`로 검증하고,
+`resolveStudentId()`가 본문 없음/null이면 `UUID.randomUUID()`를 돌려준다.
+
+⚠️ **보낸 `sub`가 그대로 돌아온다고 가정하면 안 된다.** 서버가 소문자로 정규화하는데
+`Feedback.studentId`는 문자열을 그대로 비교하므로, 대문자로 보낸 값을 클라이언트가
+따로 기억해 쓰면 편지함이 둘로 갈린다. **신원은 항상 응답 토큰에서 다시 읽는다.**
+웹(`studentFetch.ts`)은 발급 응답의 `accessToken`만 저장하고 `sub`는 매번 토큰에서
+꺼내므로 이 조건을 이미 만족한다.
+
+**UUIDv4 제약은 형식 검증이 아니라 권한 경계다.**
+`JwtAuthenticationFilter`가 토큰의 `sub`로 `loadUserByUsername()` → `findUserByUserId()`를
+호출하고, `validateToken()`은 서명과 subject 일치만 본다. 임의 문자열 `sub`를 허용하면
+관리자 `userId`를 담은 토큰을 무인증 엔드포인트에서 정당하게 발급받을 수 있다.
+`userId` 패턴(`^(?=.*[a-z])[a-zA-Z\d!@#$~]{5,20}$`)은 하이픈 불가·최대 20자라
+UUIDv4(36자, 하이픈 포함)와 구조적으로 충돌할 수 없다. 이 제약만으로 경로가 닫힌다.
+
+아래는 결정 배경으로 남겨 둔다.
 
 지금은 구독 푸시에 영향이 없다. `createOrClaimToken()`이 같은 FCM 토큰 레코드를 찾아
 `updateStudentId()`로 새 신원에 갈아끼워 주기 때문에, studentId가 바뀌어도 구독이 따라온다.
@@ -702,7 +728,16 @@ localStorage의 `sub`로 재발급이 가능해지면 **`sub`를 훔친 스크�
 
 두 번째는 로그인이 없는 구조의 한계이고, 8-1의 쿠키로도 완전히는 못 막는다.
 
-고칠 때는 `sub`가 곧 인증 수단이 되므로 두 가지가 따라붙는다.
+`sub`가 곧 인증 수단이 되므로 두 가지가 따라붙었다.
 
-- 앱의 UUID 생성이 `Math.random()` 기반이다(`services/auth-token-storage.ts`). CSPRNG로 교체해야 한다.
-- 서버에서 UUIDv4 형식을 검증해야 임의 문자열로 의도적 충돌을 막을 수 있다.
+- ~~서버에서 UUIDv4 형식을 검증해야 임의 문자열로 의도적 충돌을 막을 수 있다~~ ✅ 위 참조.
+- ⚠️ **앱의 UUID 생성이 `Math.random()` 기반이다 — 아직 안 고쳤다.**
+  `moadong-react-native/services/auth-token-storage.ts`의 `generateUuidV4()`가
+  `Math.floor(Math.random() * 16)`으로 UUID를 만들고, `issueAccessToken()`이 그 값을
+  `sub`로 보낸다. 서버가 `sub`를 무시하던 때는 버려지는 값이었지만 **이제는 인증 수단이다.**
+  `Math.random()`은 CSPRNG가 아니라 예측 가능한 시드 기반 PRNG이므로, 예측된 `sub`로
+  서버가 정당하게 서명한 토큰을 받아 그 사람의 편지함을 열 수 있다.
+  노출 범위는 해당 학생의 편지함(받은 편지·보낸 편지)이고, UUIDv4는 `userId`와 충돌하지
+  않으므로 관리자 권한으로는 번지지 않는다.
+  → `expo-crypto`의 `randomUUID()` 등 CSPRNG로 교체해야 한다. **앱 레포 작업이다.**
+  웹은 스스로 UUID를 만들지 않고 서버가 발급한 토큰에서 읽은 `sub`만 보내므로 해당 없다.

--- a/frontend/docs/features/admin/application/desktop.md
+++ b/frontend/docs/features/admin/application/desktop.md
@@ -20,16 +20,18 @@ API는 `ApplicationFormGroup[]`를 내려주는데, 같은 `semesterYear`라도 
 ```
 
 프론트에서 `Map<number, ApplicationFormItem[]>`으로 머지해 같은 년도를 하나의 그룹으로 합친다.
-`Number()` 변환으로 타입 불일치(`string` vs `number`) 방어.
+`semesterYear`는 타입상 `number`라 변환 없이 그대로 키로 쓴다.
 
 ```ts
 const yearMap = new Map<number, ApplicationFormItem[]>();
 formGroups.forEach((group) => {
-  const year = Number(group.semesterYear);
-  const existing = yearMap.get(year) ?? [];
-  yearMap.set(year, [...existing, ...group.forms]);
+  const year = group.semesterYear;
+  if (!yearMap.has(year)) yearMap.set(year, []);
+  yearMap.get(year)!.push(...group.forms);
 });
 ```
+
+합친 뒤 `semesterYear` 내림차순으로 정렬해 최신 년도를 위에 둔다.
 
 ## UI 텍스트 규칙
 

--- a/frontend/docs/features/admin/intro/mobile-award.md
+++ b/frontend/docs/features/admin/intro/mobile-award.md
@@ -1,12 +1,11 @@
 # 수상 내역 모바일 섹션
 
 `ClubIntroEditTabMobile`의 "이런 상을 받았어요" 섹션.
-수상 내역 목록을 표시하며 행 클릭 시 편집 서브페이지로 이동하는 구조이나,
-현재 `ClubIntroEditTabMobile`에서는 `onNavigate`를 전달하지 않아 편집 기능이 미구현 상태다.
+행을 누르면 같은 탭 안에서 `AwardEditPage` 서브페이지로 전환된다.
 
 ## 표시 동작
 
-- 수상 이력 없음: "없음" 텍스트 + 화살표 버튼 (클릭해도 onNavigate 미연결)
+- 수상 이력 없음: "없음" 텍스트 + 화살표 버튼
 - 수상 이력 있음: 학기별 행 목록, 최신순(연도·학기 내림차순)으로 정렬
   - 행마다 `SemesterChip`(예: "2024 1학기")과 수상 개수(`achievements.length`) 표시
 
@@ -17,16 +16,29 @@
 | `awards` | `Award[]` | 수상 내역 배열 |
 | `onNavigate` | `(award?: Award) => void` (optional) | 행 클릭 핸들러. 미전달 시 클릭 무반응 |
 
-`onNavigate`에 `award`를 전달하면 특정 학기 편집, 생략하면 새 학기 추가로 구분하는 설계.
+`AwardSection`은 행을 누를 때 해당 `award`를 넘기지만,
+`ClubIntroEditTabMobile`의 `handleNavigateToAward`는 인자를 쓰지 않는다.
+`AwardEditPage`가 목록 전체를 편집하는 화면이라 어느 행에서 들어와도 같은 화면이 뜬다.
 
-## 미구현 사항
+## 서브페이지 전환
 
-모바일 수상 편집 서브페이지(`AwardEditPage`)가 없음.
-`AwardSection`을 `ClubIntroEditTabMobile`에 연결할 때 `onNavigate`와 함께
-`activePage` 분기 또는 별도 라우트 추가가 필요하다.
+라우트를 늘리지 않고 `activePage` 상태(`'main' | 'award'`)로 갈아 끼운다.
+
+- 진입: 현재 `window.scrollY`를 `savedScrollY`에 저장하고 `activePage`를 `'award'`로 바꾼다
+- 복귀: `AwardEditPage`의 `onBack`이 `'main'`으로 되돌리고, 이펙트가 저장해 둔 위치로 스크롤을 복원한다
+
+## 저장 흐름
+
+`AwardEditPage`는 두 개의 저장 콜백을 받는다.
+
+| prop | 연결 대상 | 역할 |
+|---|---|---|
+| `onSave` | `setAwards` | 편집 결과를 탭 로컬 상태에 반영 |
+| `onSaveToServer` | `handleUpdateClubWithAwards` | 수정된 배열로 동아리 상세 업데이트 요청 |
 
 ## 관련 코드
 
 - `src/pages/AdminPage/tabs/ClubIntroEditTab/components/mobile/AwardSection/AwardSection.tsx` — 수상 섹션 컴포넌트
 - `src/pages/AdminPage/tabs/ClubIntroEditTab/components/mobile/AwardSection/AwardSection.styles.ts` — 스타일
-- `src/pages/AdminPage/tabs/ClubIntroEditTab/ClubIntroEditTabMobile.tsx` — 현재 onNavigate 미연결
+- `src/pages/AdminPage/tabs/ClubIntroEditTab/components/mobile/AwardEditPage/AwardEditPage.tsx` — 편집 서브페이지
+- `src/pages/AdminPage/tabs/ClubIntroEditTab/ClubIntroEditTabMobile.tsx` — `activePage` 분기와 저장 콜백 연결

--- a/frontend/src/apis/auth/studentFetch.test.ts
+++ b/frontend/src/apis/auth/studentFetch.test.ts
@@ -15,8 +15,11 @@ const jsonResponse = (body: unknown, status = 200) =>
 const issued = (accessToken: string) =>
   jsonResponse({ statuscode: '200', message: 'ok', data: { accessToken } });
 
+const headersOf = (call: [RequestInfo, RequestInit?]) =>
+  new Headers(call[1]?.headers);
+
 const authHeaderOf = (call: [RequestInfo, RequestInit?]) =>
-  (call[1]?.headers as Record<string, string>)?.Authorization;
+  headersOf(call).get('Authorization');
 
 const bodyOf = (call: [RequestInfo, RequestInit?]) =>
   JSON.parse((call[1]?.body as string) ?? '{}');
@@ -184,5 +187,28 @@ describe('studentFetch', () => {
 
       expect(authHeaderOf(fetchMock.mock.calls[0])).toBe('Bearer app-token-2');
     });
+  });
+
+  // 객체 전개로 헤더를 합치면 Headers 인스턴스와 튜플 배열이 통째로 사라진다
+  describe('헤더 보존', () => {
+    it.each<[string, HeadersInit]>([
+      ['객체', { 'Content-Type': 'application/json' }],
+      ['Headers', new Headers({ 'Content-Type': 'application/json' })],
+      ['튜플 배열', [['Content-Type', 'application/json']]],
+    ])(
+      '%s 형식으로 준 헤더를 유지한 채 Authorization을 얹는다',
+      async (_, headers) => {
+        localStorage.setItem(STORAGE_KEYS.STUDENT_ACCESS_TOKEN, 'web-token');
+
+        await studentFetch('/api/student/feedback', {
+          method: 'POST',
+          headers,
+        });
+
+        const sent = headersOf(fetchMock.mock.calls[0]);
+        expect(sent.get('Content-Type')).toBe('application/json');
+        expect(sent.get('Authorization')).toBe('Bearer web-token');
+      },
+    );
   });
 });

--- a/frontend/src/apis/auth/studentFetch.ts
+++ b/frontend/src/apis/auth/studentFetch.ts
@@ -40,6 +40,8 @@ const getTokenSubject = (token: string) => {
  * 토큰에 만료가 없으므로 관리자용 secureFetch와 달리 refresh 흐름이 없다.
  *
  * sub를 함께 보내면 서버가 그 신원으로 다시 발급한다. 안 보내면 새 신원이라 편지함이 비어 보인다.
+ * 서버가 sub를 소문자로 정규화하므로 보낸 값을 신원으로 기억하면 안 된다. 토큰만 저장하고
+ * 신원이 필요하면 그때 토큰에서 다시 읽는다.
  */
 const issueStudentToken = async (sub?: string) => {
   const response = await fetchWithTimeout(`${API_BASE_URL}/auth/student`, {

--- a/frontend/src/apis/auth/studentFetch.ts
+++ b/frontend/src/apis/auth/studentFetch.ts
@@ -102,13 +102,16 @@ const getStudentToken = async () => {
   );
 };
 
-const withAuthorization = (init: RequestInit | undefined, token: string) => ({
-  ...init,
-  headers: {
-    ...(init?.headers || {}),
-    Authorization: `Bearer ${token}`,
-  },
-});
+/**
+ * 호출자가 headers를 Headers 인스턴스나 [key, value] 배열로 줄 수도 있다.
+ * 객체 전개로는 그 두 형식이 통째로 사라지므로 Headers로 정규화한 뒤 Authorization만 얹는다.
+ */
+const withAuthorization = (init: RequestInit | undefined, token: string) => {
+  const headers = new Headers(init?.headers);
+  headers.set('Authorization', `Bearer ${token}`);
+
+  return { ...init, headers };
+};
 
 export const studentFetch = async (
   input: RequestInfo,

--- a/frontend/src/apis/feedback.test.ts
+++ b/frontend/src/apis/feedback.test.ts
@@ -37,11 +37,8 @@ describe('feedback API', () => {
 
     await getReceivedLetters();
 
-    const headers = fetchMock.mock.calls[0][1]?.headers as Record<
-      string,
-      string
-    >;
-    expect(headers.Authorization).toBe('Bearer student-token');
+    const headers = new Headers(fetchMock.mock.calls[0][1]?.headers);
+    expect(headers.get('Authorization')).toBe('Bearer student-token');
   });
 
   it('저장된 토큰이 없으면 먼저 발급받아 저장한다', async () => {
@@ -57,11 +54,8 @@ describe('feedback API', () => {
       'issued-token',
     );
 
-    const headers = fetchMock.mock.calls[1][1]?.headers as Record<
-      string,
-      string
-    >;
-    expect(headers.Authorization).toBe('Bearer issued-token');
+    const headers = new Headers(fetchMock.mock.calls[1][1]?.headers);
+    expect(headers.get('Authorization')).toBe('Bearer issued-token');
   });
 
   describe('createFeedback', () => {

--- a/frontend/src/apis/feedback.ts
+++ b/frontend/src/apis/feedback.ts
@@ -83,7 +83,7 @@ export const uploadFeedbackImages = async (files: File[]) => {
 };
 
 export const getReceivedLetters = async (category?: LetterCategory) => {
-  const query = category ? `?category=${category}` : '';
+  const query = category ? `?category=${encodeURIComponent(category)}` : '';
   const response = await studentFetch(`${FEEDBACK_BASE_URL}/received${query}`);
 
   const data = await handleResponse<{ letters: ReceivedLetter[] }>(
@@ -96,7 +96,7 @@ export const getReceivedLetters = async (category?: LetterCategory) => {
 
 export const getReceivedLetter = async (letterId: string) => {
   const response = await studentFetch(
-    `${FEEDBACK_BASE_URL}/received/${letterId}`,
+    `${FEEDBACK_BASE_URL}/received/${encodeURIComponent(letterId)}`,
   );
 
   return handleResponse<ReceivedLetterDetail>(
@@ -107,7 +107,7 @@ export const getReceivedLetter = async (letterId: string) => {
 
 export const markReceivedLetterAsRead = async (letterId: string) => {
   const response = await studentFetch(
-    `${FEEDBACK_BASE_URL}/received/${letterId}/read`,
+    `${FEEDBACK_BASE_URL}/received/${encodeURIComponent(letterId)}/read`,
     { method: 'PATCH' },
   );
 
@@ -116,7 +116,7 @@ export const markReceivedLetterAsRead = async (letterId: string) => {
 
 export const getSentFeedback = async (feedbackId: string) => {
   const response = await studentFetch(
-    `${FEEDBACK_BASE_URL}/sent/${feedbackId}`,
+    `${FEEDBACK_BASE_URL}/sent/${encodeURIComponent(feedbackId)}`,
   );
 
   return handleResponse<SentFeedback>(

--- a/frontend/src/components/common/SatisfactionModal/SatisfactionModal.tsx
+++ b/frontend/src/components/common/SatisfactionModal/SatisfactionModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useId, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Modal from '@/components/common/Modal/Modal';
 import {
@@ -23,6 +23,8 @@ const SatisfactionModal = () => {
   const handleLink = useNavigator();
 
   // 응답률을 구하려면 노출 자체를 남겨야 한다. 리렌더로 중복되지 않게 ref로 막는다.
+  const titleId = useId();
+
   const trackedShownRef = useRef(false);
   useEffect(() => {
     if (!isOpen || trackedShownRef.current) return;
@@ -51,8 +53,8 @@ const SatisfactionModal = () => {
 
   return (
     <Modal isOpen={isOpen} onClose={handleSnooze} closeOnBackdrop={false}>
-      <Styled.Dialog role='dialog' aria-modal='true'>
-        <Styled.Title>모아동, 잘 사용하고 계신가요?</Styled.Title>
+      <Styled.Dialog role='dialog' aria-modal='true' aria-labelledby={titleId}>
+        <Styled.Title id={titleId}>모아동, 잘 사용하고 계신가요?</Styled.Title>
         <Styled.Actions>
           <Styled.ActionButton type='button' onClick={handleUnsatisfied}>
             아니요

--- a/frontend/src/pages/AdminPage/tabs/ClubIntroEditTab/hooks/useClubIntroEdit.ts
+++ b/frontend/src/pages/AdminPage/tabs/ClubIntroEditTab/hooks/useClubIntroEdit.ts
@@ -35,7 +35,8 @@ const useClubIntroEdit = () => {
     introDescription !== initialState.introDescription ||
     activityDescription !== initialState.activityDescription ||
     benefits !== initialState.benefits ||
-    idealCandidate.content !== initialState.idealCandidate.content ||
+    JSON.stringify(idealCandidate) !==
+      JSON.stringify(initialState.idealCandidate) ||
     JSON.stringify(awards) !== JSON.stringify(initialState.awards) ||
     JSON.stringify(faqs) !== JSON.stringify(initialState.faqs);
 

--- a/frontend/src/pages/FeedbackPage/FeedbackWritePage.tsx
+++ b/frontend/src/pages/FeedbackPage/FeedbackWritePage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router-dom';
 import { getServerErrorMessage } from '@/apis/utils/getServerErrorMessage';
 import AttachErrorIcon from '@/assets/images/icons/feedback/feedback_image_attach_error.svg?react';
@@ -111,6 +111,22 @@ const FeedbackWritePage = () => {
   const [openedModal, setOpenedModal] = useState<'exit' | 'save' | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
+  /**
+   * unmount 시 해제하려면 만들어 둔 URL 전부를 알아야 하는데 images 클로저로는 첫 렌더 값만 잡힌다.
+   * 이미 해제된 URL을 다시 해제해도 아무 일도 일어나지 않아 중복 해제는 문제되지 않는다.
+   */
+  const createdPreviewsRef = useRef<string[]>([]);
+  useEffect(
+    () => () =>
+      createdPreviewsRef.current.forEach((preview) =>
+        URL.revokeObjectURL(preview),
+      ),
+    [],
+  );
+
+  /** isPending은 렌더 결과라, 렌더 전에 두 번 눌리면 두 호출 모두 false를 읽고 전송된다 */
+  const submittingRef = useRef(false);
+
   const feedbackType = parseFeedbackType(typeParam);
   // React Compiler가 프로퍼티 접근을 조기 반환 위로 끌어올려도 안전하도록 구조분해를 피한다.
   const meta = feedbackType ? FEEDBACK_TYPE_META[feedbackType] : null;
@@ -147,10 +163,13 @@ const FeedbackWritePage = () => {
     }
 
     // 시안의 (2/4) → (4/4) 흐름대로 여러 번 나눠 골라도 쌓인다
-    const merged = [
-      ...images,
-      ...files.map((file) => ({ file, preview: URL.createObjectURL(file) })),
-    ];
+    const picked = files.map((file) => ({
+      file,
+      preview: URL.createObjectURL(file),
+    }));
+    createdPreviewsRef.current.push(...picked.map((image) => image.preview));
+
+    const merged = [...images, ...picked];
     const kept = merged.slice(0, FEEDBACK_IMAGE_MAX_COUNT);
 
     merged
@@ -169,7 +188,8 @@ const FeedbackWritePage = () => {
 
   const handleSubmit = () => {
     // 확인 모달은 전송 중에도 떠 있어서 다시 누를 수 있다. 중복 전송을 막는다.
-    if (isPending) return;
+    if (submittingRef.current) return;
+    submittingRef.current = true;
 
     createFeedback(
       {
@@ -188,6 +208,7 @@ const FeedbackWritePage = () => {
         },
         // 이미지가 R2에 없거나(601-2) 길이 검증에 걸리면 조용히 막힌다.
         onError: (error) => {
+          submittingRef.current = false;
           trackEvent(USER_EVENT.FEEDBACK_SUBMIT_FAILED, {
             type: feedbackType,
             imageCount: images.length,


### PR DESCRIPTION
## #️⃣연관된 이슈

릴리즈 PR #1941에 달린 CodeRabbit 리뷰 반영

## 📝작업 내용

리뷰 지적 12건 중 **프론트에서 고칠 수 있는 것**을 처리

### 코드

| 파일 | 내용 |
| --- | --- |
| `apis/auth/studentFetch.ts` | `withAuthorization`이 `init.headers`를 객체로 전개해서, 호출자가 `Headers` 인스턴스나 `[key, value]` 배열을 주면 기존 헤더가 통째로 사라졌다. `Headers`로 정규화한 뒤 `Authorization`만 `set`한다. 세 형식을 각각 검증하는 회귀 테스트 추가 |
| `apis/feedback.ts` | `letterId`·`feedbackId`·`category`를 `encodeURIComponent`로 감쌌다 |
| `FeedbackWritePage.tsx` | **중복 전송** — 잠금이 `isPending`(렌더 결과)이라 렌더 전에 두 번 눌리면 둘 다 통과해 같은 편지가 두 통 남는다. ref 동기 잠금으로 바꾸고 `onError`에서만 푼다<br>**미리보기 URL** — 목록에 남은 채 화면을 떠나면 blob이 남는다. 만든 URL을 ref에 모아 unmount 때 전부 해제 |
| `useClubIntroEdit.ts` | `isDirty`가 `idealCandidate.content`만 봐서, 태그만 고치면 편집 중으로 안 잡히고 다음 `clubDetail` 갱신 때 서버 값으로 되돌아갔다. `awards`·`faqs`와 같은 방식으로 전체 비교 |
| `SatisfactionModal.tsx` | `role='dialog'`에 `aria-labelledby`가 없어 스크린리더가 이름을 못 읽는다. 같은 흐름의 `FeedbackConfirmModal`과 동일하게 `useId`로 제목 연결 |

### 문서

문서가 이미 있는 기능을 없다고 적어 두면 다음 사람이 다시 만든다. 3곳을 현재 구현에 맞췄다.

- **우체통 핸드오프 §6** — "전부 MSW 목으로 동작"이라고 돼 있었다. 목은 #1925에서 제거됐고 실제 API를 호출한다. 만족도 모달·보낸 편지 사진 그리드도 미구현 목록에서 뺐다 (둘 다 구현됨)
- **지원서 년도 병합** — `Number()` 변환과 배열 전개로 적혀 있으나 실제 코드는 `semesterYear`를 그대로 키로 쓰고 `Map` 항목에 `push`한다. 타입이 `number`라 변환이 필요 없다
- **모바일 수상 편집** — "`AwardEditPage`가 없고 `onNavigate` 미연결"이라고 돼 있었으나 둘 다 구현돼 있다. `activePage` 전환과 저장 콜백 흐름으로 다시 썼다

markdownlint 지적(H1 다음 H3, 언어 없는 코드 블록 9곳, 공백 들어간 코드 범위)도 함께 정리했다.

## 중점적으로 리뷰받고 싶은 부분

**`ClubCard`의 `club.logo` 의존성 지적은 반영하지 않았다.** CodeRabbit은
`club.logo`를 `useEffect` deps에 넣으라고 했는데, 이건 #1936의 `54f602f`에서
**의도적으로 뺀 것**이다.

> 로고 URL이 바뀌면 observer effect가 재시작되면서 cleanup이 이전 로고로
> ClubCard Viewed를 한 번 더 쏘고 SS_LAST_KEY를 갱신한다. 새 observer는
> 2초 cooldown에 막혀 노출 측정을 시작하지 못하므로 노출이 중복 집계되고
> 클릭의 has_logo와 어긋난다.

넣으면 이미 고친 중복 집계 버그가 돌아온다. `has_logo`가 세션 중 로고 변경을
못 따라가는 건 맞지만, 노출 이중 집계보다 그쪽이 낫다는 게 당시 판단이었고
그대로 두는 게 맞다고 본다. 다른 의견 있으면 알려 달라.

## 논의하고 싶은 부분

### ✅ `POST /auth/student` 재발급 계약 — 백엔드에서 해결됨

백엔드가 `sub`를 받도록 고쳤다. `StudentIssueRequest`가 `@Pattern(UUID_V4)`로 검증하고
`resolveStudentId()`가 본문 없음/null이면 새 UUID를 돌려준다. 유닛 테스트 5케이스 통과 확인.

| 요청 본문 | 동작 |
| --- | --- |
| 없음 / `{}` / `{"sub": null}` | 새 UUID (하위 호환) |
| `{"sub": "<UUIDv4>"}` | **소문자로 정규화 후** 그 sub로 발급 |
| UUIDv4 아닌 값 | 400 |

**프론트는 코드 변경이 필요 없다.** 백엔드가 "보낸 sub가 그대로 돌아온다고 가정하지 말고
응답 토큰에서 다시 읽으라"고 했는데, `studentFetch`는 애초에 `sub`를 저장하지 않는다 —
발급 응답의 `accessToken`만 `localStorage`에 넣고, 신원이 필요할 때마다 `getTokenSubject()`로
토큰에서 꺼낸다. `sub`는 `studentFetch.ts` 밖에서 전혀 쓰이지 않는 것도 확인했다.
나중에 누가 "sub를 기억해 두자"고 고치는 걸 막으려고 주석만 한 줄 남겼다.

**배포 순서 제약 없음** — 본문 없이 POST하는 기존 클라이언트도 그대로 동작한다.
릴리즈 PR #1941은 이 건으로 막히지 않는다.

### ✅ 앱의 `sub` 생성 — 앱 PR #32에서 이미 해결됨

핸드오프 문서 §8-2에 "앱의 UUID 생성이 `Math.random()` 기반이라 CSPRNG로 교체해야 한다"가
미해결로 남아 있었으나, 앱 PR
[Moadong/moadong-react-native#32](https://github.com/Moadong/moadong-react-native/pull/32)
(2026-08-18 머지)에서 처리됐다.

- `generateUuidV4()`가 `crypto.getRandomValues` 기반으로 교체됨 (`react-native-get-random-values` 폴리필)
- `resolveAuthSubject()` 추가 — 저장된 토큰이 있으면 그 `payload.sub`를 다시 보내고,
  신규 설치에서만 `@auth_subject`를 쓴다. 서버가 `sub`를 무시하던 시절의 기존 설치는
  `@auth_subject`와 토큰 안 신원이 어긋나 있고, 편지함이 달린 쪽은 토큰이라 필요한 처리다

웹은 해당 없다 — 스스로 UUID를 만들지 않고 서버가 발급한 토큰에서 읽은 `sub`만 보낸다.

### ✅ presigned `requiredHeaders` — 현행 유지

백엔드가 `Content-Type` 하나로 고정이고 확장 계획이 없다고 확인해 줬다
(`CloudflareImageService`가 `putObjectRequest.contentType()`만 지정 → 서명 대상은
host + Content-Type). 프론트가 `file.type`을 직접 보내도 presign 요청에 같은 값을
싣기 때문에 어긋나지 않는다. 다만 **두 지점이 갈라지면 R2가 403**이라 한쪽만 고치면 안 된다는
점을 문서에 적어 뒀다.

## 🫡 참고사항

- `tsc --noEmit` 통과 / jest 444개 전부 통과 (52 suites)
- eslint 경고 2건은 stash 대조로 사전 존재 확인. 이 PR이 늘린 경고는 없다
- markdownlint의 MD013·MD060은 레포에 설정 파일이 없어 CI에서 돌지 않는 기본 규칙이라 손대지 않았다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 피드백 작성 중 이미지 미리보기 리소스를 자동 정리해 불필요한 메모리 사용을 줄였습니다.
  - 피드백 제출 중복을 방지하고, 오류 발생 시 다시 제출할 수 있도록 개선했습니다.
  - 피드백 관련 URL의 특수문자 처리를 강화했습니다.
  - 지원서 연도별 병합 및 정렬이 안정적으로 처리됩니다.
  - 지원서 수정 시 태그 변경도 저장 필요 상태로 정확히 감지합니다.
  - 모바일 수상 내역 편집 및 저장 흐름이 문서화되었습니다.

- **접근성**
  - 만족도 모달의 제목이 보조기기에 올바르게 전달되도록 개선했습니다.

- **문서**
  - 인증, 이미지 업로드, 초안·컬렉션, 토큰 및 푸시 처리 안내를 최신화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->