### PR TITLE
[feature] 홍보 이미지 업로드에 presigned URL 발급 추가

### DIFF
--- a/backend/src/main/java/moadong/club/entity/PromotionArticle.java
+++ b/backend/src/main/java/moadong/club/entity/PromotionArticle.java
@@ -19,6 +19,9 @@ import java.util.List;
 @NoArgsConstructor
 public class PromotionArticle {
 
+    /** 게시글 1건당 첨부 가능한 이미지 수. 동아리 활동사진(server.feed.max-count)과 같은 15장. */
+    public static final int MAX_IMAGE_COUNT = 15;
+
     @Id
     private String id;
 

--- a/backend/src/main/java/moadong/club/service/PromotionArticleService.java
+++ b/backend/src/main/java/moadong/club/service/PromotionArticleService.java
@@ -41,6 +41,7 @@ public class PromotionArticleService {
         String clubId = resolveClubId(request.clubId(), user);
         Club club = getClub(clubId);
         validateClubApproved(club, user);
+        validateImageCount(request.images());
 
         PromotionArticle article = PromotionArticle.builder()
             .clubId(clubId)
@@ -67,6 +68,7 @@ public class PromotionArticleService {
         String clubId = resolveClubId(request.clubId(), user);
         Club club = getClub(clubId);
         validateClubApproved(club, user);
+        validateImageCount(request.images());
 
         article.update(clubId, request, club.getName());
         promotionArticleRepository.save(article);
@@ -95,6 +97,16 @@ public class PromotionArticleService {
     private void validateClubApproved(Club club, CustomUserDetails user) {
         if (!user.isDeveloper() && club.getState() != ClubState.AVAILABLE) {
             throw new RestApiException(ErrorCode.PROMOTION_CLUB_NOT_APPROVED);
+        }
+    }
+
+    /**
+     * 업로드 URL 발급 쪽에서도 잔여분만 내주지만, images를 통째로 받는 저장 경로가
+     * 유일한 진실이므로 여기서 총량을 다시 막는다.
+     */
+    private void validateImageCount(List<String> images) {
+        if (images != null && images.size() > PromotionArticle.MAX_IMAGE_COUNT) {
+            throw new RestApiException(ErrorCode.TOO_MANY_FILES);
         }
     }
 

--- a/backend/src/main/java/moadong/club/service/PromotionArticleService.java
+++ b/backend/src/main/java/moadong/club/service/PromotionArticleService.java
@@ -14,6 +14,7 @@ import moadong.club.repository.PromotionArticleRepository;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
 import moadong.global.util.ObjectIdConverter;
+import moadong.media.service.PromotionImageUploadService;
 import moadong.user.payload.CustomUserDetails;
 import org.bson.types.ObjectId;
 import org.springframework.stereotype.Service;
@@ -27,6 +28,7 @@ public class PromotionArticleService {
 
     private final PromotionArticleRepository promotionArticleRepository;
     private final ClubRepository clubRepository;
+    private final PromotionImageUploadService promotionImageUploadService;
 
     public PromotionArticleResponse getPromotionArticles() {
         List<PromotionArticleDto> articles = promotionArticleRepository.findAllActiveOrderByCreatedAtDesc()
@@ -70,8 +72,11 @@ public class PromotionArticleService {
         validateClubApproved(club, user);
         validateImageCount(request.images());
 
+        List<String> previousImages = article.getImages();
         article.update(clubId, request, club.getName());
         promotionArticleRepository.save(article);
+        // 저장이 끝난 뒤에 지운다. 저장이 실패하면 아직 참조 중인 객체를 지우게 된다.
+        promotionImageUploadService.deleteRemovedImages(articleId, previousImages, request.images());
     }
 
     @Transactional

--- a/backend/src/main/java/moadong/media/controller/PromotionImageController.java
+++ b/backend/src/main/java/moadong/media/controller/PromotionImageController.java
@@ -3,9 +3,12 @@ package moadong.media.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import moadong.global.payload.Response;
+import moadong.media.dto.PresignedUploadResponse;
 import moadong.media.dto.PromotionImageUploadResponse;
+import moadong.media.dto.UploadUrlRequest;
 import moadong.media.service.PromotionImageUploadService;
 import moadong.user.annotation.CurrentUser;
 import moadong.user.payload.CustomUserDetails;
@@ -14,10 +17,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/promotion")
@@ -36,5 +42,16 @@ public class PromotionImageController {
                                                   @RequestPart("file") MultipartFile file) {
         PromotionImageUploadResponse response = promotionImageUploadService.upload(articleId, file, user);
         return Response.ok("홍보 이미지가 업로드되었습니다.", response);
+    }
+
+    @PostMapping("/{articleId}/upload-url")
+    @PreAuthorize("hasAnyRole('DEVELOPER', 'CLUB_ADMIN')")
+    @SecurityRequirement(name = "BearerAuth")
+    @Operation(summary = "홍보 이미지 업로드 URL 생성", description = "홍보 게시글 이미지 업로드를 위한 Presigned URL을 여러 개 한 번에 생성합니다. 게시글에는 반영되지 않으며, 업로드한 finalUrl은 게시글 수정 API의 images로 전달해야 저장됩니다. 동아리 관리자는 본인 동아리 게시글에만 발급받을 수 있습니다.")
+    public ResponseEntity<?> generatePromotionImageUploadUrls(@CurrentUser CustomUserDetails user,
+                                                             @PathVariable String articleId,
+                                                             @RequestBody @Valid List<UploadUrlRequest> requests) {
+        List<PresignedUploadResponse> responses = promotionImageUploadService.createUploadUrls(articleId, requests, user);
+        return Response.ok("홍보 이미지 업로드 URL이 생성되었습니다.", responses);
     }
 }

--- a/backend/src/main/java/moadong/media/service/PromotionImageUploadService.java
+++ b/backend/src/main/java/moadong/media/service/PromotionImageUploadService.java
@@ -1,36 +1,65 @@
 package moadong.media.service;
 
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import moadong.club.entity.PromotionArticle;
 import moadong.club.repository.PromotionArticleRepository;
 import moadong.global.config.properties.AwsProperties;
+import moadong.global.config.properties.ServerProperties;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
+import moadong.media.dto.PresignedUploadResponse;
 import moadong.media.dto.PromotionImageUploadResponse;
+import moadong.media.dto.UploadUrlRequest;
 import moadong.user.payload.CustomUserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.regex.Pattern;
+
+import static moadong.media.util.ClubImageUtil.isImageExtension;
 
 @Service
 @RequiredArgsConstructor
 public class PromotionImageUploadService {
 
+    /**
+     * {@code UploadUrlRequest}의 @Pattern은 {@code @Valid List<T>}에서 요소까지 내려가지 않아 동작하지 않는다.
+     * 서명에 들어가는 값이라 서버에서 직접 막는다. (우체통 {@code FeedbackImageService}와 동일)
+     */
+    private static final Pattern ALLOWED_CONTENT_TYPE = Pattern.compile("^image/(jpeg|jpg|png|gif|bmp|webp)$");
+
     private final PromotionArticleRepository promotionArticleRepository;
     private final R2ImageUploadService r2ImageUploadService;
+    private final S3Presigner s3Presigner;
     private final AwsProperties awsProperties;
+    private final ServerProperties serverProperties;
+
+    private String normalizedViewEndpoint;
+
+    @PostConstruct
+    private void init() {
+        String viewEndpoint = awsProperties.s3().viewEndpoint();
+        if (viewEndpoint == null || viewEndpoint.isEmpty()) {
+            throw new IllegalStateException("cloud.aws.s3.view-endpoint must be configured");
+        }
+        normalizedViewEndpoint = viewEndpoint.replaceAll("/+$", "");
+    }
 
     public PromotionImageUploadResponse upload(String articleId, MultipartFile file, CustomUserDetails user) {
-        PromotionArticle article = promotionArticleRepository.findActiveById(articleId)
-            .orElseThrow(() -> new RestApiException(ErrorCode.PROMOTION_ARTICLE_NOT_FOUND));
-        if (!user.isDeveloper() && !user.getClubId().equals(article.getClubId())) {
-            throw new RestApiException(ErrorCode.USER_UNAUTHORIZED);
-        }
-        String key = buildPromotionImageKey(articleId, file);
+        validateArticleAccess(articleId, user);
+        String key = buildPromotionImageKey(articleId, (file != null) ? file.getOriginalFilename() : null);
         String imageUrl = r2ImageUploadService.upload(
             file,
             awsProperties.s3().bucket(),
@@ -41,9 +70,72 @@ public class PromotionImageUploadService {
         return new PromotionImageUploadResponse(imageUrl);
     }
 
-    private String buildPromotionImageKey(String articleId, MultipartFile file) {
+    /**
+     * 동아리 활동사진({@code generateFeedUploadUrls})·우체통 첨부와 같은 부분 성공 응답을 돌려준다.
+     * 한 건이 실패해도 나머지는 발급되고, 실패 항목은 success=false로 표시된다.
+     * URL 발급만 하고 게시글은 건드리지 않는다. 이미지 반영은 게시글 수정 API의 images가 전담한다.
+     */
+    public List<PresignedUploadResponse> createUploadUrls(String articleId, List<UploadUrlRequest> requests,
+                                                          CustomUserDetails user) {
+        validateArticleAccess(articleId, user);
+        if (requests == null || requests.isEmpty()) {
+            return List.of();
+        }
+
+        List<PresignedUploadResponse> results = new ArrayList<>(requests.size());
+        for (UploadUrlRequest request : requests) {
+            try {
+                results.add(createUploadUrl(articleId, request));
+            } catch (RestApiException e) {
+                results.add(errorResponse(e.getErrorCode()));
+            }
+        }
+        return results;
+    }
+
+    private PresignedUploadResponse createUploadUrl(String articleId, UploadUrlRequest request) {
+        if (!isImageExtension(request.fileName())) {
+            throw new RestApiException(ErrorCode.UNSUPPORTED_FILE_TYPE);
+        }
+        if (request.contentType() == null || !ALLOWED_CONTENT_TYPE.matcher(request.contentType()).matches()) {
+            throw new RestApiException(ErrorCode.UNSUPPORTED_FILE_TYPE);
+        }
+
+        String key = buildPromotionImageKey(articleId, request.fileName());
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+            .bucket(awsProperties.s3().bucket())
+            .key(key)
+            .contentType(request.contentType())
+            .build();
+
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+            .signatureDuration(Duration.ofMinutes(serverProperties.fileUrl().expirationTime()))
+            .putObjectRequest(putObjectRequest)
+            .build();
+
+        return new PresignedUploadResponse(
+            s3Presigner.presignPutObject(presignRequest).url().toString(),
+            normalizedViewEndpoint + "/" + key,
+            Map.of("Content-Type", request.contentType()),
+            true,
+            null
+        );
+    }
+
+    private PresignedUploadResponse errorResponse(ErrorCode errorCode) {
+        return new PresignedUploadResponse(null, null, null, false, errorCode.getMessage());
+    }
+
+    private void validateArticleAccess(String articleId, CustomUserDetails user) {
+        PromotionArticle article = promotionArticleRepository.findActiveById(articleId)
+            .orElseThrow(() -> new RestApiException(ErrorCode.PROMOTION_ARTICLE_NOT_FOUND));
+        if (!user.isDeveloper() && !user.getClubId().equals(article.getClubId())) {
+            throw new RestApiException(ErrorCode.USER_UNAUTHORIZED);
+        }
+    }
+
+    private String buildPromotionImageKey(String articleId, String originalFilename) {
         LocalDate today = LocalDate.now(ZoneOffset.UTC);
-        String originalFilename = (file != null) ? file.getOriginalFilename() : null;
         String filename = StringUtils.cleanPath(originalFilename == null ? "" : originalFilename);
         String sanitizedFilename = sanitizeFilename(StringUtils.getFilename(filename));
         String sanitizedArticleId = sanitizePathSegment(articleId, "article");

--- a/backend/src/main/java/moadong/media/service/PromotionImageUploadService.java
+++ b/backend/src/main/java/moadong/media/service/PromotionImageUploadService.java
@@ -2,6 +2,7 @@ package moadong.media.service;
 
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import moadong.club.entity.PromotionArticle;
 import moadong.club.repository.PromotionArticleRepository;
 import moadong.global.config.properties.AwsProperties;
@@ -15,7 +16,10 @@ import moadong.user.payload.CustomUserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
@@ -30,6 +34,7 @@ import java.util.regex.Pattern;
 
 import static moadong.media.util.ClubImageUtil.isImageExtension;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PromotionImageUploadService {
@@ -42,6 +47,7 @@ public class PromotionImageUploadService {
 
     private final PromotionArticleRepository promotionArticleRepository;
     private final R2ImageUploadService r2ImageUploadService;
+    private final S3Client s3Client;
     private final S3Presigner s3Presigner;
     private final AwsProperties awsProperties;
     private final ServerProperties serverProperties;
@@ -133,6 +139,51 @@ public class PromotionImageUploadService {
             true,
             null
         );
+    }
+
+    /**
+     * 게시글에서 빠진 이미지를 R2에서 지운다. 활동사진({@code deleteFeedImages})과 같은
+     * "저장 검증을 통과한 뒤 누락분만 삭제" 경계다.
+     *
+     * <p>수정 요청의 images는 URL 형식을 검증하지 않으므로, 남의 동아리 이미지 URL을
+     * 넣었다 빼는 식으로 임의 객체를 지울 수 있다. 그래서 이 게시글의 키 접두사에
+     * 속한 객체만 지운다.
+     *
+     * <p>삭제 실패는 로그만 남긴다. 버킷 정리 때문에 게시글 수정이 막혀서는 안 된다.
+     */
+    public void deleteRemovedImages(String articleId, List<String> previousImages, List<String> newImages) {
+        if (previousImages == null || previousImages.isEmpty()) {
+            return;
+        }
+        List<String> retained = (newImages == null) ? List.of() : newImages;
+        String articleKeyPrefix = "promotion/articles/" + sanitizePathSegment(articleId, "article") + "/";
+        for (String imageUrl : previousImages) {
+            if (retained.contains(imageUrl)) {
+                continue;
+            }
+            String key = extractKeyOrNull(imageUrl);
+            if (key == null || !key.startsWith(articleKeyPrefix)) {
+                log.warn("Skip deleting promotion image outside the article prefix: articleId={}, url={}", articleId, imageUrl);
+                continue;
+            }
+            deleteQuietly(key);
+        }
+    }
+
+    private String extractKeyOrNull(String imageUrl) {
+        String prefix = normalizedViewEndpoint + "/";
+        return (imageUrl != null && imageUrl.startsWith(prefix)) ? imageUrl.substring(prefix.length()) : null;
+    }
+
+    private void deleteQuietly(String key) {
+        try {
+            s3Client.deleteObject(DeleteObjectRequest.builder()
+                .bucket(awsProperties.s3().bucket())
+                .key(key)
+                .build());
+        } catch (S3Exception e) {
+            log.warn("Failed to delete promotion image from R2: key={}, error={}", key, e.getMessage());
+        }
     }
 
     private PresignedUploadResponse errorResponse(ErrorCode errorCode) {

--- a/backend/src/main/java/moadong/media/service/PromotionImageUploadService.java
+++ b/backend/src/main/java/moadong/media/service/PromotionImageUploadService.java
@@ -58,7 +58,10 @@ public class PromotionImageUploadService {
     }
 
     public PromotionImageUploadResponse upload(String articleId, MultipartFile file, CustomUserDetails user) {
-        validateArticleAccess(articleId, user);
+        PromotionArticle article = getAuthorizedArticle(articleId, user);
+        if (imageCountOf(article) >= PromotionArticle.MAX_IMAGE_COUNT) {
+            throw new RestApiException(ErrorCode.TOO_MANY_FILES);
+        }
         String key = buildPromotionImageKey(articleId, (file != null) ? file.getOriginalFilename() : null);
         String imageUrl = r2ImageUploadService.upload(
             file,
@@ -73,22 +76,32 @@ public class PromotionImageUploadService {
     /**
      * 동아리 활동사진({@code generateFeedUploadUrls})·우체통 첨부와 같은 부분 성공 응답을 돌려준다.
      * 한 건이 실패해도 나머지는 발급되고, 실패 항목은 success=false로 표시된다.
+     * 이미 담긴 이미지를 뺀 잔여분까지만 발급하고, 초과분에는 TOO_MANY_FILES를 덧붙인다.
      * URL 발급만 하고 게시글은 건드리지 않는다. 이미지 반영은 게시글 수정 API의 images가 전담한다.
      */
     public List<PresignedUploadResponse> createUploadUrls(String articleId, List<UploadUrlRequest> requests,
                                                           CustomUserDetails user) {
-        validateArticleAccess(articleId, user);
+        PromotionArticle article = getAuthorizedArticle(articleId, user);
         if (requests == null || requests.isEmpty()) {
             return List.of();
         }
 
-        List<PresignedUploadResponse> results = new ArrayList<>(requests.size());
-        for (UploadUrlRequest request : requests) {
+        int remaining = PromotionArticle.MAX_IMAGE_COUNT - imageCountOf(article);
+        if (remaining <= 0) {
+            return List.of(errorResponse(ErrorCode.TOO_MANY_FILES));
+        }
+
+        int limit = Math.min(remaining, requests.size());
+        List<PresignedUploadResponse> results = new ArrayList<>(limit + 1);
+        for (int i = 0; i < limit; i++) {
             try {
-                results.add(createUploadUrl(articleId, request));
+                results.add(createUploadUrl(articleId, requests.get(i)));
             } catch (RestApiException e) {
                 results.add(errorResponse(e.getErrorCode()));
             }
+        }
+        if (requests.size() > limit) {
+            results.add(errorResponse(ErrorCode.TOO_MANY_FILES));
         }
         return results;
     }
@@ -126,12 +139,17 @@ public class PromotionImageUploadService {
         return new PresignedUploadResponse(null, null, null, false, errorCode.getMessage());
     }
 
-    private void validateArticleAccess(String articleId, CustomUserDetails user) {
+    private PromotionArticle getAuthorizedArticle(String articleId, CustomUserDetails user) {
         PromotionArticle article = promotionArticleRepository.findActiveById(articleId)
             .orElseThrow(() -> new RestApiException(ErrorCode.PROMOTION_ARTICLE_NOT_FOUND));
         if (!user.isDeveloper() && !user.getClubId().equals(article.getClubId())) {
             throw new RestApiException(ErrorCode.USER_UNAUTHORIZED);
         }
+        return article;
+    }
+
+    private int imageCountOf(PromotionArticle article) {
+        return (article.getImages() == null) ? 0 : article.getImages().size();
     }
 
     private String buildPromotionImageKey(String articleId, String originalFilename) {

--- a/backend/src/test/java/moadong/club/service/PromotionArticleServiceTest.java
+++ b/backend/src/test/java/moadong/club/service/PromotionArticleServiceTest.java
@@ -11,6 +11,7 @@ import moadong.club.repository.ClubRepository;
 import moadong.club.repository.PromotionArticleRepository;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
+import moadong.media.service.PromotionImageUploadService;
 import moadong.user.entity.User;
 import moadong.user.entity.enums.UserRole;
 import moadong.user.payload.CustomUserDetails;
@@ -47,6 +48,9 @@ class PromotionArticleServiceTest {
 
     @Mock
     private ClubRepository clubRepository;
+
+    @Mock
+    private PromotionImageUploadService promotionImageUploadService;
 
     @InjectMocks
     private PromotionArticleService promotionArticleService;
@@ -441,6 +445,43 @@ class PromotionArticleServiceTest {
             "신규 설명",
             images
         );
+    }
+
+    @Test
+    void 수정하면_이전_이미지와_새_이미지를_넘겨_빠진_이미지_삭제를_맡긴다() {
+        String clubId = new ObjectId().toHexString();
+        PromotionArticle article = PromotionArticle.builder()
+            .id("article-1")
+            .clubId(clubId)
+            .images(List.of("old-1", "old-2"))
+            .build();
+        when(promotionArticleRepository.findActiveById("article-1")).thenReturn(Optional.of(article));
+        when(clubRepository.findClubById(new ObjectId(clubId))).thenReturn(Optional.of(club("수정 동아리")));
+
+        promotionArticleService.updatePromotionArticle("article-1",
+            updateRequest(clubId, List.of("old-1", "new-1")), developer());
+
+        verify(promotionImageUploadService).deleteRemovedImages("article-1",
+            List.of("old-1", "old-2"), List.of("old-1", "new-1"));
+    }
+
+    @Test
+    void 저장에_실패하면_이미지를_지우지_않는다() {
+        String clubId = new ObjectId().toHexString();
+        PromotionArticle article = PromotionArticle.builder()
+            .id("article-1")
+            .clubId(clubId)
+            .images(List.of("old-1"))
+            .build();
+        when(promotionArticleRepository.findActiveById("article-1")).thenReturn(Optional.of(article));
+        when(clubRepository.findClubById(new ObjectId(clubId))).thenReturn(Optional.of(club("수정 동아리")));
+        when(promotionArticleRepository.save(article)).thenThrow(new IllegalStateException("save failed"));
+
+        assertThrows(IllegalStateException.class,
+            () -> promotionArticleService.updatePromotionArticle("article-1",
+                updateRequest(clubId, List.of("new-1")), developer()));
+
+        verify(promotionImageUploadService, never()).deleteRemovedImages(any(), any(), any());
     }
 
     private static List<String> images(int count) {

--- a/backend/src/test/java/moadong/club/service/PromotionArticleServiceTest.java
+++ b/backend/src/test/java/moadong/club/service/PromotionArticleServiceTest.java
@@ -429,6 +429,57 @@ class PromotionArticleServiceTest {
         return club;
     }
 
+    private static PromotionArticleCreateRequest createRequest(String clubId, List<String> images) {
+        return new PromotionArticleCreateRequest(
+            clubId,
+            "신규 제목",
+            "신규 장소",
+            37.5665,
+            126.9780,
+            Instant.parse("2026-04-01T00:00:00Z"),
+            Instant.parse("2026-04-10T00:00:00Z"),
+            "신규 설명",
+            images
+        );
+    }
+
+    private static List<String> images(int count) {
+        return java.util.stream.IntStream.range(0, count).mapToObj(i -> "image-" + i).toList();
+    }
+
+    @Test
+    void 상한을_넘는_이미지로는_게시글을_생성할_수_없다() {
+        String clubId = new ObjectId().toHexString();
+        when(clubRepository.findClubById(new ObjectId(clubId))).thenReturn(Optional.of(club("생성 동아리")));
+
+        RestApiException exception = assertThrows(RestApiException.class,
+            () -> promotionArticleService.createPromotionArticle(
+                createRequest(clubId, images(PromotionArticle.MAX_IMAGE_COUNT + 1)), developer()));
+
+        assertEquals(ErrorCode.TOO_MANY_FILES, exception.getErrorCode());
+        verify(promotionArticleRepository, never()).save(any(PromotionArticle.class));
+    }
+
+    @Test
+    void 상한을_넘는_이미지로는_게시글을_수정할_수_없다() {
+        String clubId = new ObjectId().toHexString();
+        PromotionArticle article = PromotionArticle.builder()
+            .id("article-1")
+            .clubId(clubId)
+            .images(List.of("old-image"))
+            .build();
+        when(promotionArticleRepository.findActiveById("article-1")).thenReturn(Optional.of(article));
+        when(clubRepository.findClubById(new ObjectId(clubId))).thenReturn(Optional.of(club("수정 동아리")));
+
+        RestApiException exception = assertThrows(RestApiException.class,
+            () -> promotionArticleService.updatePromotionArticle("article-1",
+                updateRequest(clubId, images(PromotionArticle.MAX_IMAGE_COUNT + 1)), developer()));
+
+        assertEquals(ErrorCode.TOO_MANY_FILES, exception.getErrorCode());
+        assertEquals(List.of("old-image"), article.getImages());
+        verify(promotionArticleRepository, never()).save(any(PromotionArticle.class));
+    }
+
     private static PromotionArticleCreateRequest createRequest(String clubId) {
         return new PromotionArticleCreateRequest(
             clubId,
@@ -440,6 +491,20 @@ class PromotionArticleServiceTest {
             Instant.parse("2026-04-10T00:00:00Z"),
             "신규 설명",
             List.of()
+        );
+    }
+
+    private static PromotionArticleUpdateRequest updateRequest(String clubId, List<String> images) {
+        return new PromotionArticleUpdateRequest(
+            clubId,
+            "수정 제목",
+            "수정 장소",
+            37.5665,
+            126.9780,
+            Instant.parse("2026-04-01T00:00:00Z"),
+            Instant.parse("2026-04-10T00:00:00Z"),
+            "수정 설명",
+            images
         );
     }
 

--- a/backend/src/test/java/moadong/media/service/PromotionImageUploadServiceTest.java
+++ b/backend/src/test/java/moadong/media/service/PromotionImageUploadServiceTest.java
@@ -15,11 +15,14 @@ import moadong.user.payload.CustomUserDetails;
 import moadong.util.annotations.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
@@ -44,11 +47,16 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class PromotionImageUploadServiceTest {
 
+    private static final String CDN = "https://cdn.example.com";
+
     @Mock
     private PromotionArticleRepository promotionArticleRepository;
 
     @Mock
     private R2ImageUploadService r2ImageUploadService;
+
+    @Mock
+    private S3Client s3Client;
 
     @Mock
     private S3Presigner s3Presigner;
@@ -248,6 +256,37 @@ class PromotionImageUploadServiceTest {
         assertEquals(ErrorCode.TOO_MANY_FILES, exception.getErrorCode());
         verify(r2ImageUploadService, never()).upload(any(), any(), any(), any());
         verify(promotionArticleRepository, never()).addImageToActiveArticle(any(), any());
+    }
+
+    @Test
+    void 수정으로_빠진_이미지는_R2에서_지우고_남은_이미지는_그대로_둔다() {
+        givenViewEndpoint();
+        String kept = CDN + "/promotion/articles/article-1/2026/09/uuid-kept.png";
+        String removed = CDN + "/promotion/articles/article-1/2026/09/uuid-removed.png";
+
+        promotionImageUploadService.deleteRemovedImages("article-1", List.of(kept, removed), List.of(kept));
+
+        ArgumentCaptor<DeleteObjectRequest> captor = ArgumentCaptor.forClass(DeleteObjectRequest.class);
+        verify(s3Client).deleteObject(captor.capture());
+        assertEquals("promotion/articles/article-1/2026/09/uuid-removed.png", captor.getValue().key());
+    }
+
+    @Test
+    void 이_게시글_경로가_아닌_URL은_지우지_않는다() {
+        givenViewEndpoint();
+        String otherClubLogo = CDN + "/other-club-id/logo/stolen.png";
+        String otherArticle = CDN + "/promotion/articles/article-2/2026/09/uuid-other.png";
+        String external = "https://evil.example.com/promotion/articles/article-1/x.png";
+
+        promotionImageUploadService.deleteRemovedImages("article-1",
+            List.of(otherClubLogo, otherArticle, external), List.of());
+
+        verify(s3Client, never()).deleteObject(any(DeleteObjectRequest.class));
+    }
+
+    private void givenViewEndpoint() {
+        when(awsProperties.s3()).thenReturn(new AwsProperties.S3("moadong-dev", "https://r2.example.com", CDN));
+        ReflectionTestUtils.invokeMethod(promotionImageUploadService, "init");
     }
 
     private static List<String> images(int count) {

--- a/backend/src/test/java/moadong/media/service/PromotionImageUploadServiceTest.java
+++ b/backend/src/test/java/moadong/media/service/PromotionImageUploadServiceTest.java
@@ -3,9 +3,12 @@ package moadong.media.service;
 import moadong.club.entity.PromotionArticle;
 import moadong.club.repository.PromotionArticleRepository;
 import moadong.global.config.properties.AwsProperties;
+import moadong.global.config.properties.ServerProperties;
 import moadong.global.exception.ErrorCode;
 import moadong.global.exception.RestApiException;
+import moadong.media.dto.PresignedUploadResponse;
 import moadong.media.dto.PromotionImageUploadResponse;
+import moadong.media.dto.UploadUrlRequest;
 import moadong.user.entity.User;
 import moadong.user.entity.enums.UserRole;
 import moadong.user.payload.CustomUserDetails;
@@ -16,15 +19,23 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
+import java.net.URL;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -40,7 +51,13 @@ class PromotionImageUploadServiceTest {
     private R2ImageUploadService r2ImageUploadService;
 
     @Mock
+    private S3Presigner s3Presigner;
+
+    @Mock
     private AwsProperties awsProperties;
+
+    @Mock
+    private ServerProperties serverProperties;
 
     @InjectMocks
     private PromotionImageUploadService promotionImageUploadService;
@@ -119,6 +136,84 @@ class PromotionImageUploadServiceTest {
 
         assertEquals(uploadedUrl, response.imageUrl());
         verify(promotionArticleRepository).addImageToActiveArticle(articleId, uploadedUrl);
+    }
+
+    @Test
+    void 업로드URL은_요청한_개수만큼_발급되고_게시글은_변경하지_않는다() {
+        String articleId = "article-1";
+        givenPresigner();
+        when(promotionArticleRepository.findActiveById(articleId)).thenReturn(Optional.of(article(articleId, "my-club")));
+
+        List<PresignedUploadResponse> responses = promotionImageUploadService.createUploadUrls(
+            articleId,
+            List.of(new UploadUrlRequest("poster.png", "image/png"), new UploadUrlRequest("poster2.jpg", "image/jpeg")),
+            clubAdmin("my-club"));
+
+        assertEquals(2, responses.size());
+        assertTrue(responses.get(0).success());
+        assertTrue(responses.get(0).finalUrl().startsWith("https://cdn.example.com/promotion/articles/" + articleId + "/"));
+        assertTrue(responses.get(0).finalUrl().endsWith(".png"));
+        assertTrue(responses.get(1).finalUrl().endsWith(".jpg"));
+        assertEquals("image/png", responses.get(0).requiredHeaders().get("Content-Type"));
+        verify(promotionArticleRepository, never()).addImageToActiveArticle(any(), any());
+    }
+
+    @Test
+    void 지원하지_않는_확장자와_contentType은_그_항목만_실패한다() {
+        String articleId = "article-1";
+        givenPresigner();
+        when(promotionArticleRepository.findActiveById(articleId)).thenReturn(Optional.of(article(articleId, "my-club")));
+
+        List<PresignedUploadResponse> responses = promotionImageUploadService.createUploadUrls(
+            articleId,
+            List.of(
+                new UploadUrlRequest("poster.png", "image/png"),
+                new UploadUrlRequest("poster.txt", "image/png"),
+                new UploadUrlRequest("poster.png", "text/html")),
+            clubAdmin("my-club"));
+
+        assertTrue(responses.get(0).success());
+        assertFalse(responses.get(1).success());
+        assertEquals(ErrorCode.UNSUPPORTED_FILE_TYPE.getMessage(), responses.get(1).failureReason());
+        assertFalse(responses.get(2).success());
+        assertEquals(ErrorCode.UNSUPPORTED_FILE_TYPE.getMessage(), responses.get(2).failureReason());
+    }
+
+    @Test
+    void 동아리관리자는_다른_동아리_게시글의_업로드URL을_받을_수_없다() {
+        when(promotionArticleRepository.findActiveById("article-1")).thenReturn(Optional.of(article("article-1", "other-club")));
+
+        RestApiException exception = assertThrows(RestApiException.class,
+            () -> promotionImageUploadService.createUploadUrls("article-1",
+                List.of(new UploadUrlRequest("poster.png", "image/png")), clubAdmin("my-club")));
+
+        assertEquals(ErrorCode.USER_UNAUTHORIZED, exception.getErrorCode());
+        verify(s3Presigner, never()).presignPutObject(any(PutObjectPresignRequest.class));
+    }
+
+    @Test
+    void 존재하지_않는_홍보게시글이면_업로드URL을_발급하지_않는다() {
+        when(promotionArticleRepository.findActiveById("missing")).thenReturn(Optional.empty());
+
+        RestApiException exception = assertThrows(RestApiException.class,
+            () -> promotionImageUploadService.createUploadUrls("missing",
+                List.of(new UploadUrlRequest("poster.png", "image/png")), developer()));
+
+        assertEquals(ErrorCode.PROMOTION_ARTICLE_NOT_FOUND, exception.getErrorCode());
+        verify(s3Presigner, never()).presignPutObject(any(PutObjectPresignRequest.class));
+    }
+
+    private void givenPresigner() {
+        AwsProperties.S3 s3 = new AwsProperties.S3("moadong-dev", "https://r2.example.com", "https://cdn.example.com/");
+        when(awsProperties.s3()).thenReturn(s3);
+        when(serverProperties.fileUrl()).thenReturn(new ServerProperties.FileUrl(200, 10));
+        // @PostConstruct는 단위 테스트에서 호출되지 않는다.
+        ReflectionTestUtils.invokeMethod(promotionImageUploadService, "init");
+        when(s3Presigner.presignPutObject(any(PutObjectPresignRequest.class))).thenAnswer(invocation -> {
+            PresignedPutObjectRequest presigned = mock(PresignedPutObjectRequest.class);
+            when(presigned.url()).thenReturn(new URL("https://r2.example.com/upload?sig=abc"));
+            return presigned;
+        });
     }
 
     private static PromotionArticle article(String id, String clubId) {

--- a/backend/src/test/java/moadong/media/service/PromotionImageUploadServiceTest.java
+++ b/backend/src/test/java/moadong/media/service/PromotionImageUploadServiceTest.java
@@ -203,6 +203,57 @@ class PromotionImageUploadServiceTest {
         verify(s3Presigner, never()).presignPutObject(any(PutObjectPresignRequest.class));
     }
 
+    @Test
+    void 이미_상한을_채운_게시글은_업로드URL을_발급하지_않는다() {
+        String articleId = "article-1";
+        when(promotionArticleRepository.findActiveById(articleId))
+            .thenReturn(Optional.of(article(articleId, "my-club", images(PromotionArticle.MAX_IMAGE_COUNT))));
+
+        List<PresignedUploadResponse> responses = promotionImageUploadService.createUploadUrls(
+            articleId, List.of(new UploadUrlRequest("poster.png", "image/png")), clubAdmin("my-club"));
+
+        assertEquals(1, responses.size());
+        assertFalse(responses.get(0).success());
+        assertEquals(ErrorCode.TOO_MANY_FILES.getMessage(), responses.get(0).failureReason());
+        verify(s3Presigner, never()).presignPutObject(any(PutObjectPresignRequest.class));
+    }
+
+    @Test
+    void 잔여분까지만_발급하고_초과분에는_TOO_MANY_FILES를_덧붙인다() {
+        String articleId = "article-1";
+        givenPresigner();
+        when(promotionArticleRepository.findActiveById(articleId))
+            .thenReturn(Optional.of(article(articleId, "my-club", images(PromotionArticle.MAX_IMAGE_COUNT - 1))));
+
+        List<PresignedUploadResponse> responses = promotionImageUploadService.createUploadUrls(
+            articleId,
+            List.of(new UploadUrlRequest("poster.png", "image/png"), new UploadUrlRequest("poster2.png", "image/png")),
+            clubAdmin("my-club"));
+
+        assertEquals(2, responses.size());
+        assertTrue(responses.get(0).success());
+        assertFalse(responses.get(1).success());
+        assertEquals(ErrorCode.TOO_MANY_FILES.getMessage(), responses.get(1).failureReason());
+    }
+
+    @Test
+    void 이미_상한을_채운_게시글은_multipart_업로드도_막는다() {
+        when(promotionArticleRepository.findActiveById("article-1"))
+            .thenReturn(Optional.of(article("article-1", "my-club", images(PromotionArticle.MAX_IMAGE_COUNT))));
+        MockMultipartFile file = new MockMultipartFile("file", "poster.png", "image/png", "img".getBytes());
+
+        RestApiException exception = assertThrows(RestApiException.class,
+            () -> promotionImageUploadService.upload("article-1", file, clubAdmin("my-club")));
+
+        assertEquals(ErrorCode.TOO_MANY_FILES, exception.getErrorCode());
+        verify(r2ImageUploadService, never()).upload(any(), any(), any(), any());
+        verify(promotionArticleRepository, never()).addImageToActiveArticle(any(), any());
+    }
+
+    private static List<String> images(int count) {
+        return java.util.stream.IntStream.range(0, count).mapToObj(i -> "image-" + i).toList();
+    }
+
     private void givenPresigner() {
         AwsProperties.S3 s3 = new AwsProperties.S3("moadong-dev", "https://r2.example.com", "https://cdn.example.com/");
         when(awsProperties.s3()).thenReturn(s3);
@@ -217,7 +268,11 @@ class PromotionImageUploadServiceTest {
     }
 
     private static PromotionArticle article(String id, String clubId) {
-        return PromotionArticle.builder().id(id).clubId(clubId).build();
+        return article(id, clubId, List.of());
+    }
+
+    private static PromotionArticle article(String id, String clubId, List<String> images) {
+        return PromotionArticle.builder().id(id).clubId(clubId).images(images).build();
     }
 
     private static CustomUserDetails developer() {


### PR DESCRIPTION
## #️⃣연관된 이슈

<!-- 이슈 번호를 채워주세요 -->

## 📝작업 내용

홍보 이미지 업로드에 presigned URL 발급 엔드포인트를 추가했습니다. 프론트 #2012가 multipart 업로드를 presigned 방식으로 전환하는 데 필요합니다.

지금의 multipart 업로드는 서버가 업로드와 동시에 게시글에 이미지를 append합니다. 그래서 프론트에 "작성은 업로드로 끝, 수정은 PUT으로 전체 교체"라는 비대칭 분기가 생깁니다. presigned로 바꾸면 작성·수정 모두 `게시글 확보 → presigned 업로드 → PUT(전체 images)` 한 흐름이 됩니다.

**`POST /api/promotion/{articleId}/upload-url`**

- 인증: 기존 multipart와 동일 (Bearer, `DEVELOPER` 또는 `CLUB_ADMIN`, 본인 동아리 게시글만)
- 요청: `List<UploadUrlRequest>{fileName, contentType}`
- 응답: `List<PresignedUploadResponse>{presignedUrl, finalUrl, requiredHeaders, success, failureReason}`
- 클럽 활동사진 `feed/upload-url`, 우체통 첨부와 같은 타입·같은 부분 성공 규약입니다. 한 건이 실패해도 나머지는 발급되고 실패 항목만 `success: false`로 내려갑니다
- presignedUrl 유효시간 10분

