### PR TITLE
[refactor] 실험 배정 모듈 정리 및 오염 계측 추가

### DIFF
--- a/frontend/src/experiments/CLAUDE.md
+++ b/frontend/src/experiments/CLAUDE.md
@@ -17,15 +17,32 @@ const variant = useExperimentVariant(mainBannerExperiment);
 배정이 뒤집힌 방문을 분석에서 걸러내기 위해 `fetchAndAssignExperiments`가
 매 부팅마다 super property 두 개를 register한다.
 
-| property                     | true인 경우                      | 의미                        |
-| ---------------------------- | -------------------------------- | --------------------------- |
-| `experiment_storage_blocked` | localStorage 쓰기 실패           | 다음 방문에 다시 추첨된다   |
-| `experiment_reassigned`      | 기존 배정이 현재 variants에 없음 | 정의 변경으로 그룹이 갈렸다 |
+| property                        | true인 경우                      | 의미                        |
+| ------------------------------- | -------------------------------- | --------------------------- |
+| `experiment_storage_blocked`    | localStorage 쓰기 실패           | 다음 방문에 다시 추첨된다   |
+| `experiment_definition_changed` | 기존 배정이 현재 variants에 없음 | 정의 변경으로 그룹이 갈렸다 |
 
 둘 다 방문 단위 값이라 매번 true/false로 덮어쓴다. 실험 결과를 볼 때
 이 비율을 먼저 확인해야 차이가 진짜인지 오염인지 구분할 수 있다.
 
-배정 고정이 깨지는 경로는 이 둘 외에 **Safari ITP 7일 만료, 시크릿 모드,
-사용자의 사이트 데이터 삭제, 기기·브라우저 분리**가 있다. 모두 코드로
-막을 수 없고, 근본 해결은 `hash(userId + key)` 기반 결정론적 버킷팅이다.
-로그인 사용자 대상 실험을 설계할 때 검토한다.
+### 이 둘로 재추첨률을 대신할 수 없다
+
+배정이 **아예 없어서** 새로 뽑은 방문은 두 플래그가 모두 false다. 그런데
+**Safari ITP 7일 만료, 시크릿 모드, 사용자의 사이트 데이터 삭제, 기기·브라우저
+분리**가 전부 그 경로다. 이 경우 localStorage 쓰기 자체는 정상이라
+`experiment_storage_blocked`도 false로 남는다.
+
+결국 실제로 잡히는 건 쓰기가 throw하는 **권한 거부**뿐이고, 저장 payload가 작아
+쿼터 초과도 거의 걸리지 않는다. 그러므로 **`experiment_storage_blocked` 비율이
+낮게 나와도 랜덤 배정이 안전하다는 근거가 되지 않는다.** 오염의 큰 몫이 애초에
+측정되지 않았기 때문이다.
+
+ITP 몫은 클라이언트만으로 측정할 수 없다. ITP는 JS로 심은 쿠키도 7일로 자르므로
+Mixpanel `distinct_id`가 배정과 함께 사라져, 재방문인지 신규 방문인지 구분할
+식별자가 남지 않는다.
+
+대응은 둘 중 하나다.
+
+- 배정부터 결과 지표까지의 관측 창을 7일 미만으로 잡아 ITP 만료 영향을 줄인다.
+- 로그인 사용자 대상이면 `hash(userId + key)` 기반 결정론적 버킷팅으로 바꾼다.
+  localStorage에 의존하지 않으므로 위 경로가 전부 사라진다.

--- a/frontend/src/experiments/CLAUDE.md
+++ b/frontend/src/experiments/CLAUDE.md
@@ -3,11 +3,11 @@
 Mixpanel 기반 실험 관리:
 
 - `definitions.ts` - 실험 정의 (key, variants, weights)
-- `ExperimentRepository.ts` - 실험 할당 및 변형 조회 로직
+- `experimentAssignments.ts` - 실험 할당 및 변형 조회 로직
 - `initializeExperiments.ts` - 앱 시작 시 실험 초기화
-- `useExperiment()` 훅으로 컴포넌트에서 실험 변형 사용
+- `useExperimentVariant()` 훅(`src/hooks/Experiment/`)으로 컴포넌트에서 실험 변형 사용
 
 ```typescript
-const { variant } = useExperiment(mainBannerExperiment);
+const variant = useExperimentVariant(mainBannerExperiment);
 // variant는 'A' 또는 'B'
 ```

--- a/frontend/src/experiments/CLAUDE.md
+++ b/frontend/src/experiments/CLAUDE.md
@@ -11,3 +11,21 @@ Mixpanel 기반 실험 관리:
 const variant = useExperimentVariant(mainBannerExperiment);
 // variant는 'A' 또는 'B'
 ```
+
+## 오염 계측
+
+배정이 뒤집힌 방문을 분석에서 걸러내기 위해 `fetchAndAssignExperiments`가
+매 부팅마다 super property 두 개를 register한다.
+
+| property                     | true인 경우                      | 의미                        |
+| ---------------------------- | -------------------------------- | --------------------------- |
+| `experiment_storage_blocked` | localStorage 쓰기 실패           | 다음 방문에 다시 추첨된다   |
+| `experiment_reassigned`      | 기존 배정이 현재 variants에 없음 | 정의 변경으로 그룹이 갈렸다 |
+
+둘 다 방문 단위 값이라 매번 true/false로 덮어쓴다. 실험 결과를 볼 때
+이 비율을 먼저 확인해야 차이가 진짜인지 오염인지 구분할 수 있다.
+
+배정 고정이 깨지는 경로는 이 둘 외에 **Safari ITP 7일 만료, 시크릿 모드,
+사용자의 사이트 데이터 삭제, 기기·브라우저 분리**가 있다. 모두 코드로
+막을 수 없고, 근본 해결은 `hash(userId + key)` 기반 결정론적 버킷팅이다.
+로그인 사용자 대상 실험을 설계할 때 검토한다.

--- a/frontend/src/experiments/ExperimentRepository.ts
+++ b/frontend/src/experiments/ExperimentRepository.ts
@@ -62,8 +62,10 @@ const pickWeightedVariant = <V extends ExperimentVariant>(
 };
 
 class ExperimentRepository {
+  private assignments: ExperimentAssignments = safeReadAssignments();
+
   fetchAndAssignExperiments(experiments: readonly ExperimentDefinition<any>[]) {
-    const assignments = safeReadAssignments();
+    const assignments = this.assignments;
     const definedKeys = new Set(experiments.map((e) => e.key));
 
     // 정의에서 사라진 실험은 Mixpanel super property 및 로컬 배정 정리.
@@ -95,8 +97,7 @@ class ExperimentRepository {
   getVariant<V extends ExperimentVariant>(
     experiment: ExperimentDefinition<V>,
   ): V {
-    const assignments = safeReadAssignments();
-    const assignedVariant = assignments[experiment.key];
+    const assignedVariant = this.assignments[experiment.key];
 
     if (assignedVariant && experiment.variants.includes(assignedVariant as V)) {
       return assignedVariant as V;
@@ -106,6 +107,7 @@ class ExperimentRepository {
   }
 
   resetAssignments() {
+    this.assignments = {};
     localStorage.removeItem(ASSIGNMENT_STORAGE_KEY);
   }
 }

--- a/frontend/src/experiments/experimentAssignments.test.ts
+++ b/frontend/src/experiments/experimentAssignments.test.ts
@@ -1,0 +1,124 @@
+jest.mock('mixpanel-browser', () => ({
+  __esModule: true,
+  default: { register: jest.fn(), unregister: jest.fn() },
+}));
+
+type ExperimentAssignmentsModule =
+  typeof import('@/experiments/experimentAssignments');
+
+// 새 페이지 로드를 재현한다. 모듈이 다시 평가되며 메모리 캐시는 비워지고,
+// localStorage는 그대로 남는다.
+const openNewSession = (): ExperimentAssignmentsModule => {
+  let module: ExperimentAssignmentsModule;
+  jest.isolateModules(() => {
+    module = require('@/experiments/experimentAssignments');
+  });
+  return module!;
+};
+
+const experiment = {
+  key: 'test_experiment',
+  variants: ['A', 'B'] as const,
+  defaultVariant: 'A' as const,
+  weights: { A: 3, B: 1 },
+};
+
+// 재배정 확률이 회당 37.5%라 200회에서 한 번도 안 바뀔 확률은 0.625^200 ≈ 10^-41.
+// 확률적이지만 사실상 결정론적이다.
+const SESSION_COUNT = 200;
+
+const assignInNewSession = (
+  definition: { key: string } & Record<string, unknown> = experiment,
+) => {
+  const session = openNewSession();
+  session.fetchAndAssignExperiments([definition as never]);
+  return session.getVariant(definition as never);
+};
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('가중치 추첨', () => {
+  // 표본 4000은 허용오차 0.05 기준 실패율 0%(20만 회 시뮬레이션).
+  // 1000이면 약 3200회에 1번 실패한다.
+  it('weights 3:1이면 4000번 배정에서 대략 3:1이 나온다', () => {
+    const session = openNewSession();
+    const counts: Record<string, number> = { A: 0, B: 0 };
+
+    for (let i = 0; i < 4000; i += 1) {
+      session.resetAssignments();
+      session.fetchAndAssignExperiments([experiment]);
+      counts[session.getVariant(experiment)] += 1;
+    }
+
+    expect(counts.A / 4000).toBeCloseTo(0.75, 1);
+  });
+});
+
+describe('배정 고정성', () => {
+  it('다시 방문해도 같은 그룹에 남는다', () => {
+    for (let i = 0; i < SESSION_COUNT; i += 1) {
+      localStorage.clear();
+      expect(assignInNewSession()).toBe(assignInNewSession());
+    }
+  });
+
+  it('localStorage가 비워지면 다시 추첨된다', () => {
+    // Safari ITP 7일 만료, 시크릿 모드 종료, 사용자의 사이트 데이터 삭제.
+    let flipped = 0;
+    for (let i = 0; i < SESSION_COUNT; i += 1) {
+      localStorage.clear();
+      const today = assignInNewSession();
+      localStorage.clear();
+      if (assignInNewSession() !== today) flipped += 1;
+    }
+    expect(flipped).toBeGreaterThan(0);
+  });
+
+  it('localStorage 쓰기가 막히면 매 방문마다 다시 추첨된다', () => {
+    const setItem = jest
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation(() => {
+        throw new DOMException('QuotaExceededError');
+      });
+
+    let flipped = 0;
+    for (let i = 0; i < SESSION_COUNT; i += 1) {
+      localStorage.clear();
+      const today = assignInNewSession();
+      if (assignInNewSession() !== today) flipped += 1;
+    }
+
+    setItem.mockRestore();
+    expect(flipped).toBeGreaterThan(0);
+  });
+
+  it('배포로 variants 목록이 바뀌면 재배정된다', () => {
+    const previous = assignInNewSession();
+    const redefined = {
+      ...experiment,
+      variants: ['C', 'D'] as const,
+      defaultVariant: 'C' as const,
+    };
+
+    const current = assignInNewSession(redefined);
+
+    expect(['C', 'D']).toContain(current);
+    expect(current).not.toBe(previous);
+  });
+});
+
+describe('메모리 캐시', () => {
+  it('getVariant는 localStorage를 읽지 않는다', () => {
+    const session = openNewSession();
+    session.fetchAndAssignExperiments([experiment]);
+
+    const getItem = jest.spyOn(Storage.prototype, 'getItem');
+    for (let i = 0; i < 50; i += 1) session.getVariant(experiment);
+    const readCount = getItem.mock.calls.length;
+    getItem.mockRestore();
+
+    expect(readCount).toBe(0);
+  });
+});

--- a/frontend/src/experiments/experimentAssignments.test.ts
+++ b/frontend/src/experiments/experimentAssignments.test.ts
@@ -1,7 +1,18 @@
+// isolateModules로 모듈을 다시 평가해도 같은 목을 보도록 바깥에 둔다.
+const mockMixpanel = { register: jest.fn(), unregister: jest.fn() };
+
 jest.mock('mixpanel-browser', () => ({
   __esModule: true,
-  default: { register: jest.fn(), unregister: jest.fn() },
+  default: mockMixpanel,
 }));
+
+// 마지막으로 register된 super property 값을 읽는다.
+const lastRegistered = (property: string): unknown => {
+  const calls = mockMixpanel.register.mock.calls.filter(
+    ([properties]) => properties && property in properties,
+  );
+  return calls.length ? calls[calls.length - 1][0][property] : undefined;
+};
 
 type ExperimentAssignmentsModule =
   typeof import('@/experiments/experimentAssignments');
@@ -37,6 +48,8 @@ const assignInNewSession = (
 
 beforeEach(() => {
   localStorage.clear();
+  mockMixpanel.register.mockClear();
+  mockMixpanel.unregister.mockClear();
 });
 
 describe('가중치 추첨', () => {
@@ -120,5 +133,40 @@ describe('메모리 캐시', () => {
     getItem.mockRestore();
 
     expect(readCount).toBe(0);
+  });
+});
+
+describe('오염 계측', () => {
+  it('정상 저장이면 오염 플래그가 모두 false다', () => {
+    assignInNewSession();
+
+    expect(lastRegistered('experiment_storage_blocked')).toBe(false);
+    expect(lastRegistered('experiment_reassigned')).toBe(false);
+  });
+
+  it('저장이 막히면 experiment_storage_blocked를 표시한다', () => {
+    const setItem = jest
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation(() => {
+        throw new DOMException('QuotaExceededError');
+      });
+
+    assignInNewSession();
+    setItem.mockRestore();
+
+    expect(lastRegistered('experiment_storage_blocked')).toBe(true);
+  });
+
+  it('정의가 바뀌어 재배정되면 experiment_reassigned를 표시한다', () => {
+    assignInNewSession();
+    expect(lastRegistered('experiment_reassigned')).toBe(false);
+
+    assignInNewSession({
+      ...experiment,
+      variants: ['C', 'D'] as const,
+      defaultVariant: 'C' as const,
+    });
+
+    expect(lastRegistered('experiment_reassigned')).toBe(true);
   });
 });

--- a/frontend/src/experiments/experimentAssignments.test.ts
+++ b/frontend/src/experiments/experimentAssignments.test.ts
@@ -141,7 +141,7 @@ describe('오염 계측', () => {
     assignInNewSession();
 
     expect(lastRegistered('experiment_storage_blocked')).toBe(false);
-    expect(lastRegistered('experiment_reassigned')).toBe(false);
+    expect(lastRegistered('experiment_definition_changed')).toBe(false);
   });
 
   it('저장이 막히면 experiment_storage_blocked를 표시한다', () => {
@@ -157,9 +157,9 @@ describe('오염 계측', () => {
     expect(lastRegistered('experiment_storage_blocked')).toBe(true);
   });
 
-  it('정의가 바뀌어 재배정되면 experiment_reassigned를 표시한다', () => {
+  it('정의가 바뀌어 재배정되면 experiment_definition_changed를 표시한다', () => {
     assignInNewSession();
-    expect(lastRegistered('experiment_reassigned')).toBe(false);
+    expect(lastRegistered('experiment_definition_changed')).toBe(false);
 
     assignInNewSession({
       ...experiment,
@@ -167,6 +167,6 @@ describe('오염 계측', () => {
       defaultVariant: 'C' as const,
     });
 
-    expect(lastRegistered('experiment_reassigned')).toBe(true);
+    expect(lastRegistered('experiment_definition_changed')).toBe(true);
   });
 });

--- a/frontend/src/experiments/experimentAssignments.test.ts
+++ b/frontend/src/experiments/experimentAssignments.test.ts
@@ -1,3 +1,7 @@
+// 최상위 import/export가 없으면 TS가 이 파일을 전역 스크립트로 보고 아래
+// 선언들이 전역에 새어나가, 같은 이름을 쓰는 다른 테스트와 충돌한다.
+export {};
+
 // isolateModules로 모듈을 다시 평가해도 같은 목을 보도록 바깥에 둔다.
 const mockMixpanel = { register: jest.fn(), unregister: jest.fn() };
 

--- a/frontend/src/experiments/experimentAssignments.ts
+++ b/frontend/src/experiments/experimentAssignments.ts
@@ -7,6 +7,11 @@ import type {
 
 const ASSIGNMENT_STORAGE_KEY = 'moadong_experiments';
 
+// 배정을 믿을 수 없는 방문을 표시해 분석에서 걸러내기 위한 super property.
+// 실험 결과 해석 시 오염된 표본의 비율을 알아야 차이가 진짜인지 판단할 수 있다.
+const STORAGE_BLOCKED_PROPERTY = 'experiment_storage_blocked';
+const REASSIGNED_PROPERTY = 'experiment_reassigned';
+
 const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
@@ -24,12 +29,14 @@ const safeReadAssignments = (): ExperimentAssignments => {
   }
 };
 
-const writeAssignments = (assignments: ExperimentAssignments) => {
+const writeAssignments = (assignments: ExperimentAssignments): boolean => {
   try {
     localStorage.setItem(ASSIGNMENT_STORAGE_KEY, JSON.stringify(assignments));
+    return true;
   } catch {
-    // localStorage 쓰기 실패(용량 초과, 권한 거부 등)는 무시하고 진행한다.
-    // 실패해도 배정값은 메모리에서 유효하며, 다음 새로고침 시 재배정된다.
+    // 쓰기 실패(용량 초과, 권한 거부 등)해도 이번 방문은 메모리 배정으로 진행한다.
+    // 다만 다음 방문에 다시 추첨되므로 배정이 고정되지 않는다.
+    return false;
   }
 };
 
@@ -76,6 +83,8 @@ export const fetchAndAssignExperiments = (
     delete assignments[key];
   });
 
+  let reassigned = false;
+
   experiments.forEach((experiment) => {
     const existing = assignments[experiment.key];
     const isValidExisting =
@@ -86,12 +95,21 @@ export const fetchAndAssignExperiments = (
       return;
     }
 
+    // 기존 배정이 현재 variants에 없다 = 정의가 바뀌어 그룹이 갈렸다.
+    // 배정이 아예 없던 첫 방문은 오염이 아니므로 구분한다.
+    if (existing) reassigned = true;
+
     const variant = pickWeightedVariant(experiment);
     assignments[experiment.key] = variant;
     mixpanel.register({ [experiment.key]: variant });
   });
 
-  writeAssignments(assignments);
+  const stored = writeAssignments(assignments);
+
+  mixpanel.register({
+    [STORAGE_BLOCKED_PROPERTY]: !stored,
+    [REASSIGNED_PROPERTY]: reassigned,
+  });
 };
 
 export const getVariant = <V extends ExperimentVariant>(

--- a/frontend/src/experiments/experimentAssignments.ts
+++ b/frontend/src/experiments/experimentAssignments.ts
@@ -61,55 +61,52 @@ const pickWeightedVariant = <V extends ExperimentVariant>(
   return experiment.defaultVariant;
 };
 
-class ExperimentRepository {
-  private assignments: ExperimentAssignments = safeReadAssignments();
+let assignments: ExperimentAssignments = safeReadAssignments();
 
-  fetchAndAssignExperiments(experiments: readonly ExperimentDefinition<any>[]) {
-    const assignments = this.assignments;
-    const definedKeys = new Set(experiments.map((e) => e.key));
+export const fetchAndAssignExperiments = (
+  experiments: readonly ExperimentDefinition<any>[],
+) => {
+  const definedKeys = new Set(experiments.map((e) => e.key));
 
-    // 정의에서 사라진 실험은 Mixpanel super property 및 로컬 배정 정리.
-    // 누락 시 종료된 실험 key가 모든 이벤트에 계속 따라붙어 데이터가 오염됨.
-    Object.keys(assignments).forEach((key) => {
-      if (definedKeys.has(key)) return;
-      mixpanel.unregister(key);
-      delete assignments[key];
-    });
+  // 정의에서 사라진 실험은 Mixpanel super property 및 로컬 배정 정리.
+  // 누락 시 종료된 실험 key가 모든 이벤트에 계속 따라붙어 데이터가 오염됨.
+  Object.keys(assignments).forEach((key) => {
+    if (definedKeys.has(key)) return;
+    mixpanel.unregister(key);
+    delete assignments[key];
+  });
 
-    experiments.forEach((experiment) => {
-      const existing = assignments[experiment.key];
-      const isValidExisting =
-        !!existing && experiment.variants.includes(existing);
+  experiments.forEach((experiment) => {
+    const existing = assignments[experiment.key];
+    const isValidExisting =
+      !!existing && experiment.variants.includes(existing);
 
-      if (isValidExisting) {
-        mixpanel.register({ [experiment.key]: existing });
-        return;
-      }
-
-      const variant = pickWeightedVariant(experiment);
-      assignments[experiment.key] = variant;
-      mixpanel.register({ [experiment.key]: variant });
-    });
-
-    writeAssignments(assignments);
-  }
-
-  getVariant<V extends ExperimentVariant>(
-    experiment: ExperimentDefinition<V>,
-  ): V {
-    const assignedVariant = this.assignments[experiment.key];
-
-    if (assignedVariant && experiment.variants.includes(assignedVariant as V)) {
-      return assignedVariant as V;
+    if (isValidExisting) {
+      mixpanel.register({ [experiment.key]: existing });
+      return;
     }
 
-    return experiment.defaultVariant;
+    const variant = pickWeightedVariant(experiment);
+    assignments[experiment.key] = variant;
+    mixpanel.register({ [experiment.key]: variant });
+  });
+
+  writeAssignments(assignments);
+};
+
+export const getVariant = <V extends ExperimentVariant>(
+  experiment: ExperimentDefinition<V>,
+): V => {
+  const assignedVariant = assignments[experiment.key];
+
+  if (assignedVariant && experiment.variants.includes(assignedVariant as V)) {
+    return assignedVariant as V;
   }
 
-  resetAssignments() {
-    this.assignments = {};
-    localStorage.removeItem(ASSIGNMENT_STORAGE_KEY);
-  }
-}
+  return experiment.defaultVariant;
+};
 
-export const experimentRepository = new ExperimentRepository();
+export const resetAssignments = () => {
+  assignments = {};
+  localStorage.removeItem(ASSIGNMENT_STORAGE_KEY);
+};

--- a/frontend/src/experiments/experimentAssignments.ts
+++ b/frontend/src/experiments/experimentAssignments.ts
@@ -71,7 +71,7 @@ const pickWeightedVariant = <V extends ExperimentVariant>(
 let assignments: ExperimentAssignments = safeReadAssignments();
 
 export const fetchAndAssignExperiments = (
-  experiments: readonly ExperimentDefinition<any>[],
+  experiments: readonly ExperimentDefinition<ExperimentVariant>[],
 ) => {
   const definedKeys = new Set(experiments.map((e) => e.key));
 

--- a/frontend/src/experiments/experimentAssignments.ts
+++ b/frontend/src/experiments/experimentAssignments.ts
@@ -10,7 +10,7 @@ const ASSIGNMENT_STORAGE_KEY = 'moadong_experiments';
 // 배정을 믿을 수 없는 방문을 표시해 분석에서 걸러내기 위한 super property.
 // 실험 결과 해석 시 오염된 표본의 비율을 알아야 차이가 진짜인지 판단할 수 있다.
 const STORAGE_BLOCKED_PROPERTY = 'experiment_storage_blocked';
-const REASSIGNED_PROPERTY = 'experiment_reassigned';
+const DEFINITION_CHANGED_PROPERTY = 'experiment_definition_changed';
 
 const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -83,7 +83,7 @@ export const fetchAndAssignExperiments = (
     delete assignments[key];
   });
 
-  let reassigned = false;
+  let definitionChanged = false;
 
   experiments.forEach((experiment) => {
     const existing = assignments[experiment.key];
@@ -97,7 +97,7 @@ export const fetchAndAssignExperiments = (
 
     // 기존 배정이 현재 variants에 없다 = 정의가 바뀌어 그룹이 갈렸다.
     // 배정이 아예 없던 첫 방문은 오염이 아니므로 구분한다.
-    if (existing) reassigned = true;
+    if (existing) definitionChanged = true;
 
     const variant = pickWeightedVariant(experiment);
     assignments[experiment.key] = variant;
@@ -108,7 +108,7 @@ export const fetchAndAssignExperiments = (
 
   mixpanel.register({
     [STORAGE_BLOCKED_PROPERTY]: !stored,
-    [REASSIGNED_PROPERTY]: reassigned,
+    [DEFINITION_CHANGED_PROPERTY]: definitionChanged,
   });
 };
 

--- a/frontend/src/experiments/initializeExperiments.ts
+++ b/frontend/src/experiments/initializeExperiments.ts
@@ -1,6 +1,6 @@
 import { ALL_EXPERIMENTS } from './definitions';
-import { experimentRepository } from './ExperimentRepository';
+import { fetchAndAssignExperiments } from './experimentAssignments';
 
 export const initializeExperiments = () => {
-  experimentRepository.fetchAndAssignExperiments(ALL_EXPERIMENTS);
+  fetchAndAssignExperiments(ALL_EXPERIMENTS);
 };

--- a/frontend/src/hooks/Experiment/useExperimentVariant.ts
+++ b/frontend/src/hooks/Experiment/useExperimentVariant.ts
@@ -1,4 +1,4 @@
-import { experimentRepository } from '@/experiments/ExperimentRepository';
+import { getVariant } from '@/experiments/experimentAssignments';
 import type {
   ExperimentDefinition,
   ExperimentVariant,
@@ -7,5 +7,5 @@ import type {
 export const useExperimentVariant = <V extends ExperimentVariant>(
   experiment: ExperimentDefinition<V>,
 ): V => {
-  return experimentRepository.getVariant(experiment);
+  return getVariant(experiment);
 };


### PR DESCRIPTION


## 변경 내용

### 1. 배정을 메모리에 캐시 

`getVariant`가 호출될 때마다 `localStorage.getItem` + `JSON.parse`를 돌았다. 렌더 중 호출되는 경로라 실험이 붙으면 리렌더마다 동기 I/O가 반복된다. 모듈 변수 조회로 바꾸고 localStorage는 부팅 시 복원·영속화만 맡는다.

`resetAssignments`가 메모리 캐시도 함께 비우지 않으면 리셋이 먹지 않으므로 같이 초기화한다.

### 2. 클래스 해체 

인스턴스가 하나뿐이고 클래스를 export하지 않아 상속·다중 인스턴스·DI 중 무엇도 쓰지 않던 껍데기였다. 모듈 스코프로 바꾸면 `assignments`가 모듈 스코프에 갇혀 TS 전용인 `private`보다 은닉이 강해지고, 함수 export 위주인 `apis` 레이어와 모양이 같아진다. 로직은 그대로다.

클래스가 사라져 `ExperimentRepository.ts` → `experimentAssignments.ts`로 옮겼다.

### 3. 테스트 9개 

A/B 결과를 믿으려면 같은 사용자가 계속 같은 그룹에 남아야 한다. 그 조건이 언제 깨지는지를 못박았다.

| 시나리오 | 결과 |
| --- | --- |
| 정상 재방문 | 200회 전부 유지 |
| localStorage 삭제 후 재방문 | 재추첨됨 |
| localStorage 쓰기 차단 | 200회 중 77회 그룹 변경 |
| 배포로 `variants` 변경 | 재배정됨 |

뒤의 셋은 결함이 아니라 현재 설계의 한계라 기대값으로 기록했다.

분포 검증은 표본 4000을 쓴다. 1000은 허용오차 0.05에서 약 3200회에 한 번 실패해 CI에서 원인 모를 flake가 된다(20만 회 시뮬레이션으로 측정). 4000은 0건이고 실행 시간은 14ms다.

### 4. 오염 계측

`writeAssignments`의 catch가 실패를 통째로 삼키고 있어, 저장이 막힌 사용자가 전체의 1%인지 30%인지 알 방법이 없었다. 그 사용자는 매 방문 재추첨되어 실험 결과를 오염시킨다.

super property 두 개를 매 부팅 register한다. 분모를 알아야 비율을 계산할 수 있어 항상 true/false를 붙인다.

| property | true인 경우 |
| --- | --- |
| `experiment_storage_blocked` | localStorage 쓰기 실패 |
| `experiment_definition_changed` | 기존 배정이 현재 variants에 없음 |

## 알려진 한계

**가장 큰 오염 경로인 Safari ITP 7일 만료·시크릿 모드·사이트 데이터 삭제는 이 두 플래그로 잡히지 않는다.** 저장소가 비면 신규 사용자와 구별되지 않고, 이때 쓰기는 정상이라 `experiment_storage_blocked`도 false다. 따라서 **두 플래그가 낮다고 랜덤 배정이 안전하다고 판단하면 안 된다.**

근본 해결은 `hash(userId + key)` 기반 결정론적 버킷팅이며, 첫 실험의 배정 단위(로그인 사용자 vs 익명 방문자)가 정해져야 결정할 수 있어 이번 범위에서 제외했다. hash기반으로 하려면 로그인이 전제되어야 하는데 우리 서비스를 로그인이 없기에 다른 방법을 생각해봐야 할 것 같다.