### PR TITLE
[chore] 프론트엔드 CI에 유닛 테스트 추가

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Test
+        run: npm test
+
       - name: Tracking audit (미사용 USER_EVENT 검사)
         run: npm run audit:tracking
 

--- a/frontend/src/utils/formatKSTDateTime.test.ts
+++ b/frontend/src/utils/formatKSTDateTime.test.ts
@@ -85,7 +85,7 @@ describe('formatKSTDateTimeFull', () => {
 
     expect(result).toContain('3월');
     expect(result).toContain('25');
-    expect(result).toMatch(/오전|오후/); // 한국 시간 포맷
+    expect(result).toMatch(/오전|오후|AM|PM/); // 12시간제 표기(문구는 런타임 ICU가 정한다)
   });
 
   it('날짜 경계가 넘어가는 경우도 올바르게 처리한다', () => {

--- a/frontend/src/utils/formatRelativeDateTime.test.ts
+++ b/frontend/src/utils/formatRelativeDateTime.test.ts
@@ -1,5 +1,8 @@
 import { formatRelativeDateTime } from './formatRelativeDateTime';
 
+// 오전/오후는 런타임 ICU(CLDR) 데이터가 정한다. 브라우저(Chrome 151)는 한글로 내지만
+// Node 20.20의 ICU는 AM/PM으로 내므로 둘 다 허용한다. 검증 대상은 12시간제 표기다.
+
 describe('formatRelativeDateTime', () => {
   beforeEach(() => {
     jest.useFakeTimers();
@@ -15,7 +18,7 @@ describe('formatRelativeDateTime', () => {
 
       const result = formatRelativeDateTime('2024-01-15T14:30:00');
 
-      expect(result).toMatch(/오후.*2.*30/);
+      expect(result).toMatch(/(오후|PM).*2.*30/);
     });
 
     it('오늘 오전 9시를 시간 형식으로 반환해야 한다', () => {
@@ -23,7 +26,7 @@ describe('formatRelativeDateTime', () => {
 
       const result = formatRelativeDateTime('2024-01-15T09:00:00');
 
-      expect(result).toMatch(/오전.*9/);
+      expect(result).toMatch(/(오전|AM).*9/);
     });
 
     it('오늘 자정을 시간 형식으로 반환해야 한다', () => {
@@ -31,7 +34,7 @@ describe('formatRelativeDateTime', () => {
 
       const result = formatRelativeDateTime('2024-01-15T00:00:00');
 
-      expect(result).toMatch(/오전.*12.*00/);
+      expect(result).toMatch(/(오전|AM).*12.*00/);
     });
   });
 
@@ -77,7 +80,7 @@ describe('formatRelativeDateTime', () => {
 
       const result = formatRelativeDateTime('2024-01-15T23:59:00');
 
-      expect(result).toMatch(/오후.*11.*59/);
+      expect(result).toMatch(/(오후|PM).*11.*59/);
     });
 
     it('월이 바뀌는 경우 날짜 형식으로 반환해야 한다', () => {


### PR DESCRIPTION
## 📝 작업 내용

1. `frontend-ci.yml`의 Lint와 Tracking audit 사이에 테스트 실행 스텝을 추가한다.

```yaml
- name: Test
  run: npm test
```

2. 게이트를 붙이자 깨진 테스트 5개를 고친다. (아래 "게이트가 바로 잡은 것")

## 🤔 배경

프론트엔드 CI가 jest를 실행하지 않는다. `frontend-ci.yml`은 Prettier / Lint / Tracking audit / Build만 돌리고, 테스트를 돌리던 `codecov.yml`은 2025-06-04(`46ca6478`)에 전체 주석 처리된 뒤 복구되지 않았다.

그래서 테스트가 실패한 채 머지돼도 아무도 모른다. 실제로 두 번 방치됐다.

- `window.open`에 `'_blank', 'noopener'`를 넘기도록 바뀐 뒤 기대값이 갱신되지 않아 실패 상태로 남아 있었다 (`d2a56a35`)
- useNavigator 웹뷰 라우팅을 React Router로 통일(#1662)한 뒤 옛 동작을 기대하는 테스트가 깨진 채로 있다가, 2주 뒤 #1783에서 뒤늦게 수습됐다

## 🔍 게이트가 바로 잡은 것

스텝을 붙인 첫 실행에서 **2 suites / 5 tests가 실패**했다. 로컬에서는 전부 통과하던 것들이다.

원인은 타임존이 아니라 **ICU(CLDR) 데이터 차이**였다.

| | Node | `ko-KR` 시간 표기 |
|---|---|---|
| 로컬 | v20.19.5 | `3월 25일 (수) 오전 09:00` |
| CI | v20.20.2 | `3월 25일 (수) **AM** 09:00` |

`setup-node`의 `node-version: 20`은 최신 20.x를 받아오므로 로컬과 패치 버전이 갈리고, 그 안의 ICU가 한국어 오전/오후를 AM/PM으로 낸다.

**실사용자 영향은 없다.** Chrome 151에서 직접 확인한 결과 `formatKSTDateTimeFull` → `"3월 25일 (수) 오전 09:00"`, `formatRelativeDateTime` → `"오후 2:30"`으로 정상 출력된다. 문제는 테스트가 Node에 들어 있는 CLDR 문구를 단정하고 있던 것이다.

이 테스트들이 검증하려는 건 "오늘이면 12시간제 시간 형식으로 분기한다"이지 표기 문구가 아니므로, 표기만 두 형태를 허용하도록 고쳤다. 시·분 값 단정은 그대로다.

```diff
- expect(result).toMatch(/오후.*2.*30/);
+ expect(result).toMatch(/(오후|PM).*2.*30/);
```

## ✅ 확인한 것

- **CI 전체 통과** — Prettier / Lint / **Test (55 suites, 460 tests)** / Tracking audit / Build 전부 success
- 정규식이 CI가 실제로 뱉은 문자열(`"PM 2:30"`, `"AM 12:00"`, `"3월 25일 (수) AM 09:00"`)과 기존 한글 출력 양쪽에 매치하는지 별도 확인
- 이 워크플로우의 `paths` 필터에 `.github/workflows/frontend-ci.yml`이 이미 들어 있어, 이 PR 자체가 새 스텝을 포함해 실행된다

## 🙋 범위 밖으로 둔 것

- **CI Node 버전 고정** — 근본적으로는 `.nvmrc` 등으로 로컬과 맞추는 게 맞지만, ICU는 계속 바뀌므로 버전 고정은 미봉책이고 브라우저 ICU와 맞출 방법도 아니다. 별도 판단이 필요하다.
- **커버리지 업로드(`codecov.yml`) 복구** — 팀에서 의도적으로 끈 것이라 손대지 않았다.
- **`jest.config.js`의 `collectCoverage: true`** — 그대로라 CI 로그에 커버리지 표가 매번 찍힌다. 거슬리면 후속으로 정리하면 된다.
- **`frontend/src/utils/semester.ts`** — 작업 중 발견. 어디서도 import되지 않는 죽은 코드로 보인다(커버리지 0%). #1792에서 테스트와 함께 들어왔다가 `f6f3fea2`(학기 기반 → 연도+활성 전환)에서 테스트만 삭제되고 구현이 남았다. 이 PR 범위 밖이라 두었다.

Closes #1960
