### PR TITLE
[feature] 관리자는 동아리 상세 페이지에서 지원서 모집 기간을 원클릭으로 수정할 수 있다

### DIFF
--- a/frontend/src/components/common/ToggleButton/ToggleButton.styles.ts
+++ b/frontend/src/components/common/ToggleButton/ToggleButton.styles.ts
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+import { colors } from '@/styles/theme/colors';
+import { setTypography, typography } from '@/styles/theme/typography';
+
+export const Button = styled.button<{ $active: boolean }>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+  padding: 9px 16px;
+  ${setTypography(typography.button.button1)};
+  cursor: pointer;
+  transition:
+    background-color 0.12s ease,
+    transform 0.06s ease;
+
+  color: ${({ $active }) => ($active ? colors.base.white : colors.gray[700])};
+  background-color: ${({ $active }) =>
+    $active ? colors.primary[800] : colors.gray[300]};
+  border: ${({ $active }) =>
+    $active ? `1px solid transparent` : `1px solid ${colors.gray[500]}`};
+
+  &:active {
+    transform: translateY(1px);
+  }
+`;

--- a/frontend/src/components/common/ToggleButton/ToggleButton.tsx
+++ b/frontend/src/components/common/ToggleButton/ToggleButton.tsx
@@ -1,0 +1,19 @@
+import type { ButtonHTMLAttributes } from 'react';
+import * as Styled from './ToggleButton.styles';
+
+interface ToggleButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  active: boolean;
+}
+
+const ToggleButton = ({
+  active,
+  children,
+  type = 'button',
+  ...rest
+}: ToggleButtonProps) => (
+  <Styled.Button $active={active} type={type} {...rest}>
+    {children}
+  </Styled.Button>
+);
+
+export default ToggleButton;

--- a/frontend/src/constants/adminFieldLimits.ts
+++ b/frontend/src/constants/adminFieldLimits.ts
@@ -13,6 +13,8 @@ export const FAQ_ANSWER_MAX = 300;
 
 // 모집 정보 수정 (RecruitEditTab)
 export const RECRUIT_TARGET_MAX = 10;
+// 상시모집 종료일로 쓰는 더미 연도
+export const FAR_FUTURE_YEAR = 2999;
 
 // 계정 관리 (AccountEditTab)
 export const PASSWORD_MAX = 20;

--- a/frontend/src/constants/queryKeys.ts
+++ b/frontend/src/constants/queryKeys.ts
@@ -32,6 +32,8 @@ export const queryKeys = {
   },
   club: {
     all: ['clubs'] as const,
+    /** 모든 clubDetail 쿼리를 한 번에 무효화하는 prefix */
+    allDetails: ['clubDetail'] as const,
     detail: (clubParam: string) => ['clubDetail', clubParam] as const,
     calendarEvents: (clubParam: string) =>
       ['clubCalendarEvents', clubParam] as const,

--- a/frontend/src/constants/storageKeys.ts
+++ b/frontend/src/constants/storageKeys.ts
@@ -11,4 +11,6 @@ export const STORAGE_KEYS = {
   SATISFACTION_ANSWERED: 'satisfactionAnswered',
   HAS_CONSENTED_PERSONAL_INFO: 'hasConsentedPersonalInfo',
   QUERY_CACHE: 'MOADONG_QUERY_CACHE',
+  /** 관리자 로그인 시 귀속된 동아리 ID. 새로고침 후에도 관리자 UI 유지에 사용 */
+  ADMIN_CLUB_ID: 'adminClubId',
 } as const;

--- a/frontend/src/hooks/Queries/useClub.ts
+++ b/frontend/src/hooks/Queries/useClub.ts
@@ -122,9 +122,12 @@ export const useUpdateClubDescription = () => {
   return useMutation({
     mutationFn: (updatedData: ClubDescription) =>
       updateClubDescription(updatedData),
-    onSuccess: (_, variables) => {
+    onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: queryKeys.club.detail(variables.id),
+        queryKey: queryKeys.club.allDetails,
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.club.all,
       });
     },
     onError: (error) => {

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -4,17 +4,14 @@ import { getClubIdByToken } from '@/apis/auth';
 const useAuth = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
-  const [clubId, setClubId] = useState<string | null>(null);
 
   useEffect(() => {
     const checkAuth = async () => {
       try {
-        const clubId = await getClubIdByToken();
-        setClubId(clubId);
+        await getClubIdByToken();
         setIsAuthenticated(true);
       } catch {
         setIsAuthenticated(false);
-        setClubId(null);
       } finally {
         setIsLoading(false);
       }
@@ -23,7 +20,7 @@ const useAuth = () => {
     checkAuth();
   }, []);
 
-  return { isLoading, isAuthenticated, clubId };
+  return { isLoading, isAuthenticated };
 };
 
 export default useAuth;

--- a/frontend/src/hooks/useLogout.ts
+++ b/frontend/src/hooks/useLogout.ts
@@ -2,10 +2,12 @@ import { useNavigate } from 'react-router-dom';
 import { logout } from '@/apis/auth';
 import { ADMIN_EVENT } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
+import { useAdminClubId } from '@/store/useAdminClubStore';
 
 const useLogout = () => {
   const navigate = useNavigate();
   const trackEvent = useMixpanelTrack();
+  const { setClubId } = useAdminClubId();
 
   const handleLogout = async () => {
     const confirmed = window.confirm('정말 로그아웃하시겠습니까?');
@@ -15,6 +17,7 @@ const useLogout = () => {
       await logout();
       trackEvent(ADMIN_EVENT.LOGOUT_BUTTON_CLICKED);
       localStorage.removeItem('accessToken');
+      setClubId(null);
       navigate('/admin/login', { replace: true });
     } catch {
       alert('로그아웃에 실패했습니다.');

--- a/frontend/src/pages/AdminPage/auth/LoginTab/LoginTab.tsx
+++ b/frontend/src/pages/AdminPage/auth/LoginTab/LoginTab.tsx
@@ -10,6 +10,7 @@ import { STORAGE_KEYS } from '@/constants/storageKeys';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import useTrackPageView from '@/hooks/Mixpanel/useTrackPageView';
 import useAuth from '@/hooks/useAuth';
+import { useAdminClubId } from '@/store/useAdminClubStore';
 import * as Styled from './LoginTab.styles';
 
 const LoginTab = () => {
@@ -22,6 +23,7 @@ const LoginTab = () => {
   const navigate = useNavigate();
 
   const { isAuthenticated, isLoading: authLoading } = useAuth();
+  const { setClubId } = useAdminClubId();
 
   useEffect(() => {
     if (!authLoading && isAuthenticated) {
@@ -42,6 +44,7 @@ const LoginTab = () => {
         STORAGE_KEYS.HAS_CONSENTED_PERSONAL_INFO,
         JSON.stringify(loginData.allowedPersonalInformation),
       );
+      setClubId(loginData.clubId);
       alert('로그인 성공! 관리자 페이지로 이동합니다.');
       navigate('/admin');
     } catch (error: unknown) {

--- a/frontend/src/pages/AdminPage/auth/PrivateRoute/PrivateRoute.tsx
+++ b/frontend/src/pages/AdminPage/auth/PrivateRoute/PrivateRoute.tsx
@@ -1,22 +1,12 @@
-import { useEffect } from 'react';
 import { Navigate } from 'react-router-dom';
 import Spinner from '@/components/common/Spinner/Spinner';
 import useAuth from '@/hooks/useAuth';
-import { useAdminClubId } from '@/store/useAdminClubStore';
 
 const PrivateRoute = ({ children }: { children: React.ReactNode }) => {
-  const { isLoading, isAuthenticated, clubId } = useAuth();
-  const { clubId: storeClubId, setClubId } = useAdminClubId();
-
-  useEffect(() => {
-    if (clubId) {
-      setClubId(clubId);
-    }
-  }, [clubId, setClubId]);
+  const { isLoading, isAuthenticated } = useAuth();
 
   if (isLoading) return <Spinner />;
   if (!isAuthenticated) return <Navigate to='/admin/login' replace />;
-  if (clubId && storeClubId !== clubId) return <Spinner />;
 
   return <>{children}</>;
 };

--- a/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.styles.ts
+++ b/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.styles.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { colors } from '@/styles/theme/colors';
+import { setTypography, typography } from '@/styles/theme/typography';
 
 export const Container = styled.div`
   display: flex;
@@ -13,33 +13,13 @@ export const RecruitPeriodContainer = styled.div`
   max-width: 706px;
 `;
 
-export const AlwaysRecruitButton = styled.button<{ $isAlwaysActive: boolean }>`
-  border-radius: 10px;
-  width: 120px;
-  height: 45px;
-  padding: 0px 16px;
-  font-weight: 600;
-  font-size: 1rem;
-  cursor: pointer;
+export const AlwaysRecruitButtonWrapper = styled.div`
   flex-shrink: 0;
 
-  color: ${colors.gray[700]};
-  background-color: ${colors.gray[300]};
-  border: 1px solid ${colors.gray[500]};
-
-  ${({ $isAlwaysActive }) =>
-    $isAlwaysActive &&
-    `
-  color: ${colors.base.white};
-  background-color: ${colors.primary[800]};
-  border: none;
-  `}
-  transition:
-    background-color 0.12s ease,
-    transform 0.06s ease;
-
-  &:active {
-    transform: translateY(1px);
+  button {
+    width: 120px;
+    height: 45px;
+    ${setTypography(typography.paragraph.p2)};
   }
 `;
 

--- a/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.tsx
+++ b/frontend/src/pages/AdminPage/tabs/RecruitEditTab/RecruitEditTab.tsx
@@ -1,10 +1,13 @@
 import { useEffect, useRef, useState } from 'react';
 import { useOutletContext } from 'react-router-dom';
-import { useQueryClient } from '@tanstack/react-query';
 import { setYear } from 'date-fns';
 import Button from '@/components/common/Button/Button';
 import InputField from '@/components/common/InputField/InputField';
-import { RECRUIT_TARGET_MAX } from '@/constants/adminFieldLimits';
+import ToggleButton from '@/components/common/ToggleButton/ToggleButton';
+import {
+  FAR_FUTURE_YEAR,
+  RECRUIT_TARGET_MAX,
+} from '@/constants/adminFieldLimits';
 import { ADMIN_EVENT, PAGE_VIEW } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import useTrackPageView from '@/hooks/Mixpanel/useTrackPageView';
@@ -14,8 +17,6 @@ import { ClubDetail } from '@/types/club';
 import { recruitmentDateParser } from '@/utils/recruitmentDateParser';
 import DateTimeRangePicker from './components/DateTimeRangePicker/DateTimeRangePicker';
 import * as Styled from './RecruitEditTab.styles';
-
-const FAR_FUTURE_YEAR = 2999;
 
 const RecruitEditTab = () => {
   const trackEvent = useMixpanelTrack();
@@ -153,14 +154,15 @@ const RecruitEditTab = () => {
                 onChangeRecruitmentEnd={handleEndChange}
                 disabledEnd={isAlwaysRecruiting}
               />
-              <Styled.AlwaysRecruitButton
-                type='button'
-                $isAlwaysActive={isAlwaysRecruiting}
-                onClick={toggleAlwaysRecruiting}
-                aria-pressed={isAlwaysRecruiting}
-              >
-                상시모집
-              </Styled.AlwaysRecruitButton>
+              <Styled.AlwaysRecruitButtonWrapper>
+                <ToggleButton
+                  active={isAlwaysRecruiting}
+                  onClick={toggleAlwaysRecruiting}
+                  aria-pressed={isAlwaysRecruiting}
+                >
+                  상시모집
+                </ToggleButton>
+              </Styled.AlwaysRecruitButtonWrapper>
             </Styled.RecruitPeriodContainer>
           </div>
           <InputField

--- a/frontend/src/pages/ClubDetailPage/components/AdminPeriodButton/AdminPeriodButton.styles.ts
+++ b/frontend/src/pages/ClubDetailPage/components/AdminPeriodButton/AdminPeriodButton.styles.ts
@@ -43,12 +43,11 @@ export const StatusInfo = styled.div`
   color: ${colors.gray[500]};
 `;
 
-export const StatusDot = styled.span<{ $isAlways: boolean }>`
+export const StatusDot = styled.span`
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: ${({ $isAlways }) =>
-    $isAlways ? colors.secondary[3].main : colors.primary[800]};
+  background: ${colors.primary[800]};
 `;
 
 export const StatusText = styled.span`

--- a/frontend/src/pages/ClubDetailPage/components/AdminPeriodButton/AdminPeriodButton.styles.ts
+++ b/frontend/src/pages/ClubDetailPage/components/AdminPeriodButton/AdminPeriodButton.styles.ts
@@ -1,0 +1,86 @@
+import styled from 'styled-components';
+import { media } from '@/styles/mediaQuery';
+import { colors } from '@/styles/theme/colors';
+import { setTypography, typography } from '@/styles/theme/typography';
+import { Z_INDEX } from '@/styles/zIndex';
+
+export const ButtonArea = styled.div`
+  position: sticky;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 0 24px;
+  z-index: ${Z_INDEX.clubDetailFooter};
+  background: ${colors.base.white};
+  box-shadow: 0px 0px 14px rgba(0, 0, 0, 0.16);
+
+  ${media.tablet} {
+    position: fixed;
+    bottom: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 100%;
+    max-width: 500px;
+    padding: 10px 20px calc(20px + env(safe-area-inset-bottom));
+    background: transparent;
+    box-shadow: none;
+  }
+
+  ${media.mobile} {
+    left: 0;
+    transform: none;
+    max-width: 100%;
+  }
+`;
+
+export const StatusInfo = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  ${setTypography(typography.paragraph.p7)};
+  color: ${colors.gray[500]};
+`;
+
+export const StatusDot = styled.span<{ $isAlways: boolean }>`
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: ${({ $isAlways }) =>
+    $isAlways ? colors.secondary[3].main : colors.primary[800]};
+`;
+
+export const StatusText = styled.span`
+  color: ${colors.gray[600]};
+  font-weight: 600;
+`;
+
+export const StatusDate = styled.span`
+  color: ${colors.gray[500]};
+  font-weight: 600;
+`;
+
+export const ChangePeriodButton = styled.button`
+  width: 517px;
+  height: 60px;
+  border-radius: 14px;
+  border: 1.5px solid ${colors.primary[800]};
+  background: ${colors.base.white};
+  ${setTypography(typography.title.title5)};
+  color: ${colors.primary[800]};
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease;
+
+  &:hover {
+    background: ${colors.primary[500]};
+  }
+
+  ${media.tablet} {
+    width: 100%;
+    height: 50px;
+    ${setTypography(typography.paragraph.p2)};
+  }
+`;

--- a/frontend/src/pages/ClubDetailPage/components/AdminPeriodButton/AdminPeriodButton.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/AdminPeriodButton/AdminPeriodButton.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
+import Toast from '@/components/common/Toast/Toast';
+import { ClubDetail } from '@/types/club';
+import getDeadlineText from '@/utils/getDeadLineText';
+import { recruitmentDateParser } from '@/utils/recruitmentDateParser';
+import RecruitmentPeriodModal from '../RecruitmentPeriodModal/RecruitmentPeriodModal';
+import * as Styled from './AdminPeriodButton.styles';
+
+interface AdminPeriodButtonProps {
+  clubDetail: ClubDetail;
+}
+
+const AdminPeriodButton = ({ clubDetail }: AdminPeriodButtonProps) => {
+  const [isPeriodModalOpen, setIsPeriodModalOpen] = useState(false);
+  const [isSuccessToastOpen, setIsSuccessToastOpen] = useState(false);
+
+  const { recruitmentStatus } = clubDetail;
+  const isAlwaysRecruiting = recruitmentStatus === 'ALWAYS';
+
+  const deadlineText = getDeadlineText(
+    recruitmentDateParser(clubDetail.recruitmentStart),
+    recruitmentDateParser(clubDetail.recruitmentEnd),
+    recruitmentStatus,
+  );
+
+  const endDate = recruitmentDateParser(clubDetail.recruitmentEnd);
+
+  const statusText = isAlwaysRecruiting
+    ? '상시 모집 중'
+    : deadlineText
+      ? `모집 중 · ${deadlineText}`
+      : '모집 중';
+
+  const dateRangeText =
+    !isAlwaysRecruiting && endDate
+      ? `(~ ${format(endDate, 'MM.dd', { locale: ko })} 마감)`
+      : null;
+
+  return (
+    <>
+      <Styled.ButtonArea>
+        <Styled.StatusInfo>
+          <Styled.StatusDot $isAlways={isAlwaysRecruiting} />
+          <Styled.StatusText>{statusText}</Styled.StatusText>
+          {dateRangeText && (
+            <Styled.StatusDate>{dateRangeText}</Styled.StatusDate>
+          )}
+        </Styled.StatusInfo>
+        <Styled.ChangePeriodButton
+          type='button'
+          onClick={() => setIsPeriodModalOpen(true)}
+        >
+          지원 기간 변경
+        </Styled.ChangePeriodButton>
+      </Styled.ButtonArea>
+
+      <RecruitmentPeriodModal
+        isOpen={isPeriodModalOpen}
+        onClose={() => setIsPeriodModalOpen(false)}
+        clubDetail={clubDetail}
+        onSuccess={() => setIsSuccessToastOpen(true)}
+      />
+
+      <Toast
+        isOpen={isSuccessToastOpen}
+        onClose={() => setIsSuccessToastOpen(false)}
+        message='모집 기간이 변경됐어요.'
+      />
+    </>
+  );
+};
+
+export default AdminPeriodButton;

--- a/frontend/src/pages/ClubDetailPage/components/AdminPeriodButton/AdminPeriodButton.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/AdminPeriodButton/AdminPeriodButton.tsx
@@ -42,7 +42,7 @@ const AdminPeriodButton = ({ clubDetail }: AdminPeriodButtonProps) => {
     <>
       <Styled.ButtonArea>
         <Styled.StatusInfo>
-          <Styled.StatusDot $isAlways={isAlwaysRecruiting} />
+          <Styled.StatusDot />
           <Styled.StatusText>{statusText}</Styled.StatusText>
           {dateRangeText && (
             <Styled.StatusDate>{dateRangeText}</Styled.StatusDate>
@@ -52,7 +52,7 @@ const AdminPeriodButton = ({ clubDetail }: AdminPeriodButtonProps) => {
           type='button'
           onClick={() => setIsPeriodModalOpen(true)}
         >
-          지원 기간 변경
+          모집 기간 변경
         </Styled.ChangePeriodButton>
       </Styled.ButtonArea>
 

--- a/frontend/src/pages/ClubDetailPage/components/ClubApplyButton/ClubApplyButton.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/ClubApplyButton/ClubApplyButton.tsx
@@ -6,9 +6,12 @@ import { USER_EVENT } from '@/constants/eventName';
 import useMixpanelTrack from '@/hooks/Mixpanel/useMixpanelTrack';
 import { useGetClubDetail } from '@/hooks/Queries/useClub';
 import useNavigator from '@/hooks/useNavigator';
+import { useAdminClubId } from '@/store/useAdminClubStore';
 import { ApplicationForm, ApplicationFormMode } from '@/types/application';
+import { asClubId } from '@/types/branded';
 import getDeadlineText from '@/utils/getDeadLineText';
 import { recruitmentDateParser } from '@/utils/recruitmentDateParser';
+import AdminPeriodButton from '../AdminPeriodButton/AdminPeriodButton';
 import ApplicationSelectModal from '../ApplicationSelectModal/ApplicationSelectModal';
 import * as Styled from './ClubApplyButton.styles';
 
@@ -21,6 +24,7 @@ const ClubApplyButton = () => {
   const handleLink = useNavigator();
   const trackEvent = useMixpanelTrack();
   const { data: clubDetail } = useGetClubDetail((clubName ?? clubId) || '');
+  const { clubId: adminClubId } = useAdminClubId();
 
   const [isApplicationModalOpen, setIsApplicationModalOpen] = useState(false);
   const [applicationOptions, setApplicationOptions] = useState<
@@ -28,6 +32,26 @@ const ClubApplyButton = () => {
   >([]);
 
   if (!clubId || !clubDetail) return null;
+
+  const recruitmentStatus = clubDetail.recruitmentStatus;
+  const isRecruitmentClosed = recruitmentStatus === 'CLOSED';
+  const isRecruitmentUpcoming = recruitmentStatus === 'UPCOMING';
+  const isAlwaysRecruiting = recruitmentStatus === 'ALWAYS';
+
+  const isAdmin =
+    adminClubId !== null && asClubId(adminClubId) === clubDetail.id;
+  const canManagePeriod =
+    isAdmin && (recruitmentStatus === 'OPEN' || isAlwaysRecruiting);
+
+  if (canManagePeriod) {
+    return <AdminPeriodButton clubDetail={clubDetail} />;
+  }
+
+  const deadlineText = getDeadlineText(
+    recruitmentDateParser(clubDetail.recruitmentStart),
+    recruitmentDateParser(clubDetail.recruitmentEnd),
+    recruitmentStatus,
+  );
 
   const navigateToApplicationForm = async (formId: string) => {
     try {
@@ -86,17 +110,6 @@ const ClubApplyButton = () => {
       console.error('지원서 옵션 조회 중 오류가 발생했습니다.', e);
     }
   };
-
-  const recruitmentStatus = clubDetail.recruitmentStatus;
-  const isRecruitmentClosed = recruitmentStatus === 'CLOSED';
-  const isRecruitmentUpcoming = recruitmentStatus === 'UPCOMING';
-  const isAlwaysRecruiting = recruitmentStatus === 'ALWAYS';
-
-  const deadlineText = getDeadlineText(
-    recruitmentDateParser(clubDetail.recruitmentStart),
-    recruitmentDateParser(clubDetail.recruitmentEnd),
-    recruitmentStatus,
-  );
 
   const renderButtonContent = () => {
     if (isRecruitmentClosed || isRecruitmentUpcoming) {

--- a/frontend/src/pages/ClubDetailPage/components/RecruitmentPeriodModal/RecruitmentPeriodModal.styles.ts
+++ b/frontend/src/pages/ClubDetailPage/components/RecruitmentPeriodModal/RecruitmentPeriodModal.styles.ts
@@ -1,0 +1,162 @@
+import styled from 'styled-components';
+import { colors } from '@/styles/theme/colors';
+import { setTypography, typography } from '@/styles/theme/typography';
+
+export const Dialog = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 280px;
+  border: 1px solid ${colors.gray[200]};
+  border-radius: 14px;
+  background: ${colors.base.white};
+  overflow: hidden;
+`;
+
+export const Body = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 16px 24px 20px;
+`;
+
+export const Title = styled.p`
+  ${setTypography(typography.title.title6)};
+  color: ${colors.base.black};
+  text-align: center;
+  letter-spacing: -0.32px;
+`;
+
+export const PeriodDescription = styled.p`
+  ${setTypography(typography.paragraph.p5)};
+  color: ${colors.gray[600]};
+  text-align: center;
+  letter-spacing: -0.28px;
+  margin-bottom: 8px;
+`;
+
+export const FieldsContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+
+  & > *:last-child {
+    margin-top: 4px;
+  }
+`;
+
+export const FieldGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+`;
+
+export const FieldLabel = styled.span`
+  ${setTypography(typography.paragraph.p7)};
+  color: ${colors.gray[800]};
+  font-weight: 600;
+  letter-spacing: -0.24px;
+`;
+
+export const InputRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+export const InputFieldWrapper = styled.div`
+  width: 64px;
+  flex-shrink: 0;
+
+  input {
+    height: 38px;
+    padding: 0 8px;
+    text-align: center;
+    font-size: 14px;
+    min-width: unset;
+
+    &::placeholder {
+      font-size: 14px;
+    }
+  }
+`;
+
+export const InputSuffix = styled.span`
+  ${setTypography(typography.paragraph.p5)};
+  color: ${colors.gray[700]};
+  letter-spacing: -0.28px;
+  white-space: nowrap;
+`;
+
+export const Preview = styled.span<{ $empty?: boolean }>`
+  ${setTypography(typography.paragraph.p7)};
+  color: ${({ $empty }) => ($empty ? colors.gray[400] : colors.primary[800])};
+  letter-spacing: -0.24px;
+  white-space: nowrap;
+`;
+
+export const Divider = styled.hr`
+  border: none;
+  border-top: 1px solid ${colors.gray[200]};
+  width: calc(100% + 48px);
+  margin: 0 -24px;
+`;
+
+export const AlwaysToggleWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+
+  button {
+    width: 100%;
+    letter-spacing: -0.28px;
+  }
+`;
+
+export const AlwaysToggleHint = styled.span`
+  ${setTypography(typography.paragraph.p7)};
+  color: ${colors.gray[400]};
+  text-align: center;
+  letter-spacing: -0.24px;
+`;
+
+export const Footer = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 100%;
+  height: 44px;
+  border-top: 1px solid ${colors.gray[200]};
+`;
+
+export const FooterButton = styled.button<{ $emphasized?: boolean }>`
+  flex: 1;
+  height: 100%;
+  padding: 12px 10px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  letter-spacing: -0.28px;
+  ${({ $emphasized }) =>
+    $emphasized
+      ? setTypography(typography.button.button1)
+      : setTypography(typography.paragraph.p5)};
+  color: ${({ $emphasized }) =>
+    $emphasized ? colors.primary[800] : colors.gray[700]};
+
+  &:disabled {
+    color: ${({ $emphasized }) =>
+      $emphasized ? colors.primary[800] : colors.gray[700]};
+    opacity: 0.35;
+    cursor: not-allowed;
+  }
+
+  & + & {
+    border-left: 1px solid ${colors.gray[200]};
+  }
+`;

--- a/frontend/src/pages/ClubDetailPage/components/RecruitmentPeriodModal/RecruitmentPeriodModal.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/RecruitmentPeriodModal/RecruitmentPeriodModal.tsx
@@ -145,10 +145,10 @@ const RecruitmentPeriodModal = ({
       <Styled.Dialog
         role='dialog'
         aria-modal='true'
-        aria-label='지원 기간 변경'
+        aria-label='모집 기간 변경'
       >
         <Styled.Body>
-          <Styled.Title>지원 기간 변경</Styled.Title>
+          <Styled.Title>모집 기간 변경</Styled.Title>
           <Styled.PeriodDescription>
             현재 모집 기간: {currentPeriodText}
           </Styled.PeriodDescription>

--- a/frontend/src/pages/ClubDetailPage/components/RecruitmentPeriodModal/RecruitmentPeriodModal.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/RecruitmentPeriodModal/RecruitmentPeriodModal.tsx
@@ -1,0 +1,251 @@
+import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { addDays, format, setYear } from 'date-fns';
+import { ko } from 'date-fns/locale';
+import InputField from '@/components/common/InputField/InputField';
+import Modal from '@/components/common/Modal/Modal';
+import ToggleButton from '@/components/common/ToggleButton/ToggleButton';
+import { FAR_FUTURE_YEAR } from '@/constants/adminFieldLimits';
+import { queryKeys } from '@/constants/queryKeys';
+import { useUpdateClubDescription } from '@/hooks/Queries/useClub';
+import { ClubDetail } from '@/types/club';
+import { recruitmentDateParser } from '@/utils/recruitmentDateParser';
+import * as Styled from './RecruitmentPeriodModal.styles';
+
+const formatPreview = (date: Date) => format(date, 'M월 d일', { locale: ko });
+
+const formatShort = (date: Date | null) =>
+  date ? format(date, 'MM.dd', { locale: ko }) : '?';
+
+interface RecruitmentPeriodModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  clubDetail: ClubDetail;
+  onSuccess: () => void;
+}
+
+const RecruitmentPeriodModal = ({
+  isOpen,
+  onClose,
+  clubDetail,
+  onSuccess,
+}: RecruitmentPeriodModalProps) => {
+  const [earlyCloseDays, setEarlyCloseDays] = useState('');
+  const [extendDays, setExtendDays] = useState('');
+  const [switchToAlways, setSwitchToAlways] = useState(false);
+
+  const queryClient = useQueryClient();
+  const { mutate: updateClubDescription, isPending } =
+    useUpdateClubDescription();
+
+  const isAlways = clubDetail.recruitmentStatus === 'ALWAYS';
+  const currentEnd = recruitmentDateParser(clubDetail.recruitmentEnd);
+  const currentStart = recruitmentDateParser(clubDetail.recruitmentStart);
+
+  const earlyCloseNum = parseInt(earlyCloseDays, 10);
+  const extendNum = parseInt(extendDays, 10);
+
+  const validEarlyClose =
+    earlyCloseDays !== '' && !isNaN(earlyCloseNum) && earlyCloseNum > 0;
+  const validExtend =
+    extendDays !== '' && !isNaN(extendNum) && extendNum > 0 && !!currentEnd;
+
+  const exitAlwaysCanSubmit = isAlways && switchToAlways;
+  const canSubmit =
+    (validEarlyClose ||
+      validExtend ||
+      (!isAlways && switchToAlways) ||
+      exitAlwaysCanSubmit) &&
+    !isPending;
+
+  const today = new Date();
+  const earlyClosePreview = validEarlyClose
+    ? addDays(today, earlyCloseNum)
+    : null;
+  const extendPreview =
+    validExtend && currentEnd ? addDays(currentEnd, extendNum) : null;
+
+  const exitAlwaysDefaultDate =
+    isAlways && switchToAlways && !validEarlyClose ? currentStart : null;
+
+  const handleEarlyCloseDaysChange = (value: string) => {
+    if (value !== '' && !/^\d+$/.test(value)) return;
+    setEarlyCloseDays(value);
+    if (isAlways) {
+      setSwitchToAlways(value !== '');
+    } else {
+      setExtendDays('');
+      setSwitchToAlways(false);
+    }
+  };
+
+  const handleExtendDaysChange = (value: string) => {
+    if (value !== '' && !/^\d+$/.test(value)) return;
+    setExtendDays(value);
+    setEarlyCloseDays('');
+    setSwitchToAlways(false);
+  };
+
+  const handleToggleAlways = () => {
+    setSwitchToAlways((prev) => {
+      const next = !prev;
+      if (!isAlways && next) {
+        setEarlyCloseDays('');
+        setExtendDays('');
+      }
+      return next;
+    });
+  };
+
+  const handleClose = () => {
+    setEarlyCloseDays('');
+    setExtendDays('');
+    setSwitchToAlways(false);
+    onClose();
+  };
+
+  const handleConfirm = () => {
+    let newEnd: Date;
+
+    if (isAlways && switchToAlways) {
+      newEnd = validEarlyClose
+        ? addDays(today, earlyCloseNum)
+        : (currentStart ?? today);
+    } else if (!isAlways && switchToAlways) {
+      newEnd = setYear(currentStart ?? today, FAR_FUTURE_YEAR);
+    } else if (validEarlyClose) {
+      newEnd = addDays(today, earlyCloseNum);
+    } else if (validExtend && currentEnd) {
+      newEnd = addDays(currentEnd, extendNum);
+    } else {
+      return;
+    }
+
+    updateClubDescription(
+      {
+        id: clubDetail.id,
+        recruitmentStart: currentStart?.toISOString() ?? null,
+        recruitmentEnd: newEnd.toISOString(),
+        recruitmentTarget: clubDetail.recruitmentTarget,
+      },
+      {
+        onSuccess: () => {
+          // 훅 내부 invalidate는 clubDetail.id 기반이라 clubName slug로 캐싱된
+          // ClubDetailPage 쿼리를 갱신하지 못한다. prefix로 전체 무효화한다.
+          void queryClient.invalidateQueries({
+            queryKey: queryKeys.club.allDetails,
+          });
+          handleClose();
+          onSuccess();
+        },
+      },
+    );
+  };
+
+  const currentPeriodText = isAlways
+    ? '상시 모집 중'
+    : `${formatShort(currentStart)} ~ ${formatShort(currentEnd)}`;
+
+  const earlyCloseDisabled = !isAlways && switchToAlways;
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose}>
+      <Styled.Dialog
+        role='dialog'
+        aria-modal='true'
+        aria-label='지원 기간 변경'
+      >
+        <Styled.Body>
+          <Styled.Title>지원 기간 변경</Styled.Title>
+          <Styled.PeriodDescription>
+            현재 모집 기간: {currentPeriodText}
+          </Styled.PeriodDescription>
+
+          <Styled.Divider />
+
+          <Styled.FieldsContainer>
+            <Styled.FieldGroup>
+              <Styled.FieldLabel>조기 마감</Styled.FieldLabel>
+              <Styled.InputRow>
+                <Styled.InputFieldWrapper>
+                  <InputField
+                    width='100%'
+                    showClearButton={false}
+                    placeholder='0'
+                    value={earlyCloseDays}
+                    onChange={(e) => handleEarlyCloseDaysChange(e.target.value)}
+                    disabled={earlyCloseDisabled}
+                  />
+                </Styled.InputFieldWrapper>
+                <Styled.InputSuffix>일 뒤 마감</Styled.InputSuffix>
+                <Styled.Preview $empty={!earlyClosePreview}>
+                  {earlyClosePreview
+                    ? `→ ${formatPreview(earlyClosePreview)} 마감`
+                    : '→ 날짜 미리보기'}
+                </Styled.Preview>
+              </Styled.InputRow>
+            </Styled.FieldGroup>
+
+            {!isAlways && (
+              <Styled.FieldGroup>
+                <Styled.FieldLabel>기간 연장</Styled.FieldLabel>
+                <Styled.InputRow>
+                  <Styled.InputFieldWrapper>
+                    <InputField
+                      width='100%'
+                      showClearButton={false}
+                      placeholder='0'
+                      value={extendDays}
+                      onChange={(e) => handleExtendDaysChange(e.target.value)}
+                      disabled={switchToAlways}
+                    />
+                  </Styled.InputFieldWrapper>
+                  <Styled.InputSuffix>일 연장</Styled.InputSuffix>
+                  <Styled.Preview $empty={!extendPreview}>
+                    {extendPreview
+                      ? `→ ${formatPreview(extendPreview)}까지 연장`
+                      : '→ 날짜 미리보기'}
+                  </Styled.Preview>
+                </Styled.InputRow>
+              </Styled.FieldGroup>
+            )}
+
+            <Styled.AlwaysToggleWrapper>
+              <ToggleButton
+                active={switchToAlways}
+                onClick={handleToggleAlways}
+              >
+                {isAlways ? '상시 모집 해제' : '상시 모집으로 전환'}
+              </ToggleButton>
+              {isAlways &&
+                switchToAlways &&
+                !validEarlyClose &&
+                exitAlwaysDefaultDate && (
+                  <Styled.AlwaysToggleHint>
+                    일수 미입력 시 {formatPreview(exitAlwaysDefaultDate)}{' '}
+                    기준으로 마감 설정
+                  </Styled.AlwaysToggleHint>
+                )}
+            </Styled.AlwaysToggleWrapper>
+          </Styled.FieldsContainer>
+        </Styled.Body>
+
+        <Styled.Footer>
+          <Styled.FooterButton type='button' onClick={handleClose}>
+            취소
+          </Styled.FooterButton>
+          <Styled.FooterButton
+            type='button'
+            $emphasized
+            disabled={!canSubmit}
+            onClick={handleConfirm}
+          >
+            확인
+          </Styled.FooterButton>
+        </Styled.Footer>
+      </Styled.Dialog>
+    </Modal>
+  );
+};
+
+export default RecruitmentPeriodModal;

--- a/frontend/src/pages/ClubDetailPage/components/RecruitmentPeriodModal/RecruitmentPeriodModal.tsx
+++ b/frontend/src/pages/ClubDetailPage/components/RecruitmentPeriodModal/RecruitmentPeriodModal.tsx
@@ -1,12 +1,10 @@
 import { useState } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
 import { addDays, format, setYear } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import InputField from '@/components/common/InputField/InputField';
 import Modal from '@/components/common/Modal/Modal';
 import ToggleButton from '@/components/common/ToggleButton/ToggleButton';
 import { FAR_FUTURE_YEAR } from '@/constants/adminFieldLimits';
-import { queryKeys } from '@/constants/queryKeys';
 import { useUpdateClubDescription } from '@/hooks/Queries/useClub';
 import { ClubDetail } from '@/types/club';
 import { recruitmentDateParser } from '@/utils/recruitmentDateParser';
@@ -34,7 +32,6 @@ const RecruitmentPeriodModal = ({
   const [extendDays, setExtendDays] = useState('');
   const [switchToAlways, setSwitchToAlways] = useState(false);
 
-  const queryClient = useQueryClient();
   const { mutate: updateClubDescription, isPending } =
     useUpdateClubDescription();
 
@@ -130,11 +127,6 @@ const RecruitmentPeriodModal = ({
       },
       {
         onSuccess: () => {
-          // 훅 내부 invalidate는 clubDetail.id 기반이라 clubName slug로 캐싱된
-          // ClubDetailPage 쿼리를 갱신하지 못한다. prefix로 전체 무효화한다.
-          void queryClient.invalidateQueries({
-            queryKey: queryKeys.club.allDetails,
-          });
           handleClose();
           onSuccess();
         },

--- a/frontend/src/store/useAdminClubStore.ts
+++ b/frontend/src/store/useAdminClubStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
-import { subscribeWithSelector } from 'zustand/middleware';
+import { persist } from 'zustand/middleware';
+import { STORAGE_KEYS } from '@/constants/storageKeys';
 
 interface AdminClubStore {
   clubId: string | null;
@@ -7,10 +8,21 @@ interface AdminClubStore {
 }
 
 export const useAdminClubStore = create<AdminClubStore>()(
-  subscribeWithSelector((set) => ({
-    clubId: null,
-    setClubId: (id) => set({ clubId: id }),
-  })),
+  persist(
+    (set) => ({
+      clubId: null,
+      setClubId: (id) => set({ clubId: id }),
+    }),
+    {
+      name: STORAGE_KEYS.ADMIN_CLUB_ID,
+      partialize: (state) => ({ clubId: state.clubId }),
+      onRehydrateStorage: () => (state) => {
+        if (!localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN)) {
+          state?.setClubId(null);
+        }
+      },
+    },
+  ),
 );
 
 export const useAdminClubId = () => {


### PR DESCRIPTION
## #️⃣연관된 이슈

> MOA-1098, MOA-1100

## 📝작업 내용

### 관리자용 모집 기간 변경 UI

- `ClubDetailPage`에서 관리자 로그인 시 `ClubApplyButton` 대신 `AdminPeriodButton` 노출 (모집중 · 상시모집 상태)
- `AdminPeriodButton`: 현재 모집 상태·마감일 표시 + "모집 기간 변경" 버튼
- `RecruitmentPeriodModal`: 조기 마감(N일 뒤) / 기간 연장(N일) / 상시 모집 전환·해제 토글 지원, 날짜 미리보기 인라인 표시
- 모집 기간 변경 성공 시 Toast 표시 및 홈 목록·동아리 상세 캐시 즉시 무효화

### 공통 ConfirmModal 도입 및 모달 리팩토링

- `ConfirmModal` 공통 컴포넌트 추가 (`warning` / `check` variant)
- `FeedbackConfirmModal`, `DisconnectConfirmModal` → `ConfirmModal`로 교체
- `ApplicationSelectModal` → `ClubDetailPage`로 이동, `ModalLayout` 의존성 제거

### 기타

- `ToggleButton` 공통 컴포넌트 추가 (AdminPage `RecruitEditTab` 상시모집 버튼에도 적용)
- `FAR_FUTURE_YEAR` 상수화 (`src/constants/adminFieldLimits.ts`)
- 관리자 `clubId` Zustand persist 미들웨어 적용 및 인증 흐름 개선
- `modal_warning` / `modal_check` 아이콘 추가

### 스크린샷

| 모집중 (관리자) | 모집 기간 변경 모달(모집중) | 모집 기간 변경 모달(상시모집중) |
|---|---|---|
| <img width="277" height="532" alt="스크린샷 2026-09-11 161238" src="https://github.com/user-attachments/assets/14377aa7-0258-462b-80c1-3649a169c8a0" /> | <img width="276" height="535" alt="스크린샷 2026-09-11 161255" src="https://github.com/user-attachments/assets/3c86cd7a-06a2-4757-83f9-ba3e432db5e2" /> | <img width="275" height="533" alt="스크린샷 2026-09-11 161322" src="https://github.com/user-attachments/assets/84c15c54-0843-4829-b63e-5c6b06f788ca" /> |

## 중점적으로 리뷰받고 싶은 부분(선택)

- `useUpdateClubDescription` `onSuccess`에서 `queryKeys.club.allDetails`(상세) + `queryKeys.club.all`(목록) 두 키를 모두 무효화하는 방식이 적절한지
- `RecruitEditTab`이 `useOutletContext`를 사용하기 때문에 `refetchType: 'all'`을 넣지 않은 점 — 더 나은 방법이 있다면 의견 부탁드립니다

## 논의하고 싶은 부분(선택)

## 🫡 참고사항

- UPCOMING(모집 예정) 상태 관리자 UI는 별도 커밋으로 분리 예정이며 이 PR에 포함되지 않습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 관리자가 동아리 상세 페이지에서 모집 기간을 조기 마감하거나 연장하고, 상시모집으로 전환할 수 있습니다.
  - 모집 상태와 마감일을 확인할 수 있는 관리 기능을 추가했습니다.
  - 공용 토글 버튼과 모집 기간 변경 모달을 제공합니다.
  - 관리자 동아리 선택 정보가 로그인 후 유지되고 로그아웃 시 초기화됩니다.

- **개선 사항**
  - 동아리 설명 수정 후 관련 목록과 상세 정보가 최신 상태로 갱신됩니다.
  - 모집 기간 입력값 검증과 날짜 미리보기를 지원합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->