### PR TITLE
[feature] 동아리 행사일정 캘린더 사용자 이벤트 로깅 추가

### DIFF
--- a/frontend/src/constants/eventName.ts
+++ b/frontend/src/constants/eventName.ts
@@ -41,6 +41,11 @@ export const USER_EVENT = {
   CLUB_FEED_TAB_CLICKED: 'Club Feed Tab Clicked',
   CLUB_SCHEDULE_TAB_CLICKED: 'Club Schedule Tab Clicked',
 
+  // 동아리 행사일정 캘린더
+  CLUB_SCHEDULE_CALENDAR_VIEWED: 'Club Schedule Calendar Viewed',
+  CLUB_SCHEDULE_MONTH_CHANGED: 'Club Schedule Month Changed',
+  CLUB_SCHEDULE_TODAY_BUTTON_CLICKED: 'Club Schedule Today Button Clicked',
+
   // 동아리방 지도
   CLUB_MAP_CLICKED: 'Club Map Clicked',
 

--- a/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
@@ -106,6 +106,35 @@ const ClubDetailPage = () => {
     countClubView();
   }, [clubDetail?.id]);
 
+  /**
+   * 일정 탭에 실제로 도달했을 때 볼 일정이 있었는지 남긴다.
+   * 탭 클릭뿐 아니라 `?tab=schedule` 딥링크 진입도 포함해야 해서 탭 클릭 이벤트와 별개로 둔다.
+   */
+  const scheduleViewedClubIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    const viewedClubId = clubDetail?.id;
+    if (activeTab !== TAB_TYPE.SCHEDULE || !viewedClubId || isCalendarLoading) {
+      return;
+    }
+    if (scheduleViewedClubIdRef.current === viewedClubId) return;
+
+    scheduleViewedClubIdRef.current = viewedClubId;
+    trackEvent(USER_EVENT.CLUB_SCHEDULE_CALENDAR_VIEWED, {
+      club_id: viewedClubId,
+      club_name: clubDetail?.name,
+      event_count: calendarEvents.length,
+      has_calendar_connection: hasCalendarConnection,
+    });
+  }, [
+    activeTab,
+    clubDetail?.id,
+    clubDetail?.name,
+    isCalendarLoading,
+    calendarEvents.length,
+    hasCalendarConnection,
+    trackEvent,
+  ]);
+
   const [showStickyTabs, setShowStickyTabs] = useState(false);
   const [inlineTabsEl, setInlineTabsEl] = useState<HTMLDivElement | null>(null);
 
@@ -259,6 +288,7 @@ const ClubDetailPage = () => {
                   key={clubId ?? clubName}
                   events={calendarEvents}
                   isLoading={isCalendarLoading}
+                  clubId={clubDetail.id}
                 />
               </div>
             </Styled.TabContent>

--- a/frontend/src/pages/ClubDetailPage/components/ClubScheduleCalendar/ClubScheduleCalendar.test.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubScheduleCalendar/ClubScheduleCalendar.test.tsx
@@ -1,7 +1,14 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
+import { USER_EVENT } from '@/constants/eventName';
 import type { ClubCalendarEvent } from '@/types/club';
 import ClubScheduleCalendar from './ClubScheduleCalendar';
+
+const trackEvent = jest.fn();
+jest.mock('@/hooks/Mixpanel/useMixpanelTrack', () => ({
+  __esModule: true,
+  default: () => trackEvent,
+}));
 
 /**
  * 공개 피드(ClubCalendarEventResult)가 실제로 내려주는 형태.
@@ -45,6 +52,7 @@ const PUBLIC_FEED: ClubCalendarEvent[] = [
 
 // 캘린더는 항상 '이번 달'로 열리므로 기준 시각을 고정한다
 beforeEach(() => {
+  trackEvent.mockClear();
   jest.useFakeTimers().setSystemTime(new Date(2026, 2, 13));
 });
 
@@ -148,5 +156,21 @@ describe('ClubScheduleCalendar', () => {
     expect(
       screen.getByText('곧 새로운 일정이 업데이트될 예정이에요'),
     ).toBeInTheDocument();
+  });
+
+  it('월 이동·오늘 버튼을 로깅한다', () => {
+    render(<ClubScheduleCalendar events={PUBLIC_FEED} clubId='club-1' />);
+
+    fireEvent.click(screen.getByRole('button', { name: '다음 달' }));
+    expect(trackEvent).toHaveBeenCalledWith(
+      USER_EVENT.CLUB_SCHEDULE_MONTH_CHANGED,
+      { club_id: 'club-1', direction: 'next', month: '2026-04' },
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '오늘' }));
+    expect(trackEvent).toHaveBeenCalledWith(
+      USER_EVENT.CLUB_SCHEDULE_TODAY_BUTTON_CLICKED,
+      { club_id: 'club-1' },
+    );
   });
 });

--- a/frontend/src/pages/ClubDetailPage/components/ClubScheduleCalendar/ClubScheduleCalendar.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubScheduleCalendar/ClubScheduleCalendar.tsx
@@ -5,6 +5,8 @@ import {
   CALENDAR_EVENT_COLOR_ORDER,
   CALENDAR_EVENT_COLORS,
 } from '@/constants/calendarEventColors';
+import { USER_EVENT } from '@/constants/eventName';
+import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import type { CalendarEventColor, ClubCalendarEvent } from '@/types/club';
 import {
   buildDateKeyFromDate,
@@ -83,12 +85,17 @@ interface ClubScheduleCalendarProps {
   events: ClubCalendarEvent[];
   /** 연동 캘린더는 서버에서 모아오느라 느려서 캘린더 자리에 스피너를 띄운다 */
   isLoading?: boolean;
+  /** 이벤트 로깅용 */
+  clubId?: string;
 }
 
 const ClubScheduleCalendar = ({
   events,
   isLoading = false,
+  clubId,
 }: ClubScheduleCalendarProps) => {
+  const trackEvent = useMixpanelTrack();
+
   const sortedEvents = [...events]
     .filter((event) => parseDateKey(event.start))
     .sort((a, b) => a.start.localeCompare(b.start));
@@ -195,12 +202,23 @@ const ClubScheduleCalendar = ({
     monthKey === `${today.getFullYear()}-${today.getMonth() + 1}`;
 
   const changeMonth = (diff: number) => {
-    setVisibleMonth(
-      new Date(visibleMonth.getFullYear(), visibleMonth.getMonth() + diff, 1),
+    const nextMonth = new Date(
+      visibleMonth.getFullYear(),
+      visibleMonth.getMonth() + diff,
+      1,
     );
+    trackEvent(USER_EVENT.CLUB_SCHEDULE_MONTH_CHANGED, {
+      club_id: clubId,
+      direction: diff > 0 ? 'next' : 'prev',
+      month: `${nextMonth.getFullYear()}-${String(nextMonth.getMonth() + 1).padStart(2, '0')}`,
+    });
+    setVisibleMonth(nextMonth);
   };
 
   const moveToToday = () => {
+    trackEvent(USER_EVENT.CLUB_SCHEDULE_TODAY_BUTTON_CLICKED, {
+      club_id: clubId,
+    });
     const today = new Date();
     setVisibleMonth(new Date(today.getFullYear(), today.getMonth(), 1));
   };


### PR DESCRIPTION
Close #2004

## 변경 내용

동아리 상세 **행사일정 탭(학생용 화면)** 에 Mixpanel 이벤트 3개를 추가했다. UI 동작·마크업은 그대로다.

| 이벤트 | 발화 지점 | 프로퍼티 |
| --- | --- | --- |
| `Club Schedule Calendar Viewed` | 일정 탭이 실제로 활성화되고 캘린더 로딩이 끝났을 때 (동아리당 1회) | `club_id`, `club_name`, `event_count`, `has_calendar_connection` |
| `Club Schedule Month Changed` | 이전/다음 달 버튼 | `club_id`, `direction`(prev/next), `month`(이동 후 `YYYY-MM`) |
| `Club Schedule Today Button Clicked` | 오늘 버튼 | `club_id` |

- `constants/eventName.ts` — `USER_EVENT`에 이벤트명 3개
- `ClubScheduleCalendar.tsx` — 로깅용 `clubId?` prop + 월 이동/오늘 버튼 로깅
- `ClubDetailPage.tsx` — Viewed 이펙트, `clubId` 전달
- `ClubScheduleCalendar.test.tsx` — 월 이동·오늘 로깅 테스트

## 변경 이유

관리자 캘린더는 `ADMIN_EVENT.CALENDAR_*`로 월 이동·날짜 클릭·일정 저장까지 남는데, 사용자 캘린더는 계측이 하나도 없어 `Club Schedule Tab Clicked` 하나로만 보고 있었다. 그래서 두 가지를 알 수 없었다.

1. `?tab=schedule` 딥링크로 바로 들어온 조회 — 탭 클릭 이벤트가 안 찍힌다
2. 일정 탭에 도달한 사람이 볼 일정이 있었는지 — 빈 캘린더("곧 새로운 일정이 업데이트될 예정이에요")를 본 비율

`Club Schedule Calendar Viewed`를 탭 클릭 이벤트와 따로 둔 이유가 이 둘이다. `event_count = 0`인 조회 비율이 이 탭의 이탈을 설명하는 축이라 분모로 쓸 이벤트가 필요했다.

## 범위 밖

사용자 캘린더는 날짜 셀·일정 리스트에 클릭 핸들러가 없는 읽기 전용 UI다. 관리자의 `캘린더 날짜 클릭`에 대응하는 이벤트를 넣으려면 UI 동작 자체를 새로 만들어야 해서, "날짜 탭 → 그날 일정 보기"는 별도 건으로 남긴다.
