### PR TITLE
[fix] 백경극예술연구회 정보 수정

### DIFF
--- a/frontend/src/constants/clubLocation.ts
+++ b/frontend/src/constants/clubLocation.ts
@@ -34,7 +34,7 @@ export const clubLocations = [
     lat: 35.132367,
     lng: 129.106974,
     building: '한울관(E31)',
-    detailLocation: '301호',
+    detailLocation: '302호',
   },
   {
     clubName: '보블리스',


### PR DESCRIPTION
## #️⃣연관된 이슈

closes #1970

## 📝작업 내용

백경극예술연구회의 동아리방 호실이 실제와 다르게 표시되어 수정했습니다.

- `frontend/src/constants/clubLocation.ts` — `detailLocation`을 `301호` → `302호`로 수정 (1줄)

**변경 이유** — 한울관(E31) 301호로 표시되고 있으나 실제 동아리방은 302호입니다.

**영향 범위** — 학생용 화면 2곳입니다.

- 동아리 상세 페이지 프로필 카드 (`ClubProfileCard.tsx:133`)
- 동아리 상세 페이지 지도 하단 위치 텍스트 (`ClubDetailPage.tsx:211`)

좌표(`lat`/`lng`)와 `building`(한울관 E31)은 같은 건물 내 호실 변경이라 그대로 뒀습니다. 지도 핀 위치는 변하지 않습니다. 관리자 화면·API·백엔드에는 영향이 없습니다(동아리방 위치는 프론트엔드 상수라 서버 저장 값이 없습니다).

**검증 방법** — 백경극예술연구회 상세 페이지에서 프로필 카드와 지도 하단 위치 텍스트가 모두 `한울관(E31) 302호`로 표시되는지 확인.

## 🫡 참고사항

- 동아리방 위치는 현재 프론트엔드 하드코딩 상수이고, 동아리 이름 문자열로 매칭합니다(`ClubDetailPage.tsx:150`). 그래서 값을 고치려면 배포가 필요하고, 동아리 이름이 바뀌면 매칭이 끊겨 지도 섹션이 조용히 사라집니다.
- 백엔드 `Club` 엔티티에 위치 필드를 추가하고 관리자 설정 UI로 빼는 작업, 그리고 이름 매칭을 clubId 매칭으로 바꾸는 작업은 별도 이슈로 진행할 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - ‘백경극예술연구회’ 동아리의 상세 위치를 301호에서 302호로 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->