### PR TITLE
[feature] MOA-1082 A/B 실험 노출 이벤트($experiment_started) 발송 추가

### DIFF
--- a/frontend/src/constants/eventName.ts
+++ b/frontend/src/constants/eventName.ts
@@ -60,6 +60,9 @@ export const USER_EVENT = {
   APPLICATION_FORM_SUBMITTED: 'Application Form Submitted',
   FAQ_TOGGLE_CLICKED: 'FAQ Toggle Clicked',
 
+  // A/B 실험 노출 (Mixpanel 예약 이벤트)
+  EXPERIMENT_STARTED: '$experiment_started',
+
   // 필터칩
   FILTER_OPTION_CLICKED: 'Filter Option Clicked',
 

--- a/frontend/src/experiments/CLAUDE.md
+++ b/frontend/src/experiments/CLAUDE.md
@@ -12,6 +12,33 @@ const variant = useExperimentVariant(mainBannerExperiment);
 // variant는 'A' 또는 'B'
 ```
 
+## 노출 이벤트는 배정 시점이 아니라 렌더 시점에 보낸다
+
+`trackExperimentExposure(experiment)`가 Mixpanel `$experiment_started`를 보낸다.
+실험당 페이지 로드 1회로 막혀 있다.
+
+**부팅 때 한꺼번에 보내면 안 된다.**
+
+배정은 사이트에 들어온 **모든 사람**에게 일어난다. 하지만 실험으로 화면이
+갈리는 건 그중 일부다. 예를 들어 개편이 모바일에만 적용되면 데스크톱
+사용자는 control이든 treatment든 **똑같은 화면**을 본다.
+
+부팅할 때 노출 이벤트를 다 보내면 이 사람들도 실험 참가자로 집계된다. 같은
+화면을 보니 두 그룹에 절반씩 똑같이 섞이고, 결과적으로 진짜 차이를 묽게
+만든다. 실제로 5%p 차이가 났어도 참가자의 절반이 화면 차이를 못 본
+사람이면 측정값은 2.5%p로 줄어든다.
+
+그래서 **그 화면이 실제로 그려질 때만** 보낸다.
+
+```typescript
+useEffect(() => {
+  if (isNarrow) trackExperimentExposure(someExperiment);
+}, [isNarrow]);
+```
+
+super property 등록(부팅 시)과 노출 이벤트(렌더 시)는 목적이 다르다. 전자는
+"이 방문의 배정이 무엇인가", 후자는 "누구를 분석 모집단에 넣을 것인가"다.
+
 ## 오염 계측
 
 배정이 뒤집힌 방문을 분석에서 걸러내기 위해 `fetchAndAssignExperiments`가

--- a/frontend/src/experiments/experimentAssignments.ts
+++ b/frontend/src/experiments/experimentAssignments.ts
@@ -1,4 +1,5 @@
 import mixpanel from 'mixpanel-browser';
+import { USER_EVENT } from '@/constants/eventName';
 import type {
   ExperimentAssignments,
   ExperimentDefinition,
@@ -124,7 +125,27 @@ export const getVariant = <V extends ExperimentVariant>(
   return experiment.defaultVariant;
 };
 
+const exposedKeys = new Set<string>();
+
+/**
+ * Mixpanel 실험 분석용 노출 이벤트. 배정 시점이 아니라 변형이 실제로 화면에
+ * 그려지는 시점에 호출해야 한다. 부팅 때 일괄로 보내면 그 화면을 보지 않는
+ * 사용자까지 분석 모집단에 들어와 효과가 희석된다.
+ */
+export const trackExperimentExposure = <V extends ExperimentVariant>(
+  experiment: ExperimentDefinition<V>,
+) => {
+  if (exposedKeys.has(experiment.key)) return;
+  exposedKeys.add(experiment.key);
+
+  mixpanel.track(USER_EVENT.EXPERIMENT_STARTED, {
+    'Experiment name': experiment.key,
+    'Variant name': getVariant(experiment),
+  });
+};
+
 export const resetAssignments = () => {
   assignments = {};
+  exposedKeys.clear();
   localStorage.removeItem(ASSIGNMENT_STORAGE_KEY);
 };


### PR DESCRIPTION
Closes #1983

## 왜

[Mixpanel 실험 배정 방식 결정](https://app.notion.com/p/3cdaad23209681299418e082b0fe5424)에서 "기존 localStorage 배정을 유지하고 Mixpanel에는 `$experiment_started` 노출 이벤트만 보낸다"고 정했는데, 코드에는 super property 등록만 있고 노출 이벤트 발송이 없었습니다. 그대로 두면 Mixpanel Experiments의 통계 파이프라인(SRM·순차검정·다중비교보정)을 못 쓰고 유의성 판정을 눈으로 하게 됩니다.

## 무엇

- `trackExperimentExposure(experiment)` 추가 — 실험당 페이지 로드 1회로 중복 차단
- `USER_EVENT.EXPERIMENT_STARTED` 상수 추가 (이벤트명 하드코딩 금지 룰)
- `experiments/CLAUDE.md`에 사용 규약 기록

## 왜 부팅 때가 아니라 화면 그려질 때 보내나

**실험 배정은 사이트에 들어온 모든 사람에게 일어납니다.** 하지만 실험으로 화면이 갈리는 건 그중 일부입니다. 예를 들어 개편이 모바일에만 적용되면, 데스크톱 사용자는 control이든 treatment든 **똑같은 화면**을 봅니다.

부팅할 때 노출 이벤트를 다 보내버리면 이 사람들도 실험 참가자로 집계됩니다. 같은 화면을 보니 두 그룹에 절반씩 똑같이 섞이고, 결과적으로 **진짜 차이를 구분할 수 없게 만듭니다.** 실제로 5%p 차이가 났어도 참가자의 절반이 화면 차이를 못 본 사람이면 측정값은 2.5%p로 줄어듭니다.

그래서 **그 화면이 실제로 그려질 때만** 보냅니다.

```ts
useEffect(() => {
  if (isNarrow) trackExperimentExposure(someExperiment);
}, [isNarrow]);
```

부팅 때 하는 super property 등록과는 목적이 다릅니다. 등록은 "이 방문의 배정이 무엇인가"를 남기는 것이고, 노출 이벤트는 "누구를 분석 대상에 넣을 것인가"를 정하는 것입니다.

## 영향 범위

`ALL_EXPERIMENTS`가 비어 있어서 `trackExperimentExposure`를 호출하는 곳이 아직 없습니다. 실제 사용은 후속 PR(#1986)에서 들어갑니다.

