### PR TITLE
[feature] 어드민 지원자 현황 불합격 카운트 응답 추가

### DIFF
--- a/backend/src/main/java/moadong/club/payload/response/ClubApplyInfoResponse.java
+++ b/backend/src/main/java/moadong/club/payload/response/ClubApplyInfoResponse.java
@@ -11,6 +11,7 @@ public record ClubApplyInfoResponse(
         int reviewRequired,
         int scheduledInterview,
         int accepted,
+        int declined,
         List<ClubApplicantsResult> applicants
 ) {
 }

--- a/backend/src/main/java/moadong/club/service/ClubApplyAdminService.java
+++ b/backend/src/main/java/moadong/club/service/ClubApplyAdminService.java
@@ -124,6 +124,7 @@ public class ClubApplyAdminService {
         int reviewRequired = 0;
         int scheduledInterview = 0;
         int accepted = 0;
+        int declined = 0;
 
         for (ClubApplicant app : submittedApplications) {
             ClubApplicant sortedApp = sortApplicationAnswers(applicationForm, app);
@@ -133,10 +134,11 @@ public class ClubApplyAdminService {
                 case SUBMITTED -> reviewRequired++;
                 case INTERVIEW_SCHEDULED -> scheduledInterview++;
                 case ACCEPTED -> accepted++;
+                case DECLINED -> declined++;
             }
         }
 
-        return ClubApplyInfoResponse.builder().total(applications.size()).reviewRequired(reviewRequired).scheduledInterview(scheduledInterview).accepted(accepted).applicants(applications).build();
+        return ClubApplyInfoResponse.builder().total(applications.size()).reviewRequired(reviewRequired).scheduledInterview(scheduledInterview).accepted(accepted).declined(declined).applicants(applications).build();
     }
 
     private ClubApplicant sortApplicationAnswers(ClubApplicationForm application, ClubApplicant app) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #1948 

## 📝작업 내용

`GET /api/club/apply/info/{applicationFormId}` 응답에 `declined` 필드
   추가

  - `ClubApplyInfoResponse`에 `declined` 필드 추가
  - `getClubApplyInfo`에서 `DECLINED` 상태 지원자 수 집계
  - 기존 `total`, `reviewRequired`, `scheduledInterview`, `accepted`와
  동일한 방식으로 계산

  프론트에서 `applicants` 배열을 순회해 직접 계산하는 방식보다 기존 다른 필드와 같이 백엔드에서 일관되게 제공하도록 변경

## 중점적으로 리뷰받고 싶은 부분(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 논의하고 싶은 부분(선택)

> 논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항
