### PR TITLE
[feature] MOA-1095 동아리 상세 기본 탭을 소개내용으로 원복

### DIFF
--- a/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
+++ b/frontend/src/pages/ClubDetailPage/ClubDetailPage.tsx
@@ -59,16 +59,12 @@ const ClubDetailPage = () => {
 
   const hasCalendarConnection = clubDetail?.hasCalendarConnection ?? false;
 
-  const hasFeeds = (clubDetail?.feeds?.length ?? 0) > 0;
-
   const activeTab: TabType = useMemo(() => {
     if (!tabParam || !Object.values(TAB_TYPE).includes(tabParam)) {
-      // 체류시간 중앙값이 7초라 첫 화면이 판단을 좌우한다.
-      // 유저가 스스로 이동하는 탭도 활동사진이 가장 많아 기본값으로 둔다.
-      return hasFeeds ? TAB_TYPE.PHOTOS : TAB_TYPE.INTRO;
+      return TAB_TYPE.INTRO;
     }
     return tabParam;
-  }, [tabParam, hasFeeds]);
+  }, [tabParam]);
 
   const { data: calendarEvents = [], isLoading: isCalendarLoading } =
     useGetClubCalendarEvents((clubName ?? clubId) || '', {


### PR DESCRIPTION
## #️⃣연관된 이슈

close #2008

## 📝작업 내용

`ClubDetailPage`의 기본 탭 결정 로직을 fcee3403 이전 상태로 되돌립니다.

- `hasFeeds` 분기 제거, 기본 탭을 `TAB_TYPE.INTRO`로 고정
- `useMemo` 의존성도 `[tabParam]`으로 원복


## 🫡 참고사항

- URL `?tab=` 파라미터 우선순위는 변경 전과 동일합니다. 활동사진 탭 직링크와 탭 전환은 영향이 없고, 파라미터 없이 들어온 경우만 소개내용으로 열립니다.
