### PR TITLE
[feature] AI 지원서 초안 Mixpanel 이벤트 추가

### DIFF
--- a/frontend/src/constants/eventName.ts
+++ b/frontend/src/constants/eventName.ts
@@ -148,6 +148,15 @@ export const ADMIN_EVENT = {
   CALENDAR_UNLINK_CANCELED: '캘린더 연동 해제 취소',
   CALENDAR_EVENT_VISIBILITY_TOGGLED: '연동 일정 표시 토글',
 
+  // 지원서 관리
+  AI_DRAFT_BUTTON_VIEWED: 'AI 지원서 초안 버튼노출',
+  AI_DRAFT_BUTTON_CLICKED: 'AI 지원서 초안 생성 버튼클릭',
+  AI_DRAFT_OVERWRITE_CANCELED: 'AI 지원서 초안 덮어쓰기 취소',
+  AI_DRAFT_GENERATED: 'AI 지원서 초안 생성 완료',
+  AI_DRAFT_LIMIT_REACHED: 'AI 지원서 초안 생성 한도 초과',
+  AI_DRAFT_GENERATION_FAILED: 'AI 지원서 초안 생성 실패',
+  APPLICATION_FORM_SAVED: '지원서 저장',
+
   // 비밀번호 수정
   PASSWORD_CHANGE_BUTTON_CLICKED: '비밀번호 변경 버튼클릭',
   NEW_PASSWORD_CLEAR_BUTTON_CLICKED: '새 비밀번호 입력 초기화 버튼클릭',

--- a/frontend/src/pages/AdminPage/tabs/ApplicationTab/ApplicationEditTab/ApplicationEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/ApplicationTab/ApplicationEditTab/ApplicationEditTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import {
@@ -10,9 +10,11 @@ import Button from '@/components/common/Button/Button';
 import CustomTextArea from '@/components/common/CustomTextArea/CustomTextArea';
 import Spinner from '@/components/common/Spinner/Spinner';
 import { APPLICATION_FORM } from '@/constants/applicationForm';
+import { ADMIN_EVENT } from '@/constants/eventName';
 import INITIAL_FORM_DATA from '@/constants/initialFormData';
 import { queryKeys } from '@/constants/queryKeys';
 import { ApiError } from '@/errors';
+import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import {
   useAiDraftQuota,
   useGetApplication,
@@ -40,6 +42,7 @@ const ApplicationEditTab = () => {
     applicationFormId?: string;
   }>();
   const { clubId } = useAdminClubId();
+  const trackEvent = useMixpanelTrack();
 
   const {
     data: existingFormData,
@@ -65,6 +68,17 @@ const ApplicationEditTab = () => {
   const [remainingOverride, setRemainingOverride] = useState<number>();
   const remaining = remainingOverride ?? draftQuota?.remaining;
   const isDraftLimitReached = remaining === 0;
+  // 저장된 지원서가 AI 초안에서 출발했는지 구분한다
+  const [draftSource, setDraftSource] = useState<'manual' | 'ai' | 'template'>(
+    'manual',
+  );
+
+  const isDraftButtonViewTracked = useRef(false);
+  useEffect(() => {
+    if (!isDraftButtonVisible || isDraftButtonViewTracked.current) return;
+    isDraftButtonViewTracked.current = true;
+    trackEvent(ADMIN_EVENT.AI_DRAFT_BUTTON_VIEWED);
+  }, [isDraftButtonVisible, trackEvent]);
 
   useEffect(() => {
     if (!existingFormData) return;
@@ -88,6 +102,11 @@ const ApplicationEditTab = () => {
     mutationFn: (payload: ApplicationFormData) => createApplication(payload),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.application.all });
+      trackEvent(ADMIN_EVENT.APPLICATION_FORM_SAVED, {
+        isEdit: false,
+        formMode: applicationFormMode,
+        draftSource,
+      });
       alert('지원서가 성공적으로 생성되었습니다.');
       navigate(`/admin/application-list`);
     },
@@ -110,6 +129,11 @@ const ApplicationEditTab = () => {
           clubId ?? 'unknown',
           formId ?? '',
         ),
+      });
+      trackEvent(ADMIN_EVENT.APPLICATION_FORM_SAVED, {
+        isEdit: true,
+        formMode: applicationFormMode,
+        draftSource,
       });
       alert('지원서가 성공적으로 수정되었습니다.');
       navigate('/admin/application-list');
@@ -134,6 +158,12 @@ const ApplicationEditTab = () => {
         questions: [nameQuestion, ...draftQuestions],
       }));
       setNextId(draftQuestions.length + 2);
+      setDraftSource(draft.aiGenerated ? 'ai' : 'template');
+      trackEvent(ADMIN_EVENT.AI_DRAFT_GENERATED, {
+        aiGenerated: draft.aiGenerated,
+        questionCount: draftQuestions.length,
+        remaining: draft.remaining,
+      });
       if (typeof draft.remaining === 'number') {
         setRemainingOverride(draft.remaining);
       }
@@ -146,9 +176,14 @@ const ApplicationEditTab = () => {
     onError: (err: Error) => {
       if (err instanceof ApiError && err.status === 429) {
         setRemainingOverride(0);
+        trackEvent(ADMIN_EVENT.AI_DRAFT_LIMIT_REACHED);
         alert('이번 달 AI 초안 생성 횟수(3회)를 모두 사용했어요.');
         return;
       }
+      trackEvent(ADMIN_EVENT.AI_DRAFT_GENERATION_FAILED, {
+        status: err instanceof ApiError ? err.status : undefined,
+        message: err.message,
+      });
       alert(`지원서 초안 생성에 실패했습니다: ${err.message}`);
     },
   });
@@ -161,10 +196,15 @@ const ApplicationEditTab = () => {
         (q, index) =>
           index > 0 && (q.title.trim() !== '' || q.description.trim() !== ''),
       );
+    trackEvent(ADMIN_EVENT.AI_DRAFT_BUTTON_CLICKED, {
+      hasUserInput,
+      remaining,
+    });
     if (
       hasUserInput &&
       !confirm('작성 중인 내용을 AI 초안으로 덮어씁니다. 계속할까요?')
     ) {
+      trackEvent(ADMIN_EVENT.AI_DRAFT_OVERWRITE_CANCELED);
       return;
     }
     generateDraft();


### PR DESCRIPTION
## 변경 내용

AI 지원서 초안 기능(관리자 화면)에 Mixpanel 이벤트를 추가한다.

`ADMIN_EVENT`에 추가한 키:

| 키 | 이벤트명 | 발생 지점 |
| --- | --- | --- |
| `AI_DRAFT_BUTTON_VIEWED` | AI 지원서 초안 버튼노출 | 신규 작성 + 모아동지원서 모드일 때 1회 |
| `AI_DRAFT_BUTTON_CLICKED` | AI 지원서 초안 생성 버튼클릭 | 버튼 클릭 (`hasUserInput`, `remaining`) |
| `AI_DRAFT_OVERWRITE_CANCELED` | AI 지원서 초안 덮어쓰기 취소 | 덮어쓰기 confirm 취소 |
| `AI_DRAFT_GENERATED` | AI 지원서 초안 생성 완료 | 생성 성공 (`aiGenerated`, `questionCount`, `remaining`) |
| `AI_DRAFT_LIMIT_REACHED` | AI 지원서 초안 생성 한도 초과 | 429 응답 |
| `AI_DRAFT_GENERATION_FAILED` | AI 지원서 초안 생성 실패 | 그 외 실패 (`status`, `message`) |
| `APPLICATION_FORM_SAVED` | 지원서 저장 | 지원서 생성/수정 성공 (`isEdit`, `formMode`, `draftSource`) |

`draftSource`는 `manual` / `ai` / `template` 중 하나로, 저장된 지원서가 AI 초안에서 출발했는지 구분한다. 백엔드가 `aiGenerated: false`로 폴백 템플릿을 내려준 경우는 `template`으로 남는다.

## 변경 이유

AI 초안 기능에 계측이 하나도 없어서, 월 3회 제한이 적정한지 판단할 데이터가 없다. 특히 **생성한 초안을 실제로 저장까지 했는지**를 구분할 수 없어 기능의 성패를 알 수 없다.

- 버튼 노출 → 클릭 → 생성 → 저장 퍼널을 볼 수 있다
- 3회 소진 도달 동아리 수를 보고 한도를 조정할 수 있다
- AI 생성 성공 vs 폴백 템플릿 비율로 백엔드 생성 품질을 추적할 수 있다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - AI 지원서 초안 버튼 노출 및 클릭, 초안 생성 결과를 추적합니다.
  - 초안 생성 성공·실패·한도 초과와 덮어쓰기 취소를 기록합니다.
  - 지원서 저장 및 수정 시 저장 방식과 지원서 모드를 함께 기록합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->