### PR TITLE
[docs] 상태관리 가이드의 Context 사용 기준 문구 수정

### DIFF
--- a/frontend/.claude/agents/상태관리부서.md
+++ b/frontend/.claude/agents/상태관리부서.md
@@ -38,9 +38,10 @@ Q6. 메모리(새로고침 시 리셋)로 충분한가?
 Q7. 실시간 이벤트(SSE/WebSocket)인가?
     YES → 커스텀 훅 (`useXxxSSE`)
 
-Q8. 특정 서브트리에서만 공유가 필요하고
-    Provider 패턴이 명확히 필요한가?
-    YES → React Context (현재 프로젝트에서는 Zustand 우선 고려)
+Q8. 인스턴스별로 값이 달라야 하거나(합성 컴포넌트),
+    앱 생애주기 동안 안 바뀌는 값의 주입인가?
+    YES → React Context
+    NO  → Zustand (저장소 용도로 Context를 새로 만들지 않는다)
 ```
 
 ---
@@ -325,11 +326,18 @@ export const useApplicantSSE = (applicationFormId: string | undefined) => {
 
 **React Context 사용 기준**:
 
-Context는 현재 프로젝트에서 사용하지 않는다. 아래 기준으로 판단:
+Context는 **상태 저장소로는 쓰지 않는다.** value가 자주 바뀌면 Provider 하위 구독자가 전부 리렌더되기 때문이다(`SearchContext`, `CategoryContext`, `AdminClubContext`를 Zustand로 옮긴 이유).
+
+다만 아래 두 용도는 Context가 맞고, 현재도 사용 중이다:
+
+- **불변 값 주입(DI)** — `ThemeProvider`, `PersistQueryClientProvider` (`src/App.tsx`). value가 앱 생애주기 동안 바뀌지 않아 리렌더 문제가 생기지 않는다.
+- **컴포넌트 합성 API** — `CustomDropDown` (`src/components/common/CustomDropDown/CustomDropDown.tsx`). `<Dropdown.Trigger>`가 어느 `<Dropdown>` 인스턴스에 속하는지 prop drilling 없이 전달하는 용도. Zustand store는 모듈 싱글톤이라 인스턴스별 상태를 표현할 수 없어 대체 불가.
+
+판단 순서:
 
 - 전역 공유 상태 → Zustand
 - 실시간 이벤트 → 커스텀 훅
-- 특정 서브트리 공유 + Provider 패턴이 명확히 필요한 경우에만 Context 고려
+- 서브트리 한정 + 인스턴스별 상태, 또는 불변 값 주입 → Context
 
 ---
 
@@ -345,6 +353,7 @@ Context는 현재 프로젝트에서 사용하지 않는다. 아래 기준으로
 | 경로 식별자                     | `useParams`                          |
 | 서버 데이터                     | `React Query` → API훅부서            |
 | 실시간 이벤트 (SSE/WebSocket)   | 커스텀 훅 (`useXxxSSE`)              |
+| 컴포넌트 합성 / 불변 값 주입    | `React Context`                      |
 
 ---
 

--- a/frontend/.claude/agents/상태관리부서.md
+++ b/frontend/.claude/agents/상태관리부서.md
@@ -331,7 +331,7 @@ Context는 **상태 저장소로는 쓰지 않는다.** value가 자주 바뀌�
 다만 아래 두 용도는 Context가 맞고, 현재도 사용 중이다:
 
 - **불변 값 주입(DI)** — `ThemeProvider`, `PersistQueryClientProvider` (`src/App.tsx`). value가 앱 생애주기 동안 바뀌지 않아 리렌더 문제가 생기지 않는다.
-- **컴포넌트 합성 API** — `CustomDropDown` (`src/components/common/CustomDropDown/CustomDropDown.tsx`). `<Dropdown.Trigger>`가 어느 `<Dropdown>` 인스턴스에 속하는지 prop drilling 없이 전달하는 용도. Zustand store는 모듈 싱글톤이라 인스턴스별 상태를 표현할 수 없어 대체 불가.
+- **컴포넌트 합성 API** — `CustomDropDown` (`src/components/common/CustomDropDown/CustomDropDown.tsx`). `<CustomDropDown.Trigger>`가 어느 `<CustomDropDown>` 인스턴스에 속하는지 prop drilling 없이 전달하는 용도. Zustand store는 모듈 싱글톤이라 인스턴스별 상태를 표현할 수 없어 대체 불가.
 
 판단 순서:
 


### PR DESCRIPTION
## #️⃣연관된 이슈

close #1958

## 📝작업 내용

`frontend/.claude/agents/상태관리부서.md`가 "React Context는 현재 프로젝트에서 사용하지 않는다"고 단정하고 있었는데, 실제 코드에는 Context가 두 군데 살아 있습니다.

- **불변 값 주입(DI)** — `ThemeProvider`, `PersistQueryClientProvider` (`frontend/src/App.tsx:89-100`)
- **컴포넌트 합성 API** — `CustomDropDown` (`frontend/src/components/common/CustomDropDown/CustomDropDown.tsx`)

문서가 **"상태 저장소 용도로는 쓰지 않는다"를 "쓰지 않는다"로 줄여 쓴** 게 원인입니다. Zustand로 옮긴 건 `SearchContext` / `CategoryContext` / `AdminClubContext`처럼 **value가 자주 바뀌어 Provider 하위 구독자를 전부 리렌더시키던** 저장소 역할이었지, Context 자체를 걷어낸 게 아니었습니다.

이대로 두면 가이드를 따르는 쪽에서 **인스턴스별 상태가 필요한 합성 컴포넌트까지 Zustand로 만들려는 오판**이 나올 수 있습니다. Zustand store는 모듈 싱글톤이라 인스턴스가 하나뿐이고, `QuestionBuilder`처럼 드롭다운을 질문 수만큼 렌더하는 화면에서는 하나를 열면 전부 열립니다.

### 수정 3곳 (+14 / -5)

**1. 결정 트리 Q8** — "Provider 패턴이 명확히 필요한가 → Context(단 Zustand 우선 고려)"라는 모호한 문장을, Context가 유일한 답인 조건으로 교체

```diff
-Q8. 특정 서브트리에서만 공유가 필요하고
-    Provider 패턴이 명확히 필요한가?
-    YES → React Context (현재 프로젝트에서는 Zustand 우선 고려)
+Q8. 인스턴스별로 값이 달라야 하거나(합성 컴포넌트),
+    앱 생애주기 동안 안 바뀌는 값의 주입인가?
+    YES → React Context
+    NO  → Zustand (저장소 용도로 Context를 새로 만들지 않는다)
```

**2. "React Context 사용 기준" 섹션** — 사실과 다른 단정을 삭제하고 `저장소로는 안 씀 / 주입·합성으로는 씀`으로 분리. 사용 중인 두 곳을 경로와 함께 명시하고, "store는 모듈 싱글톤이라 인스턴스별 상태 표현 불가"라는 대체 불가 사유를 남겼습니다.

**3. 도구별 비교 요약 표** — Context 행이 아예 빠져 있어 `| 컴포넌트 합성 / 불변 값 주입 | React Context |` 추가

## 🫡 참고사항

- **문서만 수정합니다. 런타임 코드 변경 0줄** → 빌드/테스트 영향 없음
- 같은 폴더의 `frontend/docs/features/store/useAdminClubStore.md`도 확인했으나, Context 관련 서술이 마이그레이션 배경 설명뿐이라 사실과 어긋나는 부분이 없어 손대지 않았습니다
- Jira: MOA-1069


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * React Context 사용 기준을 업데이트했습니다.
  * Context를 상태 저장소로 사용하지 않고, 불변 값 주입과 컴포넌트 합성에 활용하도록 원칙을 명확히 했습니다.
  * 상태 관리 도구 비교표에 React Context의 적합한 사용 사례를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->