### PR TITLE
[refactor] 메인 팝업 이미지의 scale(1.1) 크롭 제거

### DIFF
--- a/frontend/src/pages/MainPage/components/Popup/Popup.styles.ts
+++ b/frontend/src/pages/MainPage/components/Popup/Popup.styles.ts
@@ -49,8 +49,6 @@ export const PopupImage = styled.img`
   width: 100%;
   height: auto;
   display: block;
-  transform: scale(1.1);
-  transform-origin: center;
 `;
 
 export const ButtonGroup = styled.div`


### PR DESCRIPTION
Close #1997

## 무엇을

`Popup.styles.ts`의 `PopupImage`에서 `transform: scale(1.1)` / `transform-origin: center` 2줄을 제거한다.

## 왜

이 스타일은 2026-05-11 `200a4ea9b`에서 **대동제 팝업 이미지 한 장의 흰 여백을 잘라내려고** 넣은 임시 보정이다. 커밋 메시지에도 "대동제 종료 후 제거 예정"으로 적혀 있다.

사흘 뒤 `b7eb1fd8b`가 대동제 팝업을 제거하면서 `popupConfigs.ts` / `MainPage.tsx` / `WebviewMainPage.tsx`는 되돌렸지만, `Popup.styles.ts`는 그 커밋에 포함되지 않아 크롭만 남았다.

그 결과 **앱 다운로드 팝업이 사방 4.5%씩 잘린 채 넉 달째 노출되고 있다.**

- "지금 바로 다운로드" CTA 알약 버튼의 왼쪽이 잘림
- 폰 목업 하단이 잘림

`scale`이 대체한 원래 값은 `object-fit: cover`인데 `width: 100%; height: auto`인 `img`에는 효과가 없다. 즉 이 팝업은 **원래 크롭이 전혀 없었고**, `scale(1.1)`이 처음으로 크롭을 만들었다. 제거하면 2026-03-02에 확정된 이미지의 원래 렌더로 돌아간다.

## 확인

로컬에서 모바일 폭(390px)으로 before/after 비교했다. 제거 후 CTA 버튼과 폰 목업이 온전히 노출된다.

`ImageWrapper`의 `overflow: hidden`은 해당 커밋 이전부터 있던 것이라 유지했다. `PopupImage`는 `Popup.tsx` 한 곳에서만 쓰여 영향 범위가 팝업 밖으로 나가지 않는다.


## 참고

- 이 PR이 머지된 뒤 #1998 (앱 전용 우체통 팝업)이 이어진다. 크롭이 남아 있으면 우체통 팝업의 CTA 버튼 아래 여백이 5px만 남아 하단 버튼 그룹과 붙어 보인다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 팝업 이미지의 1.1배 확대 효과가 제거되어 원본 크기로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->