### PR TITLE
[feature] 홍보게시판 CRUD를 동아리 관리자에게 개방

### DIFF
--- a/backend/src/main/java/moadong/club/controller/PromotionArticleController.java
+++ b/backend/src/main/java/moadong/club/controller/PromotionArticleController.java
@@ -10,6 +10,8 @@ import moadong.club.payload.request.PromotionArticleUpdateRequest;
 import moadong.club.payload.response.PromotionArticleResponse;
 import moadong.club.service.PromotionArticleService;
 import moadong.global.payload.Response;
+import moadong.user.annotation.CurrentUser;
+import moadong.user.payload.CustomUserDetails;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
@@ -38,32 +40,35 @@ public class PromotionArticleController {
     }
 
     @PostMapping
-    @Operation(summary = "홍보 게시글 생성", description = "새로운 홍보 게시글을 생성합니다.")
-    @PreAuthorize("hasRole('DEVELOPER')")
+    @Operation(summary = "홍보 게시글 생성", description = "새로운 홍보 게시글을 생성합니다. 동아리 관리자는 요청의 clubId와 무관하게 본인 동아리로 생성됩니다.")
+    @PreAuthorize("hasAnyRole('DEVELOPER', 'CLUB_ADMIN')")
     @SecurityRequirement(name = "BearerAuth")
     public ResponseEntity<?> createPromotionArticle(
+        @CurrentUser CustomUserDetails user,
         @RequestBody @Validated PromotionArticleCreateRequest request) {
-        PromotionArticleCreateResultDto response = promotionArticleService.createPromotionArticle(request);
+        PromotionArticleCreateResultDto response = promotionArticleService.createPromotionArticle(request, user);
         return Response.ok("홍보 게시글이 생성되었습니다.", response);
     }
 
     @PutMapping("/{articleId}")
-    @Operation(summary = "홍보 게시글 수정", description = "기존 홍보 게시글을 수정합니다.")
-    @PreAuthorize("hasRole('DEVELOPER')")
+    @Operation(summary = "홍보 게시글 수정", description = "기존 홍보 게시글을 수정합니다. 동아리 관리자는 본인 동아리 게시글만 수정할 수 있습니다.")
+    @PreAuthorize("hasAnyRole('DEVELOPER', 'CLUB_ADMIN')")
     @SecurityRequirement(name = "BearerAuth")
     public ResponseEntity<?> updatePromotionArticle(
+        @CurrentUser CustomUserDetails user,
         @PathVariable String articleId,
         @RequestBody @Validated PromotionArticleUpdateRequest request) {
-        promotionArticleService.updatePromotionArticle(articleId, request);
+        promotionArticleService.updatePromotionArticle(articleId, request, user);
         return Response.ok("홍보 게시글이 수정되었습니다.");
     }
 
     @DeleteMapping("/{articleId}")
-    @Operation(summary = "홍보 게시글 삭제", description = "기존 홍보 게시글을 삭제합니다.")
-    @PreAuthorize("hasRole('DEVELOPER')")
+    @Operation(summary = "홍보 게시글 삭제", description = "기존 홍보 게시글을 삭제합니다. 동아리 관리자는 본인 동아리 게시글만 삭제할 수 있습니다.")
+    @PreAuthorize("hasAnyRole('DEVELOPER', 'CLUB_ADMIN')")
     @SecurityRequirement(name = "BearerAuth")
-    public ResponseEntity<?> deletePromotionArticle(@PathVariable String articleId) {
-        promotionArticleService.deletePromotionArticle(articleId);
+    public ResponseEntity<?> deletePromotionArticle(@PathVariable String articleId,
+                                                    @CurrentUser CustomUserDetails user) {
+        promotionArticleService.deletePromotionArticle(articleId, user);
         return Response.ok("홍보 게시글이 삭제되었습니다.", null);
     }
 }

--- a/backend/src/main/java/moadong/club/entity/PromotionArticle.java
+++ b/backend/src/main/java/moadong/club/entity/PromotionArticle.java
@@ -50,8 +50,8 @@ public class PromotionArticle {
 
     private Instant deletedAt;
 
-    public void update(PromotionArticleUpdateRequest request, String clubName) {
-        this.clubId = request.clubId();
+    public void update(String clubId, PromotionArticleUpdateRequest request, String clubName) {
+        this.clubId = clubId;
         this.clubName = clubName;
         this.title = request.title();
         this.location = request.location();

--- a/backend/src/main/java/moadong/club/repository/PromotionArticleRepository.java
+++ b/backend/src/main/java/moadong/club/repository/PromotionArticleRepository.java
@@ -21,9 +21,6 @@ public interface PromotionArticleRepository extends MongoRepository<PromotionArt
     @Query("{ '_id': ?0, 'deleted': { $ne: true } }")
     Optional<PromotionArticle> findActiveById(String id);
 
-    @Query(value = "{ '_id': ?0, 'deleted': { $ne: true } }", exists = true)
-    boolean existsActiveById(String id);
-
     @Query("{ '_id': ?0, 'deleted': { $ne: true } }")
     @Update("{ '$addToSet': { 'images': ?1 } }")
     long addImageToActiveArticle(String id, String imageUrl);

--- a/backend/src/main/java/moadong/club/service/PromotionArticleService.java
+++ b/backend/src/main/java/moadong/club/service/PromotionArticleService.java
@@ -3,6 +3,7 @@ package moadong.club.service;
 import lombok.RequiredArgsConstructor;
 import moadong.club.entity.Club;
 import moadong.club.entity.PromotionArticle;
+import moadong.club.enums.ClubState;
 import moadong.club.payload.dto.PromotionArticleDto;
 import moadong.club.payload.dto.PromotionArticleCreateResultDto;
 import moadong.club.payload.request.PromotionArticleCreateRequest;
@@ -13,6 +14,7 @@ import moadong.club.repository.PromotionArticleRepository;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
 import moadong.global.util.ObjectIdConverter;
+import moadong.user.payload.CustomUserDetails;
 import org.bson.types.ObjectId;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,11 +37,13 @@ public class PromotionArticleService {
     }
 
     @Transactional
-    public PromotionArticleCreateResultDto createPromotionArticle(PromotionArticleCreateRequest request) {
-        Club club = getClub(request.clubId());
+    public PromotionArticleCreateResultDto createPromotionArticle(PromotionArticleCreateRequest request, CustomUserDetails user) {
+        String clubId = resolveClubId(request.clubId(), user);
+        Club club = getClub(clubId);
+        validateClubApproved(club, user);
 
         PromotionArticle article = PromotionArticle.builder()
-            .clubId(request.clubId())
+            .clubId(clubId)
             .clubName(club.getName())
             .title(request.title())
             .location(request.location())
@@ -56,22 +60,48 @@ public class PromotionArticleService {
     }
 
     @Transactional
-    public void updatePromotionArticle(String articleId, PromotionArticleUpdateRequest request) {
+    public void updatePromotionArticle(String articleId, PromotionArticleUpdateRequest request, CustomUserDetails user) {
         PromotionArticle article = promotionArticleRepository.findActiveById(articleId)
             .orElseThrow(() -> new RestApiException(ErrorCode.PROMOTION_ARTICLE_NOT_FOUND));
-        Club club = getClub(request.clubId());
+        validateOwnership(article, user);
+        String clubId = resolveClubId(request.clubId(), user);
+        Club club = getClub(clubId);
+        validateClubApproved(club, user);
 
-        article.update(request, club.getName());
+        article.update(clubId, request, club.getName());
         promotionArticleRepository.save(article);
     }
 
     @Transactional
-    public void deletePromotionArticle(String articleId) {
+    public void deletePromotionArticle(String articleId, CustomUserDetails user) {
         PromotionArticle article = promotionArticleRepository.findActiveById(articleId)
             .orElseThrow(() -> new RestApiException(ErrorCode.PROMOTION_ARTICLE_NOT_FOUND));
+        validateOwnership(article, user);
 
         article.softDelete();
         promotionArticleRepository.save(article);
+    }
+
+    /**
+     * 개발자는 요청의 clubId를 그대로 쓰고, 동아리 관리자는 요청값을 무시하고 본인 동아리로 강제한다.
+     */
+    private String resolveClubId(String requestedClubId, CustomUserDetails user) {
+        return user.isDeveloper() ? requestedClubId : user.getClubId();
+    }
+
+    /**
+     * 동아리 관리자는 심사가 완료된(AVAILABLE) 동아리만 게시글을 작성·수정할 수 있다.
+     */
+    private void validateClubApproved(Club club, CustomUserDetails user) {
+        if (!user.isDeveloper() && club.getState() != ClubState.AVAILABLE) {
+            throw new RestApiException(ErrorCode.PROMOTION_CLUB_NOT_APPROVED);
+        }
+    }
+
+    private void validateOwnership(PromotionArticle article, CustomUserDetails user) {
+        if (!user.isDeveloper() && !user.getClubId().equals(article.getClubId())) {
+            throw new RestApiException(ErrorCode.USER_UNAUTHORIZED);
+        }
     }
 
     private Club getClub(String clubId) {

--- a/backend/src/main/java/moadong/global/exception/ErrorCode.java
+++ b/backend/src/main/java/moadong/global/exception/ErrorCode.java
@@ -81,6 +81,7 @@ public enum ErrorCode {
 
     // 902xx: 홍보게시판 오류
     PROMOTION_ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "902-1", "홍보 게시글이 존재하지 않습니다."),
+    PROMOTION_CLUB_NOT_APPROVED(HttpStatus.FORBIDDEN, "902-2", "심사가 완료된 동아리만 홍보 게시글을 작성할 수 있습니다."),
 
     // 903xx: 통계/분석 오류
     MIXPANEL_EXPORT_FAILED(HttpStatus.BAD_GATEWAY, "903-1", "Mixpanel 데이터 조회에 실패했습니다."),

--- a/backend/src/main/java/moadong/media/controller/PromotionImageController.java
+++ b/backend/src/main/java/moadong/media/controller/PromotionImageController.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import moadong.global.payload.Response;
 import moadong.media.dto.PromotionImageUploadResponse;
 import moadong.media.service.PromotionImageUploadService;
+import moadong.user.annotation.CurrentUser;
+import moadong.user.payload.CustomUserDetails;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -26,12 +28,13 @@ public class PromotionImageController {
     private final PromotionImageUploadService promotionImageUploadService;
 
     @PostMapping(value = "/{articleId}/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @PreAuthorize("hasRole('DEVELOPER')")
+    @PreAuthorize("hasAnyRole('DEVELOPER', 'CLUB_ADMIN')")
     @SecurityRequirement(name = "BearerAuth")
-    @Operation(summary = "홍보 이미지 업로드", description = "홍보 게시글 이미지를 공용 R2 버킷의 promotion 경로에 업로드하고 최종 URL을 반환합니다.")
-    public ResponseEntity<?> uploadPromotionImage(@PathVariable String articleId,
+    @Operation(summary = "홍보 이미지 업로드", description = "홍보 게시글 이미지를 공용 R2 버킷의 promotion 경로에 업로드하고 최종 URL을 반환합니다. 동아리 관리자는 본인 동아리 게시글에만 업로드할 수 있습니다.")
+    public ResponseEntity<?> uploadPromotionImage(@CurrentUser CustomUserDetails user,
+                                                  @PathVariable String articleId,
                                                   @RequestPart("file") MultipartFile file) {
-        PromotionImageUploadResponse response = promotionImageUploadService.upload(articleId, file);
+        PromotionImageUploadResponse response = promotionImageUploadService.upload(articleId, file, user);
         return Response.ok("홍보 이미지가 업로드되었습니다.", response);
     }
 }

--- a/backend/src/main/java/moadong/media/service/PromotionImageUploadService.java
+++ b/backend/src/main/java/moadong/media/service/PromotionImageUploadService.java
@@ -1,11 +1,13 @@
 package moadong.media.service;
 
 import lombok.RequiredArgsConstructor;
+import moadong.club.entity.PromotionArticle;
 import moadong.club.repository.PromotionArticleRepository;
 import moadong.global.config.properties.AwsProperties;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
 import moadong.media.dto.PromotionImageUploadResponse;
+import moadong.user.payload.CustomUserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
@@ -22,8 +24,12 @@ public class PromotionImageUploadService {
     private final R2ImageUploadService r2ImageUploadService;
     private final AwsProperties awsProperties;
 
-    public PromotionImageUploadResponse upload(String articleId, MultipartFile file) {
-        validateActivePromotionArticle(articleId);
+    public PromotionImageUploadResponse upload(String articleId, MultipartFile file, CustomUserDetails user) {
+        PromotionArticle article = promotionArticleRepository.findActiveById(articleId)
+            .orElseThrow(() -> new RestApiException(ErrorCode.PROMOTION_ARTICLE_NOT_FOUND));
+        if (!user.isDeveloper() && !user.getClubId().equals(article.getClubId())) {
+            throw new RestApiException(ErrorCode.USER_UNAUTHORIZED);
+        }
         String key = buildPromotionImageKey(articleId, file);
         String imageUrl = r2ImageUploadService.upload(
             file,
@@ -33,12 +39,6 @@ public class PromotionImageUploadService {
         );
         promotionArticleRepository.addImageToActiveArticle(articleId, imageUrl);
         return new PromotionImageUploadResponse(imageUrl);
-    }
-
-    private void validateActivePromotionArticle(String articleId) {
-        if (!promotionArticleRepository.existsActiveById(articleId)) {
-            throw new RestApiException(ErrorCode.PROMOTION_ARTICLE_NOT_FOUND);
-        }
     }
 
     private String buildPromotionImageKey(String articleId, MultipartFile file) {

--- a/backend/src/main/java/moadong/user/payload/CustomUserDetails.java
+++ b/backend/src/main/java/moadong/user/payload/CustomUserDetails.java
@@ -39,4 +39,9 @@ public class CustomUserDetails implements UserDetails {
         return password;
     }
 
+    public boolean isDeveloper() {
+        return authorities.stream()
+            .anyMatch(authority -> "ROLE_DEVELOPER".equals(authority.getAuthority()));
+    }
+
 }

--- a/backend/src/test/java/moadong/club/controller/PromotionArticleControllerTest.java
+++ b/backend/src/test/java/moadong/club/controller/PromotionArticleControllerTest.java
@@ -2,6 +2,10 @@ package moadong.club.controller;
 
 import moadong.club.service.PromotionArticleService;
 import moadong.global.payload.Response;
+import moadong.user.entity.User;
+import moadong.user.entity.enums.UserRole;
+import moadong.user.payload.CustomUserDetails;
+import moadong.util.annotations.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -12,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 
+@UnitTest
 @ExtendWith(MockitoExtension.class)
 class PromotionArticleControllerTest {
 
@@ -23,12 +28,15 @@ class PromotionArticleControllerTest {
 
     @Test
     void 홍보게시글을_삭제하면_성공응답을_반환한다() {
-        ResponseEntity<?> response = promotionArticleController.deletePromotionArticle("article-1");
+        CustomUserDetails user = new CustomUserDetails(User.builder()
+            .id("user-doc-id").userId("user-1").password("password").clubId("club-1").role(UserRole.CLUB_ADMIN).build());
+
+        ResponseEntity<?> response = promotionArticleController.deletePromotionArticle("article-1", user);
 
         assertEquals(200, response.getStatusCode().value());
         @SuppressWarnings("unchecked")
         Response<Object> body = (Response<Object>) response.getBody();
         assertEquals("홍보 게시글이 삭제되었습니다.", body.message());
-        verify(promotionArticleService).deletePromotionArticle("article-1");
+        verify(promotionArticleService).deletePromotionArticle("article-1", user);
     }
 }

--- a/backend/src/test/java/moadong/club/service/PromotionArticleServiceTest.java
+++ b/backend/src/test/java/moadong/club/service/PromotionArticleServiceTest.java
@@ -2,6 +2,7 @@ package moadong.club.service;
 
 import moadong.club.entity.Club;
 import moadong.club.entity.PromotionArticle;
+import moadong.club.enums.ClubState;
 import moadong.club.payload.dto.PromotionArticleCreateResultDto;
 import moadong.club.payload.request.PromotionArticleCreateRequest;
 import moadong.club.payload.request.PromotionArticleUpdateRequest;
@@ -10,12 +11,18 @@ import moadong.club.repository.ClubRepository;
 import moadong.club.repository.PromotionArticleRepository;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
+import moadong.user.entity.User;
+import moadong.user.entity.enums.UserRole;
+import moadong.user.payload.CustomUserDetails;
 import org.bson.types.ObjectId;
+import moadong.util.annotations.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Instant;
 import java.util.List;
@@ -25,11 +32,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@UnitTest
 @ExtendWith(MockitoExtension.class)
 class PromotionArticleServiceTest {
 
@@ -112,7 +121,7 @@ class PromotionArticleServiceTest {
             .userId("user-1")
             .build()));
 
-        promotionArticleService.updatePromotionArticle("article-1", request);
+        promotionArticleService.updatePromotionArticle("article-1", request, developer());
 
         assertEquals(clubId, article.getClubId());
         assertEquals("수정 동아리", article.getClubName());
@@ -163,7 +172,7 @@ class PromotionArticleServiceTest {
         when(clubRepository.findClubById(new ObjectId(clubId))).thenReturn(Optional.of(club));
         when(promotionArticleRepository.save(any(PromotionArticle.class))).thenReturn(savedArticle);
 
-        PromotionArticleCreateResultDto result = promotionArticleService.createPromotionArticle(request);
+        PromotionArticleCreateResultDto result = promotionArticleService.createPromotionArticle(request, developer());
 
         assertNotNull(result);
         assertEquals("created-article-id", result.articleId());
@@ -186,7 +195,7 @@ class PromotionArticleServiceTest {
         when(promotionArticleRepository.findActiveById("missing-article")).thenReturn(Optional.empty());
 
         RestApiException exception = assertThrows(RestApiException.class,
-            () -> promotionArticleService.updatePromotionArticle("missing-article", request));
+            () -> promotionArticleService.updatePromotionArticle("missing-article", request, developer()));
 
         assertEquals(ErrorCode.PROMOTION_ARTICLE_NOT_FOUND, exception.getErrorCode());
         verify(clubRepository, never()).findClubById(org.mockito.ArgumentMatchers.any());
@@ -208,7 +217,7 @@ class PromotionArticleServiceTest {
         when(promotionArticleRepository.findActiveById("deleted-article")).thenReturn(Optional.empty());
 
         RestApiException exception = assertThrows(RestApiException.class,
-            () -> promotionArticleService.updatePromotionArticle("deleted-article", request));
+            () -> promotionArticleService.updatePromotionArticle("deleted-article", request, developer()));
 
         assertEquals(ErrorCode.PROMOTION_ARTICLE_NOT_FOUND, exception.getErrorCode());
         verify(clubRepository, never()).findClubById(org.mockito.ArgumentMatchers.any());
@@ -221,7 +230,7 @@ class PromotionArticleServiceTest {
             .build();
         when(promotionArticleRepository.findActiveById("article-1")).thenReturn(Optional.of(article));
 
-        promotionArticleService.deletePromotionArticle("article-1");
+        promotionArticleService.deletePromotionArticle("article-1", developer());
 
         assertTrue(article.isDeleted());
         assertNotNull(article.getDeletedAt());
@@ -234,9 +243,217 @@ class PromotionArticleServiceTest {
         when(promotionArticleRepository.findActiveById("missing-article")).thenReturn(Optional.empty());
 
         RestApiException exception = assertThrows(RestApiException.class,
-            () -> promotionArticleService.deletePromotionArticle("missing-article"));
+            () -> promotionArticleService.deletePromotionArticle("missing-article", developer()));
 
         assertEquals(ErrorCode.PROMOTION_ARTICLE_NOT_FOUND, exception.getErrorCode());
         verify(promotionArticleRepository, never()).deleteById("missing-article");
+    }
+
+    @Test
+    void 동아리관리자가_생성하면_요청_clubId를_무시하고_본인_동아리로_저장한다() {
+        String ownClubId = new ObjectId().toHexString();
+        String otherClubId = new ObjectId().toHexString();
+        PromotionArticleCreateRequest request = createRequest(otherClubId);
+        when(clubRepository.findClubById(new ObjectId(ownClubId))).thenReturn(Optional.of(club("내 동아리")));
+        when(promotionArticleRepository.save(any(PromotionArticle.class)))
+            .thenReturn(PromotionArticle.builder().id("created-article-id").build());
+
+        promotionArticleService.createPromotionArticle(request, clubAdmin(ownClubId));
+
+        ArgumentCaptor<PromotionArticle> captor = ArgumentCaptor.forClass(PromotionArticle.class);
+        verify(promotionArticleRepository).save(captor.capture());
+        assertEquals(ownClubId, captor.getValue().getClubId());
+        assertEquals("내 동아리", captor.getValue().getClubName());
+        verify(clubRepository, never()).findClubById(new ObjectId(otherClubId));
+    }
+
+    @Test
+    void 동아리관리자가_수정하면_요청_clubId를_무시하고_본인_동아리를_유지한다() {
+        String ownClubId = new ObjectId().toHexString();
+        String otherClubId = new ObjectId().toHexString();
+        PromotionArticle article = PromotionArticle.builder()
+            .id("article-1")
+            .clubId(ownClubId)
+            .clubName("내 동아리")
+            .title("이전 제목")
+            .build();
+        PromotionArticleUpdateRequest request = updateRequest(otherClubId);
+        when(promotionArticleRepository.findActiveById("article-1")).thenReturn(Optional.of(article));
+        when(clubRepository.findClubById(new ObjectId(ownClubId))).thenReturn(Optional.of(club("내 동아리")));
+
+        promotionArticleService.updatePromotionArticle("article-1", request, clubAdmin(ownClubId));
+
+        assertEquals(ownClubId, article.getClubId());
+        assertEquals("수정 제목", article.getTitle());
+        verify(promotionArticleRepository).save(article);
+    }
+
+    @Test
+    void 동아리관리자는_다른_동아리_게시글을_수정할_수_없다() {
+        String ownClubId = new ObjectId().toHexString();
+        String otherClubId = new ObjectId().toHexString();
+        PromotionArticle article = PromotionArticle.builder()
+            .id("article-1")
+            .clubId(otherClubId)
+            .title("이전 제목")
+            .build();
+        when(promotionArticleRepository.findActiveById("article-1")).thenReturn(Optional.of(article));
+
+        RestApiException exception = assertThrows(RestApiException.class,
+            () -> promotionArticleService.updatePromotionArticle("article-1", updateRequest(ownClubId), clubAdmin(ownClubId)));
+
+        assertEquals(ErrorCode.USER_UNAUTHORIZED, exception.getErrorCode());
+        assertEquals("이전 제목", article.getTitle());
+        verify(promotionArticleRepository, never()).save(any());
+    }
+
+    @Test
+    void 동아리관리자는_다른_동아리_게시글을_삭제할_수_없다() {
+        String ownClubId = new ObjectId().toHexString();
+        PromotionArticle article = PromotionArticle.builder()
+            .id("article-1")
+            .clubId(new ObjectId().toHexString())
+            .build();
+        when(promotionArticleRepository.findActiveById("article-1")).thenReturn(Optional.of(article));
+
+        RestApiException exception = assertThrows(RestApiException.class,
+            () -> promotionArticleService.deletePromotionArticle("article-1", clubAdmin(ownClubId)));
+
+        assertEquals(ErrorCode.USER_UNAUTHORIZED, exception.getErrorCode());
+        assertFalse(article.isDeleted());
+        verify(promotionArticleRepository, never()).save(any());
+    }
+
+    @Test
+    void 동아리관리자는_본인_동아리_게시글을_삭제할_수_있다() {
+        String ownClubId = new ObjectId().toHexString();
+        PromotionArticle article = PromotionArticle.builder()
+            .id("article-1")
+            .clubId(ownClubId)
+            .build();
+        when(promotionArticleRepository.findActiveById("article-1")).thenReturn(Optional.of(article));
+
+        promotionArticleService.deletePromotionArticle("article-1", clubAdmin(ownClubId));
+
+        assertTrue(article.isDeleted());
+        verify(promotionArticleRepository).save(article);
+    }
+
+    @Test
+    void 개발자는_다른_동아리_게시글을_삭제할_수_있다() {
+        PromotionArticle article = PromotionArticle.builder()
+            .id("article-1")
+            .clubId(new ObjectId().toHexString())
+            .build();
+        when(promotionArticleRepository.findActiveById("article-1")).thenReturn(Optional.of(article));
+
+        promotionArticleService.deletePromotionArticle("article-1", developer());
+
+        assertTrue(article.isDeleted());
+        verify(promotionArticleRepository).save(article);
+    }
+
+    @Test
+    void 심사전_동아리관리자는_게시글을_생성할_수_없다() {
+        String ownClubId = new ObjectId().toHexString();
+        when(clubRepository.findClubById(new ObjectId(ownClubId))).thenReturn(Optional.of(club("", ClubState.UNAVAILABLE)));
+
+        RestApiException exception = assertThrows(RestApiException.class,
+            () -> promotionArticleService.createPromotionArticle(createRequest(ownClubId), clubAdmin(ownClubId)));
+
+        assertEquals(ErrorCode.PROMOTION_CLUB_NOT_APPROVED, exception.getErrorCode());
+        verify(promotionArticleRepository, never()).save(any());
+    }
+
+    @Test
+    void 심사전_동아리관리자는_게시글을_수정할_수_없다() {
+        String ownClubId = new ObjectId().toHexString();
+        PromotionArticle article = PromotionArticle.builder()
+            .id("article-1")
+            .clubId(ownClubId)
+            .title("이전 제목")
+            .build();
+        when(promotionArticleRepository.findActiveById("article-1")).thenReturn(Optional.of(article));
+        when(clubRepository.findClubById(new ObjectId(ownClubId))).thenReturn(Optional.of(club("", ClubState.UNAVAILABLE)));
+
+        RestApiException exception = assertThrows(RestApiException.class,
+            () -> promotionArticleService.updatePromotionArticle("article-1", updateRequest(ownClubId), clubAdmin(ownClubId)));
+
+        assertEquals(ErrorCode.PROMOTION_CLUB_NOT_APPROVED, exception.getErrorCode());
+        assertEquals("이전 제목", article.getTitle());
+        verify(promotionArticleRepository, never()).save(any());
+    }
+
+    @Test
+    void 개발자는_심사전_동아리로도_게시글을_생성할_수_있다() {
+        String clubId = new ObjectId().toHexString();
+        when(clubRepository.findClubById(new ObjectId(clubId))).thenReturn(Optional.of(club("", ClubState.UNAVAILABLE)));
+        when(promotionArticleRepository.save(any(PromotionArticle.class)))
+            .thenReturn(PromotionArticle.builder().id("created-article-id").build());
+
+        PromotionArticleCreateResultDto result = promotionArticleService.createPromotionArticle(createRequest(clubId), developer());
+
+        assertEquals("created-article-id", result.articleId());
+    }
+
+    private static CustomUserDetails developer() {
+        return userDetails(new ObjectId().toHexString(), UserRole.DEVELOPER);
+    }
+
+    private static CustomUserDetails clubAdmin(String clubId) {
+        return userDetails(clubId, UserRole.CLUB_ADMIN);
+    }
+
+    private static CustomUserDetails userDetails(String clubId, UserRole role) {
+        return new CustomUserDetails(User.builder()
+            .id("user-doc-id")
+            .userId("user-1")
+            .password("password")
+            .clubId(clubId)
+            .role(role)
+            .build());
+    }
+
+    private static Club club(String name) {
+        return club(name, ClubState.AVAILABLE);
+    }
+
+    private static Club club(String name, ClubState state) {
+        Club club = Club.builder()
+            .name(name)
+            .category("category")
+            .division("division")
+            .userId("user-1")
+            .build();
+        ReflectionTestUtils.setField(club, "state", state);
+        return club;
+    }
+
+    private static PromotionArticleCreateRequest createRequest(String clubId) {
+        return new PromotionArticleCreateRequest(
+            clubId,
+            "신규 제목",
+            "신규 장소",
+            37.5665,
+            126.9780,
+            Instant.parse("2026-04-01T00:00:00Z"),
+            Instant.parse("2026-04-10T00:00:00Z"),
+            "신규 설명",
+            List.of()
+        );
+    }
+
+    private static PromotionArticleUpdateRequest updateRequest(String clubId) {
+        return new PromotionArticleUpdateRequest(
+            clubId,
+            "수정 제목",
+            "수정 장소",
+            37.5665,
+            126.9780,
+            Instant.parse("2026-04-01T00:00:00Z"),
+            Instant.parse("2026-04-10T00:00:00Z"),
+            "수정 설명",
+            List.of("new-image")
+        );
     }
 }

--- a/backend/src/test/java/moadong/media/service/PromotionImageUploadServiceTest.java
+++ b/backend/src/test/java/moadong/media/service/PromotionImageUploadServiceTest.java
@@ -1,10 +1,14 @@
 package moadong.media.service;
 
+import moadong.club.entity.PromotionArticle;
 import moadong.club.repository.PromotionArticleRepository;
 import moadong.global.config.properties.AwsProperties;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
 import moadong.media.dto.PromotionImageUploadResponse;
+import moadong.user.entity.User;
+import moadong.user.entity.enums.UserRole;
+import moadong.user.payload.CustomUserDetails;
 import moadong.util.annotations.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,6 +16,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
+
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -46,14 +52,14 @@ class PromotionImageUploadServiceTest {
         AwsProperties.S3 s3 = new AwsProperties.S3("moadong-dev", "https://r2.example.com", "https://cdn.example.com");
         String uploadedUrl = "https://cdn.example.com/promotion/articles/" + articleId + "/2026/03/uuid-poster_main.png";
         when(awsProperties.s3()).thenReturn(s3);
-        when(promotionArticleRepository.existsActiveById(articleId)).thenReturn(true);
+        when(promotionArticleRepository.findActiveById(articleId)).thenReturn(Optional.of(article(articleId, "club-1")));
         when(r2ImageUploadService.upload(eq(file), eq("moadong-dev"), eq("https://cdn.example.com"), startsWith("promotion/articles/" + articleId + "/")))
             .thenReturn(uploadedUrl);
         when(promotionArticleRepository.addImageToActiveArticle(articleId, uploadedUrl)).thenReturn(1L);
 
-        PromotionImageUploadResponse response = promotionImageUploadService.upload(articleId, file);
+        PromotionImageUploadResponse response = promotionImageUploadService.upload(articleId, file, developer());
 
-        verify(promotionArticleRepository).existsActiveById(articleId);
+        verify(promotionArticleRepository).findActiveById(articleId);
         verify(r2ImageUploadService).upload(eq(file), eq("moadong-dev"), eq("https://cdn.example.com"), startsWith("promotion/articles/" + articleId + "/"));
         verify(promotionArticleRepository).addImageToActiveArticle(articleId, uploadedUrl);
         verify(promotionArticleRepository, never()).save(any());
@@ -63,24 +69,77 @@ class PromotionImageUploadServiceTest {
 
     @Test
     void 존재하지_않는_홍보게시글이면_예외를_던진다() {
-        when(promotionArticleRepository.existsActiveById("missing")).thenReturn(false);
+        when(promotionArticleRepository.findActiveById("missing")).thenReturn(Optional.empty());
         MockMultipartFile file = new MockMultipartFile("file", "poster.png", "image/png", "img".getBytes());
 
         RestApiException exception = assertThrows(RestApiException.class,
-            () -> promotionImageUploadService.upload("missing", file));
+            () -> promotionImageUploadService.upload("missing", file, developer()));
 
         assertEquals(ErrorCode.PROMOTION_ARTICLE_NOT_FOUND, exception.getErrorCode());
     }
 
     @Test
     void 삭제된_홍보게시글이면_이미지_업로드를_막는다() {
-        when(promotionArticleRepository.existsActiveById("deleted-article")).thenReturn(false);
+        when(promotionArticleRepository.findActiveById("deleted-article")).thenReturn(Optional.empty());
         MockMultipartFile file = new MockMultipartFile("file", "poster.png", "image/png", "img".getBytes());
 
         RestApiException exception = assertThrows(RestApiException.class,
-            () -> promotionImageUploadService.upload("deleted-article", file));
+            () -> promotionImageUploadService.upload("deleted-article", file, developer()));
 
         assertEquals(ErrorCode.PROMOTION_ARTICLE_NOT_FOUND, exception.getErrorCode());
-        verify(promotionArticleRepository).existsActiveById("deleted-article");
+        verify(promotionArticleRepository).findActiveById("deleted-article");
+    }
+
+    @Test
+    void 동아리관리자는_다른_동아리_게시글에_이미지를_업로드할_수_없다() {
+        when(promotionArticleRepository.findActiveById("article-1")).thenReturn(Optional.of(article("article-1", "other-club")));
+        MockMultipartFile file = new MockMultipartFile("file", "poster.png", "image/png", "img".getBytes());
+
+        RestApiException exception = assertThrows(RestApiException.class,
+            () -> promotionImageUploadService.upload("article-1", file, clubAdmin("my-club")));
+
+        assertEquals(ErrorCode.USER_UNAUTHORIZED, exception.getErrorCode());
+        verify(r2ImageUploadService, never()).upload(any(), any(), any(), any());
+        verify(promotionArticleRepository, never()).addImageToActiveArticle(any(), any());
+    }
+
+    @Test
+    void 동아리관리자는_본인_동아리_게시글에_이미지를_업로드할_수_있다() {
+        String articleId = "article-1";
+        MockMultipartFile file = new MockMultipartFile("file", "poster.png", "image/png", "img".getBytes());
+        AwsProperties.S3 s3 = new AwsProperties.S3("moadong-dev", "https://r2.example.com", "https://cdn.example.com");
+        String uploadedUrl = "https://cdn.example.com/promotion/articles/article-1/2026/03/uuid-poster.png";
+        when(awsProperties.s3()).thenReturn(s3);
+        when(promotionArticleRepository.findActiveById(articleId)).thenReturn(Optional.of(article(articleId, "my-club")));
+        when(r2ImageUploadService.upload(eq(file), eq("moadong-dev"), eq("https://cdn.example.com"), startsWith("promotion/articles/" + articleId + "/")))
+            .thenReturn(uploadedUrl);
+        when(promotionArticleRepository.addImageToActiveArticle(articleId, uploadedUrl)).thenReturn(1L);
+
+        PromotionImageUploadResponse response = promotionImageUploadService.upload(articleId, file, clubAdmin("my-club"));
+
+        assertEquals(uploadedUrl, response.imageUrl());
+        verify(promotionArticleRepository).addImageToActiveArticle(articleId, uploadedUrl);
+    }
+
+    private static PromotionArticle article(String id, String clubId) {
+        return PromotionArticle.builder().id(id).clubId(clubId).build();
+    }
+
+    private static CustomUserDetails developer() {
+        return userDetails("dev-club", UserRole.DEVELOPER);
+    }
+
+    private static CustomUserDetails clubAdmin(String clubId) {
+        return userDetails(clubId, UserRole.CLUB_ADMIN);
+    }
+
+    private static CustomUserDetails userDetails(String clubId, UserRole role) {
+        return new CustomUserDetails(User.builder()
+            .id("user-doc-id")
+            .userId("user-1")
+            .password("password")
+            .clubId(clubId)
+            .role(role)
+            .build());
     }
 }


### PR DESCRIPTION
## Summary
- 홍보게시판 생성/수정/삭제/이미지 업로드 4개 엔드포인트를 `hasRole('DEVELOPER')` → `hasAnyRole('DEVELOPER', 'CLUB_ADMIN')`으로 개방
- **CLUB_ADMIN**: 요청 바디의 `clubId`는 무시하고 토큰의 동아리로 강제 (거절 대신 덮어쓰기). 타 동아리 게시글 수정/삭제/업로드 시 `USER_UNAUTHORIZED`(403)
- **심사 전 동아리 차단**: `state != AVAILABLE`인 동아리의 관리자는 생성/수정 불가. 새 에러코드 `PROMOTION_CLUB_NOT_APPROVED`(902-2, 403) 추가
- **DEVELOPER**: 기존과 동일하게 모든 동아리 게시글 관리 가능, 심사 전 동아리로도 생성 가능
- 목록 조회 GET은 공개 API 그대로

## 설계 결정: clubId를 역할별로 다르게 정하는 이유

| 역할 | 저장되는 clubId | 이유 |
|---|---|---|
| DEVELOPER | 요청 바디 | 개발자 포털은 다른 동아리를 **대신해서** 글을 올리는 도구. 개발자 토큰의 clubId는 계정 생성 시 붙는 자리표시자라 의미가 없음 |
| CLUB_ADMIN | 토큰 | 관리자는 자기 동아리에만 글을 쓸 수 있음. 바디 값은 정보를 더하지 않고 위조 가능성만 더함 |

**바디 clubId가 다를 때 거절(403) 대신 덮어쓰기를 택한 트레이드오프**

- 얻는 것: 관리자는 화면에서 clubId를 고를 수 없어서, 그 값이 틀렸다고 거절하면 사용자가 할 수 있는 조치가 없음. 프론트 상태가 꼬여도(계정 전환 후 남은 값 등) 글은 항상 토큰 주인 동아리로 저장됨. 소속 위조 경로가 원천 차단됨.
- 잃는 것: 프론트가 잘못된 clubId를 보내고 있어도 서버는 성공을 돌려주므로 버그가 드러나지 않음. `clubId`가 필수값인데 CLUB_ADMIN에게는 무시되는 어색함이 남음.
- 판단: 관리자 계정 하나에 동아리 하나가 고정된 현재 구조에서는 어긋날 시나리오가 드물어 사용자 경험 안정성을 우선함.

## Changes
- `PromotionArticleController`, `PromotionImageController`: `@CurrentUser` 주입, 권한 완화
- `PromotionArticleService`: `resolveClubId` / `validateOwnership` / `validateClubApproved` 추가
- `PromotionImageUploadService`: 존재 여부 대신 게시글 조회 후 소유권 검사 (`existsActiveById` 제거)
- `CustomUserDetails.isDeveloper()` 추가, `PromotionArticle.update`는 확정된 `clubId`를 인자로 받음

## Notes
- 요청 바디의 `clubId`는 여전히 `@NotBlank`라 관리자 클라이언트도 값을 보내야 함 (무시됨). CLUB_ADMIN에 한해 선택값으로 바꾸는 건 후속 작업 후보
- 삭제/이미지 업로드에는 심사 상태 검사를 걸지 않음. 심사 전 동아리는 자기 게시글을 만들 수 없어 도달할 게시글이 없음
- 프론트 관리자용 홍보게시판 UI는 별도 작업

## Test plan
- [x] `./gradlew unitTest` 전체 통과 (`PromotionArticleServiceTest` 17건, `PromotionImageUploadServiceTest` 5건, `PromotionArticleControllerTest` 1건 포함)
- [x] CLUB_ADMIN 본인 동아리 생성/수정/삭제/업로드 성공
- [x] CLUB_ADMIN 타 동아리 게시글 수정/삭제/업로드 → 403
- [x] 심사 전 동아리 관리자 생성/수정 → 403 (902-2)
- [x] DEVELOPER 우회 유지
- 참고: `./gradlew test` 전체에서는 Firebase 빈 부재로 Spring 컨텍스트 테스트 20건이 로컬에서 실패하며 본 변경과 무관