### PR TITLE
[fix] 동아리 상세 응답의 state를 목록과 같은 enum 이름으로 통일

### DIFF
--- a/backend/src/main/java/moadong/club/payload/dto/ClubDetailedResult.java
+++ b/backend/src/main/java/moadong/club/payload/dto/ClubDetailedResult.java
@@ -68,7 +68,7 @@ public record ClubDetailedResult(
                         : clubRecruitmentInformation.getCover())
                 .tags(clubRecruitmentInformation.getTags() == null ? List.of()
                         : clubRecruitmentInformation.getTags())
-                .state(club.getState() == null ? "" : club.getState().getDesc())
+                .state(club.getState() == null ? "" : club.getState().getName())
                 .feeds(clubRecruitmentInformation.getFeedImages() == null ? List.of()
                         : clubRecruitmentInformation.getFeedImages())
                 .category(club.getCategory() == null ? "" : club.getCategory())

--- a/backend/src/main/java/moadong/club/payload/dto/ClubDetailedResult.java
+++ b/backend/src/main/java/moadong/club/payload/dto/ClubDetailedResult.java
@@ -68,7 +68,7 @@ public record ClubDetailedResult(
                         : clubRecruitmentInformation.getCover())
                 .tags(clubRecruitmentInformation.getTags() == null ? List.of()
                         : clubRecruitmentInformation.getTags())
-                .state(club.getState() == null ? "" : club.getState().getName())
+                .state(club.getState() == null ? "" : club.getState().name())
                 .feeds(clubRecruitmentInformation.getFeedImages() == null ? List.of()
                         : clubRecruitmentInformation.getFeedImages())
                 .category(club.getCategory() == null ? "" : club.getCategory())

--- a/backend/src/test/java/moadong/club/payload/dto/ClubDetailedResultTest.java
+++ b/backend/src/test/java/moadong/club/payload/dto/ClubDetailedResultTest.java
@@ -1,0 +1,52 @@
+package moadong.club.payload.dto;
+
+import moadong.club.entity.Club;
+import moadong.club.entity.ClubRecruitmentInformation;
+import moadong.club.enums.ClubState;
+import moadong.util.annotations.UnitTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@UnitTest
+class ClubDetailedResultTest {
+
+    @ParameterizedTest
+    @EnumSource(ClubState.class)
+    void state는_설명값이_아닌_enum_이름으로_내려간다(ClubState state) {
+        Club club = createClub(state);
+
+        assertThat(ClubDetailedResult.of(club).state()).isEqualTo(state.name());
+    }
+
+    @ParameterizedTest
+    @EnumSource(ClubState.class)
+    void state는_목록_응답과_같은_값을_내려간다(ClubState state) {
+        Club club = createClub(state);
+
+        assertThat(ClubDetailedResult.of(club).state())
+                .isEqualTo(ClubSearchResult.of(club).state());
+    }
+
+    @Test
+    void state가_null이면_빈_문자열을_내려간다() {
+        Club club = createClub(null);
+
+        assertThat(ClubDetailedResult.of(club).state()).isEmpty();
+    }
+
+    private Club createClub(ClubState state) {
+        Club club = Club.builder()
+                .name("모아동")
+                .category("학술")
+                .division("중앙")
+                .userId("userId")
+                .clubRecruitmentInformation(ClubRecruitmentInformation.builder().build())
+                .build();
+        ReflectionTestUtils.setField(club, "state", state);
+        return club;
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

동아리 상세 API와 목록 API가 같은 `state` 필드에 서로 다른 값을 내려주던 불일치를 정리합니다.

| 엔드포인트 | 기존 | 변경 후 |
|---|---|---|
| `GET /api/club/search/` | `"AVAILABLE"` | (변경 없음) |
| `GET /api/club/{id}` | `"활성화"` | `"AVAILABLE"` |

원인은 `ClubDetailedResult`만 enum의 설명값인 `getDesc()`를 쓰고 있던 것입니다.

- `ClubDetailedResult`의 state 매핑을 `getDesc()` → `name()`으로 변경
- null 폴백 `""`은 그대로 유지
- `ClubState`의 `desc` 필드와 `fromString`은 건드리지 않음 (응답 매핑만 변경)

**응답 DTO 3곳 표현 통일**

| DTO | 기존 | 변경 후 |
|---|---|---|
| `ClubSearchResult:36` | `getState().name()` | (변경 없음) |
| `ClubHistoryResponse:56` | `getState().name()` | (변경 없음) |
| `ClubDetailedResult:71` | `getState().getDesc()` | `getState().name()` |


