### PR TITLE
[feature] 개발자 포털에 보낸 편지 목록 추가

### DIFF
--- a/backend/src/main/java/moadong/feedback/controller/FeedbackAdminController.java
+++ b/backend/src/main/java/moadong/feedback/controller/FeedbackAdminController.java
@@ -9,6 +9,7 @@ import moadong.feedback.payload.request.FeedbackStatusUpdateRequest;
 import moadong.feedback.payload.request.LetterCreateRequest;
 import moadong.feedback.payload.request.LetterDraftRequest;
 import moadong.feedback.payload.response.AdminFeedbackListResponse;
+import moadong.feedback.payload.response.AdminSentLetterListResponse;
 import moadong.feedback.payload.response.FeedbackReplyResponse;
 import moadong.feedback.payload.response.LetterCreateResponse;
 import moadong.feedback.payload.response.LetterDraftListResponse;
@@ -63,6 +64,13 @@ public class FeedbackAdminController {
     ) {
         FeedbackReplyResponse response = feedbackAdminService.reply(feedbackId, request);
         return Response.ok("답장이 발행되었습니다.", response);
+    }
+
+    @GetMapping("/letters")
+    @Operation(summary = "보낸 편지 목록", description = "발행한 답장과 전체 편지를 최신순으로 조회합니다.")
+    public ResponseEntity<?> getSentLetters() {
+        AdminSentLetterListResponse response = feedbackAdminService.getSentLetters();
+        return Response.ok(response);
     }
 
     @PostMapping("/letters")

--- a/backend/src/main/java/moadong/feedback/payload/response/AdminSentLetterListResponse.java
+++ b/backend/src/main/java/moadong/feedback/payload/response/AdminSentLetterListResponse.java
@@ -1,0 +1,8 @@
+package moadong.feedback.payload.response;
+
+import java.util.List;
+
+public record AdminSentLetterListResponse(
+        List<AdminSentLetterResponse> letters
+) {
+}

--- a/backend/src/main/java/moadong/feedback/payload/response/AdminSentLetterResponse.java
+++ b/backend/src/main/java/moadong/feedback/payload/response/AdminSentLetterResponse.java
@@ -1,0 +1,36 @@
+package moadong.feedback.payload.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import moadong.feedback.entity.Letter;
+import moadong.feedback.enums.LetterCategory;
+
+import java.time.Instant;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record AdminSentLetterResponse(
+        String id,
+        LetterCategory category,
+        String title,
+        String body,
+        // REPLY 편지의 받는 사람. 학생 UUID 대신 피드백 목록과 같은 표시용 익명 식별자를 쓴다.
+        // 전체 발행 편지(UPDATE / STORY)는 받는 사람이 없어 null이다.
+        String recipient,
+        // REPLY 편지가 답장한 원본 피드백. 그 외 카테고리는 null이다.
+        String feedbackId,
+        int pushSuccessCount,
+        Instant createdAt
+) {
+
+    public static AdminSentLetterResponse of(Letter letter, String recipient) {
+        return new AdminSentLetterResponse(
+                letter.getId(),
+                letter.getCategory(),
+                letter.getTitle(),
+                letter.getBody(),
+                recipient,
+                letter.getFeedbackId(),
+                letter.getPushSuccessCount(),
+                letter.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/moadong/feedback/repository/LetterRepository.java
+++ b/backend/src/main/java/moadong/feedback/repository/LetterRepository.java
@@ -24,6 +24,11 @@ public interface LetterRepository extends MongoRepository<Letter, String> {
             sort = "{ 'createdAt': -1 }")
     List<Letter> findInboxByStudentIdAndCategory(String studentId, LetterCategory category);
 
+    /**
+     * 개발자 포털의 보낸 편지함 = 답장과 전체 발행 편지를 모두 합친 목록.
+     */
+    List<Letter> findAllByOrderByCreatedAtDesc();
+
     @Query("{ '_id': ?0 }")
     @Update("{ '$addToSet': { 'readStudentIds': ?1 } }")
     long markRead(String letterId, String studentId);

--- a/backend/src/main/java/moadong/feedback/service/FeedbackAdminService.java
+++ b/backend/src/main/java/moadong/feedback/service/FeedbackAdminService.java
@@ -18,6 +18,8 @@ import moadong.feedback.payload.request.FeedbackStatusUpdateRequest;
 import moadong.feedback.payload.request.LetterCreateRequest;
 import moadong.feedback.payload.response.AdminFeedbackListResponse;
 import moadong.feedback.payload.response.AdminFeedbackResponse;
+import moadong.feedback.payload.response.AdminSentLetterListResponse;
+import moadong.feedback.payload.response.AdminSentLetterResponse;
 import moadong.feedback.payload.response.FeedbackReplyResponse;
 import moadong.feedback.payload.response.LetterCreateResponse;
 import moadong.feedback.repository.FeedbackRepository;
@@ -63,6 +65,20 @@ public class FeedbackAdminService {
         return new AdminFeedbackListResponse(
                 feedbacks,
                 feedbackRepository.countByStatusNot(FeedbackStatus.REPLIED));
+    }
+
+    /**
+     * 개발자가 보낸 편지(답장 + 전체 발행)를 최신순으로 돌려준다.
+     * 답장의 받는 사람은 피드백 목록과 같은 익명 식별자로 맞춰, 두 목록에서 같은 학생을 같은 값으로 알아볼 수 있게 한다.
+     */
+    public AdminSentLetterListResponse getSentLetters() {
+        List<AdminSentLetterResponse> letters = letterRepository.findAllByOrderByCreatedAtDesc().stream()
+                .map(letter -> AdminSentLetterResponse.of(
+                        letter,
+                        letter.isBroadcast() ? null : anonymousSender(letter.getRecipientStudentId())))
+                .toList();
+
+        return new AdminSentLetterListResponse(letters);
     }
 
     /**

--- a/backend/src/main/resources/static/dev/index.html
+++ b/backend/src/main/resources/static/dev/index.html
@@ -176,6 +176,13 @@
     .feedback-upload-row { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 12px; }
     .feedback-upload-row button { margin: 0; }
     .feedback-upload-help { color: #666; font-size: 0.8rem; }
+    .feedback-sent-panel { margin-top: 16px; }
+    .sent-letter-title-cell { max-width: 320px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    #sentLetterList th:nth-child(1), #sentLetterList td:nth-child(1),
+    #sentLetterList th:nth-child(3), #sentLetterList td:nth-child(3),
+    #sentLetterList th:nth-child(4), #sentLetterList td:nth-child(4),
+    #sentLetterList th:nth-child(5), #sentLetterList td:nth-child(5) { white-space: nowrap; }
+    .sent-letter-body-row td { background: #f9fafb; white-space: pre-wrap; font-size: 0.9rem; }
     .promotion-upload-row { display: flex; align-items: end; gap: 12px; flex-wrap: wrap; margin-bottom: 12px; }
     .promotion-upload-row .form-row { flex: 1 1 240px; margin-bottom: 0; }
     .promotion-upload-row button { margin: 0; }
@@ -588,6 +595,20 @@
           <div id="feedbackSaveResult" class="message-box hidden"></div>
         </div>
       </div>
+
+      <div class="promotion-panel feedback-sent-panel">
+        <h3>보낸 편지</h3>
+        <p id="sentLetterSummary" class="promotion-summary">보낸 편지 목록을 불러오세요.</p>
+        <div id="sentLetterListLoading" class="hidden">목록 불러오는 중...</div>
+        <div class="table-wrap">
+          <table id="sentLetterList">
+            <thead><tr><th>분류</th><th>제목</th><th>받는 사람</th><th>보낸 날짜</th><th>푸시</th></tr></thead>
+            <tbody>
+              <tr><td colspan="5">보낸 편지 목록을 불러오세요.</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
     </section>
 
     <section id="banner" class="hidden">
@@ -827,6 +848,7 @@
     const PORTAL_SECTION_IDS = ['api-docs', 'club', 'dict', 'promotion', 'feedback', 'banner', 'fcm', 'statistics-backfill', 'conversion-batch'];
     const FEEDBACK_TYPE_LABELS = { BUG: '문제 신고', FEATURE: '기능 요청', QUESTION: '문의', CHEER: '응원' };
     const FEEDBACK_STATUS_LABELS = { WAITING: '답장 대기', IN_PROGRESS: '확인 중', REPLIED: '답장 완료' };
+    const LETTER_CATEGORY_LABELS = { REPLY: '답장', UPDATE: '업데이트', STORY: '이야기' };
     let feedbacks = [];
     let feedbackSelectedId = '';
     let feedbackMode = 'reply';
@@ -838,6 +860,11 @@
     let feedbackIsUploading = false;
     // 발행이 실패해 다시 시도할 때 같은 값을 보내야 편지가 두 번 만들어지지 않는다.
     let feedbackLetterRequestId = '';
+    let sentLetters = [];
+    let sentLettersHaveLoaded = false;
+    let sentLettersAreLoading = false;
+    // 본문을 펼쳐 둔 편지. 한 번에 하나만 펼친다.
+    let sentLetterExpandedId = '';
     let fcmTokens = [];
     let fcmFilteredTokens = [];
     let fcmCurrentPage = 1;
@@ -3308,6 +3335,7 @@
     function loadFeedbackIfVisible() {
       if (feedbackHasLoaded || feedbackIsLoading) return;
       reloadFeedbackList();
+      reloadSentLetters();
     }
 
     function updateFeedbackNavBadge(count) {
@@ -3392,6 +3420,91 @@
 
     function getSelectedFeedback() {
       return feedbacks.find((feedback) => feedback.id === feedbackSelectedId) || null;
+    }
+
+    async function reloadSentLetters() {
+      if (sentLettersAreLoading) return;
+      sentLettersAreLoading = true;
+      document.getElementById('sentLetterListLoading').classList.remove('hidden');
+      try {
+        const res = await fetch(API_BASE + '/api/admin/feedback/letters', { headers: headers() });
+        const data = await readJsonOrEmpty(res);
+        if (!res.ok) {
+          sentLetters = [];
+          showToast(data.message || '보낸 편지 목록 조회 실패 (HTTP ' + res.status + ')', 'error');
+        } else {
+          sentLetters = data.data?.letters || [];
+        }
+        sentLettersHaveLoaded = true;
+      } catch (e) {
+        sentLetters = [];
+        showToast(e.message || '보낸 편지 목록 조회 실패', 'error');
+      } finally {
+        sentLettersAreLoading = false;
+        document.getElementById('sentLetterListLoading').classList.add('hidden');
+        renderSentLetterList();
+      }
+    }
+
+    function renderSentLetterList() {
+      const tbody = document.querySelector('#sentLetterList tbody');
+      const summary = document.getElementById('sentLetterSummary');
+      tbody.innerHTML = '';
+
+      if (!sentLetters.length) {
+        const tr = document.createElement('tr');
+        const td = document.createElement('td');
+        td.colSpan = 5;
+        td.textContent = sentLettersHaveLoaded ? '보낸 편지가 없습니다.' : '보낸 편지 목록을 불러오세요.';
+        tr.appendChild(td);
+        tbody.appendChild(tr);
+        summary.textContent = sentLettersHaveLoaded ? '총 0개 편지' : '보낸 편지 목록을 불러오세요.';
+        return;
+      }
+
+      summary.textContent = '총 ' + sentLetters.length + '개 편지 · 행을 누르면 본문을 볼 수 있습니다.';
+      sentLetters.forEach((letter) => {
+        const isExpanded = letter.id === sentLetterExpandedId;
+        const tr = document.createElement('tr');
+        tr.tabIndex = 0;
+        tr.setAttribute('role', 'button');
+        tr.setAttribute('aria-label', (letter.title || '제목 없음') + ' 편지 본문 ' + (isExpanded ? '접기' : '펼치기'));
+        tr.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
+        tr.classList.toggle('is-selected', isExpanded);
+        tr.appendChild(document.createElement('td')).textContent =
+          LETTER_CATEGORY_LABELS[letter.category] || letter.category || '-';
+        const titleCell = tr.appendChild(document.createElement('td'));
+        titleCell.className = 'sent-letter-title-cell';
+        titleCell.textContent = letter.title || '';
+        titleCell.title = letter.title || '';
+        // 받는 사람이 없는 편지는 전체 사용자에게 발행한 편지다.
+        tr.appendChild(document.createElement('td')).textContent = letter.recipient || '전체';
+        tr.appendChild(document.createElement('td')).textContent = formatFeedbackDate(letter.createdAt);
+        tr.appendChild(document.createElement('td')).textContent =
+          letter.pushSuccessCount ? letter.pushSuccessCount + '건' : '-';
+        const toggleCurrentLetter = () => {
+          sentLetterExpandedId = isExpanded ? '' : letter.id;
+          renderSentLetterList();
+        };
+        tr.onclick = toggleCurrentLetter;
+        tr.onkeydown = (event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            toggleCurrentLetter();
+          }
+        };
+        tbody.appendChild(tr);
+
+        if (isExpanded) {
+          const bodyRow = document.createElement('tr');
+          bodyRow.className = 'sent-letter-body-row';
+          const bodyCell = document.createElement('td');
+          bodyCell.colSpan = 5;
+          bodyCell.textContent = letter.body || '(본문 없음)';
+          bodyRow.appendChild(bodyCell);
+          tbody.appendChild(bodyRow);
+        }
+      });
     }
 
     function generateFeedbackRequestId() {
@@ -3687,6 +3800,7 @@
         feedbackLetterRequestId = '';
         feedbackMode = 'reply';
         await reloadFeedbackList();
+        await reloadSentLetters();
       } catch (e) {
         setMessageBox('feedbackSaveResult', false, e.message || '발행 실패');
       } finally {
@@ -3714,7 +3828,10 @@
       await reloadFeedbackDrafts();
     }
 
-    document.getElementById('btnLoadFeedback').onclick = () => reloadFeedbackList();
+    document.getElementById('btnLoadFeedback').onclick = () => {
+      reloadFeedbackList();
+      reloadSentLetters();
+    };
     document.getElementById('btnNewFeedbackLetter').onclick = () => enterFeedbackLetterMode();
     document.getElementById('btnClearFeedbackSelection').onclick = () => clearFeedbackSelection();
     document.getElementById('btnPublishFeedbackReply').onclick = () => publishFeedbackLetter();

--- a/backend/src/test/java/moadong/feedback/service/FeedbackAdminServiceTest.java
+++ b/backend/src/test/java/moadong/feedback/service/FeedbackAdminServiceTest.java
@@ -15,6 +15,7 @@ import moadong.feedback.payload.request.FeedbackReplyRequest;
 import moadong.feedback.payload.request.FeedbackStatusUpdateRequest;
 import moadong.feedback.payload.request.LetterCreateRequest;
 import moadong.feedback.payload.response.AdminFeedbackListResponse;
+import moadong.feedback.payload.response.AdminSentLetterListResponse;
 import moadong.feedback.payload.response.FeedbackReplyResponse;
 import moadong.feedback.payload.response.LetterCreateResponse;
 import moadong.feedback.repository.FeedbackRepository;
@@ -117,6 +118,21 @@ class FeedbackAdminServiceTest {
         assertEquals("user_11111111", response.feedbacks().get(0).sender());
         assertNotEquals(response.feedbacks().get(0).sender(), response.feedbacks().get(1).sender());
         assertEquals(2L, response.unansweredCount());
+    }
+
+    @Test
+    void 보낸_편지_목록은_답장의_받는_사람만_익명_식별자로_표시한다() {
+        when(letterRepository.findAllByOrderByCreatedAtDesc()).thenReturn(List.of(
+                Letter.reply(STUDENT_ID, "feedback-1", "답장 제목", "답장 본문"),
+                Letter.broadcast(LetterCategory.UPDATE, "공지 제목", "공지 본문", "request-1")));
+
+        AdminSentLetterListResponse response = feedbackAdminService.getSentLetters();
+
+        assertEquals(2, response.letters().size());
+        assertEquals("user_11111111", response.letters().get(0).recipient());
+        assertEquals("feedback-1", response.letters().get(0).feedbackId());
+        assertEquals("답장 본문", response.letters().get(0).body());
+        assertNull(response.letters().get(1).recipient());
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

개발자 포털에서는 **받은 피드백**만 볼 수 있어, 지금까지 어떤 편지를 발행했는지 확인할 방법이 없었습니다. 개발자가 보낸 편지(답장 + 전체 발행)를 한 목록으로 볼 수 있게 했습니다.

**백엔드**
- `GET /api/admin/feedback/letters` — 발행한 편지를 최신순으로 조회 (`FeedbackAdminController`). 기존 `/letters/drafts` 와 경로가 겹치지 않습니다.
- `FeedbackAdminService.getSentLetters()` — REPLY / UPDATE / STORY 를 모두 포함합니다. 답장의 받는 사람은 피드백 목록과 **같은 익명 식별자**(`user_11111111`)를 써서, 두 목록에서 같은 학생을 같은 값으로 알아볼 수 있게 했습니다. 전체 발행 편지는 `recipient` 가 null 입니다.
- `AdminSentLetterResponse` / `AdminSentLetterListResponse` 추가 — id, 분류, 제목, 본문, 받는 사람, 원본 feedbackId, 푸시 성공 건수, 발행일.
- `LetterRepository.findAllByOrderByCreatedAtDesc()` 추가.

**개발자 포털 (`static/dev/index.html`)**
- "받은 피드백" 섹션 아래 `보낸 편지` 표 추가 (분류 / 제목 / 받는 사람 / 보낸 날짜 / 푸시). 받는 사람이 없는 편지는 `전체` 로 표시합니다.
- 행 클릭(또는 Enter/Space)하면 그 아래로 본문이 펼쳐집니다. 한 번에 하나만 펼쳐집니다.
- 섹션 진입, `목록 새로고침`, 답장·편지 발행 직후에 피드백 목록과 함께 갱신됩니다.
- 조회 실패는 상단 배너 대신 토스트로 알립니다. 배너는 피드백 목록이 성공하면 지우기 때문에 메시지가 덮입니다.

## 중점적으로 리뷰받고 싶은 부분(선택)

- **목록에 본문을 함께 실었습니다.** 상세 엔드포인트를 따로 두지 않은 이유는 편지가 개발자가 직접 쓴 것이라 건수가 적어서입니다. 편지 수가 늘어날 여지가 있다면 분리하는 편이 나을지 의견 부탁드립니다.
- `findAllByOrderByCreatedAtDesc()` 는 `Letter` 에 `createdAt` 단독 인덱스가 없어 전체 정렬입니다. `Feedback` 의 `created_at_idx` 처럼 인덱스를 추가할지 판단이 필요합니다.

## 논의하고 싶은 부분(선택)

- 지금은 답장과 전체 발행 편지를 한 표에 섞어 보여줍니다. 분류 필터가 필요할지 궁금합니다.

