### PR TITLE
[chore] PR 첫 런에도 타입체크 캐시가 적용되도록 develop-fe push 트리거 추가

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -6,6 +6,11 @@ on:
     paths:
       - 'frontend/**'
       - '.github/workflows/frontend-ci.yml'
+  push:
+    branches: [develop-fe]
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend-ci.yml'
 
 jobs:
   ci:


### PR DESCRIPTION
## #️⃣연관된 이슈

#2018

## 📝작업 내용

`frontend-ci.yml`에 `push: branches: [develop-fe]` 트리거를 추가합니다. 변경은 5줄입니다.

### 배경

#2007(MOA-1094)에서 `.tsbuildinfo`를 `dist` 밖으로 옮기고 CI 캐시 스텝을 추가해 Build 스텝이 50s → 24s가 됐습니다. 머지 후 다른 PR에서도 히트가 확인됐습니다.

```
PR #2012 런:  Cache restored from key: tsbuildinfo-Linux-d6e0810b...
              Build: 27s  (✓ built in 20.82s → 타입체크 약 6초)
```

다만 **PR의 두 번째 런부터만** 효과가 있습니다. Frontend CI가 `pull_request`에서만 돌아서 `develop-fe`에는 캐시가 생기지 않고, 각 PR은 자기 첫 런에서 캐시를 만들기만 하기 때문입니다. 실측상 런의 55%만 혜택을 봅니다.

### 이 방식이 동작하는 근거

PR 런이 base/default 브랜치의 캐시를 복원할 수 있다는 건 이 레포에서 이미 관측됩니다. npm 캐시가 그렇게 동작하고 있습니다.

```
저장 위치:   refs/heads/main   node-cache-Linux-x64-npm-fa32f083...  (08-30 생성)
PR #2007:   Cache restored from key: node-cache-Linux-x64-npm-fa32f083...
```

`.tsbuildinfo`도 저장할 자리만 생기면 같은 원리로 동작합니다.

### 기대 효과

| | 현재 | 변경 후 |
| --- | --- | --- |
| PR **첫 번째** 런 Build | 50s | 약 24s |
| PR 2번째 런부터 | 24s | 24s |
| 혜택 받는 런 | 55% | 100% |

### 비용

```
절약:  주당 PR 첫 런 약 21회 × 26초 = 약 9분   (PR을 기다리는 시간)
지출:  주당 develop-fe push 약 15.6회 × 130초 = 약 34분  (머지 후, 아무도 안 기다림)
```

성격이 다른 시간을 맞바꿉니다. 지출하는 쪽은 머지가 끝난 뒤 백그라운드에서 도는 시간이라 아무도 대기하지 않고, 절약하는 쪽은 리뷰를 막고 있는 시간입니다. 레포가 PUBLIC이라 Actions 분은 무료입니다.

덤으로, 지금은 머지된 develop-fe가 초록인지 아무도 확인하지 않는데 **머지 직후 깨짐을 감지하는 신호**가 생깁니다.

## 중점적으로 리뷰받고 싶은 부분(선택)

`paths` 필터를 `pull_request`와 동일하게 뒀습니다. frontend와 무관한 머지에서는 CI가 안 돌아 캐시도 안 갱신되는데, 그런 머지는 타입에 영향이 없으니 기존 캐시가 그대로 유효하다고 봤습니다. 이 판단이 맞는지 봐주시면 좋겠습니다.

## 🫡 참고사항

### 머지 후 확인이 필요합니다

제가 실증한 건 **default 브랜치(main)** 캐시를 PR이 복원한다는 사실입니다. `develop-fe`는 이 레포의 default가 아니라 PR의 **base** 브랜치입니다.

GitHub 문서상 PR 런은 base 브랜치 캐시도 복원할 수 있다고 돼 있지만, 이 레포에서 직접 관측하진 못했습니다(develop-fe에 캐시가 아예 없어 관측 대상이 없습니다). 이 PR이 머지되면 첫 push 런이 캐시를 만들고, **그다음 PR의 첫 런 로그에서 `Cache restored`가 찍히는지** 확인하면 됩니다.

예상대로 안 되면 트리거를 `main`으로 바꾸는 대안이 있습니다. 다만 main은 릴리스 때만 갱신돼 캐시가 오래됩니다.

### 대안으로 검토했다 뺀 것

캐시만 굽는 별도 워크플로(`npm ci` + `tsc --noEmit`만, 약 60초)를 만들면 지출이 주당 34분 → 16분으로 줍니다. 다만 파일이 하나 늘고 develop-fe 검증이라는 덤을 못 얻습니다. Actions 분이 무료인 이상 60초를 아끼자고 워크플로를 추가할 이유가 약하다고 판단해 3줄짜리 트리거를 택했습니다.
