### PR TITLE
[fix] 활동사진 저장 시 새로 올린 사진이 맨 뒤로 밀리는 문제 수정

### DIFF
--- a/frontend/src/hooks/Queries/useClubImages.test.tsx
+++ b/frontend/src/hooks/Queries/useClubImages.test.tsx
@@ -68,6 +68,28 @@ describe('useUploadFeed', () => {
     expect(data.urlByFile.size).toBe(1);
   });
 
+  it('finalUrl이 없는 응답은 업로드하지 않고 실패로 처리한다', async () => {
+    mockedGetUploadUrls.mockResolvedValue([
+      success('a.jpg'),
+      {
+        presignedUrl: 'https://r2.example/put/b.jpg',
+        finalUrl: '',
+        success: true,
+        failureReason: null,
+      },
+    ]);
+
+    const files = [makeFile('a.jpg'), makeFile('b.jpg')];
+    const data = await uploadFiles(files);
+
+    expect(data.failedFiles).toEqual(['b.jpg']);
+    expect(mockedUploadToStorage).toHaveBeenCalledTimes(1);
+    expect(mockedUploadToStorage).toHaveBeenCalledWith(
+      'https://r2.example/put/a.jpg',
+      files[0],
+    );
+  });
+
   it('업로드 결과를 파일 참조 기준으로 매핑한다', async () => {
     mockedGetUploadUrls.mockResolvedValue([success('a.jpg'), success('b.jpg')]);
     mockedUploadToStorage.mockImplementation((_url: string, file: File) =>

--- a/frontend/src/hooks/Queries/useClubImages.test.tsx
+++ b/frontend/src/hooks/Queries/useClubImages.test.tsx
@@ -48,6 +48,26 @@ describe('useUploadFeed', () => {
     mockedUploadToStorage.mockResolvedValue(undefined);
   });
 
+  it('presigned 응답이 요청보다 짧아도 터지지 않고 남은 파일을 실패로 처리한다', async () => {
+    // 서버는 개수 제한에 걸리면 남은 슬롯만큼 + 에러 1개만 돌려준다
+    mockedGetUploadUrls.mockResolvedValue([
+      success('a.jpg'),
+      {
+        presignedUrl: null,
+        finalUrl: null,
+        success: false,
+        failureReason: '파일 개수 초과',
+      },
+    ]);
+
+    const files = [makeFile('a.jpg'), makeFile('b.jpg'), makeFile('c.jpg')];
+    const data = await uploadFiles(files);
+
+    expect(data.failedFiles).toEqual(['b.jpg', 'c.jpg']);
+    expect(data.urlByFile.get(files[0])).toBe('https://cdn.example/a.jpg');
+    expect(data.urlByFile.size).toBe(1);
+  });
+
   it('업로드 결과를 파일 참조 기준으로 매핑한다', async () => {
     mockedGetUploadUrls.mockResolvedValue([success('a.jpg'), success('b.jpg')]);
     mockedUploadToStorage.mockImplementation((_url: string, file: File) =>

--- a/frontend/src/hooks/Queries/useClubImages.test.tsx
+++ b/frontend/src/hooks/Queries/useClubImages.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { feedApi, uploadToStorage } from '@/apis/image';
+import { useUploadFeed } from './useClubImages';
+
+jest.mock('@/apis/image', () => ({
+  feedApi: { getUploadUrls: jest.fn(), updateFeeds: jest.fn() },
+  logoApi: {
+    getUploadUrl: jest.fn(),
+    completeUpload: jest.fn(),
+    delete: jest.fn(),
+  },
+  uploadToStorage: jest.fn(),
+}));
+
+const mockedGetUploadUrls = feedApi.getUploadUrls as jest.Mock;
+const mockedUploadToStorage = uploadToStorage as jest.Mock;
+
+const makeFile = (name: string) => new File([''], name, { type: 'image/jpeg' });
+
+const success = (name: string) => ({
+  presignedUrl: `https://r2.example/put/${name}`,
+  finalUrl: `https://cdn.example/${name}`,
+  success: true,
+  failureReason: null,
+});
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+const uploadFiles = async (files: File[]) => {
+  const { result } = renderHook(() => useUploadFeed(), { wrapper });
+  const promise = result.current.mutateAsync({ clubId: 'club-1', files });
+  await waitFor(() => expect(result.current.isPending).toBe(false));
+  return promise;
+};
+
+describe('useUploadFeed', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUploadToStorage.mockResolvedValue(undefined);
+  });
+
+  it('업로드 결과를 파일 참조 기준으로 매핑한다', async () => {
+    mockedGetUploadUrls.mockResolvedValue([success('a.jpg'), success('b.jpg')]);
+    mockedUploadToStorage.mockImplementation((_url: string, file: File) =>
+      file.name === 'a.jpg'
+        ? Promise.reject(new Error('실패'))
+        : Promise.resolve(),
+    );
+
+    const files = [makeFile('a.jpg'), makeFile('b.jpg')];
+    const data = await uploadFiles(files);
+
+    expect(data.failedFiles).toEqual(['a.jpg']);
+    expect(data.urlByFile.get(files[1])).toBe('https://cdn.example/b.jpg');
+  });
+
+  it('저장(updateFeeds)은 호출하지 않는다', async () => {
+    mockedGetUploadUrls.mockResolvedValue([success('a.jpg')]);
+    await uploadFiles([makeFile('a.jpg')]);
+    expect(feedApi.updateFeeds).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/Queries/useClubImages.ts
+++ b/frontend/src/hooks/Queries/useClubImages.ts
@@ -50,7 +50,7 @@ export const useUploadFeed = () => {
       const uploadResults = await Promise.allSettled(
         files.map((file, i) => {
           const res = feedResArr[i];
-          if (!res?.success || !res.presignedUrl) {
+          if (!res?.success || !res.presignedUrl || !res.finalUrl) {
             return Promise.reject(
               new Error(res?.failureReason ?? 'presigned URL 생성 실패'),
             );

--- a/frontend/src/hooks/Queries/useClubImages.ts
+++ b/frontend/src/hooks/Queries/useClubImages.ts
@@ -8,7 +8,6 @@ type ItemStatus = 'pending' | 'uploading' | 'failed';
 interface FeedUploadParams {
   clubId: string;
   files: File[];
-  existingUrls: string[];
   onItemStatusChange?: (file: File, status: ItemStatus) => void;
 }
 
@@ -23,13 +22,10 @@ interface LogoUploadParams {
 }
 
 export const useUploadFeed = () => {
-  const queryClient = useQueryClient();
-
   return useMutation({
     mutationFn: async ({
       clubId,
       files,
-      existingUrls,
       onItemStatusChange,
     }: FeedUploadParams) => {
       // 1. presigned URL 요청
@@ -62,14 +58,14 @@ export const useUploadFeed = () => {
         }),
       );
 
-      // 3. 성공한 파일만 추출
-      const successfulUrls: string[] = [];
+      // 3. 성공한 파일만 추출 (파일 -> 최종 URL 매핑)
+      const urlByFile = new Map<File, string>();
       const failedFiles: string[] = [];
 
       uploadResults.forEach((result, i) => {
         const finalUrl = feedResArr[i].finalUrl;
         if (result.status === 'fulfilled' && finalUrl) {
-          successfulUrls.push(finalUrl);
+          urlByFile.set(files[i], finalUrl);
         } else {
           failedFiles.push(files[i].name);
           onItemStatusChange?.(files[i], 'failed');
@@ -77,25 +73,15 @@ export const useUploadFeed = () => {
       });
 
       // 4. 성공한 파일이 없으면 에러
-      if (successfulUrls.length === 0) {
+      if (urlByFile.size === 0) {
         throw new Error('모든 파일 업로드에 실패했습니다.');
       }
 
-      // 5. 기존 URL과 성공한 URL만 합쳐서 전체 배열 생성
-      const allUrls = [...existingUrls, ...successfulUrls];
-
-      // 6. 서버에 전체 배열 PUT으로 갱신
-      await feedApi.updateFeeds(clubId, allUrls);
-
-      // 7. 실패한 파일 정보 및 성공 URL 반환
-      return { clubId, failedFiles, successfulUrls };
+      // 5. 저장(updateFeeds)은 호출부가 한다.
+      // 화면 순서를 모르는 여기서 배열을 조립하면 새 사진이 항상 뒤로 밀린다.
+      return { failedFiles, urlByFile };
     },
 
-    onSuccess: (data) => {
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.club.detail(data.clubId),
-      });
-    },
     onError: () => {
       console.error('Error uploading feed images');
     },

--- a/frontend/src/hooks/Queries/useClubImages.ts
+++ b/frontend/src/hooks/Queries/useClubImages.ts
@@ -45,16 +45,17 @@ export const useUploadFeed = () => {
 
       // 2. r2에 병렬 업로드 (개별 성공/실패 추적)
       // presigned URL 생성 자체가 실패한 항목은 업로드 건너뜀
+      // 서버가 개수 제한에 걸리면 요청보다 짧은 배열을 돌려준다.
+      // 인덱스로 매칭하므로 없는 항목도 실패로 처리해야 뒤 파일에서 터지지 않는다.
       const uploadResults = await Promise.allSettled(
         files.map((file, i) => {
-          if (!feedResArr[i].success || !feedResArr[i].presignedUrl) {
+          const res = feedResArr[i];
+          if (!res?.success || !res.presignedUrl) {
             return Promise.reject(
-              new Error(
-                feedResArr[i].failureReason ?? 'presigned URL 생성 실패',
-              ),
+              new Error(res?.failureReason ?? 'presigned URL 생성 실패'),
             );
           }
-          return uploadToStorage(feedResArr[i].presignedUrl, file);
+          return uploadToStorage(res.presignedUrl, file);
         }),
       );
 
@@ -63,7 +64,7 @@ export const useUploadFeed = () => {
       const failedFiles: string[] = [];
 
       uploadResults.forEach((result, i) => {
-        const finalUrl = feedResArr[i].finalUrl;
+        const finalUrl = feedResArr[i]?.finalUrl;
         if (result.status === 'fulfilled' && finalUrl) {
           urlByFile.set(files[i], finalUrl);
         } else {

--- a/frontend/src/pages/AdminPage/tabs/PhotoEditTab/hooks/useFeedItems.ts
+++ b/frontend/src/pages/AdminPage/tabs/PhotoEditTab/hooks/useFeedItems.ts
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 import { useUpdateFeed, useUploadFeed } from '@/hooks/Queries/useClubImages';
 import {
+  buildFinalUrls,
   extractLocalItems,
-  extractUploadedUrls,
   findOversizedFile,
   hasPendingChanges,
   sliceToLimit,
@@ -75,7 +75,6 @@ export const useFeedItems = (clubId: string, originalFeeds: string[]) => {
     if (item.type !== 'local' || item.status !== 'failed') return;
 
     const targetFile = item.file;
-    const uploadedUrls = extractUploadedUrls(feedItems);
 
     setFeedItems((prev) =>
       prev.map((it, i) =>
@@ -86,10 +85,10 @@ export const useFeedItems = (clubId: string, originalFeeds: string[]) => {
     );
 
     uploadFeed(
-      { clubId, files: [targetFile], existingUrls: uploadedUrls },
+      { clubId, files: [targetFile] },
       {
-        onSuccess: (data) => {
-          const finalUrl = data.successfulUrls[0];
+        onSuccess: ({ urlByFile }) => {
+          const finalUrl = urlByFile.get(targetFile);
           if (!finalUrl) return;
           setFeedItems((prev) =>
             prev.map((it) => {
@@ -97,6 +96,10 @@ export const useFeedItems = (clubId: string, originalFeeds: string[]) => {
               URL.revokeObjectURL(it.previewUrl);
               return { type: 'uploaded', url: finalUrl } as UploadedItem;
             }),
+          );
+          updateFeed(
+            { clubId, urls: buildFinalUrls(feedItems, urlByFile) },
+            { onError: () => alert('저장에 실패했어요. 다시 시도해주세요!') },
           );
         },
         onError: () => {
@@ -114,11 +117,10 @@ export const useFeedItems = (clubId: string, originalFeeds: string[]) => {
 
   const save = () => {
     const localItems = extractLocalItems(feedItems);
-    const uploadedUrls = extractUploadedUrls(feedItems);
 
     if (localItems.length === 0) {
       updateFeed(
-        { clubId, urls: uploadedUrls },
+        { clubId, urls: buildFinalUrls(feedItems, new Map<File, string>()) },
         { onError: () => alert('저장에 실패했어요. 다시 시도해주세요!') },
       );
       return;
@@ -136,7 +138,6 @@ export const useFeedItems = (clubId: string, originalFeeds: string[]) => {
       {
         clubId,
         files: filesToUpload,
-        existingUrls: uploadedUrls,
         // File 객체 참조로 매핑 — 인덱스 불일치 버그 방지
         onItemStatusChange: (file, status) => {
           setFeedItems((prev) =>
@@ -149,22 +150,26 @@ export const useFeedItems = (clubId: string, originalFeeds: string[]) => {
         },
       },
       {
-        onSuccess: (data) => {
-          if (data.failedFiles.length > 0) {
+        onSuccess: ({ failedFiles, urlByFile }) => {
+          if (failedFiles.length > 0) {
             alert(
-              `일부 파일 업로드에 실패했어요.\n실패한 파일: ${data.failedFiles.join(', ')}\n\n성공한 파일은 정상적으로 등록되었어요.`,
+              `일부 파일 업로드에 실패했어요.\n실패한 파일: ${failedFiles.join(', ')}\n\n성공한 파일은 정상적으로 등록되었어요.`,
             );
           }
-          setFeedItems((prev) => {
-            let successIdx = 0;
-            return prev.map((item) => {
-              if (item.type !== 'local' || item.status === 'failed')
-                return item;
-              const finalUrl = data.successfulUrls[successIdx++];
+          setFeedItems((prev) =>
+            prev.map((item) => {
+              if (item.type !== 'local') return item;
+              const finalUrl = urlByFile.get(item.file);
+              if (!finalUrl) return item;
               URL.revokeObjectURL(item.previewUrl);
               return { type: 'uploaded', url: finalUrl } as UploadedItem;
-            });
-          });
+            }),
+          );
+          // 화면 순서를 아는 여기서 최종 배열을 조립해 저장한다.
+          updateFeed(
+            { clubId, urls: buildFinalUrls(feedItems, urlByFile) },
+            { onError: () => alert('저장에 실패했어요. 다시 시도해주세요!') },
+          );
         },
         onError: () => {
           alert('이미지 업로드에 실패했어요. 다시 시도해주세요!');

--- a/frontend/src/pages/AdminPage/tabs/PhotoEditTab/photoEditUtils.test.ts
+++ b/frontend/src/pages/AdminPage/tabs/PhotoEditTab/photoEditUtils.test.ts
@@ -1,14 +1,15 @@
 import { MAX_FILE_COUNT, MAX_FILE_SIZE } from '@/constants/uploadLimit';
 import {
+  buildFinalUrls,
   findOversizedFile,
   hasPendingChanges,
   reorderItems,
   sliceToLimit,
 } from './photoEditUtils';
-import { FeedItem } from './types';
+import { FeedItem, LocalItem } from './types';
 
 const makeUploaded = (url: string): FeedItem => ({ type: 'uploaded', url });
-const makeLocal = (name: string): FeedItem => ({
+const makeLocal = (name: string): LocalItem => ({
   type: 'local',
   file: new File([''], name, { type: 'image/jpeg' }),
   previewUrl: `blob:${name}`,
@@ -128,5 +129,37 @@ describe('hasPendingChanges', () => {
 
   it('아이템이 없고 원본도 비어있으면 false를 반환한다', () => {
     expect(hasPendingChanges([], [])).toBe(false);
+  });
+});
+
+describe('buildFinalUrls', () => {
+  it('새로 올린 사진이 앞에 있어도 화면 순서를 그대로 유지한다', () => {
+    const local = makeLocal('new.jpg');
+    const feedItems: FeedItem[] = [local, makeUploaded('b'), makeUploaded('c')];
+    const urlByFile = new Map([[local.file, 'a']]);
+    expect(buildFinalUrls(feedItems, urlByFile)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('새로 올린 사진이 중간에 있어도 화면 순서를 그대로 유지한다', () => {
+    const local = makeLocal('new.jpg');
+    const feedItems: FeedItem[] = [makeUploaded('a'), local, makeUploaded('c')];
+    const urlByFile = new Map([[local.file, 'b']]);
+    expect(buildFinalUrls(feedItems, urlByFile)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('업로드에 실패해 URL이 없는 local 아이템은 제외한다', () => {
+    const uploaded = makeLocal('ok.jpg');
+    const failed = makeLocal('fail.jpg');
+    const feedItems: FeedItem[] = [uploaded, makeUploaded('b'), failed];
+    const urlByFile = new Map([[uploaded.file, 'a']]);
+    expect(buildFinalUrls(feedItems, urlByFile)).toEqual(['a', 'b']);
+  });
+
+  it('local 아이템이 없으면 uploaded URL을 순서대로 반환한다', () => {
+    const feedItems: FeedItem[] = [makeUploaded('b'), makeUploaded('a')];
+    expect(buildFinalUrls(feedItems, new Map<File, string>())).toEqual([
+      'b',
+      'a',
+    ]);
   });
 });

--- a/frontend/src/pages/AdminPage/tabs/PhotoEditTab/photoEditUtils.ts
+++ b/frontend/src/pages/AdminPage/tabs/PhotoEditTab/photoEditUtils.ts
@@ -35,7 +35,18 @@ export const hasPendingChanges = (
 export const extractLocalItems = (feedItems: FeedItem[]): LocalItem[] =>
   feedItems.filter((item): item is LocalItem => item.type === 'local');
 
-export const extractUploadedUrls = (feedItems: FeedItem[]): string[] =>
-  feedItems
-    .filter((item): item is UploadedItem => item.type === 'uploaded')
-    .map((item) => item.url);
+// 화면 순서(feedItems)를 그대로 보존한 최종 URL 배열을 만든다.
+// 업로드되지 않아 URL이 없는 local 아이템은 제외된다.
+export const buildFinalUrls = (
+  feedItems: FeedItem[],
+  urlByFile: Map<File, string>,
+): string[] =>
+  feedItems.reduce<string[]>((acc, item) => {
+    if (item.type === 'uploaded') {
+      acc.push(item.url);
+      return acc;
+    }
+    const url = urlByFile.get(item.file);
+    if (url) acc.push(url);
+    return acc;
+  }, []);


### PR DESCRIPTION
close #2025

## 문제

활동사진 탭에서 **새로 올린 사진이 항상 맨 뒤로 밀리던 문제**와, 그 코드 경로에 있던 **크래시 + R2 고아 파일** 문제를 함께 고쳤습니다.

## 1. 순서 버그 (5c2b2d3)

### 재현

새 사진을 맨 앞으로 드래그한 뒤 저장하면, 저장 직후에는 순서가 맞아 보이다가 리페치 시점에 맨 뒤로 밀립니다. 실패한 사진을 재시도해도 같은 현상이 납니다.

### 원인

순서를 기억하고 있는 자료구조(`feedItems` 단일 배열)와 최종 배열을 조립하는 코드(`useUploadFeed`의 concat)가 다른 층에 있어서, 순서를 모르는 쪽이 "기존 것 먼저, 신규는 나중"이라는 순서로 만들고 있었습니다.

```ts
// useFeedItems.save()
const uploadedUrls = extractUploadedUrls(feedItems);   // [B, C] ← 위치 정보 소실

// useUploadFeed
const allUrls = [...existingUrls, ...successfulUrls];  // [B, C, A]
await feedApi.updateFeeds(clubId, allUrls);
```

`extractUploadedUrls`가 `FeedItem[]` → `string[]`으로 좁히는 순간 local 아이템이 몇 번째에 끼어 있었는지가 사라집니다. 저장 직후에는 낙관적 업데이트 덕에 화면이 맞아 보이고, `invalidateQueries` → 리페치 때 서버 순서로 덮어써지면서 다시 어긋납니다. (이게 버그가 늦게 발견된 이유)

### 해결

조립을 **순서를 아는 층으로 되돌렸습니다.**

```
변경 전: useFeedItems(순서 앎) → [B,C] + [A]로 분해 → useUploadFeed(순서 모름) → concat → POST
변경 후: useUploadFeed(업로드만) → Map<File,url> → useFeedItems(순서 앎) → 조립 → POST
```

- `useUploadFeed`는 업로드 I/O만 담당하고 `updateFeeds`를 호출하지 않습니다. `existingUrls` 파라미터를 삭제해, 순서를 모르는 층에서 순서를 만들 방법 자체를 없앴습니다.
- `buildFinalUrls(feedItems, urlByFile)`를 추가해 조립 지점을 하나로 모았습니다. 불변식은 **"결과는 `feedItems`의 부분 수열"** 입니다.
- `save`의 `successfulUrls[successIdx++]` 인덱스 매칭도 File 참조 매칭으로 통일했습니다. 기존에는 "`successfulUrls` 순서 = `files` 순서 = 실패 항목을 건너뛴 순회 순서"라는 조건을 만족해야 했습니다.

## 2. presigned 응답 길이 불일치 크래시 (9f4e93e)

### 원인

서버 `generateFeedUploadUrls`는 개수 제한에 걸리면 남은 슬롯만큼만 발급하고 초과분 에러 응답을 **하나만** 덧붙입니다. 즉 `요청수 >= remaining + 2`면 응답이 요청보다 짧아지는데, 프론트는 `feedResArr[i]`를 `files` 인덱스로 매칭합니다.

프론트/서버의 `remaining` 기준이 다른 게 핵심문제입니다. 프론트는 `15 - (uploaded + local)`, 서버는 `15 - 저장된 수` — UI에서 지웠지만 아직 저장하지 않은 사진이 있으면 서로 상태가 달라집니다..

> **재현:** 저장된 12장 → UI에서 2장 삭제(미저장) → 5장 추가 → 저장
> 클라 `sliceToLimit(5, 10)`은 5장 통과 / 서버 `remaining=3` → 응답 길이 4 → `feedResArr[4]`가 `undefined`

이 throw는 `.map()` 콜백 안에서 동기적으로 발생해 `Promise.allSettled`가 아예 실행되지 않습니다. 앞선 콜백이 이미 시작한 업로드 3장은 **R2에 올라간 채 DB에 기록되지 않고 고아로 남습니다.** 화면에는 실제 원인(개수 초과) 대신 "이미지 업로드에 실패했어요"가 뜹니다.

### 해결

응답에 없는 인덱스를 개별 실패로 처리합니다. 같은 시나리오가 이제 3장 성공 / 2장 실패로 끝나고, 성공분은 `buildFinalUrls`를 거쳐 13장이 화면 순서대로 저장됩니다. 고아 파일이 생기지 않습니다.

## 동작 변화

PUT이 업로드 뮤테이션 밖으로 나오면서, **업로드는 성공했는데 저장(POST)만 실패한 경우**가 달라집니다.

- 기존: 전부 `failed`로 되돌아감 → 재시도 시 R2에 중복 업로드
- 변경 후: 사진은 `uploaded`로 남고 "저장에 실패했어요" 알림 → `hasPendingChanges`가 true라 저장 버튼이 활성 상태로 남고, 재저장 시 재업로드가 없음

화면에는 보이는데 아직 서버엔 없는 창이 생기지만, 저장 버튼이 켜져 있고 R2 고아가 줄어드는 쪽이라 개선으로 봤습니다.


