### PR TITLE
[fix] MOA-1090 500px 셸 적용 누락 수정

### DIFF
--- a/frontend/src/pages/AdminPage/tabs/StatisticsTab/StatisticsTab.styles.ts
+++ b/frontend/src/pages/AdminPage/tabs/StatisticsTab/StatisticsTab.styles.ts
@@ -24,7 +24,12 @@ export const Container = styled.div`
 `;
 
 export const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 60px;
+
   ${media.tablet} {
+    gap: 32px;
     padding: 16px 20px 20px;
   }
 `;

--- a/frontend/src/pages/FeedbackPage/FeedbackListPage.styles.ts
+++ b/frontend/src/pages/FeedbackPage/FeedbackListPage.styles.ts
@@ -85,7 +85,8 @@ export const EmptyText = styled.p`
 
 export const WriteButton = styled.button`
   position: fixed;
-  right: 20px;
+  /* 500px 셸이 중앙 카드가 되는 구간에서는 카드 오른쪽 20px에 붙인다 */
+  right: max(20px, calc(50% - 230px));
   /* 시안은 24지만 홈 인디케이터에 가리지 않도록 안전 영역을 더한다 */
   bottom: calc(24px + env(safe-area-inset-bottom));
   display: flex;

--- a/frontend/src/pages/FeedbackPage/FeedbackWritePage.styles.ts
+++ b/frontend/src/pages/FeedbackPage/FeedbackWritePage.styles.ts
@@ -146,9 +146,11 @@ export const HiddenFileInput = styled.input`
 
 export const BottomArea = styled.div`
   position: fixed;
-  left: 0;
+  left: 50%;
   bottom: 0;
+  transform: translateX(-50%);
   width: 100%;
+  max-width: 500px;
   padding: 10px 20px calc(20px + env(safe-area-inset-bottom));
   /* FixedBottomButtonArea와 같게 버튼 바깥은 비운다. filter는 자식까지 먹어서 같이 지운다 */
   background: transparent;


### PR DESCRIPTION
Close #2001

## #️⃣연관된 이슈

#2001

## 📝작업 내용

#1976(MOA-1078)에서 500px 중앙 셸을 적용하면서 누락된 두 가지를 수정했습니다. 릴리즈 PR #1987의 CodeRabbit 리뷰에서 발견된 건입니다.

**StatisticsTab 섹션 간격 복원**
- `Container`의 `gap: 60px`(태블릿 `32px`)가 새 `Content`로 옮겨지지 않고 삭제되어 기간 선택·일자별 추이·주요 검색어 섹션이 간격 없이 붙어 있었습니다. 데스크톱 포함 전 뷰포트 영향.
- `Content`에 column 레이아웃과 기존 gap 값을 그대로 복원했습니다.

**FeedbackPage 고정 컨트롤을 500px 셸에 정렬**
- 목록의 글쓰기 FAB(`right: 20px`)와 작성 페이지 `BottomArea`(`left: 0; width: 100%`)가 뷰포트 기준이라 500px 초과 화면에서 카드 밖에 표시됐습니다.
- `WriteButton`: `right: max(20px, calc(50% - 230px))`로 500px 이하에서는 기존 20px, 그보다 넓으면 카드 오른쪽 20px 안쪽.
- `BottomArea`: `FixedBottomButtonArea`와 동일한 `left: 50%; transform: translateX(-50%); max-width: 500px` 패턴 적용.

## 중점적으로 리뷰받고 싶은 부분(선택)

- `WriteButton`의 `right: max(20px, calc(50% - 230px))` 한 줄로 두 구간을 처리했는데, 미디어 쿼리 분기가 더 읽기 좋다면 바꾸겠습니다.

## 논의하고 싶은 부분(선택)

없음

## 🫡 참고사항

- eslint / tsc / jest(FeedbackPage·StatisticsTab) 통과
- 두 페이지 모두 스토리가 없어 시각 확인은 못 했고 좌표 계산으로 검산했습니다 (700px 뷰포트: 카드 100~600px, FAB `right` 120px → 580px)
- Jira: MOA-1090 (상위 MOA-1067)