### PR TITLE
[feature] MOA-1076 동아리 상세 기본 탭을 활동사진으로 변경

### DIFF
--- a/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
@@ -59,12 +59,16 @@ const ClubDetailPage = () => {
 
   const hasCalendarConnection = clubDetail?.hasCalendarConnection ?? false;
 
+  const hasFeeds = (clubDetail?.feeds?.length ?? 0) > 0;
+
   const activeTab: TabType = useMemo(() => {
     if (!tabParam || !Object.values(TAB_TYPE).includes(tabParam)) {
-      return TAB_TYPE.INTRO;
+      // 체류시간 중앙값이 7초라 첫 화면이 판단을 좌우한다.
+      // 유저가 스스로 이동하는 탭도 활동사진이 가장 많아 기본값으로 둔다.
+      return hasFeeds ? TAB_TYPE.PHOTOS : TAB_TYPE.INTRO;
     }
     return tabParam;
-  }, [tabParam]);
+  }, [tabParam, hasFeeds]);
 
   const { data: calendarEvents = [], isLoading: isCalendarLoading } =
     useGetClubCalendarEvents((clubName ?? clubId) || '', {


### PR DESCRIPTION
## #️⃣연관된 이슈

#1968

## 📝작업 내용

상세페이지 진입 시 기본 탭을 `소개내용` → `활동사진`으로 바꾼다. 6줄 변경이다.

- 활동사진이 없는 동아리는 기존대로 `소개내용`으로 폴백
- URL `?tab=` 파라미터 우선순위는 그대로 유지
- 로딩 중에는 `if (!clubDetail) return null`로 아무것도 렌더되지 않아 탭이 깜빡이지 않는다

## 🫡 참고사항 — 근거 (30일 실측)

| | |
| --- | --- |
| 체류시간 | 중앙값 **7초** · 3초 이하 30% · 10초 이하 60% |
| 활동사진 탭 클릭 | **3,451건** (행사일정 1,471건의 2.3배) |
| 소개내용 탭 클릭 | 1,593건 — 기본 탭이라 되돌아온 클릭 |
| 사진 탭 본 사람의 지원 도달률 | **37%** vs 전체 15.8% |

동아리를 고르는 페이지에서 중앙값 7초는 읽지 않았다는 뜻이다. 그 7초에 텍스트 소개가 떠 있고, 유저가 스스로 찾아가는 곳은 사진이다.

마지막 줄(37% vs 15.8%)은 **상관이지 인과가 아니다.** 이미 관심 있는 사람이 사진도 보고 지원도 하는 것일 수 있다. 근거로 쓰되 효과 크기를 이 수치로 기대하면 안 된다.

## 논의하고 싶은 부분(선택)

**A/B 없이 적용하는 판단.** 상세 방문 유저가 월 1,509명(일 50명)이라, 기준선 15.8%에서 20% 상대 리프트를 검출하려면 53일이 걸린다. 한 줄 변경에 두 달을 묶는 건 비용이 안 맞고 되돌리는 비용도 거의 없어서 적용 후 관찰로 정했다. 3월 신학기(주 2,462명, 5.6배)에는 10일이면 되므로, 근거가 더 약한 안들은 그때 실험으로 돌린다.

**테스트를 안 붙였다.** 이 저장소에 전체 페이지 단위 테스트 선례가 없고(기존 7개는 전부 컴포넌트 단위), 이 변경을 테스트하려면 router·react-query·mixpanel·naver map을 다 목킹해야 해서 6줄 변경에 비해 과하다고 판단했다. 분기 자체는 `hasFeeds ? PHOTOS : INTRO`와 `tabParam` 우선순위뿐이고 타입체크로 덮인다. 붙이는 게 낫다고 보면 알려달라.

## 측정 시 주의

변경 후에는 `Club Feed Tab Clicked`가 줄고 `Club Intro Tab Clicked`가 는다. 기본 탭이 바뀌어 클릭의 의미 자체가 달라지기 때문이다. **효과 판정은 탭 클릭이 아니라 `Club Apply Button Clicked` / `ClubDetailPage Visited`로 봐야 한다.**

상위 스토리는 MOA-1075다.

검증: `npm run typecheck` 통과 · ESLint 0 errors · `npx jest` 460개 / 55개 스위트 통과


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 클럽 상세 페이지에서 유효한 탭 파라미터가 없을 경우, 피드가 있으면 **사진 탭**을 기본으로 표시합니다.
  * 피드가 없으면 기존처럼 **소개 탭**이 기본으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->