### PR TITLE
[fix] 활동사진 presigned URL 발급이 요청보다 짧은 배열을 반환하는 문제 수정

### DIFF
--- a/backend/src/main/java/moadong/media/service/CloudflareImageService.java
+++ b/backend/src/main/java/moadong/media/service/CloudflareImageService.java
@@ -166,22 +166,23 @@ public class CloudflareImageService implements ClubImageService{
         return generatePresignedUrl(clubId, fileName, contentType, FileType.LOGO);
     }
 
+    /**
+     * 요청 수만 상한 검증하고, 통과하면 요청 수만큼 전부 발급한다.
+     * 저장된 사진 수는 보지 않는다. 발급 시점에는 아직 저장되지 않은 삭제를 알 수 없어
+     * 기준으로 쓸 수 없고, 최종 개수 검증은 updateFeeds가 담당한다.
+     * 개별 항목이 실패해도 errorResponse로 자리를 채워 응답 길이 == requests.size()를 유지한다.
+     */
     @Override
     public List<PresignedUploadResponse> generateFeedUploadUrls(String clubId, String userId, List<UploadUrlRequest> requests) {
         Club club = getAuthorizedClub(clubId, userId);
         validateClubRecruitmentInformation(club);
-        int existingCount = (club.getClubRecruitmentInformation().getFeedImages() == null)
-            ? 0
-            : club.getClubRecruitmentInformation().getFeedImages().size();
-        int remaining = Math.max(0, serverProperties.feed().maxCount() - existingCount);
-        if (remaining == 0) {
-            return java.util.List.of(errorResponse(ErrorCode.TOO_MANY_FILES));
+
+        if (requests.size() > serverProperties.feed().maxCount()) {
+            throw new RestApiException(ErrorCode.TOO_MANY_FILES);
         }
 
-        int limit = Math.min(remaining, requests.size());
-        java.util.ArrayList<PresignedUploadResponse> results = new java.util.ArrayList<>(limit + 1);
-        for (int i = 0; i < limit; i++) {
-            UploadUrlRequest req = requests.get(i);
+        java.util.ArrayList<PresignedUploadResponse> results = new java.util.ArrayList<>(requests.size());
+        for (UploadUrlRequest req : requests) {
             try {
                 validateFileName(req.fileName());
                 results.add(generatePresignedUrl(clubId, req.fileName(), req.contentType(), FileType.FEED));
@@ -191,9 +192,6 @@ public class CloudflareImageService implements ClubImageService{
                 log.error("Unexpected error generating presigned URL: clubId={}, fileName={}", clubId, req.fileName(), e);
                 results.add(errorResponse(ErrorCode.IMAGE_UPLOAD_FAILED));
             }
-        }
-        if (requests.size() > limit) {
-            results.add(errorResponse(ErrorCode.TOO_MANY_FILES));
         }
         return results;
     }

--- a/backend/src/test/java/moadong/media/service/CloudflareImageServiceFeedUploadUrlsTest.java
+++ b/backend/src/test/java/moadong/media/service/CloudflareImageServiceFeedUploadUrlsTest.java
@@ -1,0 +1,172 @@
+package moadong.media.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
+import moadong.club.entity.Club;
+import moadong.club.entity.ClubRecruitmentInformation;
+import moadong.club.repository.ClubRepository;
+import moadong.global.config.properties.AwsProperties;
+import moadong.global.config.properties.ServerProperties;
+import moadong.global.exception.ErrorCode;
+import moadong.global.exception.RestApiException;
+import moadong.media.dto.PresignedUploadResponse;
+import moadong.media.dto.UploadUrlRequest;
+import moadong.util.annotations.UnitTest;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+@ExtendWith(MockitoExtension.class)
+@UnitTest
+class CloudflareImageServiceFeedUploadUrlsTest {
+
+	private static final int MAX_FEED_COUNT = 15;
+
+	@Spy
+	@InjectMocks
+	private CloudflareImageService cloudflareImageService;
+
+	@Mock
+	private ClubRepository clubRepository;
+
+	@Mock
+	private S3Client s3Client;
+
+	@Mock
+	private S3Presigner s3Presigner;
+
+	@Mock
+	private AwsProperties awsProperties;
+
+	@Mock
+	private AwsProperties.S3 awsS3;
+
+	@Mock
+	private ServerProperties serverProperties;
+
+	@Mock
+	private ServerProperties.Feed feedProperties;
+
+	@Mock
+	private ServerProperties.FileUrl fileUrlProperties;
+
+	private String clubId;
+
+	@BeforeEach
+	void setUp() {
+		lenient().when(awsProperties.s3()).thenReturn(awsS3);
+		lenient().when(awsS3.viewEndpoint()).thenReturn("https://cdn.example.com/");
+		lenient().when(awsS3.bucket()).thenReturn("test-bucket");
+
+		lenient().when(serverProperties.feed()).thenReturn(feedProperties);
+		lenient().when(feedProperties.maxCount()).thenReturn(MAX_FEED_COUNT);
+		lenient().when(serverProperties.fileUrl()).thenReturn(fileUrlProperties);
+		lenient().when(fileUrlProperties.expirationTime()).thenReturn(10);
+
+		lenient().when(s3Presigner.presignPutObject(any(PutObjectPresignRequest.class))).thenAnswer(invocation -> {
+			PresignedPutObjectRequest presigned = mock(PresignedPutObjectRequest.class);
+			when(presigned.url()).thenReturn(new java.net.URL("https://r2.example.com/upload?sig=abc"));
+			return presigned;
+		});
+
+		ReflectionTestUtils.invokeMethod(cloudflareImageService, "init");
+
+		clubId = new ObjectId().toHexString();
+	}
+
+	private void givenSavedFeedImages(int savedCount) {
+		List<String> feedImages = IntStream.range(0, savedCount)
+			.mapToObj(i -> "https://cdn.example.com/" + clubId + "/feed/saved" + i + ".png")
+			.toList();
+		ClubRecruitmentInformation info = ClubRecruitmentInformation.builder()
+			.feedImages(feedImages)
+			.build();
+		Club club = Club.builder().userId("").clubRecruitmentInformation(info).build();
+		when(clubRepository.findClubById(any())).thenReturn(Optional.of(club));
+	}
+
+	private List<UploadUrlRequest> imageRequests(int count) {
+		List<UploadUrlRequest> requests = new ArrayList<>(count);
+		for (int i = 0; i < count; i++) {
+			requests.add(new UploadUrlRequest("photo" + i + ".png", "image/png"));
+		}
+		return requests;
+	}
+
+	@Test
+	void 저장된_사진이_많아도_요청한_개수만큼_발급한다() {
+		givenSavedFeedImages(14);
+		List<UploadUrlRequest> requests = imageRequests(5);
+
+		List<PresignedUploadResponse> responses =
+			cloudflareImageService.generateFeedUploadUrls(clubId, "", requests);
+
+		assertEquals(requests.size(), responses.size());
+		assertTrue(responses.stream().allMatch(PresignedUploadResponse::success));
+	}
+
+	@Test
+	void 저장된_사진이_상한만큼_있어도_요청이_상한_이내면_정상_발급한다() {
+		givenSavedFeedImages(MAX_FEED_COUNT);
+		List<UploadUrlRequest> requests = imageRequests(MAX_FEED_COUNT);
+
+		List<PresignedUploadResponse> responses =
+			cloudflareImageService.generateFeedUploadUrls(clubId, "", requests);
+
+		assertEquals(MAX_FEED_COUNT, responses.size());
+		assertTrue(responses.stream().allMatch(PresignedUploadResponse::success));
+	}
+
+	@Test
+	void 요청_개수가_상한을_넘으면_TOO_MANY_FILES를_던지고_부분_응답을_만들지_않는다() {
+		givenSavedFeedImages(0);
+		List<UploadUrlRequest> requests = imageRequests(MAX_FEED_COUNT + 1);
+
+		RestApiException exception = assertThrows(RestApiException.class,
+			() -> cloudflareImageService.generateFeedUploadUrls(clubId, "", requests));
+
+		assertEquals(ErrorCode.TOO_MANY_FILES, exception.getErrorCode());
+		verify(s3Presigner, never()).presignPutObject(any(PutObjectPresignRequest.class));
+	}
+
+	@Test
+	void 확장자가_잘못된_항목이_섞여도_길이는_유지되고_해당_자리만_실패한다() {
+		givenSavedFeedImages(0);
+		List<UploadUrlRequest> requests = List.of(
+			new UploadUrlRequest("ok.png", "image/png"),
+			new UploadUrlRequest("bad", "image/png"),
+			new UploadUrlRequest("also-ok.jpg", "image/jpeg"));
+
+		List<PresignedUploadResponse> responses =
+			cloudflareImageService.generateFeedUploadUrls(clubId, "", requests);
+
+		assertEquals(requests.size(), responses.size());
+		assertTrue(responses.get(0).success());
+		assertFalse(responses.get(1).success());
+		assertEquals(ErrorCode.UNSUPPORTED_FILE_TYPE.getMessage(), responses.get(1).failureReason());
+		assertTrue(responses.get(2).success());
+	}
+}


### PR DESCRIPTION


## 문제

`generateFeedUploadUrls`가 **요청한 파일 수보다 짧은 presigned 배열**을 돌려주는 경로가 있었습니다. 클라이언트는 응답을 `files`의 인덱스로 매칭하므로 인덱스 정렬이 깨집니다.

```
remaining = maxCount(15) - 저장된 사진 수
remaining == 0 → List.of(errorResponse) 하나만 반환 (길이 1)
그 외        → min(remaining, 요청수) + (요청수 > limit ? 1 : 0)
```

즉 `요청수 >= remaining + 2` 이면 응답이 요청보다 짧아집니다.

### 더 근본적인 문제: 기준 자체가 틀렸다

활동사진 삭제는 **저장 버튼을 눌러야** 반영되는데 presigned 요청은 그보다 먼저 나갑니다. 서버는 "아직 일어나지 않은 삭제"를 모르는 상태로 개수를 판단하고 있었습니다. 그래서 정상 사용에서 오탐이 납니다.

```
재현: 저장된 12장 → UI에서 2장 삭제(아직 저장 안 함) → 5장 추가 → 저장
     클라 기준 15장 이내라 통과하지만, 서버는 existingCount=12로 보고 2장을 거부
```

## 해결

**발급 단계에서 저장 수를 보지 않습니다.**

- `existingCount` / `remaining` / `limit` 계산 제거
- `requests.size() > maxCount` 이면 `RestApiException(TOO_MANY_FILES)`로 **전체를 거부**합니다. 부분 응답을 만들지 않습니다.
- 통과하면 요청 수만큼 전부 발급합니다.

결과적으로 **응답 길이 == `requests.size()`가 구조적으로 보장**됩니다. "짧게 주지 않도록 조심한다"가 아니라 "짧게 줄 방법이 없다"로 바꾸는 게 목표였습니다.

```java
if (requests.size() > serverProperties.feed().maxCount()) {
    throw new RestApiException(ErrorCode.TOO_MANY_FILES);
}

var results = new ArrayList<PresignedUploadResponse>(requests.size());
for (UploadUrlRequest req : requests) {
    try {
        validateFileName(req.fileName());
        results.add(generatePresignedUrl(...));
    } catch (RestApiException e) {
        results.add(errorResponse(e.getErrorCode()));   // 자리를 채워 인덱스 유지
    } ...
}
return results;
```

## 유지한 것

- **`validateFileName` 실패 시 `errorResponse`로 자리를 채우는 동작.** 인덱스 정렬 유지가 목적입니다.
- **`updateFeeds`의 `newFeedImageList.size() > maxCount` 검증.** 이게 최종 방어선이고, 발급 단계 검사를 없앨 수 있는 근거가 바로 "여기에 이미 있다"는 것입니다.
- `deleteFeedImages` 로직.
- `validateClubRecruitmentInformation(club)`. 개수 계산 때문에 있던 건 아니고 클럽 상태 자체에 대한 사전 조건이라 그대로 뒀습니다.

## 존재하는 리스크: R2 고아 파일

저장되지 않을 파일이 R2에 올라갈 수 있습니다. 다만

1. 프론트 `sliceToLimit`이 1차로 막고,
2. **새로 생기는 문제가 아닙니다.** `deleteFeedImages`는 "등록된 적 있는 URL 중 새 배열에 없는 것"만 지우므로, 한 번도 등록 안 된 업로드는 지금도 영구 고아입니다.


