### PR TITLE
[fix] 사용자 캘린더 기간 일정 색 띠를 보고 있는 달까지만 그리도록 수정

### DIFF
--- a/frontend/src/pages/ClubDetailPage/components/ClubScheduleCalendar/ClubScheduleCalendar.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubScheduleCalendar/ClubScheduleCalendar.tsx
@@ -262,7 +262,11 @@ const ClubScheduleCalendar = ({
 
         <Styled.WeekList>
           {weeks.map((weekDays) => {
-            const bands = buildWeekEventSegments(periodEvents, weekDays);
+            const bands = buildWeekEventSegments(
+              periodEvents,
+              weekDays,
+              visibleMonth,
+            );
 
             return (
               <Styled.Week key={buildDateKeyFromDate(weekDays[0])}>

--- a/frontend/src/utils/calendarWeekSegments.test.ts
+++ b/frontend/src/utils/calendarWeekSegments.test.ts
@@ -161,4 +161,57 @@ describe('buildWeekEventSegments', () => {
       '2026-03-21',
     ]);
   });
+
+  describe('visibleMonth를 주면 그 달 밖으로 색이 새지 않는다', () => {
+    /** 2026-08-30(일) ~ 2026-09-05(토): 8월 그리드의 마지막 주이자 9월 그리드의 첫 주 */
+    const crossMonthWeek = Array.from(
+      { length: 7 },
+      (_, index) => new Date(2026, 7, 30 + index),
+    );
+
+    const crossMonthEvent = event({
+      id: 'festival',
+      title: '축제',
+      eventType: 'PERIOD',
+      start: '2026-08-25',
+      end: '2026-09-10',
+    });
+
+    it('8월을 보고 있으면 8월 31일에서 끊는다', () => {
+      const segments = buildWeekEventSegments(
+        [crossMonthEvent],
+        crossMonthWeek,
+        new Date(2026, 7, 1),
+      );
+
+      expect(segments[0]).toMatchObject({
+        startIndex: 0,
+        span: 2, // 8/30, 8/31
+        dateKey: '2026-08-30',
+      });
+    });
+
+    it('9월을 보고 있으면 9월 1일부터 시작한다', () => {
+      const segments = buildWeekEventSegments(
+        [crossMonthEvent],
+        crossMonthWeek,
+        new Date(2026, 8, 1),
+      );
+
+      expect(segments[0]).toMatchObject({
+        startIndex: 2, // 9/1
+        span: 5, // 9/1 ~ 9/5
+        dateKey: '2026-09-01',
+      });
+    });
+
+    it('visibleMonth가 없으면 주 전체를 그대로 덮는다', () => {
+      const segments = buildWeekEventSegments(
+        [crossMonthEvent],
+        crossMonthWeek,
+      );
+
+      expect(segments[0]).toMatchObject({ startIndex: 0, span: 7 });
+    });
+  });
 });

--- a/frontend/src/utils/calendarWeekSegments.ts
+++ b/frontend/src/utils/calendarWeekSegments.ts
@@ -91,7 +91,9 @@ export const buildWeekEventSegments = (
     : null;
 
   const rangeStartKey =
-    monthStartKey && monthStartKey > weekStartKey ? monthStartKey : weekStartKey;
+    monthStartKey && monthStartKey > weekStartKey
+      ? monthStartKey
+      : weekStartKey;
   const rangeEndKey =
     monthEndKey && monthEndKey < weekEndKey ? monthEndKey : weekEndKey;
 

--- a/frontend/src/utils/calendarWeekSegments.ts
+++ b/frontend/src/utils/calendarWeekSegments.ts
@@ -66,12 +66,35 @@ const assignLanes = (
 export const buildWeekEventSegments = (
   events: ClubCalendarEvent[],
   weekDays: Date[],
+  /**
+   * 주면 이 달에 속한 날짜까지만 막대를 그린다.
+   * 월 그리드의 첫/마지막 주에는 앞뒤 달 날짜가 섞여 있는데,
+   * 그 칸까지 색이 새지 않도록 자르는 용도.
+   */
+  visibleMonth?: Date,
 ): WeekEventSegment[] => {
   if (weekDays.length === 0) return [];
 
   const weekKeys = weekDays.map(buildDateKeyFromDate);
   const weekStartKey = weekKeys[0];
   const weekEndKey = weekKeys[weekKeys.length - 1];
+
+  const monthStartKey = visibleMonth
+    ? buildDateKeyFromDate(
+        new Date(visibleMonth.getFullYear(), visibleMonth.getMonth(), 1),
+      )
+    : null;
+  const monthEndKey = visibleMonth
+    ? buildDateKeyFromDate(
+        new Date(visibleMonth.getFullYear(), visibleMonth.getMonth() + 1, 0),
+      )
+    : null;
+
+  const rangeStartKey =
+    monthStartKey && monthStartKey > weekStartKey ? monthStartKey : weekStartKey;
+  const rangeEndKey =
+    monthEndKey && monthEndKey < weekEndKey ? monthEndKey : weekEndKey;
+
   const segments: Omit<WeekEventSegment, 'lane'>[] = [];
 
   events.forEach((event) => {
@@ -80,9 +103,9 @@ export const buildWeekEventSegments = (
       const endKey = event.end ? parseDateKey(event.end) : startKey;
       if (!startKey || !endKey) return;
 
-      // 이벤트 기간과 이번 주의 교집합
-      const from = startKey > weekStartKey ? startKey : weekStartKey;
-      const to = endKey < weekEndKey ? endKey : weekEndKey;
+      // 이벤트 기간과 이번 주 표시 범위의 교집합
+      const from = startKey > rangeStartKey ? startKey : rangeStartKey;
+      const to = endKey < rangeEndKey ? endKey : rangeEndKey;
       if (from > to) return;
 
       const startIndex = weekKeys.indexOf(from);
@@ -107,6 +130,8 @@ export const buildWeekEventSegments = (
       weekDays[0],
       weekDays[weekDays.length - 1],
     ).forEach((occurrence) => {
+      if (occurrence.dateKey < rangeStartKey) return;
+      if (occurrence.dateKey > rangeEndKey) return;
       const startIndex = weekKeys.indexOf(occurrence.dateKey);
       if (startIndex === -1) return;
       segments.push({


### PR DESCRIPTION
Closes #1981

## 변경 내용

`buildWeekEventSegments`에 선택 인자 `visibleMonth`를 추가하고, 주어지면 막대를 **그 달의 1일~말일 범위로 잘라서** 그린다. 사용자 캘린더(`ClubScheduleCalendar`)에서만 이 인자를 넘긴다.

- `frontend/src/utils/calendarWeekSegments.ts` — `visibleMonth`로 `rangeStartKey`/`rangeEndKey`를 만들고, 기존의 "주 경계 교집합" 계산을 이 범위 기준으로 변경
- `frontend/src/pages/ClubDetailPage/components/ClubScheduleCalendar/ClubScheduleCalendar.tsx` — `visibleMonth` 전달

## 변경 이유

월 그리드의 첫 주·마지막 주에는 앞뒤 달 날짜가 섞여 있다. (예: 8월 뷰의 마지막 주 = 8/30 ~ 9/5)

기존에는 기간(`PERIOD`) 일정의 띠를 **주 경계**로만 잘라서, 8월을 보고 있는데도 9/1~9/5 칸까지 색이 칠해졌다. 그 칸의 날짜 숫자는 `opacity: 0`으로 숨겨져 있어서, 빈칸 아래에 색 띠만 떠 있는 모양이 됐다.

## 화면 (학생용 — 동아리 상세 > 행사일정 탭)

8/25 ~ 9/10 기간 일정 기준:

| | 변경 전 | 변경 후 |
|---|---|---|
| 8월 뷰 마지막 행 (8/30~9/5) | 8/30 ~ 9/5 전부 색칠 | **8/30 ~ 8/31 까지만** |
| 9월 뷰 첫 행 (8/30~9/5) | 8/30 ~ 9/5 전부 색칠 | **9/1 부터** |

> 앞쪽(이전 달)도 같이 자릅니다. 9월 뷰의 첫 행이 8/30, 8/31 + 9/1~9/5 이라 같은 증상이 반대 방향으로 생기기 때문입니다.

