### PR TITLE
[fix] 모바일 오픈채팅 플로팅 버튼 위치 및 노출 조건 수정

### DIFF
--- a/frontend/src/pages/AdminPage/components/AdminContactFloatingButton/AdminContactFloatingButton.styles.ts
+++ b/frontend/src/pages/AdminPage/components/AdminContactFloatingButton/AdminContactFloatingButton.styles.ts
@@ -58,11 +58,13 @@ export const ContactButton = styled.a`
   }
 
   ${media.tablet} {
-    right: 16px;
-    bottom: calc(88px + env(safe-area-inset-bottom));
+    right: 20px;
+    bottom: calc(101px + env(safe-area-inset-bottom));
 
     width: 48px;
     min-width: 48px;
+    height: 48px;
+    border-radius: 50%;
     padding: 0;
   }
 `;

--- a/frontend/src/pages/AdminPage/components/AdminContactFloatingButton/AdminContactFloatingButton.tsx
+++ b/frontend/src/pages/AdminPage/components/AdminContactFloatingButton/AdminContactFloatingButton.tsx
@@ -1,9 +1,14 @@
 import KakaoIcon from '@/assets/images/icons/kakao.svg?react';
+import { useScrollTrigger } from '@/hooks/Scroll/useScrollTrigger';
 import * as Styled from './AdminContactFloatingButton.styles';
 
 const ADMIN_CONTACT_OPEN_CHAT_URL = 'https://open.kakao.com/o/s21dRWjh';
 
 const AdminContactFloatingButton = () => {
+  const { isDisabled } = useScrollTrigger();
+
+  if (isDisabled) return null;
+
   return (
     <Styled.ContactButton
       href={ADMIN_CONTACT_OPEN_CHAT_URL}


### PR DESCRIPTION
## #️⃣연관된 이슈

#1953

## 📝작업 내용

- `SCROLL_TRIGGER_DISABLED`가 설정된 페이지(이런 상을 받았어요, 지원서 관리, 년도별 상세)에서 오픈채팅 플로팅 버튼 숨김 처리
- 모바일에서 오픈채팅 버튼 크기·위치를 + 버튼(`MobileFloatingButton`)과 동일하게 통일
  - `right: 20px`, `bottom: calc(101px + env(safe-area-inset-bottom))`, `48×48px`, `border-radius: 50%`

## 🫡 참고사항

`useScrollTrigger`의 `isDisabled`를 활용하여 별도 조건 추가 없이 기존 패턴으로 처리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 관리 페이지의 문의 버튼이 특정 스크롤 상태에서 자동으로 숨겨집니다.
  * 태블릿 화면에서 문의 버튼이 원형으로 표시되며 위치가 조정됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->