### PR TITLE
[chore] 빌드 타입체크 캐시가 매번 삭제되는 문제 수정

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -28,6 +28,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Restore TypeScript incremental cache
+        uses: actions/cache@v4
+        with:
+          path: frontend/node_modules/.cache/tsconfig.tsbuildinfo
+          key: tsbuildinfo-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            tsbuildinfo-${{ runner.os }}-
+
       - name: Prettier check
         run: npx prettier --check "**/*.{ts,tsx,js,jsx,css,scss}"
 

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -12,6 +12,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "incremental": true,
+    "tsBuildInfoFile": "./node_modules/.cache/tsconfig.tsbuildinfo",
     "baseUrl": "./",
     "paths": {
       "@/*": ["src/*"]


### PR DESCRIPTION
## #️⃣연관된 이슈

#2006

## 📝작업 내용

`npm run build`가 매번 전체 타입체크를 다시 도는 문제를 고칩니다.

### 원인

`tsconfig.json`의 `outDir`이 `./dist`라서 `.tsbuildinfo`가 `dist/` 안에 생성됩니다. 그런데 `build` 스크립트는 `tsc --noEmit && vite build` 순서이고, `vite build`는 `emptyOutDir` 기본값에 따라 dist를 통째로 비웁니다. **방금 만든 타입체크 캐시를 바로 다음 단계가 지웁니다.** `incremental: true`가 켜져 있어도 효과가 없던 이유입니다.

격리 환경에서 재현한 사이클입니다.

```
tsc --noEmit (cold)   13.2s   → dist/tsconfig.tsbuildinfo(468KB) 생성
tsc --noEmit (warm)    1.6s   ← 캐시가 있으면 8배
vite build            → dist 비움 → tsbuildinfo 삭제
tsc --noEmit (다음)   13.4s   ← 다시 cold
```

### 변경

1. `tsBuildInfoFile`을 `node_modules/.cache/tsconfig.tsbuildinfo`로 옮겨 dist 삭제의 영향을 받지 않게 합니다. 디렉터리는 `tsc`가 자동 생성합니다.
2. CI에서는 `npm ci`가 `node_modules`를 통째로 지우므로, **Install 스텝 바로 뒤**에 `.tsbuildinfo` 복원 캐시 스텝을 추가합니다.

### 측정 결과

CI Build 스텝 50초의 분해입니다 (run 33876449928 로그 타임스탬프 + vite 자체 출력 기준).

| 단계 | 시간 | 비중 |
| --- | --- | --- |
| `generate:sitemap` | 0.2s | 0.4% |
| `tsc --noEmit` | 약 29.7s | 59% |
| `vite build` | 20.46s | 41% |

이 PR 적용 후 `npm run build` 전체 시간입니다 (로컬, CI와 동일 조건: `.env` 없음 + `SKIP_DYNAMIC_SITEMAP=true`).

| 시나리오 | 시간 |
| --- | --- |
| 1회차 (캐시 없음) | 21.3s |
| 2회차 (캐시 있음) | **9.15s** (-57%) |
| 3회차 (소스 1개 수정 후) | 9.64s |

`vite build` 실행 후에도 `node_modules/.cache/tsconfig.tsbuildinfo`가 남아 있는 것을 확인했습니다.

## 중점적으로 리뷰받고 싶은 부분(선택)

CI 캐시 스텝의 위치입니다. `npm ci`가 `node_modules`를 지우기 때문에 Install **뒤**에 두어야 하는데, 이 순서가 맞는지 봐주시면 좋겠습니다.

## 🫡 참고사항

### CI 효과에는 조건이 있습니다

이 워크플로는 `pull_request`에서만 돌고, GitHub Actions 캐시는 PR ref 단위로 스코프됩니다. base 브랜치(`develop-fe`)에서는 이 워크플로가 돌지 않아 공유 캐시가 생기지 않습니다. 따라서 **같은 PR의 2번째 런부터** 효과가 납니다. 최근 60런 기준 PR당 평균 2.3런이라 대략 **런의 57%**가 해당됩니다.

첫 런까지 살리려면 `develop-fe` push 트리거를 추가해 캐시를 미리 만들어둬야 하는데, CI 실행 횟수가 늘어나는 별개 판단이라 이 PR에는 넣지 않았습니다.

### CI 실측 (이 PR에서 확인)

같은 런을 re-run 해서 캐시 히트 경로를 측정했습니다.

| 스텝 | 1번째 런 (캐시 미스) | 2번째 런 (캐시 히트) |
| --- | --- | --- |
| Restore TypeScript incremental cache | `Cache not found` | `Cache restored` |
| **Build** | **50s** | **24s** |
| job 전체 | 130s | 102s |

2번째 런에서도 `vite build`는 20.41s로 동일하므로, 줄어든 26초는 전부 타입체크 몫입니다 (약 29.7s → 약 3.5s).

### 타입 안전성

TypeScript incremental은 파일 내용 해시로 유효성을 판단하므로, 캐시가 오래돼도 변경분은 다시 검사합니다. `npm ci`를 돌리면 캐시가 함께 사라지고 그 직후 한 번은 다시 full check입니다.

### 후속 작업

같은 스토리(MOA-1093) 아래로, CI에서 typecheck를 build와 분리해 병렬 job으로 돌리는 건을 따로 잡을 수 있습니다. Frontend CI wall-clock 기준 130s → 약 100s가 될 것으로 추측합니다. 
