### PR TITLE
[feature] FCM 전체 발송 배치별 실패 errorCode 집계 로그 추가 (1단계)

### DIFF
--- a/backend/src/main/java/moadong/fcm/adapter/FirebasePushNotificationAdapter.java
+++ b/backend/src/main/java/moadong/fcm/adapter/FirebasePushNotificationAdapter.java
@@ -2,6 +2,8 @@ package moadong.fcm.adapter;
 
 import com.google.firebase.messaging.BatchResponse;
 import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.MessagingErrorCode;
 import com.google.firebase.messaging.MulticastMessage;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
@@ -24,7 +26,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 @Slf4j
 @Component
@@ -32,6 +33,7 @@ import java.util.stream.IntStream;
 public class FirebasePushNotificationAdapter implements PushNotificationPort {
 
     private static final int MULTICAST_LIMIT = 500;
+    private static final String UNKNOWN_ERROR_CODE = "UNKNOWN";
 
     private final FirebaseMessaging firebaseMessaging;
 
@@ -101,6 +103,7 @@ public class FirebasePushNotificationAdapter implements PushNotificationPort {
             return new MulticastPushResult(0, 0, 0, List.of());
         }
 
+        int totalBatches = (tokens.size() + MULTICAST_LIMIT - 1) / MULTICAST_LIMIT;
         int batchCount = 0;
         int successCount = 0;
         int failureCount = 0;
@@ -127,9 +130,11 @@ public class FirebasePushNotificationAdapter implements PushNotificationPort {
                 BatchResponse response = firebaseMessaging.sendEachForMulticast(builder.build());
                 successCount += response.getSuccessCount();
                 failureCount += response.getFailureCount();
-                collectFailedTokens(batchTokens, response.getResponses(), failedTokens);
+                Map<String, Integer> errorCodeCounts = collectFailedTokens(batchTokens, response.getResponses(), failedTokens);
+                log.info("FCM batch {}/{} - success={} failure={} codes={}",
+                        batchCount, totalBatches, response.getSuccessCount(), response.getFailureCount(), errorCodeCounts);
             } catch (Exception e) {
-                log.error("FCM batch send failed - batch: {}, error: {}", batchCount, e.getMessage(), e);
+                log.error("FCM batch {}/{} send failed - error: {}", batchCount, totalBatches, e.getMessage(), e);
                 failureCount += batchTokens.size();
                 failedTokens.addAll(batchTokens);
             }
@@ -143,11 +148,28 @@ public class FirebasePushNotificationAdapter implements PushNotificationPort {
         );
     }
 
-    private void collectFailedTokens(List<String> batchTokens, List<SendResponse> responses, List<String> failedTokens) {
-        IntStream.range(0, responses.size())
-                .filter(index -> !responses.get(index).isSuccessful())
-                .mapToObj(batchTokens::get)
-                .forEach(failedTokens::add);
+    private Map<String, Integer> collectFailedTokens(List<String> batchTokens, List<SendResponse> responses, List<String> failedTokens) {
+        Map<String, Integer> errorCodeCounts = new LinkedHashMap<>();
+        for (int index = 0; index < responses.size(); index++) {
+            SendResponse response = responses.get(index);
+            if (response.isSuccessful()) {
+                continue;
+            }
+            String token = batchTokens.get(index);
+            String errorCode = resolveErrorCode(response.getException());
+            failedTokens.add(token);
+            errorCodeCounts.merge(errorCode, 1, Integer::sum);
+            log.debug("FCM token send failed - token: {}, code: {}", mask(token), errorCode);
+        }
+        return errorCodeCounts;
+    }
+
+    private String resolveErrorCode(FirebaseMessagingException exception) {
+        if (exception == null) {
+            return UNKNOWN_ERROR_CODE;
+        }
+        MessagingErrorCode code = exception.getMessagingErrorCode();
+        return code == null ? UNKNOWN_ERROR_CODE : code.name();
     }
 
     public Map<String, String> sanitizeData(Map<String, String> data) {

--- a/backend/src/test/java/moadong/fcm/adapter/FirebasePushNotificationAdapterTest.java
+++ b/backend/src/test/java/moadong/fcm/adapter/FirebasePushNotificationAdapterTest.java
@@ -1,18 +1,33 @@
 package moadong.fcm.adapter;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.google.firebase.messaging.BatchResponse;
 import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MessagingErrorCode;
+import com.google.firebase.messaging.MulticastMessage;
+import com.google.firebase.messaging.SendResponse;
+import moadong.fcm.model.MulticastPushPayload;
+import moadong.fcm.model.MulticastPushResult;
 import moadong.fcm.model.PushPayload;
 import moadong.fcm.model.TokenPushResult;
 import moadong.util.annotations.UnitTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 
@@ -24,6 +39,24 @@ class FirebasePushNotificationAdapterTest {
 
     @Mock
     private FirebaseMessaging firebaseMessaging;
+
+    private ListAppender<ILoggingEvent> logAppender;
+
+    @BeforeEach
+    void attachLogAppender() {
+        logAppender = new ListAppender<>();
+        logAppender.start();
+        adapterLogger().addAppender(logAppender);
+    }
+
+    @AfterEach
+    void detachLogAppender() {
+        adapterLogger().detachAppender(logAppender);
+    }
+
+    private Logger adapterLogger() {
+        return (Logger) LoggerFactory.getLogger(FirebasePushNotificationAdapter.class);
+    }
 
     @Test
     void send_성공시_true를_반환하고_메시지를_전송한다() throws Exception {
@@ -56,5 +89,80 @@ class FirebasePushNotificationAdapterTest {
         TokenPushResult result = adapter.send(payload);
 
         assertThat(result.success()).isFalse();
+    }
+
+    @Test
+    void sendToTokens_배치마다_실패_errorCode_집계를_로그로_남긴다() throws Exception {
+        String tokenA = "token-aaaaaaaaaaaaaaaaaaaaaa";
+        String tokenB = "token-bbbbbbbbbbbbbbbbbbbbbb";
+        String tokenC = "token-cccccccccccccccccccccc";
+        String tokenD = "token-dddddddddddddddddddddd";
+        MulticastPushPayload payload = new MulticastPushPayload(
+                List.of(tokenA, tokenB, tokenC, tokenD), "제목", "본문", Map.of()
+        );
+
+        List<SendResponse> responses = List.of(
+                successResponse(),
+                failedResponse(MessagingErrorCode.UNREGISTERED),
+                failedResponse(MessagingErrorCode.UNREGISTERED),
+                failedResponse(MessagingErrorCode.UNAVAILABLE)
+        );
+        BatchResponse response = mock(BatchResponse.class);
+        when(response.getSuccessCount()).thenReturn(1);
+        when(response.getFailureCount()).thenReturn(3);
+        when(response.getResponses()).thenReturn(responses);
+        when(firebaseMessaging.sendEachForMulticast(any(MulticastMessage.class))).thenReturn(response);
+
+        MulticastPushResult result = adapter.sendToTokens(payload);
+
+        assertThat(result.successCount()).isEqualTo(1);
+        assertThat(result.failureCount()).isEqualTo(3);
+        assertThat(result.failedTokens()).containsExactly(tokenB, tokenC, tokenD);
+
+        List<String> messages = logAppender.list.stream().map(ILoggingEvent::getFormattedMessage).toList();
+        assertThat(messages).anySatisfy(message -> assertThat(message)
+                .contains("FCM batch 1/1")
+                .contains("success=1")
+                .contains("failure=3")
+                .contains("codes={UNREGISTERED=2, UNAVAILABLE=1}"));
+        assertThat(messages).noneSatisfy(message -> assertThat(message)
+                .containsAnyOf(tokenA, tokenB, tokenC, tokenD));
+    }
+
+    @Test
+    void sendToTokens_errorCode가_없는_실패는_UNKNOWN으로_집계한다() throws Exception {
+        MulticastPushPayload payload = new MulticastPushPayload(
+                List.of("token-aaaaaaaaaaaaaaaaaaaaaa"), "제목", "본문", Map.of()
+        );
+
+        SendResponse noCode = mock(SendResponse.class);
+        when(noCode.isSuccessful()).thenReturn(false);
+        when(noCode.getException()).thenReturn(null);
+
+        BatchResponse response = mock(BatchResponse.class);
+        when(response.getSuccessCount()).thenReturn(0);
+        when(response.getFailureCount()).thenReturn(1);
+        when(response.getResponses()).thenReturn(List.of(noCode));
+        when(firebaseMessaging.sendEachForMulticast(any(MulticastMessage.class))).thenReturn(response);
+
+        adapter.sendToTokens(payload);
+
+        assertThat(logAppender.list.stream().map(ILoggingEvent::getFormattedMessage))
+                .anySatisfy(message -> assertThat(message).contains("codes={UNKNOWN=1}"));
+    }
+
+    private SendResponse successResponse() {
+        SendResponse sendResponse = mock(SendResponse.class);
+        when(sendResponse.isSuccessful()).thenReturn(true);
+        return sendResponse;
+    }
+
+    private SendResponse failedResponse(MessagingErrorCode code) {
+        FirebaseMessagingException exception = mock(FirebaseMessagingException.class);
+        when(exception.getMessagingErrorCode()).thenReturn(code);
+        SendResponse sendResponse = mock(SendResponse.class);
+        when(sendResponse.isSuccessful()).thenReturn(false);
+        when(sendResponse.getException()).thenReturn(exception);
+        return sendResponse;
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> 연관 이슈 없음 (편지함 전체 알림 발송 실패율 31.8% 원인 파악용)

## 📝작업 내용

편지함 전체 알림 발송 결과가 총 2854 / 성공 1946 / 실패 908로 나왔는데, 현재 코드는 실패 토큰만 모으고 `SendResponse.getException().getMessagingErrorCode()`를 버려서 왜 실패했는지 확인할 수 없습니다. 이 PR은 죽은 토큰 정리(2단계)에 앞서 실패 사유 분포를 먼저 확인하기 위한 **1단계 로깅** 변경입니다.

**`FirebasePushNotificationAdapter.sendToTokens()`**
- 배치 응답에서 실패 건마다 `MessagingErrorCode`를 수집해 배치 단위로 집계 로그 1줄을 남깁니다.
  ```
  FCM batch 1/6 - success=480 failure=20 codes={UNREGISTERED=18, UNAVAILABLE=2}
  ```
- 예외가 없거나 코드가 비어 있는 실패는 `UNKNOWN`으로 집계합니다.
- 배치 자체가 예외로 실패한 error 로그에도 `n/N` 표기를 맞췄습니다.
- 토큰 원문은 로그에 남기지 않습니다. 토큰별 코드는 debug 레벨에서만 기존 `mask()`로 가려 남깁니다.
- `MulticastPushResult` 반환값과 실패 토큰 수집 동작은 그대로라 호출부 변경이 없습니다.

**테스트**
- Logback `ListAppender`로 실제 로그 문자열을 검증하는 테스트 2개 추가 (집계 형식, UNKNOWN 처리, 원문 토큰 미노출)

## 중점적으로 리뷰받고 싶은 부분(선택)

- 배치 집계 로그를 `info` 레벨로 둔 것이 적절한지 (전체 발송 시 배치 수만큼, 약 6줄)

## 🫡 참고사항

- 예약 발송(`FcmScheduledNotificationDispatcher`)은 토큰을 500개씩 잘라 `sendToTokens()`를 여러 번 호출하므로, 그 경로에서는 매 호출이 `FCM batch 1/1`로 찍힙니다. 운영 포털의 즉시 전체 발송은 `1/6, 2/6…`처럼 정상 표기됩니다.
- 배포 후 전체 발송 1회 → `FCM batch` 로그에서 errorCode 분포 확인 → `UNREGISTERED`가 대부분이면 2단계(죽은 토큰 삭제) 진행 예정입니다.
- 검증: `./gradlew unitTest` 284개 통과.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 푸시 알림 멀티캐스트 전송 결과에 배치별 성공·실패 수와 전체 배치 진행 정보가 표시됩니다.
  * 실패한 알림을 오류 코드별로 집계하며, 식별할 수 없는 오류는 `UNKNOWN`으로 분류합니다.
  * 로그에 실제 기기 토큰이 노출되지 않도록 검증이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->