### PR TITLE
[fix] checkVisibility 미지원 환경에서 숨겨진 포커스 요소 제외

### DIFF
--- a/frontend/src/hooks/useFocusTrap.test.tsx
+++ b/frontend/src/hooks/useFocusTrap.test.tsx
@@ -21,6 +21,21 @@ const Overlay = ({ isOpen, name }: { isOpen: boolean; name: string }) => {
 const pressTab = (shiftKey = false) =>
   fireEvent.keyDown(document, { key: 'Tab', shiftKey });
 
+const Edges = () => {
+  const ref = useRef<HTMLDivElement>(null);
+  useFocusTrap(true, ref);
+  return (
+    <div ref={ref} tabIndex={-1}>
+      <button style={{ display: 'none' }}>숨긴 첫</button>
+      <button style={{ visibility: 'hidden' }}>가려진 첫</button>
+      <button>첫</button>
+      <button>끝</button>
+      <button style={{ visibility: 'hidden' }}>가려진 끝</button>
+      <button style={{ display: 'none' }}>숨긴 끝</button>
+    </div>
+  );
+};
+
 describe('useFocusTrap', () => {
   it('열리면 컨테이너로 포커스가 들어간다', () => {
     render(<Overlay isOpen name='모달' />);
@@ -176,21 +191,6 @@ describe('useFocusTrap 숨겨진 요소', () => {
     delete proto.checkVisibility;
   });
 
-  const Edges = () => {
-    const ref = useRef<HTMLDivElement>(null);
-    useFocusTrap(true, ref);
-    return (
-      <div ref={ref} tabIndex={-1}>
-        <button style={{ display: 'none' }}>숨긴 첫</button>
-        <button style={{ visibility: 'hidden' }}>가려진 첫</button>
-        <button>첫</button>
-        <button>끝</button>
-        <button style={{ visibility: 'hidden' }}>가려진 끝</button>
-        <button style={{ display: 'none' }}>숨긴 끝</button>
-      </div>
-    );
-  };
-
   it('끝자리가 숨겨져 있으면 보이는 마지막 요소에서 첫 요소로 돌아온다', () => {
     render(<Edges />);
     screen.getByRole('button', { name: '끝' }).focus();
@@ -205,5 +205,48 @@ describe('useFocusTrap 숨겨진 요소', () => {
 
     expect(pressTab(true)).toBe(false);
     expect(screen.getByRole('button', { name: '끝' })).toHaveFocus();
+  });
+});
+
+/**
+ * jsdom엔 checkVisibility가 없어서 스텁을 붙이지 않으면 그대로 폴백 경로를 탄다.
+ * 위 describe와 같은 기대값이어야 미지원 환경에서도 트랩이 유지된다는 뜻이다.
+ */
+describe('useFocusTrap checkVisibility 미지원 환경', () => {
+  it('끝자리가 숨겨져 있으면 보이는 마지막 요소에서 첫 요소로 돌아온다', () => {
+    render(<Edges />);
+    screen.getByRole('button', { name: '끝' }).focus();
+
+    expect(pressTab()).toBe(false);
+    expect(screen.getByRole('button', { name: '첫' })).toHaveFocus();
+  });
+
+  it('첫자리가 숨겨져 있으면 보이는 첫 요소에서 마지막 요소로 간다', () => {
+    render(<Edges />);
+    screen.getByRole('button', { name: '첫' }).focus();
+
+    expect(pressTab(true)).toBe(false);
+    expect(screen.getByRole('button', { name: '끝' })).toHaveFocus();
+  });
+
+  it('숨긴 조상 안에 있으면 끝자리에서 제외한다', () => {
+    const Buried = () => {
+      const ref = useRef<HTMLDivElement>(null);
+      useFocusTrap(true, ref);
+      return (
+        <div ref={ref} tabIndex={-1}>
+          <button>첫</button>
+          <button>끝</button>
+          <div style={{ display: 'none' }}>
+            <button>파묻힌 끝</button>
+          </div>
+        </div>
+      );
+    };
+    render(<Buried />);
+    screen.getByRole('button', { name: '끝' }).focus();
+
+    expect(pressTab()).toBe(false);
+    expect(screen.getByRole('button', { name: '첫' })).toHaveFocus();
   });
 });

--- a/frontend/src/hooks/useFocusTrap.ts
+++ b/frontend/src/hooks/useFocusTrap.ts
@@ -23,12 +23,30 @@ const FOCUSABLE_SELECTOR = [
 const stack: HTMLElement[] = [];
 
 /**
+ * display는 상속되지 않아 조상까지 거슬러 올라가야 하고, visibility는 상속되지만
+ * 자식이 visible로 되돌릴 수 있어서 요소 자신의 계산값만 본다.
+ */
+const isHiddenByStyle = (element: HTMLElement) => {
+  if (getComputedStyle(element).visibility !== 'visible') return true;
+
+  let node: HTMLElement | null = element;
+  while (node) {
+    if (getComputedStyle(node).display === 'none') return true;
+    node = node.parentElement;
+  }
+
+  return false;
+};
+
+/**
  * display:none·visibility:hidden 요소는 셀렉터엔 걸리지만 포커스를 못 받는다.
  * 그런 요소가 끝자리에 오면 focus()가 조용히 무시돼 Tab이 먹통이 된다.
- * checkVisibility가 없는 환경(구형 Safari, jsdom)은 걸러내지 않고 그대로 둔다.
+ * checkVisibility가 없는 환경(Safari 17.3 이하)은 계산된 스타일로 대신 본다.
  */
 const isVisible = (element: HTMLElement) =>
-  element.checkVisibility?.({ visibilityProperty: true }) ?? true;
+  element.checkVisibility
+    ? element.checkVisibility({ visibilityProperty: true })
+    : !isHiddenByStyle(element);
 
 const getFocusable = (container: HTMLElement) =>
   Array.from(


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용


#1991에서 `useFocusTrap`이 `checkVisibility({ visibilityProperty: true })`로 숨겨진 요소를 탭 순환에서 빼도록 고쳤는데, 미지원 환경 폴백이 `?? true`라 API가 없으면 **모든 후보를 보이는 요소로 처리**했다. 즉 Safari 17.3 이하에서는 수정 전과 똑같이 숨겨진 요소가 끝자리를 차지하고, 보이는 마지막 요소에서 Tab을 눌러도 가로채지 못해 포커스가 오버레이 밖으로 샌다.

`checkVisibility`가 있으면 그대로 쓰고, 없을 때만 계산된 스타일로 대신 판단하게 했다.

- `display: none`은 상속되지 않으므로 조상까지 거슬러 올라가며 확인한다.
- `visibility`는 상속되지만 자식이 `visible`로 되돌릴 수 있으므로 요소 자신의 계산값만 본다.

`getClientRects().length`나 `offsetParent`는 jsdom에서 항상 비어 있어 기존 오버레이 테스트를 전부 깨뜨리므로 쓰지 않았다.

## 중점적으로 리뷰받고 싶은 부분


## 🫡 참고사항

**영향 범위**

- 학생용·관리자용 공통. 오버레이(`Modal`·`BottomSheet`)의 Tab 포커스 순환에만 영향을 준다.
- `checkVisibility`를 지원하는 브라우저(Chrome 105+, Firefox 106+, Safari 17.4+)에서는 기존 경로를 그대로 타므로 동작이 바뀌지 않는다. 새 코드는 미지원 환경에서만 실행되고, 그것도 Tab keydown 시점에만 돈다.
- MOA-1085에서 확인한 대로 웹 UA iOS 사용자 1,116명 중 17.4 미만은 3명(0.3%)이지만, 앱 WebView 사용자 1,066명은 RN이 UA를 덮어써 버전을 알 수 없다. 폴백이 실제로 동작해야 하는 이유다.
